### PR TITLE
Fix duplicate xlink namespace in SVG output.  #365

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -381,7 +381,11 @@ extends AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
      * @override
      */
     public setAttribute(node: N, name: string, value: string, ns: string = null) {
-        return (ns ? node.setAttributeNS(ns, name, value) : node.setAttribute(name, value));
+        if (!ns) {
+            return node.setAttribute(name, value);
+        }
+        name = ns.replace(/.*\//, '') + ':' + name.replace(/^.*:/, '');
+        return node.setAttributeNS(ns, name, value);
     }
 
     /**

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -424,7 +424,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
             value = String(value);
         }
         if (ns) {
-            name = ns.replace(/.*\//, '') + ':' + name;
+            name = ns.replace(/.*\//, '') + ':' + name.replace(/^.*:/, '');
         }
         node.attributes[name] = value;
         if (name === 'style') {

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -319,7 +319,7 @@ CommonWrapper<
     protected useNode(variant: string, C: string, path: string) {
         const use = this.svg('use');
         const id = '#' + this.jax.fontCache.cachePath(variant, C, path);
-        this.adaptor.setAttribute(use, 'xlink:href', id, XLINKNS);
+        this.adaptor.setAttribute(use, 'href', id, XLINKNS);
         return use;
     }
 


### PR DESCRIPTION
This PR manages the `xlink` namespace in all adaptors so that the namespace appears in the adaptor's `outerHTML` and `innerHTML`, and also in the browser's `outerHTML` and `innerHTML`.  It also works with XMLSerializer, though the `<use>` elements will have `xmlns:xlink` attributes that are probably redundant since that is on the outer `<svg>` element.

Resolves issue #365, and replaces PR #366.