### PR TITLE
Preserve special spaces in token element contents

### DIFF
--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -283,7 +283,8 @@ export class MathMLCompile<N, T, D> {
      */
     protected trimSpace(text: string) {
         return text.replace(/[\t\n\r]/g, ' ')    // whitespace to spaces
-                   .trim()                       // initial and trailing whitespace
+                   .replace(/^ +/,'')            // initial whitespace
+                   .replace(/ +$/,'')            // trailing whitespace
                    .replace(/  +/g, ' ');        // internal multiple whitespace
     }
 


### PR DESCRIPTION
Only remove actual spaces from token element contents (perserve non-breaking and other special spaces like U+2000 to U+200C).  Without this PR

```
<math>
<mi>x</mi>
<mo>&#xA0;</mo>
</mi>y</mi>
</math>
```

would remove the non-breaking space.