### PR TITLE
Make convert() handle unknown characters.   mathjax/MathJax#2309

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -629,6 +629,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
         }
         const jax = this.inputJax.reduce((jax, ijax) => (ijax.name === format ? ijax : jax), null);
         const mitem = new this.options.MathItem(math, jax, display);
+        mitem.start.node = this.adaptor.body(this.document);
         mitem.setMetrics(em, ex, containerWidth, lineWidth, scale);
         mitem.convert(this, end);
         return (mitem.typesetRoot || mitem.root);


### PR DESCRIPTION
This PR makes sure that the MathItem created in the `convert()` command has a location in the document (by setting it to the document's body element) so that if unknown characters need to be measured, that doesn't lead to an error (see the original issue linked below).

Resolved issue mathjax/MathJax#2309