### PR TITLE
Fix problem with options being improperly retained.  mathjax/MathJax-src#2301

### DIFF
--- a/ts/input/tex/config_macros/ConfigMacrosConfiguration.ts
+++ b/ts/input/tex/config_macros/ConfigMacrosConfiguration.ts
@@ -30,33 +30,44 @@ import NewcommandMethods from '../newcommand/NewcommandMethods.js';
 import {TeX} from '../../tex.js';
 
 /**
+ * The name to use for the macros map
+ */
+const MACROSMAP = 'configMacrosMap';
+
+/**
+ * Create the command map for the macros
+ *
+ * @param {Configuration} config   The configuration object for the input jax
+ */
+function configMacrosInit(config: Configuration) {
+    const macrosMap = new CommandMap(MACROSMAP, {}, {});
+    config.append(Configuration.create('configMacroDefinitions', {handler: {macro: [MACROSMAP]}}));
+}
+
+/**
  * Create the user-defined macros from the macros option
  *
  * @param {Configuration} config   The configuration object for the input jax
  * @param {TeX} jax                The TeX input jax
  */
 function configMacrosConfig(config: Configuration, jax: TeX<any, any, any>) {
-    const macros = config.options.macros;
+    const macrosMap = jax.parseOptions.handlers.retrieve(MACROSMAP) as CommandMap;
+    const macros = jax.parseOptions.options.macros;
     for (const cs of Object.keys(macros)) {
         const def = (typeof macros[cs] === 'string' ? [macros[cs]] : macros[cs]);
         const macro = Array.isArray(def[2]) ?
-            new Macro(cs, NewcommandMethods.MacroWithTemplate, def.slice(0,2).concat(def[2])) :
+            new Macro(cs, NewcommandMethods.MacroWithTemplate, def.slice(0, 2).concat(def[2])) :
             new Macro(cs, NewcommandMethods.Macro, def);
-        ConfigMacrosMap.add(cs, macro);
+        macrosMap.add(cs, macro);
     }
 }
-
-/**
- * The command map for the autoloaded macros
- */
-const ConfigMacrosMap = new CommandMap('configMacros', {}, {});
 
 /**
  * The configuration object for configMacros
  */
 export const ConfigMacrosConfiguration = Configuration.create(
     'configMacros', {
-        handler: {macro: ['configMacros']},
+        init: configMacrosInit,
         config: configMacrosConfig,
         options: {macros: expandable({})}
     }

--- a/ts/util/Options.ts
+++ b/ts/util/Options.ts
@@ -29,7 +29,8 @@
 
 const OBJECT = {}.constructor;
 function isObject(obj: any) {
-    return typeof obj === 'object' && obj !== null && obj.constructor === OBJECT;
+    return typeof obj === 'object' && obj !== null &&
+        (obj.constructor === OBJECT || obj.constructor === Expandable);
 }
 
 /*****************************************************************/
@@ -139,7 +140,7 @@ export function copy(def: OptionList): OptionList {
             props[key as string] = prop;
         }
     }
-    return Object.defineProperties({}, props);
+    return Object.defineProperties(def.constructor === Expandable ? expandable({}) : {}, props);
 }
 
 /*****************************************************************/
@@ -157,7 +158,7 @@ export function insert(dst: OptionList, src: OptionList, warn: boolean = true) {
         //
         // Check if the key is valid (i.e., is in the defaults or in an expandable block)
         //
-        if (warn && dst[key] === undefined && !(dst instanceof Expandable)) {
+        if (warn && dst[key] === undefined && dst.constructor !== Expandable) {
             if (typeof key === 'symbol') {
                 key = (key as symbol).toString();
             }


### PR DESCRIPTION
This PR fixes the `util/Options.ts`  `insert()` and `copy()` functions  to handle `Expandable` objects properly.  Without this patch, expandable option objects are inserted into the destination object directly rather than copied.  That can lead to changes being made in the source object (since part of it has been inserted into the destination object).  An example of this is the `configMacros` TeX package, where the `options: {macros: expandable({})}` in the definition of the configuration would cause the `macros` expandable object to be inserted into the default options for the TeX input jax, and in turn, into the options for the TeX jax instance itself.  Then when the user-supplied macros are inserted into the TeX instance options, they also are inserted into the `configMacros` configuration objects, which should not be changed.  That leads to the pre-defined macros from one instance of the TeX input jax being inserted into any later instances of the TeX input jax (that uses `configMacros`).

This PR makes sure that `Expandable` objects are treated like regular objects, and copied rather than inserted directly.

In addition, the `configMacros` extension was using a global macros `CommandMap`, so it would also be shared among instances of TeX input jax.  This PR cause `configMacros` to create a new macro map for each TeX jax instance.

Resolves issue mathjax/MathJax#2301.