### PR TITLE
Fix problem with convert() call with MathML input. mathjax/MathJax#2330

### DIFF
--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -128,7 +128,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
      */
     public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
         let mml = math.start.node;
-        if (!mml || this.options['forceReparse'] || this.adaptor.kind(mml) === '#text') {
+        if (!mml || !math.end.node || this.options['forceReparse'] || this.adaptor.kind(mml) === '#text') {
             let mathml = this.executeFilters(this.preFilters, math, document, math.math || '<math></math>');
             let doc = this.checkForErrors(this.adaptor.parse(mathml, 'text/' + this.options['parseAs']));
             let body = this.adaptor.body(doc);


### PR DESCRIPTION
Force reparse if either `start` or `end` nodes are empty (accommodates `convert()` calls, where `start` is defined but not `end`).

Resolves issue mathjax/MathJax#2330.