### PR TITLE
Improve support for annotation-xml mathjax/MathJax#2210

### DIFF
--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -69,6 +69,9 @@ namespace FilterUtil {
     let node = arg.data.root as MmlNode;
     node.walkTree((mml: MmlNode, d: any) => {
       let attribs = mml.attributes as any;
+      if (!attribs) {
+        return;
+      }
       for (const key of attribs.getExplicitNames()) {
         if (attribs.attributes[key] === mml.attributes.getInherited(key)) {
           delete attribs.attributes[key];

--- a/ts/output/chtml/Wrappers/semantics.ts
+++ b/ts/output/chtml/Wrappers/semantics.ts
@@ -27,6 +27,7 @@ import {CommonSemantics, CommonSemanticsMixin} from '../../common/Wrappers/seman
 import {BBox} from '../BBox.js';
 import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from '../../../core/MmlTree/MmlNodes/semantics.js';
 import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
+import {StyleList} from '../../common/CssStyles.js';
 
 /*****************************************************************/
 /**
@@ -92,6 +93,14 @@ export class CHTMLannotation<N, T, D> extends CHTMLWrapper<N, T, D> {
  */
 export class CHTMLannotationXML<N, T, D> extends CHTMLWrapper<N, T, D> {
     public static kind = MmlAnnotationXML.prototype.kind;
+
+    public static styles: StyleList = {
+        'mjx-annotation-xml': {
+            'font-family': 'initial',
+            'line-height': 'normal'
+        }
+    };
+
 }
 
 /*****************************************************************/
@@ -111,15 +120,17 @@ export class CHTMLxml<N, T, D> extends CHTMLWrapper<N, T, D> {
      * @override
      */
     public toCHTML(parent: N) {
-        this.adaptor.append(parent, this.adaptor.clone((this.node as XMLNode).getXML() as N));
+        this.chtml = this.adaptor.append(parent, this.adaptor.clone((this.node as XMLNode).getXML() as N));
     }
 
     /**
      * @override
      */
-    public computeBBox() {
-        // FIXME:  compute using the DOM, if possible
-        return this.bbox;
+    public computeBBox(bbox: BBox, recompute: boolean = false) {
+        const {w, h, d} = this.jax.measureXMLnode((this.node as XMLNode).getXML() as N);
+        bbox.w = w;
+        bbox.h = h;
+        bbox.d = d;
     }
 
     /**

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -541,6 +541,35 @@ export abstract class CommonOutputJax<
     public abstract measureTextNode(text: N): UnknownBBox;
 
     /**
+     * Measure the width, height and depth of an annotation-xml node's content
+     *
+     * @param{N} xml   The xml content node to be measured
+     * @return {Object}  The width, height, and depth of the content
+     */
+    public measureXMLnode(xml: N) {
+        const adaptor = this.adaptor;
+        const content =  this.html('mjx-xml-block', {style:{display:'inline-block'}}, [adaptor.clone(xml)]);
+        const base = this.html('mjx-baseline', {style: {display: 'inline-block', width: 0, height: 0}});
+        const style = {
+            position: 'absolute',
+            display: 'inline-block',
+            'font-family': 'initial',
+            'line-height': 'normal'
+        };
+        const node = this.html('mjx-measure-xml', {style}, [base, content]);
+        adaptor.append(adaptor.parent(this.math.start.node), this.container);
+        adaptor.append(this.container, node);
+        const em = this.math.metrics.em * this.math.metrics.scale;
+        const {left, right, bottom, top} = adaptor.nodeBBox(content);
+        const w = (right - left) / em;
+        const h = (adaptor.nodeBBox(base).top - top) / em;
+        const d = (bottom - top) / em - h;
+        adaptor.remove(this.container);
+        adaptor.remove(node);
+        return {w, h, d};
+    }
+
+    /**
      * @param {CssFontData} font   The family, style, and weight for the given font
      * @param {Styles} styles      The style object to add the font data to
      * @return {Styles}            The modified (or initialized) style object

--- a/ts/output/svg/Wrappers/semantics.ts
+++ b/ts/output/svg/Wrappers/semantics.ts
@@ -27,6 +27,7 @@ import {CommonSemantics, CommonSemanticsMixin} from '../../common/Wrappers/seman
 import {BBox} from '../BBox.js';
 import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from '../../../core/MmlTree/MmlNodes/semantics.js';
 import {MmlNode, XMLNode} from '../../../core/MmlTree/MmlNode.js';
+import {StyleList} from '../../common/CssStyles.js';
 
 /*****************************************************************/
 /**
@@ -92,6 +93,15 @@ export class SVGannotation<N, T, D> extends SVGWrapper<N, T, D> {
  */
 export class SVGannotationXML<N, T, D> extends SVGWrapper<N, T, D> {
     public static kind = MmlAnnotationXML.prototype.kind;
+
+    public static styles: StyleList = {
+        'foreignObject[data-mjx-xml]': {
+            'font-family': 'initial',
+            'line-height': 'normal',
+            overflow: 'visible'
+        }
+    };
+
 }
 
 /*****************************************************************/
@@ -112,15 +122,26 @@ export class SVGxml<N, T, D> extends SVGWrapper<N, T, D> {
      */
     public toSVG(parent: N) {
         const xml = this.adaptor.clone((this.node as XMLNode).getXML() as N);
-        this.adaptor.append(parent, this.svg('foreignObject', {}, [xml]));
+        const em = this.jax.math.metrics.em * this.jax.math.metrics.scale;
+        const scale = this.fixed(1 / em);
+        const {w, h, d} = this.getBBox();
+        this.element = this.adaptor.append(parent, this.svg('foreignObject', {
+            'data-mjx-xml': true,
+            y: this.jax.fixed(-h * em) + 'px',
+            width: this.jax.fixed(w * em) + 'px',
+            height: this.jax.fixed((h + d) * em) + 'px',
+            transform: `scale(${scale}) matrix(1 0 0 -1 0 0)`
+        }, [xml]));
     }
 
     /**
      * @override
      */
-    public computeBBox() {
-        // FIXME:  compute using the DOM, if possible
-        return this.bbox;
+    public computeBBox(bbox: BBox, recompute: boolean = false) {
+        const {w, h, d} = this.jax.measureXMLnode((this.node as XMLNode).getXML() as N);
+        bbox.w = w;
+        bbox.h = h;
+        bbox.d = d;
     }
 
     /**


### PR DESCRIPTION
This PR provides support for measuring the contents of `annotation-xml` nodes in the browser.  It also fixes SVG output for these, which was broken since it didn't specify the size of the `foreignObject` elements.  It also fixes a problem where TeX input that includes `annotation-xml` would fail during the `cleanAttributes()` filter.

Resolves issue mathjax/MathJax#2210