### PR TITLE
Remove mi2mo action

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -176,7 +176,8 @@ export class MmlMo extends AbstractMmlTokenNode {
      */
     public setTeXclass(prev: MmlNode): MmlNode {
         let {form, fence} = this.attributes.getList('form', 'fence') as {form: string, fence: string};
-        if (this.attributes.isSet('lspace') || this.attributes.isSet('rspace')) {
+        if (this.getProperty('texClass') === undefined &&
+            (this.attributes.isSet('lspace') || this.attributes.isSet('rspace'))) {
             this.texClass = TEXCLASS.NONE;
             return null;
         }

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -196,7 +196,7 @@ namespace ParseUtil {
    * empty braces (TeXAtom with child being an empty inferred row),
    * is an <mo>, precede it by an empty <mi> to force the <mo> to
    * be infix.
-   * @param {ParseOptions} configuration The current parse otpions.
+   * @param {ParseOptions} configuration The current parse options.
    * @param {MmlNodep[]} nodes The row of nodes to scan for an initial <mo>
    */
   export function fixInitialMO(configuration: ParseOptions, nodes: MmlNode[]) {

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -192,10 +192,12 @@ namespace ParseUtil {
 
 
   /**
-   *  If the initial child, skipping any initial space or
-   *  empty braces (TeXAtom with child being an empty inferred row),
-   *  is an <mo>, preceed it by an empty <mi> to force the <mo> to
-   *  be infix.
+   * If the initial child, skipping any initial space or
+   * empty braces (TeXAtom with child being an empty inferred row),
+   * is an <mo>, precede it by an empty <mi> to force the <mo> to
+   * be infix.
+   * @param {ParseOptions} configuration The current parse otpions.
+   * @param {MmlNodep[]} nodes The row of nodes to scan for an initial <mo>
    */
   export function fixInitialMO(configuration: ParseOptions, nodes: MmlNode[]) {
     for (let i = 0, m = nodes.length; i < m; i++) {
@@ -215,24 +217,7 @@ namespace ParseUtil {
 
 
   /**
-   * Rewrites an mi node into an mo node.
-   * @param {TexParser} parser The current TexParser.
-   * @param {MmlNode} mi The mi node.
-   * @return {MmlNode} The corresponding mo node.
-   */
-  export function mi2mo(parser: TexParser, mi: MmlNode): MmlNode {
-    // @test Mathop Sub, Mathop Super
-    const mo = parser.create('node', 'mo');
-    NodeUtil.copyChildren(mi, mo);
-    NodeUtil.copyAttributes(mi, mo);
-    NodeUtil.setProperties(mo, {lspace: '0', rspace: '0'});
-    NodeUtil.removeProperties(mo, 'movesupsub');
-    return mo;
-  }
-
-
-  /**
-   *  Break up a string into text and math blocks.
+   * Break up a string into text and math blocks.
    * @param {TexParser} parser The calling parser.
    * @param {string} text The text in the math expression to parse.
    * @param {number|string=} level The scriptlevel.

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -138,10 +138,6 @@ BaseMethods.Superscript = function(parser: TexParser, c: string) {
       // @test Move Superscript, Large Operator
       if (!NodeUtil.isType(base, 'munderover') || NodeUtil.isType(base, 'mover') ||
           NodeUtil.getChildAt(base, (base as MmlMunderover).over)) {
-        if (NodeUtil.getProperty(base, 'movablelimits') && NodeUtil.isType(base, 'mi')) {
-          // @test Mathop Super
-          base = ParseUtil.mi2mo(parser, base);
-        }
         // @test Large Operator
         base = parser.create('node', 'munderover', [base], {movesupsub: true});
       }
@@ -200,10 +196,6 @@ BaseMethods.Subscript = function(parser: TexParser, c: string) {
       // @test Large Operator, Move Superscript
       if (!NodeUtil.isType(base, 'munderover') || NodeUtil.isType(base, 'mover') ||
           NodeUtil.getChildAt(base, (base as MmlMunderover).under)) {
-        if (NodeUtil.getProperty(base, 'movablelimits') && NodeUtil.isType(base, 'mi')) {
-          // @test Mathop Sub
-          base = ParseUtil.mi2mo(parser, base);
-        }
         // @test Move Superscript
         base = parser.create('node', 'munderover', [base], {movesupsub: true});
       }


### PR DESCRIPTION
Remove the `mi2mo()` action for `munderover` and related constructs (since a TeX input post-filter now handles non-`mo` elements that have movable limits).  In addition, it fixes a problem where an explicitly set `texClass` could be lost if `lspace` or `rspace` was set (this was the case with `mi2mo()`, but now that that is removed).  This was a cause for some test failures from mathjax/MathJax-dev#30.  But these changes will require additional update to those tests, since the `mi` are no longer changed to `mo`.

Finally, it also adds missing jsdoc comments to one function.