### PR TITLE
Make TexParser.Push() handle inferred mrows properly. mathjax/MathJax#2261

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -31,7 +31,7 @@ import {Tags} from './Tags.js';
 import TexError from './TexError.js';
 import {AbstractSymbolMap, SymbolMap} from './SymbolMap.js';
 import {MmlMo} from '../../core/MmlTree/MmlNodes/mo.js';
-import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {MmlNode, AbstractMmlNode} from '../../core/MmlTree/MmlNode.js';
 import {ParseInput, ParseResult, ParseMethod} from './Types.js';
 import ParseOptions from './ParseOptions.js';
 import {StackItem, EnvList} from './StackItem.js';
@@ -194,11 +194,16 @@ export default class TexParser {
 
 
   /**
-   * Pushes a new item onto the stack. The item can also be a Mml node.
+   * Pushes a new item onto the stack. The item can also be a Mml node,
+   *   but if the mml item is an inferred row, push its children instead.
    * @param {StackItem|MmlNode} arg The new item.
    */
   public Push(arg: StackItem|MmlNode) {
-    this.stack.Push(arg);
+    if (arg instanceof AbstractMmlNode && arg.isInferred) {
+      this.PushAll(arg.childNodes);
+    } else {
+      this.stack.Push(arg);
+    }
   }
 
 


### PR DESCRIPTION
Make `TexParser.Push()` handle inferred `mrow` by pushing the children instead of the inferred `mrow` itself.  Elements that take inferred `mrow` as children create them automatically, and inferred `mrow`s should not be pushed directly.  They are created by `ParseArg()` as a means of identifying collections of elements that need to be pushed separately, but that wasn't being done.  This PR fixes that oversight.

Resolves issue mathjax/MathJax#2261.