### PR TITLE
Fix alignment problem with mtables.  mathjax/MathJax#2186

### DIFF
--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -60,6 +60,7 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
         },
         'mjx-table': {
             'display': 'inline-block',
+            'vertical-align': '-.5ex'
         },
         'mjx-table > mjx-itable': {
             'vertical-align': 'middle',
@@ -96,12 +97,6 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
         },
         'mjx-mtable[align="bottom"] > mjx-table': {
             'vertical-align': 'bottom'
-        },
-        'mjx-mtable[align="center"] > mjx-table': {
-            'vertical-align': 'middle'
-        },
-        'mjx-mtable[align="baseline"] > mjx-table': {
-            'vertical-align': 'middle'
         }
     };
 


### PR DESCRIPTION
Adjust for .5ex offset in CSS `vertical-align: middle` (see the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#Parent-relative_values)).  This sets CSS to compensate, and removes unneeded CSS that would have overriden this.

Resolves issues mathjax/MathJax#2186 and mathjax/MathJax#2203.