### PR TITLE
Allow applying multiple CSS classes via parser.create method

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -419,8 +419,11 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
     /**
      * @override
      */
-    public addClass(node: N, name: string) {
-        node.classList.add(name);
+    public addClass(node: N, name: string|Array<string>) {
+        if (typeof(name) === 'string') {
+            name = name.split(' ')
+        }
+        node.classList.add(...name);
     }
 
     /**


### PR DESCRIPTION
Allow addition of multiple classes to nodes when multiple classes are provided (DOMTokenList or array of classes) with the `parser.create` method.

See [this issue](https://github.com/mathjax/MathJax/issues/2230)

Previously, this would fail:

```
const def = { class: 'class1 class2' } // or const def = { class: ['class1', 'class2'] }
const math = parser.ParseArg(name)
const node = parser.create('node', 'mrow', [math], def)
```

This PR allows for

```
const def = { class: 'class1 class2' } // or const def = { class: ['class1', 'class2'] }
const math = parser.ParseArg(name)
const node = parser.create('node', 'mrow', [math], def)
```