### PR TITLE
Don't process escaped characters in a11y and menu extensions. mathjax/MathJax#2327.

### DIFF
--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -76,7 +76,7 @@ export function AssistiveMmlMathItemMixin<N, T, D, B extends Constructor<Abstrac
          * @param {MathDocument} document   The MathDocument for the MathItem
          */
         public assistiveMml(document: AssistiveMmlMathDocument<N, T, D>) {
-            if (this.state() >= STATE.ASSISTIVEMML) return;
+            if (this.state() >= STATE.ASSISTIVEMML || this.isEscaped) return;
             this.state(STATE.ASSISTIVEMML);
             const adaptor = document.adaptor;
             //

--- a/ts/a11y/complexity.ts
+++ b/ts/a11y/complexity.ts
@@ -85,7 +85,7 @@ export function ComplexityMathItemMixin<N, T, D, B extends Constructor<EnrichedM
          * @param {ComplexityMathDocument} docuemnt   The MathDocument for the MathItem
          */
         public complexity(document: ComplexityMathDocument<N, T, D>) {
-            if (this.state() < STATE.COMPLEXITY) {
+            if (this.state() < STATE.COMPLEXITY && !this.isEscaped) {
                 this.enrich(document);
                 computeComplexity(this.root);
                 this.state(STATE.COMPLEXITY);

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -118,7 +118,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
          * @param {HTMLDocument} document   The MathDocument for the MathItem
          */
         public explorable(document: ExplorerMathDocument) {
-            if (this.state() >= STATE.EXPLORER) return;
+            if (this.state() >= STATE.EXPLORER || this.isEscaped) return;
             const node = this.typesetRoot;
             const mml = toMathML(this.root);
             if (this.savedId) {

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -132,7 +132,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
          * @param {MathDocument} document   The MathDocument for the MathItem
          */
         public enrich(document: MathDocument<N, T, D>) {
-            if (this.state() >= STATE.ENRICHED) return;
+            if (this.state() >= STATE.ENRICHED || this.isEscaped) return;
             if (typeof sre === 'undefined' || !sre.Engine.isReady()) {
                 mathjax.retryAfter(sreReady);
             }

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -96,6 +96,11 @@ export interface MathItem<N, T, D> {
     display: boolean;
 
     /**
+     * Whether this item is an escaped character or not
+     */
+    isEscaped: boolean;
+
+    /**
      * The start and ending locations in the document of
      *   this expression
      */
@@ -271,6 +276,10 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
     public inputData: OptionList = {};
     public outputData: OptionList = {};
 
+    public get isEscaped() {
+        return this.display === null;
+    }
+
     /**
      * @param {string} math      The math expression for this item
      * @param {Inputjax} jax     The input jax to use for this item
@@ -315,7 +324,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
     /**
      * @override
      */
-    convert(document: MathDocument<N, T, D>, end: number = STATE.LAST) {
+    public convert(document: MathDocument<N, T, D>, end: number = STATE.LAST) {
         document.renderActions.renderConvert(this, document, end);
     }
 
@@ -334,7 +343,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
      */
     public typeset(document: MathDocument<N, T, D>) {
         if (this.state() < STATE.TYPESET) {
-            this.typesetRoot = document.outputJax[this.display === null ? 'escaped' : 'typeset'](this, document);
+            this.typesetRoot = document.outputJax[this.isEscaped ? 'escaped' : 'typeset'](this, document);
             this.state(STATE.TYPESET);
         }
     }

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -121,7 +121,7 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
          * @param {MenuMathDocument} document   The document where the menu is being added
          */
         public addMenu(document: MenuMathDocument) {
-            if (this.state() < STATE.CONTEXT_MENU) {
+            if (this.state() < STATE.CONTEXT_MENU && !this.isEscaped) {
                 document.menu.addMenu(this);
                 this.state(STATE.CONTEXT_MENU);
             }


### PR DESCRIPTION
This PR adds an `isEscaped` property to `MathItem` that tells if it is an escaped character (e.g., produced by `\$` in the TeX input jax), and uses that to prevent processing of escaped content via the a11y extensions and the menu extension.  The `assistive-mml` extension was causing errors by processing the escaped content.

Resolves issue mathjax/MathJax#2327.