### PR TITLE
Add support for serializing annotation-xml contents

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -24,6 +24,7 @@
 import {Attributes, INHERIT} from './Attributes.js';
 import {Property, PropertyList, Node, AbstractNode, AbstractEmptyNode, NodeClass} from '../Tree/Node.js';
 import {MmlFactory} from './MmlFactory.js';
+import {DOMAdaptor} from '../DOMadaptor.js';
 
 /**
  *  Used in setInheritedAttributes() to pass originating node kind as well as property value
@@ -1129,6 +1130,11 @@ export class XMLNode extends AbstractMmlEmptyNode {
     protected xml: Object = null;
 
     /**
+     * DOM adaptor for the content
+     */
+    protected adaptor: DOMAdaptor<any, any, any> = null;
+
+    /**
      * @override
      */
     public get kind() {
@@ -1146,9 +1152,17 @@ export class XMLNode extends AbstractMmlEmptyNode {
      * @param {object} xml  The XML content to be saved
      * @return {XMLNode}  The XML node (for chaining of method calls)
      */
-    public setXML(xml: Object) {
+    public setXML(xml: Object, adaptor: DOMAdaptor<any, any, any> = null) {
         this.xml = xml;
+        this.adaptor = adaptor;
         return this;
+    }
+
+    /**
+     * @return {string}  The serialized XML content
+     */
+    public getSerializedXML() {
+        return this.adaptor.outerHTML(this.xml);
     }
 
     /**

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -55,10 +55,10 @@ export class SerializedMmlVisitor extends MmlVisitor {
     /**
      * @param {XMLNode} node  The XML node to visit
      * @param {string} space  The amount of indenting for this node
-     * @return {string}       The serialization of the XML node (not implemented yet).
+     * @return {string}       The serialization of the XML node
      */
     public visitXMLNode(node: XMLNode, space: string) {
-        return '[XML Node not implemented]';
+        return space + node.getSerializedXML();
     }
 
     /**

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -174,18 +174,19 @@ export class MathMLCompile<N, T, D> {
         if (mml.arity === 0) {
             return;
         }
-        for (const child of this.adaptor.childNodes((node)) as N[]) {
-            const name = this.adaptor.kind(child);
+        const adaptor = this.adaptor;
+        for (const child of adaptor.childNodes((node)) as N[]) {
+            const name = adaptor.kind(child);
             if (name === '#comment') {
                 continue;
             }
             if (name === '#text') {
                 this.addText(mml, child);
             } else if (mml.isKind('annotation-xml')) {
-                mml.appendChild((this.factory.create('XML') as XMLNode).setXML(child));
+                mml.appendChild((this.factory.create('XML') as XMLNode).setXML(child, adaptor));
             } else {
                 let childMml = mml.appendChild(this.makeNode(child)) as MmlNode;
-                if (childMml.arity === 0 && this.adaptor.childNodes(child).length) {
+                if (childMml.arity === 0 && adaptor.childNodes(child).length) {
                     if (this.options['fixMisplacedChildren']) {
                         this.addChildren(mml, child);
                     } else {

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -175,7 +175,7 @@ export class MathMLCompile<N, T, D> {
             return;
         }
         const adaptor = this.adaptor;
-        for (const child of adaptor.childNodes((node)) as N[]) {
+        for (const child of adaptor.childNodes(node) as N[]) {
             const name = adaptor.kind(child);
             if (name === '#comment') {
                 continue;


### PR DESCRIPTION
This PR modifies the `XMLnode` object (which holds the XML content of an `annotation-xml` element) so that its contents can be serialized.  To do this, we store the adaptor from the input jax in the XML node so that it can be used to serialize the xml content when needed.  The `SerializeMmlVisitor` uses the new function of the `XMLnode` to serialize it.  The MathML input jax is modified to pass the adaptor along, but it looks like more because I made a local `adaptor` variable to simplify `this.adaptor` calls.