### PR TITLE
Fix scaling of zoomed multline environments with tags.  mathjax/MathJax-demos-web#17

### DIFF
--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -236,6 +236,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
             //
             // Use width 100% with no viewbox, and instead scale and translate to achieve the same result
             //
+            adaptor.setStyle(svg, 'min-width', this.ex(W));
             adaptor.setAttribute(svg, 'width', pwidth);
             adaptor.removeAttribute(svg, 'viewBox');
             const scale = wrapper.metrics.ex / (this.font.params.x_height * 1000);


### PR DESCRIPTION
Use `min-width` on outermost `svg` element when labels are present to prevent the main expression from shrinking if the window size shrinks (e.g., during zooming).

Resolves issue mathjax/MathJax-demos-web#17.