### PR TITLE
Fix duplicative namespace on href attribute in SVG wrapper

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -316,7 +316,7 @@ CommonWrapper<
     protected useNode(variant: string, C: string, path: string) {
         const use = this.svg('use');
         const id = '#' + this.jax.fontCache.cachePath(variant, C, path);
-        this.adaptor.setAttribute(use, 'xlink:href', id, XLINKNS);
+        this.adaptor.setAttribute(use, 'href', id, XLINKNS);
         return use;
     }
 


### PR DESCRIPTION
Fixes #365. Not sure if there is any applicable test coverage.