### PR TITLE
Set loader's mathjax path to work in more situations.  #406

### DIFF
--- a/components/src/node-main/node-main.js
+++ b/components/src/node-main/node-main.js
@@ -18,8 +18,31 @@ combineDefaults(MathJax.config, 'loader', {
 combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
 combineDefaults(MathJax.config.loader, 'paths', paths);
 combineDefaults(MathJax.config.loader, 'provides', provides);
-MathJax.config.loader.paths.mathjax =
-  path.resolve(MathJax.config.loader.require.resolve('mathjax/package.json'), '..', 'es5');
+
+MathJax.config.loader.paths.mathjax = (function () {
+  //
+  // Try to locate the mathjax-full or mathjax package
+  // If neither is found, try to use the directory where this file is located
+  //
+  try {
+    return path.resolve(MathJax.config.loader.require.resolve('mathjax-full/package.json'), '../es5');
+  } catch (err) {}
+  try {
+     return path.resolve(MathJax.config.loader.require.resolve('mathjax/package.json'), '../es5');
+  } catch (err) {
+    let dir = path.dirname(err.requireStack[0]); // err.requireStack[0] is the full path to this module
+    if (path.basename(dir) == 'node-main') {
+      //
+      // This is components/src/node-main/node-main.js, so use
+      // components/src as the mathjax directory, and load the source array
+      //
+      dir = path.dirname(dir);
+      combineDefaults(MathJax.config.loader, 'source', require('../source.js').source);
+    }
+    return dir;
+  }
+})();
+
 
 /*
  * Preload core and liteDOM adaptor (needed for node)


### PR DESCRIPTION
Fix setting of the loader's root path so that it will work in both the `mathjax` and `mathjax-full` node packages, and if you check out the `MathJax-src` respository, from the `es5` or `components/src/node-main` directories.

The current version only works for the `mathjax` npm package.

Resolves issue #406.