### PR TITLE
Fix spacing problems in superscripts.  mathjax/MathJax#2241

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -499,7 +499,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
             texClass = TEXCLASS.ORD;
         }
         let space = TEXSPACE[prevClass][texClass];
-        if (this.prevLevel > 0 && this.attributes.get('scriptlevel') > 0 && space >= 0) {
+        if ((this.prevLevel > 0 || this.attributes.get('scriptlevel') > 0) && space >= 0) {
             return '';
         }
         return TEXSPACELENGTH[Math.abs(space)];


### PR DESCRIPTION
Use script-style spacing if either of a pair of neighboring elements is in script-style (rather than requiring both to be).  This means that `<mspace>` wrapped in `<mstyle scriptstyle="0">` (as used for the fixed-size spaces in TeX) won't include extra spaces.

Resolves issue mathjax/MathJax#2241