### PR TITLE
Add AssistiveMML support to v3

### DIFF
--- a/components/src/a11y/assistive-mml/assistive-mml.js
+++ b/components/src/a11y/assistive-mml/assistive-mml.js
@@ -1,0 +1,7 @@
+import './lib/assistive-mml.js';
+
+import {AssistiveMmlHandler} from '../../../../js/a11y/assistive-mml.js';
+
+if (MathJax.startup) {
+    MathJax.startup.extendHandler(handler => AssistiveMmlHandler(handler));
+}

--- a/components/src/a11y/assistive-mml/build.json
+++ b/components/src/a11y/assistive-mml/build.json
@@ -1,0 +1,5 @@
+{
+    "component": "a11y/assistive-mml",
+    "targets": ["a11y/assistive-mml.ts"]
+}
+

--- a/components/src/a11y/assistive-mml/webpack.config.js
+++ b/components/src/a11y/assistive-mml/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../webpack.common.js');
+
+module.exports = PACKAGE(
+    'a11y/assistive-mml',               // the package to build
+    '../../../../js',                   // location of the MathJax js library
+    [                                   // packages to link to
+        'components/src/input/mml/lib',
+        'components/src/core/lib'
+    ],
+    __dirname                           // our directory
+);

--- a/components/src/mml-chtml/mml-chtml.js
+++ b/components/src/mml-chtml/mml-chtml.js
@@ -5,4 +5,5 @@ import '../input/mml/mml.js';
 import '../output/chtml/chtml.js';
 import '../output/chtml/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/mml-chtml/preload.js
+++ b/components/src/mml-chtml/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/mml',
     'output/chtml', 'output/chtml/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/mml-svg/mml-svg.js
+++ b/components/src/mml-svg/mml-svg.js
@@ -5,4 +5,5 @@ import '../input/mml/mml.js';
 import '../output/svg/svg.js';
 import '../output/svg/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/mml-svg/preload.js
+++ b/components/src/mml-svg/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/mml',
     'output/svg', 'output/svg/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -38,6 +38,7 @@ exports.source = {
     'output/chtml/fonts/tex': `${src}/output/chtml/fonts/tex/tex.js`,
     'output/svg': `${src}/output/svg/svg.js`,
     'output/svg/fonts/tex': `${src}/output/svg/fonts/tex/tex.js`,
+    'a11y/assistive-mml': `${src}/a11y/assistive-mml/assistive-mml.js`,
     'a11y/semantic-enrich': `${src}/a11y/semantic-enrich/semantic-enrich.js`,
     'a11y/complexity': `${src}/a11y/complexity/complexity.js`,
     'a11y/explorer': `${src}/a11y/explorer/explorer.js`,

--- a/components/src/tex-chtml-full/preload.js
+++ b/components/src/tex-chtml-full/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex-full',
     'output/chtml', 'output/chtml/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assisitve-mml'
 );

--- a/components/src/tex-chtml-full/preload.js
+++ b/components/src/tex-chtml-full/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex-full',
     'output/chtml', 'output/chtml/fonts/tex.js',
-    'ui/menu', 'a11y/assisitve-mml'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/tex-chtml-full/tex-chtml-full.js
+++ b/components/src/tex-chtml-full/tex-chtml-full.js
@@ -5,4 +5,5 @@ import '../input/tex-full/tex-full.js';
 import '../output/chtml/chtml.js';
 import '../output/chtml/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/tex-chtml/preload.js
+++ b/components/src/tex-chtml/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex',
     'output/chtml', 'output/chtml/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/tex-chtml/tex-chtml.js
+++ b/components/src/tex-chtml/tex-chtml.js
@@ -5,4 +5,5 @@ import '../input/tex/tex.js';
 import '../output/chtml/chtml.js';
 import '../output/chtml/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/tex-mml-chtml/preload.js
+++ b/components/src/tex-mml-chtml/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex', 'input/mml',
     'output/chtml', 'output/chtml/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/tex-mml-chtml/tex-mml-chtml.js
