### PR TITLE
Improve movablelimits support

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -144,8 +144,9 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     userOptions(parseOptions.options, rest);
     configuration.config(configuration, this);
     TeX.tags(parseOptions, configuration);
-    this.postFilters.add(FilterUtil.cleanSubSup, -5);
-    this.postFilters.add(FilterUtil.setInherited, -4);
+    this.postFilters.add(FilterUtil.cleanSubSup, -6);
+    this.postFilters.add(FilterUtil.setInherited, -5);
+    this.postFilters.add(FilterUtil.moveLimits, -4);
     this.postFilters.add(FilterUtil.cleanStretchy, -3);
     this.postFilters.add(FilterUtil.cleanAttributes, -2);
     this.postFilters.add(FilterUtil.combineRelations, -1);

--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -235,18 +235,18 @@ namespace FilterUtil {
    */
   let _moveLimits = function (options: ParseOptions, underover: string, subsup: string) {
     for (const mml of options.getList(underover)) {
-      const display = mml.attributes.get('displaystyle');
-      if (!display) {
-        const base = mml.childNodes[(mml as any).base] as MmlNode;
-        const mo = base.coreMO();
-        if (base.getProperty('movablelimits') && !mo.attributes.getExplicit('movablelimits')) {
-          let node = options.nodeFactory.create('node', subsup, mml.childNodes);
-          NodeUtil.copyAttributes(mml, node);
-          if (mml.parent) {
-            mml.parent.replaceChild(node, mml);
-          } else {
-            options.root = node;
-          }
+      if (mml.attributes.get('displaystyle')) {
+        continue;
+      }
+      const base = mml.childNodes[(mml as any).base] as MmlNode;
+      const mo = base.coreMO();
+      if (base.getProperty('movablelimits') && !mo.attributes.getExplicit('movablelimits')) {
+        let node = options.nodeFactory.create('node', subsup, mml.childNodes);
+        NodeUtil.copyAttributes(mml, node);
+        if (mml.parent) {
+          mml.parent.replaceChild(node, mml);
+        } else {
+          options.root = node;
         }
       }
     }

--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -226,6 +226,47 @@ namespace FilterUtil {
 
 
   /**
+   * Looks through the list of munderover elements for ones that have
+   * movablelimits and bases that are not mo's, and creates new msubsup
+   * elements to replace them if they aren't in displaystyle.
+   *
+   * @param {MmlNode} ath The node to rewrite.
+   * @param {ParseOptions} data The parse options.
+   */
+  let _moveLimits = function (options: ParseOptions, underover: string, subsup: string) {
+    for (const mml of options.getList(underover)) {
+      const display = mml.attributes.get('displaystyle');
+      if (!display) {
+        const base = mml.childNodes[(mml as any).base] as MmlNode;
+        const mo = base.coreMO();
+        if (base.getProperty('movablelimits') && !mo.attributes.getExplicit('movablelimits')) {
+          let node = options.nodeFactory.create('node', subsup, mml.childNodes);
+          NodeUtil.copyAttributes(mml, node);
+          if (mml.parent) {
+            mml.parent.replaceChild(node, mml);
+          } else {
+            options.root = node;
+          }
+        }
+      }
+    }
+  };
+
+  /**
+   * Visitor that rewrites in-line munderover elements with movablelimits but bases
+   * that are not mo's into explicit msubsup elements.
+   *
+   * @param {{data:ParseOptions}} arg   The parse options to use
+   */
+  export let moveLimits = function (arg: {data: ParseOptions}) {
+    const options = arg.data;
+    _moveLimits(options, 'munderover', 'msubsup');
+    _moveLimits(options, 'munder', 'msub');
+    _moveLimits(options, 'mover', 'msup');
+  };
+
+
+  /**
    * Recursively sets the inherited attributes on the math tree.
    * @param {MmlNode} math The node to rewrite.
    * @param {ParseOptions} data The parse options.

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -326,9 +326,8 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          */
         public hasMovableLimits() {
             const display = this.node.attributes.get('displaystyle');
-            const base = this.baseChild.node;
             const mo = this.baseChild.coreMO().node;
-            return (!display && (base.attributes.get('movablelimits') || mo.attributes.get('movablelimits')));
+            return (!display && mo.attributes.get('movablelimits'));
         }
 
         /**

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -326,9 +326,9 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          */
         public hasMovableLimits() {
             const display = this.node.attributes.get('displaystyle');
-            return (!display && (this.node.getProperty('movablelimits') ||
-                                 this.node.attributes.get('movablelimits') ||
-                                 this.baseChild.coreMO().node.attributes.get('movablelimits')));
+            const base = this.baseChild.node;
+            const mo = this.baseChild.coreMO().node;
+            return (!display && (base.attributes.get('movablelimits') || mo.attributes.get('movablelimits')));
         }
 
         /**


### PR DESCRIPTION
This PR adds a new post-filter to the TeX input jax that converts in-line `munderover`, `munder`, and `mover` elements with the `movablelimits` property that have a base that is not an `mo` (e.g., `\mathop{xyz}` into an explicit `msubsup`, `msub`, or `msup` element.  This means the internal MathML will be correct MathML (rather than relying on the TeX-supplied `movablelimits` property), so the output jax don't have to look for that property any more and can just go by the attribute on the core mo.  It also means the `SerializeMmlVisitor` won't have to be modified to take the property into account (it currently outputs incorrect MathML for these situations).