### PR TITLE
Fix problem with infinite loop with SRE component in IE.

### DIFF
--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -1,5 +1,5 @@
 export const dependencies = {
-    'a11y/semantic-enrich': ['input/mml', '[sre]', 'input/mml'],
+    'a11y/semantic-enrich': ['input/mml', '[sre]'],
     'a11y/complexity': ['a11y/semantic-enrich'],
     'a11y/explorer': ['a11y/semantic-enrich', 'ui/menu'],
     '[tex]/all-packages': ['input/tex-base'],

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -39,7 +39,7 @@ const srePromise = (typeof sre === 'undefined' ? asyncLoad(SRELIB) : Promise.res
  * Values to control the polling for when SRE is ready
  */
 const SRE_DELAY = 100;        // in milliseconds
-const SRE_TIMEOUT = 10 * 1000; // 10 seconds
+const SRE_TIMEOUT = 20 * 1000; // 10 seconds
 
 /**
  * A promise that resolves when SRE is loaded and ready, and rejects if

--- a/ts/components/global.ts
+++ b/ts/components/global.ts
@@ -56,7 +56,8 @@ declare const global: {MathJax: MathJaxObject | MathJaxConfig};
 export function combineConfig(dst: any, src: any) {
     for (const id of Object.keys(src)) {
         if (id === '__esModule') continue;
-        if (typeof dst[id] === 'object' && typeof src[id] === 'object') {
+        if (typeof dst[id] === 'object' && typeof src[id] === 'object' &&
+            !(src[id] instanceof Promise) /* needed for IE polyfill */) {
             combineConfig(dst[id], src[id]);
         } else if (src[id] !== null && src[id] !== undefined) {
             dst[id] = src[id];


### PR DESCRIPTION
This resolves the issue in IE where you get a stack overflow when starting up the explorer (or other tools that rely on SRE).  The issue was that the Promise polyfill would cause `combineConfig()` to loop infinitely (it apparently has a recursive reference in it).

This also lengthens the timeout from 10 to 20 seconds, since IE is slow enough to sometimes need it.