### PR TITLE
Fix name for amsCd component.  #335

### DIFF
--- a/components/src/input/tex/extensions/ams_cd/amscd.js
+++ b/components/src/input/tex/extensions/ams_cd/amscd.js
@@ -1,1 +1,1 @@
-import './lib/amscd.js';
+import './lib/amsCd.js';

--- a/components/src/input/tex/extensions/ams_cd/build.json
+++ b/components/src/input/tex/extensions/ams_cd/build.json
@@ -1,5 +1,5 @@
 {
-    "component": "input/tex/extensions/amscd",
+    "component": "input/tex/extensions/amsCd",
     "targets": ["input/tex/ams_cd"]
 }
 

--- a/components/src/input/tex/extensions/ams_cd/webpack.config.js
+++ b/components/src/input/tex/extensions/ams_cd/webpack.config.js
@@ -1,7 +1,7 @@
 const PACKAGE = require('../../../../../webpack.common.js');
 
 module.exports = PACKAGE(
-    'input/tex/extensions/amscd',       // the package to build
+    'input/tex/extensions/amsCd',       // the package to build
     '../../../../../../js',             // location of the MathJax js library
     [                                   // packages to link to
         'components/src/input/tex-base/lib',


### PR DESCRIPTION
This correctly capitalizes the `amsCd` component so that it will load properly.

Resolves issue #335.