### PR TITLE
Better path handling.  #398

### DIFF
--- a/ts/components/package.ts
+++ b/ts/components/package.ts
@@ -92,7 +92,7 @@ export class Package {
      */
     public static resolvePath(name: string, addExtension: boolean = true) {
         let file = CONFIG.source[name] || name;
-        if (!file.match(/^(?:[a-z]+:\/)?\/|\[/)) {
+        if (!file.match(/^(?:[a-z]+:\/)?\/|\[|[a-z]:\\/i)) {
             file = '[mathjax]/' + file.replace(/^\.\//, '');
         }
         if (addExtension && !file.match(/\.[^\/]+$/)) {

--- a/ts/util/asyncLoad/node.ts
+++ b/ts/util/asyncLoad/node.ts
@@ -26,11 +26,13 @@ import {mathjax} from '../../mathjax.js';
 declare var require: (name: string) => any;
 declare var __dirname: string;
 
-const root = __dirname.replace(/\/[^\/]*\/[^\/]*$/, '/');
+const path = require('path');
+
+const root = path.dirname(path.dirname(__dirname));
 
 if (!mathjax.asyncLoad && typeof require !== 'undefined') {
     mathjax.asyncLoad = (name: string) => {
-        return require(name.charAt(0) === '.' ? root + name : name);
+        return require(name.charAt(0) === '.' ? path.resolve(root, name) : name);
     };
 }
 


### PR DESCRIPTION
Use node's `path` module to handle directories, so they work in Windows. 

Resolves issue #398