### PR TITLE
Add ability to include MJXZERO to font-family used for undefined characters

### DIFF
--- a/ts/output/chtml/fonts/tex.ts
+++ b/ts/output/chtml/fonts/tex.ts
@@ -60,6 +60,8 @@ import {delimiters} from '../../common/fonts/tex/delimiters.js';
 export class TeXFont extends
 CommonTeXFontMixin<CHTMLCharOptions, CHTMLVariantData, CHTMLDelimiterData, CHTMLFontDataClass>(CHTMLFontData) {
 
+    protected static defaultCssFamilyPrefix = 'MJXZERO, ';
+
     /**
      * The classes to use for each variant
      */

--- a/ts/output/chtml/fonts/tex.ts
+++ b/ts/output/chtml/fonts/tex.ts
@@ -60,7 +60,10 @@ import {delimiters} from '../../common/fonts/tex/delimiters.js';
 export class TeXFont extends
 CommonTeXFontMixin<CHTMLCharOptions, CHTMLVariantData, CHTMLDelimiterData, CHTMLFontDataClass>(CHTMLFontData) {
 
-    protected static defaultCssFamilyPrefix = 'MJXZERO, ';
+    /**
+     * Fonts to prefix any explicit ones
+     */
+    protected static defaultCssFamilyPrefix = 'MJXZERO';
 
     /**
      * The classes to use for each variant

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -261,6 +261,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     };
 
     /**
+     * The default prefix for explicit font-family settings
+     */
+    protected static defaultCssFamilyPrefix = '';
+
+    /**
      *  The default remappings
      */
     protected static defaultAccentMap = {
@@ -374,6 +379,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     protected cssFontMap: CssFontMap = {};
 
     /**
+     * A prefix to use for explicit font-family CSS settings
+     */
+    public cssFamilyPrefix: string;
+
+    /**
      * The character maps
      */
     protected remapChars: RemapMapMap = {};
@@ -398,6 +408,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
         this.params = {...CLASS.defaultParams};
         this.sizeVariants = [...CLASS.defaultSizeVariants];
         this.cssFontMap = {...CLASS.defaultCssFonts};
+        this.cssFamilyPrefix = CLASS.defaultCssFamilyPrefix;
         this.createVariants(CLASS.defaultVariants);
         this.defineDelimiters(CLASS.defaultDelimiters);
         for (const name of Object.keys(CLASS.defaultChars)) {

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -544,7 +544,7 @@ export abstract class CommonOutputJax<
      */
     public cssFontStyles(font: CssFontData, styles: StyleList = {}) {
         const [family, italic, bold] = font;
-        styles['font-family'] = this.font.cssFamilyPrefix + family;
+        styles['font-family'] = this.font.cssFamilyPrefix + ', ' + family;
         if (italic) styles['font-style'] = 'italic';
         if (bold) styles['font-weight'] = 'bold';
         return styles;

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -120,6 +120,9 @@ export abstract class CommonOutputJax<
      */
     public font: FD;
 
+    /**
+     * The wrapper factory for the MathML nodes
+     */
     public factory: F;
 
     /**
@@ -541,7 +544,7 @@ export abstract class CommonOutputJax<
      */
     public cssFontStyles(font: CssFontData, styles: StyleList = {}) {
         const [family, italic, bold] = font;
-        styles['font-family'] = family;
+        styles['font-family'] = this.font.cssFamilyPrefix + family;
         if (italic) styles['font-style'] = 'italic';
         if (bold) styles['font-weight'] = 'bold';
         return styles;

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -326,7 +326,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         const adaptor = this.adaptor;
         if (variant !== '-explicitFont') {
             const [family, italic, bold] = this.font.getCssFont(variant);
-            adaptor.setAttribute(svg, 'font-family', this.font.cssFamilyPrefix + family);
+            adaptor.setAttribute(svg, 'font-family', this.font.cssFamilyPrefix + ', ' + family);
             if (italic) {
                 adaptor.setAttribute(svg, 'font-style', 'italic');
             }

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -326,7 +326,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
         const adaptor = this.adaptor;
         if (variant !== '-explicitFont') {
             const [family, italic, bold] = this.font.getCssFont(variant);
-            adaptor.setAttribute(svg, 'font-family', family);
+            adaptor.setAttribute(svg, 'font-family', this.font.cssFamilyPrefix + family);
             if (italic) {
                 adaptor.setAttribute(svg, 'font-style', 'italic');
             }


### PR DESCRIPTION
This PR fixes a placement issue for CHTML output when undefined characters are used.  (Unfortunately, it is an old branch that I forgot to make a PR for back in October, and I don't remember the exact situation that caused the problem.)