### PR TITLE
Use proper spacing for \mathrel in align environment.  (mathjax/MathJax#2175)

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -221,7 +221,8 @@ namespace ParseUtil {
                     (!NodeUtil.isType(child, 'TeXAtom') ||
                      (NodeUtil.getChildren(child)[0] &&
                       NodeUtil.getChildren(NodeUtil.getChildren(child)[0]).length)))) {
-        if (NodeUtil.isEmbellished(child)) {
+        if (NodeUtil.isEmbellished(child) ||
+            (NodeUtil.isType(child, 'TeXAtom') && NodeUtil.getTexClass(child) === TEXCLASS.REL)) {
           let mi = configuration.nodeFactory.create('node', 'mi');
           nodes.unshift(mi);
         }


### PR DESCRIPTION
This PR fixes a problem with the `align` environment where `\mathrel{...}` would not produce the proper spacing following `&`.  This mirrors the corresponding fix in v2.

Resolves issue mathjax/MathJax#2175.