### PR TITLE
Fixes a bug in msqrt when computing clearance value

### DIFF
--- a/ts/output/common/Wrappers/msqrt.ts
+++ b/ts/output/common/Wrappers/msqrt.ts
@@ -172,7 +172,7 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
         public getPQ(sbox: BBox) {
             const t = this.font.params.rule_thickness;
             const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
-            const q = (sbox.h + sbox.d > this.surdH ? ((sbox.h + sbox.d) - (this.surdH - t)) / 2 : t + p / 4);
+            const q = (sbox.h + sbox.d > this.surdH ? ((sbox.h + sbox.d) - (this.surdH - 2 * t - p / 2)) / 2 : t + p / 4);
             return [p, q];
         }
 


### PR DESCRIPTION
The formula to compute clearance in `sqrt` is contradicted with TeXBook definition. The result of this is that the base element is too close to the root bar. This might be a mistake in manual derivation as argued bellow unless this is purposely designed.

According to Rule 11 on TeXBook page 443 (Appendix G ).

The clearance value `psi`, which is `q` value in `getPQ`, is originally defined as `psi = t + p / 4`. 

Under condition `dy > bbox.h + bbox.d + psi`, where `dy = sbox.h + sbox.d - t`, `psi` will be changed to a new value `psi + (dy - (bbox.h + bbox.d + psi)) / 2` as stated in TeXBook.

The derivation for the condition `dy > bbox.h + bbox.d + psi` is right. 
```javascript
// since
dy = sbox.h + sbox.d - t
dy > bbox.h + bbox.d + psi
// so
sbox.h + sbox.d - t > bbox.h + bbox.d + psi
sbox.h + sbox.d  > bbox.h + bbox.d + psi + t
sbox.h + sbox.d  > bbox.h + bbox.d + t + p / 4 + t
// since
this.surdH = bbox.h + bbox.d + 2 * t + p / 4
// the condition is same as:
sbox.h + sbox.d  > this.surdH
```

However, the derivation for new assignment `psi =  psi + (dy - (bbox.h + bbox.d + psi)) / 2` is wrong.
```javascript
// since
psi =  psi + (dy - (bbox.h + bbox.d + psi)) / 2
dy = sbox.h + sbox.d - t
// then
psi =  psi + ( sbox.h + sbox.d - t - (bbox.h + bbox.d + psi)) / 2
psi =  (sbox.h + sbox.d - t - (bbox.h + bbox.d - psi)) / 2
psi = (sbox.h + sbox.d - (bbox.h + bbox.d + t - psi)) / 2
```

Here is where I believe the derivation got wrong. If the last minus sign was a plus sign.
```javascript
// if when wrong
psi = (sbox.h + sbox.d - (bbox.h + bbox.d + t + psi)) / 2
// since
this.surdH = bbox.h + bbox.d + 2 * t + p / 4
// then
psi = (sbox.h + sbox.d - (this.surdH - t)) / 2
``` 

This is the formula in the `develop` branch. The correct derivation should be

```javascript
psi = (sbox.h + sbox.d - (bbox.h + bbox.d + t - psi)) / 2
// since
this.surdH = bbox.h + bbox.d + 2 * t + p / 4
// then
psi = (sbox.h + sbox.d - (this.surdH - 2 * psi)) / 2
psi = (sbox.h + sbox.d - (this.surdH - 2 * t - p / 2)) / 2
```

This is how this pull request computes psi, the clearance value.