### PR TITLE
Fix linespacing below CHTML displayed equations.  mathjax/MathJax#2296

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -58,6 +58,8 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
      *  The default styles for CommonHTML
      */
     public static commonStyles: CssStyleList = {
+        'mjx-container[jax="CHTML"]': {'line-height': 0},
+
         'mjx-container [space="1"]': {'margin-left': '.111em'},
         'mjx-container [space="2"]': {'margin-left': '.167em'},
         'mjx-container [space="3"]': {'margin-left': '.222em'},


### PR DESCRIPTION
This PR sets `line-height: 0` on the CHTML `mjx-container` to remove unwanted spacing following the math output so that the spacing matches v2 spacing.

Resolves issue mathjax/MathJax#2296