### PR TITLE
Improve handling of displayed equations next to floating content. (mathjax/MathJax#2351)

### DIFF
--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -27,6 +27,7 @@ import {CommonMath, CommonMathMixin} from '../../common/Wrappers/math.js';
 import {MmlMath} from '../../../core/MmlTree/MmlNodes/math.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {StyleList} from '../../common/CssStyles.js';
+import {BBox} from '../BBox.js';
 
 /*****************************************************************/
 /**
@@ -81,32 +82,59 @@ export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<any, an
         super.toCHTML(parent);
         const chtml = this.chtml;
         const adaptor = this.adaptor;
-        const attributes = this.node.attributes;
-        const display = (attributes.get('display') === 'block');
+        const display = (this.node.attributes.get('display') === 'block');
         if (display) {
             adaptor.setAttribute(chtml, 'display', 'true');
             adaptor.setAttribute(parent, 'display', 'true');
-            if (adaptor.getAttribute(this.chtml, 'width') === 'full') {
-                adaptor.setAttribute(parent, 'width', 'full');
-            }
+            this.handleDisplay(parent);
         } else {
-            //
-            // Transfer right margin to container (for things like $x\hskip -2em y$)
-            //
-            const margin = adaptor.getStyle(chtml, 'margin-right');
-            if (margin) {
-                adaptor.setStyle(chtml, 'margin-right', '');
-                adaptor.setStyle(parent, 'margin-right', margin);
-                adaptor.setStyle(parent, 'width', '0');
-            }
+            this.handleInline(parent);
         }
         adaptor.addClass(chtml, 'MJX-TEX');
+    }
+
+    /**
+     *  Handle displayed equations (set min-width, and so on).
+     */
+    protected handleDisplay(parent: N) {
+        const adaptor = this.adaptor;
         const [align, shift] = this.getAlignShift();
         if (align !== 'center') {
             adaptor.setAttribute(parent, 'justify', align);
         }
-        if (display && shift && !adaptor.hasAttribute(chtml, 'width')) {
-            this.setIndent(chtml, align, shift);
+        if (this.bbox.pwidth === BBox.fullWidth) {
+            adaptor.setAttribute(parent, 'width', 'full');
+            if (this.jax.table) {
+                let {L, w, R} = this.jax.table.getBBox();
+                if (align === 'right') {
+                    R = Math.max(R || -shift, -shift);
+                } else if (align === 'left') {
+                    L = Math.max(L || shift, shift);
+                } else if (align === 'center') {
+                    w += 2 * Math.abs(shift);
+                }
+                const W = this.em(Math.max(0, L + w + R));
+                adaptor.setStyle(parent, 'min-width', W);
+                adaptor.setStyle(this.jax.table.chtml, 'min-width', W);
+            }
+        } else {
+            this.setIndent(this.chtml, align, shift);
+        }
+    }
+
+    /**
+     * Handle in-line expressions
+     */
+    protected handleInline(parent: N) {
+        //
+        // Transfer right margin to container (for things like $x\hskip -2em y$)
+        //
+        const adaptor = this.adaptor;
+        const margin = adaptor.getStyle(this.chtml, 'margin-right');
+        if (margin) {
+            adaptor.setStyle(this.chtml, 'margin-right', '');
+            adaptor.setStyle(parent, 'margin-right', margin);
+            adaptor.setStyle(parent, 'width', '0');
         }
     }
 

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -60,6 +60,9 @@ export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<any, an
             'text-align': 'center',
             margin: '1em 0'
         },
+        'mjx-container[jax="CHTML"][display="true"][width="full"]': {
+            display: 'flex'
+        },
         'mjx-container[jax="CHTML"][display="true"] mjx-math': {
             padding: 0
         },
@@ -83,6 +86,9 @@ export class CHTMLmath<N, T, D> extends CommonMathMixin<CHTMLConstructor<any, an
         if (display) {
             adaptor.setAttribute(chtml, 'display', 'true');
             adaptor.setAttribute(parent, 'display', 'true');
+            if (adaptor.getAttribute(this.chtml, 'width') === 'full') {
+                adaptor.setAttribute(parent, 'width', 'full');
+            }
         } else {
             //
             // Transfer right margin to container (for things like $x\hskip -2em y$)

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -97,6 +97,9 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
         },
         'mjx-mtable[align="bottom"] > mjx-table': {
             'vertical-align': 'bottom'
+        },
+        'mjx-mtable[side="right"] mjx-labels': {
+           'min-width': '100%'
         }
     };
 
