### PR TITLE
Prevent reading node_modules/@types from containing directories.  (mathjax/MathJax#2358)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "lib": ["es6", "dom"],
     "noLib": false,
     "sourceMap": true,
-    "outDir": "js"
+    "outDir": "js",
+    "typeRoots": ["./typings"]
   },
   "include": ["ts/**/*"],
   "exclude": ["js", "es5", "components"]


### PR DESCRIPTION
This PR resolves a problem where `../node_modules/@types` could be read while compiling MathJax.  

Resolves issue mathjax/MathJax#2358.