### PR TITLE
Use em rather than mu units for extensible arrows.  (mathjax/MathJax#2357)

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -46,7 +46,7 @@ let AmsMethods: Record<string, ParseMethod> = {};
 
 
 /**
- * Handle AMS array environments. 
+ * Handle AMS array environments.
  * @param {TexParser} parser The calling parser.
  * @param {StackItem} begin The opening stackitem.
  * @param {boolean} numbered Environment numbered.
@@ -219,7 +219,7 @@ AmsMethods.MultiIntegral = function(parser: TexParser, name: string,
  */
 AmsMethods.xArrow = function(parser: TexParser, name: string,
                              chr: number, l: number, r: number) {
-  let def = {width: '+' + (l + r) + 'mu', lspace: l + 'mu'};
+  let def = {width: '+' + ParseUtil.Em((l + r) / 18), lspace: ParseUtil.Em(l / 18)};
   let bot = parser.GetBrackets(name);
   let first = parser.ParseArg(name);
   let arrow = parser.create('token',


### PR DESCRIPTION
The `mu` units were not being translated to `em`, and so were being left verbatim in the attributes of the internal MathML.  These would then be used verbatim in the assistive MathML, causing errors in the console.

Resolves issue mathjax/MathJax#2357.