### PR TITLE
Allow \newline to work like \\.  (mathjax/MathJax#2141)

### DIFF
--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -585,7 +585,7 @@ new sm.CommandMap('macros', {
   displaylines:      ['Matrix', null, null, 'center', null, '.5em', 'D'],
   cr:                 'Cr',
   '\\':               'CrLaTeX',
-  newline:            'Cr',
+  newline:           ['CrLaTeX', true],
   hline:             ['HLine', 'solid'],
   hdashline:         ['HLine', 'dashed'],
   //      noalign:            'HandleNoAlign',

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1217,9 +1217,9 @@ BaseMethods.Cr = function(parser: TexParser, name: string) {
  * @param {TexParser} parser The calling parser.
  * @param {string} name The macro name.
  */
-BaseMethods.CrLaTeX = function(parser: TexParser, name: string) {
+BaseMethods.CrLaTeX = function(parser: TexParser, name: string, nobrackets: boolean = false) {
   let n: string;
-  if (parser.string.charAt(parser.i) === '[') {
+  if (!nobrackets && parser.string.charAt(parser.i) === '[') {
     let dim = parser.GetBrackets(name, '');
     let [value, unit, _] = ParseUtil.matchDimen(dim);
     // @test Custom Linebreak


### PR DESCRIPTION
This is the companion PR to the v2 one at mathjax/MathJax#2343.   It allows `\newline` to be used like `\\` except not allowing the bracket form (`\\[dimen]`).

Resolves issue mathjax/MathJax#2141 for v3.