@@ -493,8 +496,7 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
             const W = this.node.attributes.get('width') as string;
             const {w, L, R} = this.getBBox();
             styles.style = {
-                width: (isPercent(W) ? 'calc(' + W + ' + ' + this.em(L + R) + ')' : this.em(L + w + R)),
-                minWidth: '100%'
+                width: (isPercent(W) ? 'calc(' + W + ' + ' + this.em(L + R) + ')' : this.em(L + w + R))
             };
         }
         this.adaptor.append(this.chtml, this.html('mjx-labels', styles, [this.labels]));

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -109,6 +109,7 @@ export abstract class CommonOutputJax<
     public document: MathDocument<N, T, D>;
     public math: MathItem<N, T, D>;
     public container: N;
+    public table: AnyWrapper;
 
     /**
      * The pixels per em for the math item being processed

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -411,6 +411,9 @@ export function CommonMtableMixin<C extends AnyWrapper,
             this.hasLabels = this.childNodes.reduce((value, row) => value || row.node.isKind('mlabeledtr'), false);
             this.findContainer();
             this.isTop = !this.container || (this.container.node.isKind('math') && !this.container.parent);
+            if (this.isTop) {
+                this.jax.table = this;
+            }
             this.getPercentageWidth();
             //
             // Get the frame, row, and column parameters

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -33,7 +33,7 @@ import {TeXFont} from './svg/fonts/tex.js';
 import {StyleList as CssStyleList} from './common/CssStyles.js';
 import {FontCache} from './svg/FontCache.js';
 
-export const SVGNS = "http://www.w3.org/2000/svg";
+export const SVGNS = 'http://www.w3.org/2000/svg';
 export const XLINKNS = 'http://www.w3.org/1999/xlink';
 
 /*****************************************************************/
