### PR TITLE
Remove duplicate xmlns property from svg creation

### DIFF
--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -220,7 +220,6 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         //
         const adaptor = this.adaptor;
         const svg = adaptor.append(this.container, this.svg('svg', {
-            xmlns: SVGNS,
             width: this.ex(W), height: this.ex(h + d),
             role: 'img', focusable: false,
             style: {'vertical-align': this.ex(-d)},


### PR DESCRIPTION
This removes the duplicate `xmlns` property set when creating an svg element, because:

a) The SVG namespace is already set when creating the svg element: https://github.com/mathjax/MathJax-src/blob/master/ts/output/svg.ts#L311
b) Setting an attribute called `xmlns` without the `http://www.w3.org/2000/xmlns/` namespace leads to a duplicate `xmlns` attribute being created when the node is serialized to XML.