+++ b/components/src/tex-mml-chtml/tex-mml-chtml.js
@@ -6,4 +6,5 @@ import '../input/mml/mml.js';
 import '../output/chtml/chtml.js';
 import '../output/chtml/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/tex-mml-svg/preload.js
+++ b/components/src/tex-mml-svg/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex', 'input/mml',
     'output/svg', 'output/svg/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/tex-mml-svg/tex-mml-svg.js
+++ b/components/src/tex-mml-svg/tex-mml-svg.js
@@ -6,4 +6,5 @@ import '../input/mml/mml.js';
 import '../output/svg/svg.js';
 import '../output/svg/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/tex-svg-full/preload.js
+++ b/components/src/tex-svg-full/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex-full',
     'output/svg', 'output/svg/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/tex-svg-full/tex-svg-full.js
+++ b/components/src/tex-svg-full/tex-svg-full.js
@@ -5,4 +5,5 @@ import '../input/tex-full/tex-full.js';
 import '../output/svg/svg.js';
 import '../output/svg/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/components/src/tex-svg/preload.js
+++ b/components/src/tex-svg/preload.js
@@ -5,5 +5,5 @@ Loader.preLoad(
     'core',
     'input/tex',
     'output/svg', 'output/svg/fonts/tex.js',
-    'ui/menu'
+    'ui/menu', 'a11y/assistive-mml'
 );

--- a/components/src/tex-svg/tex-svg.js
+++ b/components/src/tex-svg/tex-svg.js
@@ -5,4 +5,5 @@ import '../input/tex/tex.js';
 import '../output/svg/svg.js';
 import '../output/svg/fonts/tex/tex.js';
 import '../ui/menu/menu.js';
+import '../a11y/assistive-mml/assistive-mml.js';
 import '../startup/startup.js';

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -110,7 +110,7 @@ export function AssistiveMmlMathItemMixin<N, T, D, B extends Constructor<Abstrac
 /*==========================================================================*/
 
 /**
- * The funtions added to MathDocument for assisitve MathML
+ * The funtions added to MathDocument for assistive MathML
  *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
@@ -121,7 +121,7 @@ export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
     /**
      * Add assistive MathML to the MathItems in the MathDocument
      *
-     * @return {AssisitiveMmlMathDocument}   The MathDocument (so calls can be chained)
+     * @return {AssisiitveMmlMathDocument}   The MathDocument (so calls can be chained)
      */
     assistiveMml(): AssistiveMmlMathDocument<N, T, D>;
 
