### PR TITLE
Make source.js and dependencies.js into ESM modules.  #420

### DIFF
--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -1,7 +1,4 @@
-"use strict";
-Object.defineProperty(exports, '__esModule', {value: true});
-
-exports.dependencies = {
+export const dependencies = {
     'a11y/semantic-enrich': ['input/mml', '[sre]', 'input/mml'],
     'a11y/complexity': ['a11y/semantic-enrich'],
     'a11y/explorer': ['a11y/semantic-enrich', 'ui/menu'],
@@ -32,10 +29,10 @@ exports.dependencies = {
     '[tex]/verb': ['input/tex-base']
 };
 
-exports.paths = {
+export const paths = {
     tex: '[mathjax]/input/tex/extensions',
     sre: '[mathjax]/sre/sre_browser'
-}
+};
 
 const allPackages = [
     '[tex]/action',
@@ -61,7 +58,7 @@ const allPackages = [
     '[tex]/verb'
 ];
 
-exports.provides = {
+export const provides = {
     'startup': ['loader'],
     'input/tex': [
         'input/tex-base',
@@ -78,4 +75,4 @@ exports.provides = {
         ...allPackages
     ],
     '[tex]/all-packages': allPackages
-}
+};

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -1,7 +1,6 @@
-"use strict";
-Object.defineProperty(exports, '__esModule', {value: true});
 const src = __dirname;
-exports.source = {
+
+export const source = {
     'core': `${src}/core/core.js`,
     'adaptors/liteDOM': `${src}/adaptors/liteDOM/liteDOM.js`,
     'input/tex': `${src}/input/tex/tex.js`,


### PR DESCRIPTION
Convert `source.js` and `dependencies.js` to ESM modules.  This is a little cleaner, and still works with web pack, but also should allow it to work with rollup (see #420).

Resolves (part of) issue #420.