### PR TITLE
Don't leak fonts and other properties to initial array entry.  mathjax/MathJax#2247

### DIFF
--- a/ts/input/tex/Stack.ts
+++ b/ts/input/tex/Stack.ts
@@ -101,7 +101,9 @@ export default class Stack {
       }
       this.stack.push(item);
       if (item.env) {
-        Object.assign(item.env, this.env);
+        if (item.copyEnv) {
+          Object.assign(item.env, this.env);
+        }
         this.env = item.env;
       } else {
         item.env = this.env;

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -254,7 +254,7 @@ export interface StackItem extends NodeStack {
 
   /**
    * Copy local properties when pushed to stack?
-   * @type {boolena}
+   * @type {boolean}
    */
    copyEnv: boolean;
 

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -253,6 +253,12 @@ export interface StackItem extends NodeStack {
    env: EnvList;
 
   /**
+   * Copy local properties when pushed to stack?
+   * @type {boolena}
+   */
+   copyEnv: boolean;
+
+  /**
    * Tests if item is of the given type.
    * @param {string} kind The type.
    * @return {boolean} True if item is of that type.
@@ -379,12 +385,27 @@ export abstract class BaseItem extends MmlStack implements StackItem {
     return 'base';
   }
 
-  get env() {
+  /**
+   * Get the private environment
+   * @return {EnvList}
+   */
+  public get env() {
     return this._env;
   }
 
-  set env(value: EnvList) {
+  /**
+   * Set the private environment
+   * @param {EnvList} value
+   */
+  public set env(value: EnvList) {
     this._env = value;
+  }
+
+  /**
+   * Default is to copy local environment when pushed on stack
+   */
+  public get copyEnv() {
+    return true;
   }
 
   /**

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -814,6 +814,12 @@ export class ArrayItem extends BaseItem {
     return true;
   }
 
+  /**
+   * @override
+   */
+  get copyEnv() {
+    return false;
+  }
 
   /**
    * @override


### PR DESCRIPTION
The local environment object should not be copied when pushing an array element on the stack.  This prevents fonts and other properties from being incorrectly copied into the first cell of the array.  E.g.

```
\bf \begin{array}{c} a & a\end{array}
```

should show two italic a's, not a bold one and an italic one.

 Resolves issue mathjax/MathJax#2247.