### PR TITLE
Stops conversion once priority is greater than end only.

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -206,7 +206,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
      */
     public renderConvert(math: MathItem<N, T, D>, document: MathDocument<N, T, D>, end = STATE.LAST) {
         for (const item of this.items) {
-            if (item.priority >= end) return;
+            if (item.priority > end) return;
             if (item.item.convert) {
                 if (item.item.renderMath(math, document)) return;
             }


### PR DESCRIPTION
I believe conversion should stop with the end state and not before that. 

Just as an example from our `tex2html.js` sample:

```JavaScript
let math = html.convert(process.argv[3] || '', {end: STATE.TYPESET});
console.log(adaptor.outerHTML(math));
```

Here conversion should stop with typesetting and not before. Otherwise we get the wrong element back. We want a `HTML` node (in our case a `LiteElement`) and not the `MathItem`.