### PR TITLE
Fix operator with movable limits when no other super- or subscripts are used.  mathjax/MathJax#2221

### DIFF
--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -90,6 +90,16 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
     public static useIC = false;
 
     /**
+     * Make sure styles get output when called from munderover with movable limits
+     *
+     * @override
+     */
+    public markUsed() {
+        super.markUsed();
+        (CHTMLmsubsup as any).used = true;
+    }
+
+    /**
      * @override
      */
     public toCHTML(parent: N) {


### PR DESCRIPTION
Make sure styles for `msubsup` are output when called from `munderover` with `movablelimits`.  

Resolves issue mathjax/MathJax#2221.