### PR TITLE
Fix problem with enabling explorer with MathML input.  mathjax/MathJax#2255

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -327,10 +327,12 @@ export namespace Startup {
     export function makeTypesetMethods() {
         MathJax.typeset = (elements: any = null) => {
             document.options.elements = elements;
+            document.reset();
             document.render();
         };
         MathJax.typesetPromise = (elements: any = null) => {
             document.options.elements = elements;
+            document.reset();
             return mathjax.handleRetriesFor(() => {
                 document.render();
             })

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -516,8 +516,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
             compile: [STATE.COMPILED],
             metrics: [STATE.METRICS, 'getMetrics', '', false],
             typeset: [STATE.TYPESET],
-            update:  [STATE.INSERTED, 'updateDocument', false],
-            reset:   [STATE.RESET, 'reset', '', false]
+            update:  [STATE.INSERTED, 'updateDocument', false]
         }) as RenderActions<any, any, any>
     };
 

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -404,7 +404,6 @@ export const STATE: {[state: string]: number} = {
     RERENDER: 125,
     TYPESET: 150,
     INSERTED: 200,
-    RESET: 500,
     LAST: 10000
 };
 

--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -128,7 +128,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
      */
     public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
         let mml = math.start.node;
-        if (!mml || this.options['forceReparse']) {
+        if (!mml || this.options['forceReparse'] || this.adaptor.kind(mml) === '#text') {
             let mathml = this.executeFilters(this.preFilters, math, document, math.math || '<math></math>');
             let doc = this.checkForErrors(this.adaptor.parse(mathml, 'text/' + this.options['parseAs']));
             let body = this.adaptor.body(doc);

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -677,7 +677,7 @@ export class Menu {
     protected setExplorer(explore: boolean) {
         this.enableExplorerItems(explore);
         if (!explore || (window.MathJax._.a11y && window.MathJax._.a11y.explorer)) {
-            this.rerender(this.settings.collapsible ? STATE.RERENDER : STATE.COMPILED + 1);
+            this.rerender(this.settings.collapsible ? STATE.RERENDER : STATE.COMPILED);
         } else {
             this.loadA11y('explorer');
         }
@@ -688,7 +688,7 @@ export class Menu {
      */
     protected setCollapsible(collapse: boolean) {
         if (!collapse || (window.MathJax._.a11y && window.MathJax._.a11y.complexity)) {
-            this.rerender(STATE.COMPILED + 1);
+            this.rerender(STATE.COMPILED);
         } else {
             this.loadA11y('complexity');
         }
@@ -734,7 +734,7 @@ export class Menu {
             }
         }
         Menu.loading--;
-        this.rerender(STATE.COMPILED + 1);
+        this.rerender(STATE.COMPILED);
     }
 
     /*======================================================================*/

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -677,7 +677,7 @@ export class Menu {
     protected setExplorer(explore: boolean) {
         this.enableExplorerItems(explore);
         if (!explore || (window.MathJax._.a11y && window.MathJax._.a11y.explorer)) {
-            this.rerender(this.settings.collapsible ? STATE.RERENDER : STATE.COMPILED);
+            this.rerender(this.settings.collapsible ? STATE.RERENDER : STATE.COMPILED + 1);
         } else {
             this.loadA11y('explorer');
         }
@@ -688,7 +688,7 @@ export class Menu {
      */
     protected setCollapsible(collapse: boolean) {
         if (!collapse || (window.MathJax._.a11y && window.MathJax._.a11y.complexity)) {
-            this.rerender(STATE.COMPILED);
+            this.rerender(STATE.COMPILED + 1);
         } else {
             this.loadA11y('complexity');
         }
@@ -734,7 +734,7 @@ export class Menu {
             }
         }
         Menu.loading--;
-        this.rerender(STATE.COMPILED);
+        this.rerender(STATE.COMPILED + 1);
     }
 
     /*======================================================================*/
@@ -804,8 +804,9 @@ export class Menu {
             this.document = startup.document = startup.getDocument();
             this.document.menu = this;
             this.transferMathList(document);
+            this.document.processed = document.processed;
             if (!Menu._loadingPromise) {
-                this.rerender(component === 'complexity' || noEnrich ? STATE.COMPILED : STATE.TYPESET);
+                this.rerender(component === 'complexity' || noEnrich ? STATE.COMPILED + 1 : STATE.TYPESET);
             }
         });
     }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -806,7 +806,7 @@ export class Menu {
             this.transferMathList(document);
             this.document.processed = document.processed;
             if (!Menu._loadingPromise) {
-                this.rerender(component === 'complexity' || noEnrich ? STATE.COMPILED + 1 : STATE.TYPESET);
+                this.rerender(component === 'complexity' || noEnrich ? STATE.COMPILED : STATE.TYPESET);
             }
         });
     }


### PR DESCRIPTION
This PR fixes the issue with turning on/off the explorer when the input is MathML.  This was caused by several issues.  First, the `reset()` call in the `renderActions` list was causing the `rerender()` action initiated by the menu when explorer is toggled to try to reprocess the entire page (leading to duplicate entries in the math list).  So the `reset()` has been moved to the `MathJax.typeset()` and `MathJax.typesetPromise()` calls.  Users calling `render()` by hand will need to call `reset()` prior to that.  (Since none of that is documented yet, it should not be an issue.)  Also the menu code that creates a new document saves the processed bits as well (since they aren't being reset).

The other problem was that when the typeset content is removed in `removeFromDocument()`, it was being replaced by a blank text element, and the `start.node` pointer was set to that empty text element.  But when MathML is compiled, the `start.node` pointer is supposed to be the MathML node itself.  So this PR adds a check to see if `start.node` is a text node, and recompiled from the original MathML text instead.