### PR TITLE
Don't remap \to to \vec when used alone as a subscript. mathjax/MathJax#2293

### DIFF
--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -274,7 +274,7 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   leftarrow:          '\u2190',
   gets:               '\u2190',
   rightarrow:         '\u2192',
-  to:                 '\u2192',
+  to:                ['\u2192', {accent: false}],
   mapsto:             '\u21A6',
   leftharpoonup:      '\u21BC',
   leftharpoondown:    '\u21BD',

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -315,7 +315,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
          * @override
          */
         public remapChars(chars: number[]) {
-            if (chars.length == 1) {
+            if (chars.length === 1) {
                 const parent = this.node.parent;
                 const isAccent = this.isAccent &&
                     (parent === (this.node as MmlMo).coreParent() || parent.isEmbellished);


### PR DESCRIPTION
Fix problem with `\to` being remapped to `\vec` when it is used alone in super- or subscripts.

 Resolves issue mathjax/MathJax#2293.