### PR TITLE
Fix problem with math following <br>.  mathjax/MathJax#2202

### DIFF
--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -94,10 +94,11 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
      * @return {Location}            The Location object for the position of the delimiter in the document
      */
     protected findPosition(N: number, index: number, delim: string, nodes: HTMLNodeArray<N, T>): Location<N, T> {
+        const adaptor = this.adaptor;
         for (const list of nodes[N]) {
             let [node, n] = list;
-            if (index <= n) {
-                return {node: node, n: index, delim: delim};
+            if (index <= n && adaptor.kind(node) === '#text') {
+                return {node: node, n: Math.max(index, 0), delim: delim};
             }
             index -= n;
         }


### PR DESCRIPTION
Make sure we use text nodes for the start and end locations (there can be `<br>` nodes in the list, since they are allowed inside math).  We want to make sure we skip over them.

Resolves issue mathjax/MathJax#2202