### PR TITLE
Add more data-mjx-* attributes to MathML serialization 

### DIFF
--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -98,9 +98,8 @@ export class SerializedMmlVisitor extends MmlVisitor {
      * @return {string}       The serialized contents of the mrow, properly indented.
      */
     public visitTeXAtomNode(node: MmlNode, space: string) {
-        let texclass = node.texClass < 0 ? 'NONE' : TEXCLASSNAMES[node.texClass];
         let children = this.childNodeMml(node, space + '  ', '\n');
-        let mml = space + '<mrow' + this.getAttributes(node) + ' data-mjx-texclass="' + texclass + '">' +
+        let mml = space + '<mrow' + this.getAttributes(node) + '>' +
             (children.match(/\S/) ? '\n' + children + space : '') + '</mrow>';
         return mml;
     }
@@ -181,6 +180,9 @@ export class SerializedMmlVisitor extends MmlVisitor {
         const variants = (this.constructor as typeof SerializedMmlVisitor).variants;
         variant && variants.hasOwnProperty(variant) && data.push(' data-mjx-variant="' + variant + '"');
         node.getProperty('variantForm') && data.push(' data-mjx-alternate="1"');
+        const texclass = node.getProperty('texClass') as number;
+        texclass !== undefined &&
+            data.push(' data-mjx-texclass="' + (texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass] + '"');
         return data.join('');
     }
 

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -24,7 +24,8 @@
 
 import {MmlVisitor} from './MmlVisitor.js';
 import {MmlFactory} from './MmlFactory.js';
-import {MmlNode, TextNode, XMLNode, TEXCLASSNAMES} from './MmlNode.js';
+import {MmlNode, TextNode, XMLNode, TEXCLASS, TEXCLASSNAMES} from './MmlNode.js';
+import {MmlMi} from './MmlNodes/mi.js';
 
 /*****************************************************************/
 /**
@@ -158,7 +159,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
         let attributes = node.attributes.getAllAttributes();
         let variants = (this.constructor as typeof SerializedMmlVisitor).variants;
         for (const name of Object.keys(attributes)) {
-            let value = attributes[name] as string;
+            let value = String(attributes[name]);
             if (value === undefined) continue;
             if (name === 'mathvariant' && variants.hasOwnProperty(value)) {
                 value = variants[value];
@@ -181,8 +182,14 @@ export class SerializedMmlVisitor extends MmlVisitor {
         variant && variants.hasOwnProperty(variant) && data.push(' data-mjx-variant="' + variant + '"');
         node.getProperty('variantForm') && data.push(' data-mjx-alternate="1"');
         const texclass = node.getProperty('texClass') as number;
-        texclass !== undefined &&
-            data.push(' data-mjx-texclass="' + (texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass] + '"');
+        if (texclass !== undefined) {
+            let setclass = true;
+            if (texclass === TEXCLASS.OP && node.isKind('mi')) {
+                const name = (node as MmlMi).getText();
+                setclass = !(name.length > 1 && name.match(MmlMi.operatorName));
+            }
+            setclass && data.push(' data-mjx-texclass="' + (texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass] + '"'));
+        }
         return data.join('');
     }
 

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -244,7 +244,7 @@ export class MathMLCompile<N, T, D> {
                 if (name === 'MJX-variant') {
                     mml.setProperty('variantForm', true);
                 } else if (name.substr(0, 11) !== 'MJX-TeXAtom') {
-                    mml.attributes.set('mathvariant', name.substr(3).replace(/caligraphic/, 'calligraphic'));
+                    mml.attributes.set('mathvariant', this.fixCalligraphic(name.substr(3)));
                 }
             } else {
                 classList.push(name);
@@ -253,6 +253,16 @@ export class MathMLCompile<N, T, D> {
         if (classList.length) {
             mml.attributes.set('class', classList.join(' '));
         }
+    }
+
+    /**
+     * Fix the old incorrect spelling of calligraphic.
+     *
+     * @param {string} variant  The mathvariant name
+     * @return {string}         The corrected variant
+     */
+    protected fixCalligraphic(variant: string) {
+        return variant.replace(/caligraphic/, 'calligraphic');
     }
 
     /**


### PR DESCRIPTION
This PR exposes more internal properties via `data-mjx-*` attributes, including the `variantForm` property (mathjax/MathJax#2237) and the internal `mathvariant` values, like `-tex-calligraphic` (mathjax/MathJax#2238).  This also moves the data for TeXAtom nodes to `data-mjx-texclass` rather than using the `class` attribute for these.  Also, the xmlns attribute is added to math elements, if needed.

The MathML input jax is modified to read these and transfer the data back to the internal elements it creates.  It still looks for the corresponding values in the `class`, however, for backward compatibility with v2 output.  It also corrects the `caligraphic` misspelling.

Resolves issues mathjax/MathJax#2237, mathjax/MathJax#2238, and mathjax/MathJax#2214.
Also resolves issue from mathjax/MathJax#2264