### PR TITLE
Add CSS to force LTR direction for SVG output.  Resolves issue #2204

### DIFF
--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -60,8 +60,11 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      *  The default styles for SVG
      */
     public static commonStyles: CssStyleList = {
+        'mjx-container[jax="SVG"]': {
+            direction: 'ltr'
+        },
         'mjx-container[jax="SVG"] > svg': {
-            'overflow': 'visible'
+            overflow: 'visible'
         },
         'mjx-container[jax="SVG"] > svg a': {
             fill: 'blue', stroke: 'blue'


### PR DESCRIPTION
This PR adds CSS to the `mjx-container` to force the direction to be `ltr` in SVG output.  This is needed for when SVG output is used in an `rtl` context, as described by issue mathjax/MathJax#2204.