### PR TITLE
Don't include extenders in SVG output if they have negative width. mathjax/MathJax#2300

### DIFF
--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -178,6 +178,7 @@ export class SVGmo<N, T, D> extends CommonMoMixin<SVGConstructor<any, any, any>>
                                                  //   (glyphs with rounded or anti-aliased ends don't stretch well,
                                                  //    so this makes for sharper ends)
         const y = (s * (h - d) - Y) / 2;         // The bottom point to clip the extender
+        if (Y <= 0) return;
         const svg = this.svg('svg', {
             width: this.fixed(w), height: this.fixed(Y),
             y: this.fixed(B - D), x: this.fixed((W - w) / 2),
@@ -242,6 +243,7 @@ export class SVGmo<N, T, D> extends CommonMoMixin<SVGConstructor<any, any, any>>
         const Y = h + d + 2 * VFUZZ;    // The height (plus some fuzz) of the extender
         const s = 1.5 * (X / w);        // Scale the width so that left- and right-bearing won't hurt us
         const D = -(d + VFUZZ);         // The bottom position of the glyph
+        if (X <= 0) return;
         const svg = this.svg('svg', {
             width: this.fixed(X), height: this.fixed(Y),
             x: this.fixed(x + L), y: this.fixed(D),


### PR DESCRIPTION
This PR fixes a problem with the SVG output that is exhibited in the Chrome browser for the example

    \overleftrightarrow{abc}

which produces errors in the console about a negative width, and displays the dash that is supposed to form the extender between the two arrows in the wrong location.

Resolves issue mathjax/MathJax#2300