@@ -134,10 +134,10 @@ export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
 }
 
 /**
- * The mixin for adding assisitve MathML to MathDocuments
+ * The mixin for adding assistive MathML to MathDocuments
  *
  * @param {B} BaseMathDocument         The MathDocument class to be extended
- * @return {AssisitveMMlMathDocument}  The Assistive MathML MathDocument class
+ * @return {AssistiveMMlMathDocument}  The Assistive MathML MathDocument class
  *
  * @template N  The HTMLElement node class
  * @template T  The Text node class

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -27,6 +27,7 @@ import {MathItem, AbstractMathItem, STATE, newState} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 import {OptionList, expandable} from '../util/Options.js';
+import {StyleList} from '../output/common/CssStyles.js';
 
 /**
  * Generic constructor for Mixins
@@ -148,7 +149,7 @@ export function AssistiveMmlMathDocumentMixin<N, T, D,
     BaseDocument: B
 ): MathDocumentConstructor<AssistiveMmlMathDocument<N, T, D>> & B {
 
-    return class extends BaseDocument {
+    return class BaseClass extends BaseDocument {
 
         public static OPTIONS: OptionList = {
             ...BaseDocument.OPTIONS,
@@ -156,6 +157,34 @@ export function AssistiveMmlMathDocumentMixin<N, T, D,
                 ...BaseDocument.OPTIONS.renderActions,
                 assistiveMml: [STATE.ASSISTIVEMML]
             })
+        };
+
+        /**
+         * styles needed for the hidden MathML
+         */
+        public static assistiveStyles: StyleList = {
+            'mjx-assistive-mml': {
+                position: 'absolute !important',
+                top: '0px', left: '0px',
+                clip: 'rect(1px, 1px, 1px, 1px)',
+                padding: '1px 0px 0px 0px !important',
+                border: '0px !important',
+                display: 'block !important',
+                width: 'auto !important',
+                overflow: 'hidden !important',
+                /*
+                 *  Don't allow the assistive MathML to become part of the selection
+                 */
+                '-webkit-touch-callout': 'none',
+                '-webkit-user-select': 'none',
+                '-khtml-user-select': 'none',
+                '-moz-user-select': 'none',
+                '-ms-user-select': 'none',
+                'user-select': 'none'
+            },
+            'mjx-assistive-mml[display="block"]': {
+                width: '100% !important'
+            }
         };
 
         /**
@@ -171,7 +200,8 @@ export function AssistiveMmlMathDocumentMixin<N, T, D,
          */
         constructor(...args: any[]) {
             super(...args);
-            const ProcessBits = (this.constructor as typeof AbstractMathDocument).ProcessBits;
+            const CLASS = (this.constructor as typeof BaseClass);
+            const ProcessBits = CLASS.ProcessBits;
             if (!ProcessBits.has('assistive-mml')) {
                 ProcessBits.allocate('assistive-mml');
             }
@@ -180,6 +210,9 @@ export function AssistiveMmlMathDocumentMixin<N, T, D,
                 AssistiveMmlMathItemMixin<N, T, D, Constructor<AbstractMathItem<N, T, D>>>(
                     this.options.MathItem
                 );
+            if ('addStyles' in this) {
+                (this as any).addStyles(CLASS.assistiveStyles);
+            }
         }
 
         /**

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -1,0 +1,239 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2019 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Mixin that adds hidden MathML to the output
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {Handler} from '../core/Handler.js';
+import {MathDocument, AbstractMathDocument, MathDocumentConstructor} from '../core/MathDocument.js';
+import {MathItem, AbstractMathItem, STATE, newState} from '../core/MathItem.js';
+import {MmlNode} from '../core/MmlTree/MmlNode.js';
+import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
+import {OptionList, expandable} from '../util/Options.js';
+
+/**
+ * Generic constructor for Mixins
+ */
+export type Constructor<T> = new(...args: any[]) => T;
+
+/*==========================================================================*/
+
+/**
+ * Add STATE value for having assistive MathML (after TYPESETTING)
+ */
+newState('ASSISTIVEMML', 153);
+
+/**
+ * The funtions added to MathItem for assistive MathML
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export interface AssistiveMmlMathItem<N, T, D> extends MathItem<N, T, D> {
+    /**
+     * @param {MathDocument} document  The document where assistive MathML is being added
+     */
+    assistiveMml(document: MathDocument<N, T, D>): void;
+}
+
+/**
+ * The mixin for adding assistive MathML to MathItems
+ *
+ * @param {B} BaseMathItem      The MathItem class to be extended
+ * @return {AssistiveMathItem}  The augmented MathItem class
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ * @template B  The MathItem class to extend
+ */
+export function AssistiveMmlMathItemMixin<N, T, D, B extends Constructor<AbstractMathItem<N, T, D>>>(
+    BaseMathItem: B
+): Constructor<AssistiveMmlMathItem<N, T, D>> & B {
+
+    return class extends BaseMathItem {
+
+        /**
+         * @param {MathDocument} document   The MathDocument for the MathItem
+         */
+        public assistiveMml(document: AssistiveMmlMathDocument<N, T, D>) {
+            if (this.state() >= STATE.ASSISTIVEMML) return;
+            this.state(STATE.ASSISTIVEMML);
+            const adaptor = document.adaptor;
+            //
+            // Get the serialized MathML
+            //
+            const mml = document.toMML(this.root).replace(/\n */g, '').replace(/<!--.*?-->/g, '');
+            //
+            // Parse is as HTML and retrieve the <math> element
+            //
+            const mmlNodes = adaptor.firstChild(adaptor.body(adaptor.parse(mml, 'text/html')));
+            //
+            // Create a container for the hidden MathML
+            //
+            const node = adaptor.node('mjx-assistive-mml', {
+                role: 'presentation', unselectable: 'on', display: (this.display ? 'block' : 'inline')
+            }, [mmlNodes]);
+            //
+            // Hide the typeset math from assistive technology and append the MathML that is visually
+            //   hidden from other users
+            //
+            adaptor.setAttribute(this.typesetRoot, 'role', 'presentation');
+            adaptor.setAttribute(adaptor.firstChild(this.typesetRoot) as N, 'aria-hidden', 'true');
+            adaptor.setStyle(this.typesetRoot, 'position', 'relative');
+            adaptor.append(this.typesetRoot, node);
+        }
+
+    };
+
+}
+
+/*==========================================================================*/
+
+/**
+ * The funtions added to MathDocument for assisitve MathML
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
+
+    /**
+     * Add assistive MathML to the MathItems in the MathDocument
+     *
+     * @return {AssisitiveMmlMathDocument}   The MathDocument (so calls can be chained)
+     */
+    assistiveMml(): AssistiveMmlMathDocument<N, T, D>;
+
+    /**
+     * @param {MmlNode} node   The node to be serializes
+     * @return {string}        The serialization of the node
+     */
+    toMML: (node: MmlNode) => string;
+
+}
+
+/**
+ * The mixin for adding assisitve MathML to MathDocuments
+ *
+ * @param {B} BaseMathDocument         The MathDocument class to be extended
+ * @return {AssisitveMMlMathDocument}  The Assistive MathML MathDocument class
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ * @template B  The MathDocument class to extend
+ */
+export function AssistiveMmlMathDocumentMixin<N, T, D,
+                                              B extends MathDocumentConstructor<AbstractMathDocument<N, T, D>>>(
+    BaseDocument: B
+): MathDocumentConstructor<AssistiveMmlMathDocument<N, T, D>> & B {
+
+    return class extends BaseDocument {
+
+        public static OPTIONS: OptionList = {
+            ...BaseDocument.OPTIONS,
+            renderActions: expandable({
+                ...BaseDocument.OPTIONS.renderActions,
+                assistiveMml: [STATE.ASSISTIVEMML]
+            })
+        };
+
+        /**
+         * Visitor used for serializing internal MathML nodes
+         */
+        protected visitor: SerializedMmlVisitor;
+
+        /**
+         * Augment the MathItem class used for this MathDocument, and create the serialization visitor.
+         *
+         * @override
+         * @constructor
+         */
+        constructor(...args: any[]) {
+            super(...args);
+            const ProcessBits = (this.constructor as typeof AbstractMathDocument).ProcessBits;
+            if (!ProcessBits.has('assistive-mml')) {
+                ProcessBits.allocate('assistive-mml');
+            }
+            this.visitor = new SerializedMmlVisitor(this.mmlFactory);
+            this.options.MathItem =
+                AssistiveMmlMathItemMixin<N, T, D, Constructor<AbstractMathItem<N, T, D>>>(
+                    this.options.MathItem
+                );
+        }
+
+        /**
+         * @param {MmlNode} node   The node to be serializes
+         * @return {string}        The serialization of the node
+         */
+        public toMML(node: MmlNode) {
+            return this.visitor.visitTree(node);
+        }
+
+        /**
+         * Add assistive MathML to the MathItems in this MathDocument
+         */
+        public assistiveMml() {
+            if (!this.processed.isSet('assistive-mml')) {
+                for (const math of this.math) {
+                    (math as AssistiveMmlMathItem<N, T, D>).assistiveMml(this);
+                }
+                this.processed.set('assistive-mml');
+            }
+            return this;
+        }
+
+        /**
+         * @override
+         */
+        public state(state: number, restore: boolean = false) {
+            super.state(state, restore);
+            if (state < STATE.ASSISTIVEMML) {
+                this.processed.clear('assistive-mml');
+            }
+            return this;
+        }
+
+    };
+
+}
+
+/*==========================================================================*/
+
+/**
+ * Add assitive MathML support a Handler instance
+ *
+ * @param {Handler} handler   The Handler instance to enhance
+ * @return {Handler}          The handler that was modified (for purposes of chainging extensions)
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export function AssistiveMmlHandler<N, T, D>(handler: Handler<N, T, D>) {
+    handler.documentClass =
+        AssistiveMmlMathDocumentMixin<N, T, D, MathDocumentConstructor<AbstractMathDocument<N, T, D>>>(
+            handler.documentClass
+        );
+    return handler;
+}

--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -29,6 +29,7 @@ import {HTMLDomStrings} from './HTMLDomStrings.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 import {InputJax} from '../../core/InputJax.js';
 import {MathItem, STATE, ProtoItem, Location} from '../../core/MathItem.js';
+import {StyleList} from '../../output/common/CssStyles.js';
 
 /*****************************************************************/
 /**
@@ -65,6 +66,8 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         DomStrings: null                  // Use the default DomString parser
     };
 
+    protected styles: StyleList[];
+
     /**
      * The DomString parser for locating the text in DOM trees
      */
