### PR TITLE
Fix tagFormat to allow it to work with ams tags.  mathjax/MathJax#2201

### DIFF
--- a/ts/input/tex/tag_format/TagFormatConfiguration.ts
+++ b/ts/input/tex/tag_format/TagFormatConfiguration.ts
@@ -41,6 +41,15 @@ let tagID = 0;
 export function tagFormatConfig(config: Configuration, jax: TeX<any, any, any>) {
 
     /**
+     * If the tag format is being added by one of the other extensions,
+     *   as is done for the 'ams' tags, make sure it is defined so we can create it.
+     */
+    const tags = jax.parseOptions.options.tags;
+    if (tags !== 'base' && config.tags.hasOwnProperty(tags)) {
+        TagsFactory.add(tags, config.tags[tags]);
+    }
+
+    /**
      * The original tag class to be extended (none, ams, or all)
      */
     const TagClass = TagsFactory.create(jax.parseOptions.options.tags).constructor as typeof AbstractTags;
@@ -103,6 +112,7 @@ export function tagFormatConfig(config: Configuration, jax: TeX<any, any, any>) 
 export const TagformatConfiguration = Configuration.create(
     'tagFormat', {
         config: tagFormatConfig,
+        configPriority: 10,
         options: {
             tagFormat: {
                 number: (n: number) => n.toString(),


### PR DESCRIPTION
Because tag formats that are defined by TeX packages (like the `ams` tag format) are not installed in the TagFactory until after the packages are fully initialized and configured, the `tagFormat` package can't locate the `ams` tag format when it needs to subclass it.  Fortunately, they are available in the Configuration object.  This PR changes `tagFormat` to look in the configuration for the tag format and adds it to the TagFactory so that the format will be available when it needs it.

We set the configuration priority to 10 so that it comes after normal packages, so that any that create tag formats will already be added to the main configuration, so we can find those tag formats there.

Resolves issue mathjax/MathJax#2201