### PR TITLE
Add attribute to identify texClass for TeXAtom output. mathjax/MathJax#2193

### DIFF
--- a/ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/ts/output/chtml/Wrappers/TeXAtom.ts
@@ -24,7 +24,7 @@
 import {CHTMLWrapper, CHTMLConstructor} from '../Wrapper.js';
 import {CommonTeXAtom, CommonTeXAtomMixin} from '../../common/Wrappers/TeXAtom.js';
 import {TeXAtom} from '../../../core/MmlTree/MmlNodes/TeXAtom.js';
-import {TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
+import {TEXCLASS, TEXCLASSNAMES} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
 /**
@@ -43,6 +43,7 @@ export class CHTMLTeXAtom<N, T, D> extends CommonTeXAtomMixin<CHTMLConstructor<a
      */
     public toCHTML(parent: N) {
         super.toCHTML(parent);
+        this.adaptor.setAttribute(this.chtml, 'texclass', TEXCLASSNAMES[this.node.texClass]);
         //
         // Center VCENTER atoms vertically
         //

--- a/ts/output/svg/Wrappers/TeXAtom.ts
+++ b/ts/output/svg/Wrappers/TeXAtom.ts
@@ -24,7 +24,7 @@
 import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
 import {CommonTeXAtom, CommonTeXAtomMixin} from '../../common/Wrappers/TeXAtom.js';
 import {TeXAtom} from '../../../core/MmlTree/MmlNodes/TeXAtom.js';
-import {TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
+import {TEXCLASS, TEXCLASSNAMES} from '../../../core/MmlTree/MmlNode.js';
 
 /*****************************************************************/
 /**
@@ -43,6 +43,7 @@ export class SVGTeXAtom<N, T, D> extends CommonTeXAtomMixin<SVGConstructor<any, 
      */
     public toSVG(parent: N) {
         super.toSVG(parent);
+        this.adaptor.setAttribute(this.element, 'data-mjx-texclass', TEXCLASSNAMES[this.node.texClass]);
         //
         // Center VCENTER atoms vertically
         //


### PR DESCRIPTION
This PR adds an attribute to CHTML and SVG output for the TeXAtom elements that identifies the texClass of the element.  This was prompted by the discussion in mathjax/MathJax#2193