@@ -80,6 +83,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         super(document, adaptor, html);
         this.domStrings = this.options['DomStrings'] || new HTMLDomStrings<N, T, D>(dom);
         this.domStrings.adaptor = adaptor;
+        this.styles = [];
     }
 
     /**
@@ -251,6 +255,22 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
      */
     public documentPageElements() {
         return this.outputJax.pageElements(this);
+    }
+
+    /**
+     * Add styles to be included in the document's stylesheet
+     *
+     * @param {StyleList} styles   The styles to include
+     */
+    public addStyles(styles: StyleList) {
+        this.styles.push(styles);
+    }
+
+    /**
+     * Get the array of document-specific styles
+     */
+    public getStyles() {
+        return this.styles;
     }
 
 }

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -403,10 +403,18 @@ export abstract class CommonOutputJax<
     public styleSheet(html: MathDocument<N, T, D>) {
         this.setDocument(html);
         //
-        //  Start with the common styles
+        // Start with the common styles
         //
         this.cssStyles.clear();
         this.cssStyles.addStyles((this.constructor as typeof CommonOutputJax).commonStyles);
+        //
+        // Add document-specific styles
+        //
+        if ('getStyles' in html) {
+            for (const styles of ((html as any).getStyles() as CssStyleList[])) {
+                this.cssStyles.addStyles(styles);
+            }
+        }
         //
         // Gather the CSS from the classes
         //

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -69,6 +69,7 @@ export interface MenuSettings {
     autocollapse: boolean;
     collapsible: boolean;
     inTabOrder: boolean;
+    assistiveMml: boolean;
     // A11y settings
     backgroundColor: string;
     braille: boolean;
@@ -120,6 +121,7 @@ export class Menu {
             autocollapse: false,
             collapsible: false,
             inTabOrder: true,
+            assistiveMml: true,
             explorer: false
         },
         jax: {
@@ -405,7 +407,8 @@ export class Menu {
                     this.a11yVar<boolean>('infoPrefix'),
                     this.variable<boolean>('autocollapse'),
                     this.variable<boolean>('collapsible', (collapse: boolean) => this.setCollapsible(collapse)),
-                    this.variable<boolean>('inTabOrder', (tab: boolean) => this.setTabOrder(tab))
+                    this.variable<boolean>('inTabOrder', (tab: boolean) => this.setTabOrder(tab)),
+                    this.variable<boolean>('assistiveMml', (mml: boolean) => this.setAssistiveMml(mml))
                 ],
                 items: [
                     this.submenu('Show', 'Show Math As', [
@@ -500,7 +503,8 @@ export class Menu {
                         this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
                         this.checkbox('AutoCollapse', 'Auto Collapse', 'autocollapse', {disabled: true}),
                         this.rule(),
-                        this.checkbox('InTabOrder', 'Include in Tab Order', 'inTabOrder')
+                        this.checkbox('InTabOrder', 'Include in Tab Order', 'inTabOrder'),
+                        this.checkbox('AssistiveMml', 'Include Hidden MathML', 'assistiveMml')
                     ]),
                     this.submenu('Language', 'Language'),
                     this.rule(),
@@ -539,6 +543,9 @@ export class Menu {
             }
             if (this.settings.explorer && (!MathJax._.a11y || !MathJax._.a11y.explorer)) {
                 this.loadA11y('explorer');
+            }
+            if (this.settings.assistiveMml && (!MathJax._.a11y || !MathJax._.a11y['assistive-mml'])) {
+                this.loadA11y('assistive-mml');
             }
         } else {
             const menu = this.menu;
@@ -669,6 +676,17 @@ export class Menu {
      */
     protected setTabOrder(tab: boolean) {
         this.menu.getStore().inTaborder(tab);
+    }
+
+    /**
+     * @param {boolean} mml   True to output hidden Mathml, false to not
+     */
+    protected setAssistiveMml(mml: boolean) {
+        if (!mml || (window.MathJax._.a11y && window.MathJax._.a11y['assistive-mml'])) {
+            this.rerender();
+        } else {
+            this.loadA11y('assistive-mml');
+        }
     }
 
     /**

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -29,6 +29,7 @@ import {HTMLDocument} from '../../handlers/html/HTMLDocument.js';
 import {Handler} from '../../core/Handler.js';
 import {ComplexityMathDocument, ComplexityMathItem} from '../../a11y/complexity.js';
 import {ExplorerMathDocument, ExplorerMathItem} from '../../a11y/explorer.js';
+import {AssistiveMmlMathDocument, AssistiveMmlMathItem} from '../../a11y/assistive-mml.js';
 import {OptionList, expandable} from '../../util/Options.js';
 
 import {Menu} from './Menu.js';
@@ -44,14 +45,16 @@ export type Constructor<T> = new(...args: any[]) => T;
  * Constructor for base MathItem for MenuMathItem
  */
 export type A11yMathItemConstructor = {
-    new(...args: any[]): ComplexityMathItem<HTMLElement, Text, Document> & ExplorerMathItem;
+    new(...args: any[]): ComplexityMathItem<HTMLElement, Text, Document> &
+        ExplorerMathItem & AssistiveMmlMathItem<HTMLElement, Text, Document>;
 }
 
 /**
  * Constructor for base document for MenuMathDocument
  */
 export type A11yDocumentConstructor =
-    MathDocumentConstructor<ComplexityMathDocument<HTMLElement, Text, Document> & ExplorerMathDocument>;
+    MathDocumentConstructor<ComplexityMathDocument<HTMLElement, Text, Document> &
+    ExplorerMathDocument & AssistiveMmlMathDocument<HTMLElement, Text, Document>>;
 
 /*==========================================================================*/
 
@@ -69,6 +72,11 @@ export interface MenuMathItem extends ComplexityMathItem<HTMLElement, Text, Docu
      * @param {MenuMathDocument} document   The document where the menu is being added
      */
     addMenu(document: MenuMathDocument): void;
+
+    /**
+     * @param {MenuMathDocument} document   The document where the menu is being added
+     */
+    assistiveMml(document: MenuMathDocument): void;
 
     /**
      * @param {MenuMathDocument} document   The document where the menu is being added
@@ -157,6 +165,16 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
             if (document.menu.settings.explorer || force) {
                 document.menu.checkComponent('a11y/explorer');
                 super.explorable(document);
+            }
+        }
+
+        /**
+         * @override
+         */
+        public assistiveMml(document: MenuMathDocument, force: boolean = false) {
+            if (document.menu.settings.assistiveMml || force) {
+                document.menu.checkComponent('a11y/assistive-mml');
+                super.assistiveMml(document);
             }
         }
 


### PR DESCRIPTION
This PR implements an assistive-mml extension that corresponds to the version 2 AssistiveMML extension.  It is implemented as an a11y extension similar to how `semantic-enrich` and the other ones operate (via extensions to the MathDocument and MathItem classes to add methods for creating the hidden MathML).  Because the extension needed to be able to generate CSS styles to hide the MathML, this required extending the HTMLDocument class to allow extensions to add CSS to the document.

This also adds a menu item to to the accessibility menu to control whether assistive MathML is inserted into the page or not (default is yes), so that those who don't need it will be able to turn it off for faster rendering.

It would probably be a good idea to move the output/common/CssStyles.ts file to utilities at some point, but I didn't do that here since it touches a number of files.

Resolves issue mathjax/MathJax#2260