### PR TITLE
Check that parent is defined before getting its metrics.  mathjax/MathJax#2191

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -334,7 +334,7 @@ export interface MathDocument<N, T, D> {
      * Convert a math string to the document's output format
      *
      * @param {string} math           The math string to convert
-     * @params {OptionList} optoins   The options for the conversion (e.g., format, ex, em, etc.)
+     * @params {OptionList} options   The options for the conversion (e.g., format, ex, em, etc.)
      * @return {MmlNode|N}            The MmlNode or N node for the converted content
      */
     convert(math: string, options?: OptionList): MmlNode | N;

--- a/ts/handlers/html/HTMLMathItem.ts
+++ b/ts/handlers/html/HTMLMathItem.ts
@@ -119,18 +119,21 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
      */
     public removeFromDocument(restore: boolean = false) {
         if (this.state() >= STATE.TYPESET) {
+            const adaptor = this.adaptor;
             let node = this.start.node;
-            let math: N | T = this.adaptor.text('');
+            let math: N | T = adaptor.text('');
             if (restore) {
                 let text = this.start.delim + this.math + this.end.delim;
                 if (this.inputJax.processStrings) {
-                    math = this.adaptor.text(text);
+                    math = adaptor.text(text);
                 } else {
-                    const doc = this.adaptor.parse(text, 'text/html');
-                    math = this.adaptor.firstChild(this.adaptor.body(doc));
+                    const doc = adaptor.parse(text, 'text/html');
+                    math = adaptor.firstChild(adaptor.body(doc));
                 }
             }
-            this.adaptor.replace(math, node);
+            if (adaptor.parent(node)) {
+                adaptor.replace(math, node);
+            }
             this.start.node = this.end.node = math;
             this.start.n = this.end.n = 0;
         }

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -301,7 +301,7 @@ export abstract class CommonOutputJax<
         for (const math of html.math) {
             const node = adaptor.parent(math.start.node);
             if (node && math.state() < STATE.METRICS) {
-                const map = domMaps[math.display? 1 : 0];
+                const map = domMaps[math.display ? 1 : 0];
                 if (!map.has(node)) {
                     map.set(node, this.getTestElement(node, math.display));
                 }

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -261,8 +261,11 @@ export abstract class CommonOutputJax<
         const maps = this.getMetricMaps(html);
         for (const math of html.math) {
             const map = maps[math.display ? 1 : 0];
-            const {em, ex, containerWidth, lineWidth, scale} = map.get(adaptor.parent(math.start.node));
-            math.setMetrics(em, ex, containerWidth, lineWidth, scale);
+            const parent = adaptor.parent(math.start.node);
+            if (parent) {
+                const {em, ex, containerWidth, lineWidth, scale} = map.get(parent);
+                math.setMetrics(em, ex, containerWidth, lineWidth, scale);
+            }
         }
     }
 
@@ -297,7 +300,7 @@ export abstract class CommonOutputJax<
         for (const math of html.math) {
             const node = adaptor.parent(math.start.node);
             const map = domMaps[math.display? 1 : 0];
-            if (!map.has(node)) {
+            if (!map.has(node) && node) {
                 map.set(node, this.getTestElement(node, math.display));
             }
         }


### PR DESCRIPTION
If a typeset expression has been removed from the page, typesetting again can cause an error when the metrics are being determined.  This PR checks that the location where the metrics are being taken has a parent element before trying to use it.

Resolves issue mathjax/MathJax#2191.