### PR TITLE
Better handling of undefined tag class.  #404

### DIFF
--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -651,7 +651,10 @@ export namespace TagsFactory {
    * @return {Tags} The newly created object.
    */
   export let create = function(name: string): Tags {
-    let constr = tagsMapping.get(name) || this.defaultTags;
+    let constr = tagsMapping.get(name) || tagsMapping.get(defaultTags);
+    if (!constr) {
+        throw Error('Unknown tags class');
+    }
     return new constr();
   };
 


### PR DESCRIPTION
Fix incorrect use of defaulTags, and report an error if the named tag class is not available.

Resolves (part of) issue #404