### PR TITLE
Only record actual 'node' nodes.  mathjax/MathJax#2283.

### DIFF
--- a/ts/input/tex/NodeFactory.ts
+++ b/ts/input/tex/NodeFactory.ts
@@ -187,7 +187,9 @@ export class NodeFactory {
   public create(kind: string, ...rest: any[]): MmlNode {
     const func = this.factory[kind] || this.factory['node'];
     const node = func(this, rest[0], ...rest.slice(1));
-    this.configuration.addNode(rest[0], node);
+    if (kind === 'node') {
+      this.configuration.addNode(rest[0], node);
+    }
     return node;
   }
 


### PR DESCRIPTION
This PR prevents text and other nodes from being recorded by `addNode()` when they are created.  They were causing problems when the text was an existing property of an object (like `constructor`).

If the text really needs to be saved (and I don't see why it would), the `nodeLists` property in `addNode()` should be changes to a Map rather than an Object.

Resolves issue mathjax/MathJax#2283.