### PR TITLE
Override for enrichSpeech option to general aria labels in A11y.

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -229,6 +229,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
 
         public static OPTIONS: OptionList = {
             ...BaseDocument.OPTIONS,
+            enrichSpeech: 'shallow',                   // overrides option in EnrichedMathDocument
             renderActions: expandable({
                 ...BaseDocument.OPTIONS.renderActions,
                 explorable: [STATE.EXPLORER]


### PR DESCRIPTION
Sets the `enrichspeech` option by default to `shallow` so aria labels will be computed when a11y is active.