### PR TITLE
Fix problem with spacing inside maligngroup elements.  mathjax/MathJax#2295

### DIFF
--- a/ts/core/MmlTree/MmlNodes/maligngroup.ts
+++ b/ts/core/MmlTree/MmlNodes/maligngroup.ts
@@ -22,7 +22,7 @@
  */
 
 import {PropertyList} from '../../Tree/Node.js';
-import {AbstractMmlNode, AttributeList} from '../MmlNode.js';
+import {AbstractMmlLayoutNode, AttributeList} from '../MmlNode.js';
 import {INHERIT} from '../Attributes.js';
 
 /*****************************************************************/
@@ -30,9 +30,9 @@ import {INHERIT} from '../Attributes.js';
  *  Implements the MmlMaligngroup node class (subclass of AbstractMmlNode)
  */
 
-export class MmlMaligngroup extends AbstractMmlNode {
+export class MmlMaligngroup extends AbstractMmlLayoutNode {
     public static defaults: PropertyList = {
-        ...AbstractMmlNode.defaults,
+        ...AbstractMmlLayoutNode.defaults,
         groupalign: INHERIT
     };
 


### PR DESCRIPTION
Fix problem with spacing inside `maligngroup` elements due to `MmlMaligngroup` being a subclass of the wrong abstract class.

Resolves issue mathjax/MathJax#2295.