### PR TITLE
Make \require{bussproofs} work properly.

### DIFF
--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -198,8 +198,7 @@ export class Configuration {
   }
 
   /**
-   * Appends configurations to this configuration. Note that fallbacks are
-   * overwritten, while order of configurations is preserved.
+   * Registers a configuration after the input jax is created.  (Used by \require.)
    *
    * @param {Configuration} config   The configuration to be registered in this one
    * @param {TeX} jax                The TeX jax where it is being registered
@@ -216,12 +215,6 @@ export class Configuration {
     defaultOptions(parser.options, config.options);
     userOptions(parser.options, options);
     config.config(this, jax);
-    for (const pre of config.preprocessors) {
-      Array.isArray(pre) ? jax.preFilters.add(pre[0], pre[1]) : jax.preFilters.add(pre);
-    }
-    for (const post of config.postprocessors) {
-      Array.isArray(post) ? jax.postFilters.add(post[0], post[1]) : jax.postFilters.add(post);
-    }
   }
 
   /**

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -76,6 +76,15 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
             //  Register the extension with the jax's configuration
             //
             (jax as any).configuration.register(handler, jax, options);
+            //
+            // If there are preprocessors, restart so that they run
+            // (we don't have access to the document or MathItem needed to call
+            //  the preprocessors from here)
+            //
+            if (handler.preprocessors.length && !handler.options.configured) {
+                handler.options.configured = true;
+                mathjax.retryAfter(Promise.resolve());
+            }
         }
     }
 }
@@ -103,7 +112,7 @@ function RegisterDependencies(jax: TeX<any, any, any>, names: string[] = []) {
  */
 export function RequireLoad(parser: TexParser, name: string) {
     const options = parser.options.require;
-    const allow = options.allow
+    const allow = options.allow;
     const extension = (name.substr(0,1) === '[' ? '' : options.prefix) + name;
     const allowed = (allow.hasOwnProperty(extension) ? allow[extension] :
                      allow.hasOwnProperty(name) ? allow[name] : options.defaultAllow);


### PR DESCRIPTION
Do a restart if a package loaded with `\require` has preprocessors (since they will need to run before the math is processed).  This allows `\require{bussproofs}` to be in the same expression as the proof itself.  (The Bussproofs package is the only one that uses preprocessors at the moment.)

Also, remove dupolication of pre- and post-processors from the `register()` function, since these are already added during the `config.config()` call just before that.

Without this patch, 

```
$$
\require{bussproofs}
\begin{prooftree}
  \AxiomC{C}
  \AxiomC{A}
  \AxiomC{B}
  \BinaryInfC{D}
  \BinaryInfC{E}
\end{prooftree}
$$
```

would produce an error if the `bussproofs` extension was not loaded and included in the package list initially.