### PR TITLE
[CHTML] Fix problem with tags being displayed horizontally. mathjax/MathJax#2200

### DIFF
--- a/ts/output/chtml/Wrappers/mtr.ts
+++ b/ts/output/chtml/Wrappers/mtr.ts
@@ -124,6 +124,7 @@ CommonMlabeledtrMixin<CHTMLmtd<any, any, any>, Constructor<CHTMLmtr<any, any, an
             const align = this.node.attributes.get('rowalign') as string;
             const attr = (align !== 'baseline' && align !== 'axis' ? {rowalign: align} : {});
             const row = this.html('mjx-mtr', attr, [child]);
+            (CHTMLmtr as any).used = true;
             this.adaptor.append((this.parent as CHTMLmtable<N, T, D>).labels, row);
         }
     }


### PR DESCRIPTION
Make sure `mjx-mtr` CSS is produced when only `mlabeledtr` are used on the page, since `mlabeledtr` use `mjx-mtr` elements that are created by hand internally in CHTML.

Resolves issue mathjax/MathJax#2200.