### PR TITLE
Changes the default for Braille output to false.

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -238,7 +238,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
                 align: 'top',
                 backgroundColor: 'Blue',
                 backgroundOpacity: .2,
-                braille: true,
+                braille: false,
                 flame: false,
                 foregroundColor: 'Black',
                 foregroundOpacity: 1,


### PR DESCRIPTION
Suppress Braille output by default, as some Windows screen readers try to pronounce the Unicode characters if no Braille display is attached.