### PR TITLE
Fix spacing around super- and subscripts.  mathjax/MathJax#2187

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -866,7 +866,7 @@ export abstract class AbstractMmlBaseNode extends AbstractMmlNode {
      */
     public setTeXclass(prev: MmlNode) {
         this.getPrevClass(prev);
-        this.texClass = TEXCLASS.NONE;
+        this.texClass = TEXCLASS.ORD;
         let base = this.childNodes[0];
         if (base) {
             if (this.isEmbellished || base.isKind('mi')) {


### PR DESCRIPTION
Correct the default `texClass` for `AbstractMmlBaseNode` elements. It should be `TEXCLASS.ORD`, not `TEXCLASS.NONE`.  This affects the situation when the base of the exponent is not a simple symbol, like when it is `\mathbb{...}` or even just `{...}`.

 Resolves mathjax/MathJax#2187