@@ -276,6 +276,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         this.fontCache.clearLocalID();
         if (this.minwidth) {
             adaptor.setStyle(svg, 'minWidth', this.ex(this.minwidth));
+            adaptor.setStyle(this.container, 'minWidth', this.ex(this.minwidth));
         } else if (this.shift) {
             const align = adaptor.getAttribute(this.container, 'justify') || 'center';
             this.setIndent(svg, align, this.shift);
@@ -300,7 +301,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      * @param {number} m  A number to be shown in ex
      * @return {string}   The number with units of ex
      */
-    ex(m: number) {
+    public ex(m: number) {
         m /= this.font.params.x_height;
         return (Math.abs(m) < .001 ? '0' : m.toFixed(3).replace(/\.?0+$/, '') + 'ex');
     }
@@ -311,7 +312,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
      * @param {(N|T)[]} children            The child nodes for this node
      * @return {N}                      The newly created node in the SVG namespace
      */
-    svg(kind: string, properties: OptionList = {}, children: (N|T)[] = []) {
+    public svg(kind: string, properties: OptionList = {}, children: (N|T)[] = []) {
         return this.html(kind, properties, children, SVGNS);
     }
 

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -63,32 +63,57 @@ export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<any, any, a
         super.toSVG(parent);
         const adaptor = this.adaptor;
         const display = (this.node.attributes.get('display') === 'block');
-        const fullWidth = (this.bbox.pwidth === BBox.fullWidth);
         if (display) {
             adaptor.setAttribute(this.jax.container, 'display', 'true');
-            if (fullWidth) {
-                adaptor.setAttribute(this.jax.container, 'width', 'full');
-            }
-        }
-        const [align, shift] = this.getAlignShift();
-        if (align !== 'center') {
-            adaptor.setAttribute(this.jax.container, 'justify', align);
-        }
-        if (display && shift && !fullWidth) {
-            this.jax.shift = shift;
+            this.handleDisplay();
         }
         if (this.jax.document.options.internalSpeechTitles) {
-            const attributes = this.node.attributes;
-            const speech = (attributes.get('aria-label') || attributes.get('data-semantic-speech')) as string;
-            if (speech) {
-                const id = this.getTitleID();
-                const label = this.svg('title', {id}, [this.text(speech)]);
-                adaptor.insert(label, adaptor.firstChild(this.element));
-                adaptor.setAttribute(this.element, 'aria-labeledby', id);
-                adaptor.removeAttribute(this.element, 'aria-label');
-                for (const child of this.childNodes[0].childNodes) {
-                    adaptor.setAttribute(child.element, 'aria-hidden', 'true');
+            this.handleSpeech();
+        }
+    }
+
+    /**
+     * Set the justification, and get the minwidth and shift needed
+     * for the displayed equation.
+     */
+    protected handleDisplay() {
+        const [align, shift] = this.getAlignShift();
+        if (align !== 'center') {
+            this.adaptor.setAttribute(this.jax.container, 'justify', align);
+        }
+        if (this.bbox.pwidth === BBox.fullWidth) {
+            this.adaptor.setAttribute(this.jax.container, 'width', 'full');
+            if (this.jax.table) {
+                let {L, w, R} = this.jax.table.getBBox();
+                if (align === 'right') {
+                    R = Math.max(R || -shift, -shift);
+                } else if (align === 'left') {
+                    L = Math.max(L || shift, shift);
+                } else if (align === 'center') {
+                    w += 2 * Math.abs(shift);
                 }
+                this.jax.minwidth = Math.max(0, L + w + R);
+            }
+        } else {
+            this.jax.shift = shift;
+        }
+    }
+
+    /**
+     * Handle adding speech to the top-level node, if any.
+     */
+    protected handleSpeech() {
+        const adaptor = this.adaptor;
+        const attributes = this.node.attributes;
+        const speech = (attributes.get('aria-label') || attributes.get('data-semantic-speech')) as string;
+        if (speech) {
+            const id = this.getTitleID();
+            const label = this.svg('title', {id}, [this.text(speech)]);
+            adaptor.insert(label, adaptor.firstChild(this.element));
+            adaptor.setAttribute(this.element, 'aria-labeledby', id);
+            adaptor.removeAttribute(this.element, 'aria-label');
+            for (const child of this.childNodes[0].childNodes) {
+                adaptor.setAttribute(child.element, 'aria-hidden', 'true');
             }
         }
     }

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -25,6 +25,7 @@ import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
 import {CommonMath, CommonMathMixin} from '../../common/Wrappers/math.js';
 import {MmlMath} from '../../../core/MmlTree/MmlNodes/math.js';
 import {StyleList} from '../../common/CssStyles.js';
+import {BBox} from '../BBox.js';
 
 /*****************************************************************/
 /**
@@ -44,6 +45,9 @@ export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<any, any, a
             'text-align': 'center',
             margin: '1em 0'
         },
+        'mjx-container[jax="SVG"][display="true"][width="full"]': {
+            display: 'flex'
+        },
         'mjx-container[jax="SVG"][justify="left"]': {
             'text-align': 'left'
         },
@@ -59,14 +63,18 @@ export class SVGmath<N, T, D> extends CommonMathMixin<SVGConstructor<any, any, a
         super.toSVG(parent);
         const adaptor = this.adaptor;
         const display = (this.node.attributes.get('display') === 'block');
+        const fullWidth = (this.bbox.pwidth === BBox.fullWidth);
         if (display) {
             adaptor.setAttribute(this.jax.container, 'display', 'true');
+            if (fullWidth) {
+                adaptor.setAttribute(this.jax.container, 'width', 'full');
+            }
         }
         const [align, shift] = this.getAlignShift();
         if (align !== 'center') {
             adaptor.setAttribute(this.jax.container, 'justify', align);
         }
-        if (display && shift) {
+        if (display && shift && !fullWidth) {
             this.jax.shift = shift;
         }
         if (this.jax.document.options.internalSpeechTitles) {

--- a/ts/output/svg/Wrappers/mtable.ts
+++ b/ts/output/svg/Wrappers/mtable.ts
@@ -375,25 +375,21 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
         const W = L + (this.pWidth || w) + R;
         const LW = this.getTableData().L;
         const [pad, align, shift] = this.getPadAlignShift(side);
-        const dx = shift + (align === 'right' ? -W : align === 'center' ? -W / 2 : 0);
+        const dx = shift + (align === 'right' ? -W : align === 'center' ? -W / 2 : 0) + L;
         const matrix = 'matrix(1 0 0 -1 0 0)';
-        const translate = (dx ? ` translate(${this.fixed(dx)} 0)` : '');
         const scale = `scale(${this.jax.fixed((this.font.params.x_height * 1000) / this.metrics.ex, 2)})`;
         const transform = `translate(0 ${this.fixed(h)}) ${matrix} ${scale}`;
         let table = this.svg('svg', {
             'data-table': true,
             preserveAspectRatio: (align === 'left' ? 'xMinYMid' : align === 'right' ? 'xMaxYMid' : 'xMidYMid'),
-            viewBox: [this.fixed(-L), this.fixed(-h), 1, this.fixed(h + d)].join(' ')
+            viewBox: [this.fixed(-dx), this.fixed(-h), 1, this.fixed(h + d)].join(' ')
         }, [
-            this.svg('g', {transform: matrix + translate}, adaptor.childNodes(svg))
+            this.svg('g', {transform: matrix}, adaptor.childNodes(svg))
         ]);
-        if (side === 'right') {
-            adaptor.setAttribute(labels, 'transform', `translate(-${this.fixed(LW)} 0) ${matrix}`);
-        }
         labels = this.svg('svg', {
             'data-labels': true,
             preserveAspectRatio: (side === 'left' ? 'xMinYMid' : 'xMaxYMid'),
-            viewBox: [0, this.fixed(-h), 1, this.fixed(h + d)].join(' ')
+            viewBox: [side === 'left' ? 0 : this.fixed(LW), this.fixed(-h), 1, this.fixed(h + d)].join(' ')
         }, [labels]);
         adaptor.append(svg, this.svg('g', {transform: transform}, [table, labels]));
         this.place(-L, 0, svg);  // remove spacing for L, which is added by the parent during appending

--- a/ts/output/svg/Wrappers/mtable.ts
+++ b/ts/output/svg/Wrappers/mtable.ts
@@ -66,10 +66,10 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
             'stroke-linecap': 'round',
             'stroke-dasharray': '0,140'
         },
-        'g[data-mml-node="mtable"] > svg': {
+        'g[data-mml-node="mtable"] > g > svg': {
             overflow: 'visible'
         }
-    }
+    };
 
     /**
      * The column for labels
@@ -220,7 +220,7 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
         const W = L + this.pWidth + R;
         const [align, shift] = this.getAlignShift();
         const CW = Math.max(this.isTop ? W : 0, this.container.getWrapWidth(this.containerI)) - L - R;
-        const dw = w - (this.pWidth > CW ? CW: this.pWidth);
+        const dw = w - (this.pWidth > CW ? CW : this.pWidth);
         const dx = (align === 'left' ? 0 : align === 'right' ? dw : dw / 2);
         if (dx) {
             const table = this.svg('g', {}, this.adaptor.childNodes(svg));
@@ -301,7 +301,7 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
                 properties['stroke-dasharray'] = (style === 'dotted' ? '0,' : '') + this.fixed(2 * t);
             }
         }
-        return properties
+        return properties;
     }
 
     /******************************************************************/
@@ -375,20 +375,25 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
         const W = L + (this.pWidth || w) + R;
         const LW = this.getTableData().L;
         const [pad, align, shift] = this.getPadAlignShift(side);
-        const translate = (shift ? ` translate(${this.fixed(shift)} 0)` : '');
+        const dx = shift + (align === 'right' ? -W : align === 'center' ? -W / 2 : 0);
+        const matrix = 'matrix(1 0 0 -1 0 0)';
+        const translate = (dx ? ` translate(${this.fixed(dx)} 0)` : '');
         const scale = `scale(${this.jax.fixed((this.font.params.x_height * 1000) / this.metrics.ex, 2)})`;
-        const transform = `translate(0, ${this.fixed(h)}) matrix(1 0 0 -1 0 0) ${scale}`;
+        const transform = `translate(0 ${this.fixed(h)}) ${matrix} ${scale}`;
         let table = this.svg('svg', {
             'data-table': true,
             preserveAspectRatio: (align === 'left' ? 'xMinYMid' : align === 'right' ? 'xMaxYMid' : 'xMidYMid'),
-            viewBox: [this.fixed(-L), this.fixed(-h), this.fixed(W), this.fixed(h + d)].join(' ')
+            viewBox: [this.fixed(-L), this.fixed(-h), 1, this.fixed(h + d)].join(' ')
         }, [
-            this.svg('g', {transform: 'matrix(1 0 0 -1 0 0)' + translate}, adaptor.childNodes(svg))
+            this.svg('g', {transform: matrix + translate}, adaptor.childNodes(svg))
         ]);
+        if (side === 'right') {
+            adaptor.setAttribute(labels, 'transform', `translate(-${this.fixed(LW)} 0) ${matrix}`);
+        }
         labels = this.svg('svg', {
             'data-labels': true,
             preserveAspectRatio: (side === 'left' ? 'xMinYMid' : 'xMaxYMid'),
-            viewBox: [0, this.fixed(-h), this.fixed(LW), this.fixed(h + d)].join(' ')
+            viewBox: [0, this.fixed(-h), 1, this.fixed(h + d)].join(' ')
         }, [labels]);
         adaptor.append(svg, this.svg('g', {transform: transform}, [table, labels]));
         this.place(-L, 0, svg);  // remove spacing for L, which is added by the parent during appending


### PR DESCRIPTION
This PR makes displayed equations with labels interact better with floating content, and improves treatment of `indentAlign` and `indentShift` and their affects on the minimum width for the expressions.  This means they don't cause the expressions to clear the floating content unless necessary.

It also refactors some of the functions that were getting a bit long so that they are several smaller functions.

Resolves Issue mathjax/MathJax#2351