### PR TITLE
Allow enrichment to occur in IE11.  #386

### DIFF
--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -107,6 +107,28 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
     return class extends BaseMathItem {
 
         /**
+         * @param {any} node  The node to be serialized
+         * @return {string}   The serialized version of node
+         */
+        protected serializeMml(node: any) {
+            if ('outerHTML' in node) {
+                return node.outerHTML;
+            }
+            //
+            //  For IE11
+            //
+            if (typeof Element !== 'undefined' && typeof window !== 'undefined' && node instanceof Element) {
+                const div = window.document.createElement('div');
+                div.appendChild(node);
+                return div.innerHTML;
+            }
+            //
+            //  For NodeJS version of SRE
+            //
+            return node.toString();
+        }
+
+        /**
          * @param {MathDocument} document   The MathDocument for the MathItem
          */
         public enrich(document: MathDocument<N, T, D>) {
@@ -119,8 +141,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
                 currentSpeech = document.options.enrichSpeech;
             }
             const math = new document.options.MathItem('', MmlJax);
-            const enriched = SRE.toEnriched(toMathML(this.root));
-            math.math = ('outerHTML' in enriched ? enriched.outerHTML : (enriched as any).toString());
+            math.math = this.serializeMml(SRE.toEnriched(toMathML(this.root)));
             math.display = this.display;
             math.compile(document);
             this.root = math.root;

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -39,7 +39,7 @@ const srePromise = (typeof sre === 'undefined' ? asyncLoad(SRELIB) : Promise.res
  * Values to control the polling for when SRE is ready
  */
 const SRE_DELAY = 100;        // in milliseconds
-const SRE_TIMEOUT = 5 * 1000; // 5 seconds
+const SRE_TIMEOUT = 10 * 1000; // 10 seconds
 
 /**
  * A promise that resolves when SRE is loaded and ready, and rejects if


### PR DESCRIPTION
This PR fixes the problem with `semantic-enrich` not serializing the SRE output properly in IE11.

Resolves issue #386.