### PR TITLE
Fix incorrect positioning of root in mroot.  (mathjax/MathJax#2347)

### DIFF
--- a/ts/output/chtml/Wrappers/mroot.ts
+++ b/ts/output/chtml/Wrappers/mroot.ts
@@ -42,9 +42,9 @@ export class CHTMLmroot<N, T, D> extends CommonMrootMixin<MrootConstructor>(CHTM
     /**
      * @override
      */
-    protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox) {
+    protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox, H: number) {
         root.toCHTML(ROOT);
-        const [x, h, dx] = this.getRootDimens(sbox);
+        const [x, h, dx] = this.getRootDimens(sbox, H);
         const bbox = root.getBBox();
         this.adaptor.setStyle(ROOT, 'verticalAlign', this.em(h));
         this.adaptor.setStyle(ROOT, 'width', this.em(x));

--- a/ts/output/chtml/Wrappers/msqrt.ts
+++ b/ts/output/chtml/Wrappers/msqrt.ts
@@ -74,6 +74,8 @@ export class CHTMLmsqrt<N, T, D> extends CommonMsqrtMixin<CHTMLConstructor<any, 
         const sbox = surd.getBBox();
         const bbox = base.getBBox();
         const [p, q] = this.getPQ(sbox);
+        const t = this.font.params.rule_thickness;
+        const H = bbox.h + q + t;
         //
         //  Create the HTML structure for the root
         //
@@ -90,7 +92,7 @@ export class CHTMLmsqrt<N, T, D> extends CommonMsqrtMixin<CHTMLConstructor<any, 
         //
         //  Add the child content
         //
-        this.addRoot(ROOT, root, sbox);
+        this.addRoot(ROOT, root, sbox, H);
         surd.toCHTML(SURD);
         base.toCHTML(BASE);
         if (surd.size < 0) {
@@ -106,11 +108,12 @@ export class CHTMLmsqrt<N, T, D> extends CommonMsqrtMixin<CHTMLConstructor<any, 
     /**
      * Add root HTML (overridden in mroot)
      *
-     * @param {N} ROOT   The container for the root
+     * @param {N} ROOT             The container for the root
      * @param {CHTMLWrapper} root  The wrapped MML root content
      * @param {BBox} sbox          The bounding box of the surd
+     * @param {number} H           The height of the root as a whole
      */
-    protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox) {
+    protected addRoot(ROOT: N, root: CHTMLWrapper<N, T, D>, sbox: BBox, H: number) {
     }
 
 }

--- a/ts/output/common/Wrappers/mroot.ts
+++ b/ts/output/common/Wrappers/mroot.ts
@@ -66,23 +66,23 @@ export function CommonMrootMixin<T extends MsqrtConstructor>(Base: T): MrootCons
         /**
          * @override
          */
-        public combineRootBBox(BBOX: BBox, sbox: BBox) {
+        public combineRootBBox(BBOX: BBox, sbox: BBox, H: number) {
             const bbox = this.childNodes[this.root].getBBox();
-            const [x, h] = this.getRootDimens(sbox);
+            const [x, h] = this.getRootDimens(sbox, H);
             BBOX.combine(bbox, 0, h);
         }
 
         /**
          * @override
          */
-        public getRootDimens(sbox: BBox) {
+        public getRootDimens(sbox: BBox, H: number) {
             const surd = this.childNodes[this.surd] as CommonMo;
             const bbox = this.childNodes[this.root].getBBox();
             const offset = (surd.size < 0 ? .5 : .6) * sbox.w;
             const {w, rscale} = bbox;
             const W = Math.max(w, offset / rscale);
             const dx = Math.max(0, W - w);
-            const h = this.rootHeight(bbox, sbox, surd.size);
+            const h = this.rootHeight(bbox, sbox, surd.size, H);
             const x = W * rscale - offset;
             return [x, h, dx];
         }
@@ -91,11 +91,12 @@ export function CommonMrootMixin<T extends MsqrtConstructor>(Base: T): MrootCons
          * @param {BBox} rbox      The bbox of the root
          * @param {BBox} sbox      The bbox of the surd
          * @param {number} size    The size of the surd
+         * @param {number} H       The height of the root as a whole
          * @return {number}        The height of the root within the surd
          */
-        public rootHeight(rbox: BBox, sbox: BBox, size: number) {
-            const H = sbox.h + sbox.d;
-            const b = (size < 0 ? 2 + .3 * (H - 4) : .55 * H) - sbox.d;
+        public rootHeight(rbox: BBox, sbox: BBox, size: number, H: number) {
+            const h = sbox.h + sbox.d;
+            const b = (size < 0 ? 1.9 : .55 * h) - (h - H);
             return b + Math.max(0, rbox.d * rbox.rscale);
         }
 

--- a/ts/output/common/Wrappers/msqrt.ts
+++ b/ts/output/common/Wrappers/msqrt.ts
@@ -56,8 +56,9 @@ export interface CommonMsqrt extends AnyWrapper {
      *
      * @param {BBox} bbox  The bounding box so far
      * @param {BBox} sbox  The bounding box of the surd
+     * @param {number} H   The height of the root as a whole
      */
-    combineRootBBox(bbox: BBox, sbox: BBox): void;
+    combineRootBBox(bbox: BBox, sbox: BBox, H: number): void;
 
     /**
      * @param {BBox} sbox  The bounding box for the surd character
@@ -67,9 +68,10 @@ export interface CommonMsqrt extends AnyWrapper {
 
     /**
      * @param {BBox} sbox  The bounding box of the surd
+     * @param {number} H   The height of the root as a whole
      * @return {number[]}  The x offset of the surd, and the height, x offset, and scale of the root
      */
-    getRootDimens(sbox: BBox): number[];
+    getRootDimens(sbox: BBox, H: Number): number[];
 
 }
 
@@ -145,11 +147,11 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
             const surdbox = this.childNodes[this.surd].getBBox();
             const basebox = new BBox(this.childNodes[this.base].getBBox());
             const [p, q] = this.getPQ(surdbox);
-            const [x] = this.getRootDimens(surdbox);
             const t = this.font.params.rule_thickness;
             const H = basebox.h + q + t;
+            const [x] = this.getRootDimens(surdbox, H);
             bbox.h = H + t;
-            this.combineRootBBox(bbox, surdbox);
+            this.combineRootBBox(bbox, surdbox, H);
             bbox.combine(surdbox, x, H - surdbox.h);
             bbox.combine(basebox, x + surdbox.w, 0);
             bbox.clean();
@@ -161,8 +163,9 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
          *
          * @param {BBox} bbox  The bounding box so far
          * @param {BBox} sbox  The bounding box of the surd
+         * @param {number} H   The height of the root as a whole
          */
-        public combineRootBBox(bbox: BBox, sbox: BBox) {
+        public combineRootBBox(bbox: BBox, sbox: BBox, H: number) {
         }
 
         /**
@@ -172,15 +175,18 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
         public getPQ(sbox: BBox) {
             const t = this.font.params.rule_thickness;
             const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
-            const q = (sbox.h + sbox.d > this.surdH ? ((sbox.h + sbox.d) - (this.surdH - 2 * t - p / 2)) / 2 : t + p / 4);
+            const q = (sbox.h + sbox.d > this.surdH ?
+                       ((sbox.h + sbox.d) - (this.surdH - 2 * t - p / 2)) / 2 :
+                       t + p / 4);
             return [p, q];
         }
 
         /**
          * @param {BBox} sbox  The bounding box of the surd
+         * @param {number} H   The height of the root as a whole
          * @return {number[]}  The x offset of the surd, and the height, x offset, and scale of the root
          */
-        public getRootDimens(sbox: BBox) {
+        public getRootDimens(sbox: BBox, H: number) {
             return [0, 0, 0, 0];
         }
 

--- a/ts/output/svg/Wrappers/mroot.ts
+++ b/ts/output/svg/Wrappers/mroot.ts
@@ -42,9 +42,9 @@ export class SVGmroot<N, T, D> extends CommonMrootMixin<Constructor<SVGmsqrt<any
     /**
      * @override
      */
-    protected addRoot(ROOT: N, root: SVGWrapper<N, T, D>, sbox: BBox) {
+    protected addRoot(ROOT: N, root: SVGWrapper<N, T, D>, sbox: BBox, H: number) {
         root.toSVG(ROOT);
-        const [x, h, dx] = this.getRootDimens(sbox);
+        const [x, h, dx] = this.getRootDimens(sbox, H);
         const bbox = root.getBBox();
         root.place(dx * bbox.rscale, h);
         this.dx = x;

--- a/ts/output/svg/Wrappers/msqrt.ts
+++ b/ts/output/svg/Wrappers/msqrt.ts
@@ -55,7 +55,9 @@ export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<any, any,
         const rbox = this.getBBox();
         const sbox = surd.getBBox();
         const bbox = base.getBBox();
+        const [p, q] = this.getPQ(sbox);
         const t = this.font.params.rule_thickness * this.bbox.scale;
+        const H = bbox.h + q + t;
         //
         //  Create the SVG structure for the root
         //
@@ -64,7 +66,7 @@ export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<any, any,
         //
         //  Place the children
         //
-        this.addRoot(SVG, root, sbox);
+        this.addRoot(SVG, root, sbox, H);
         surd.toSVG(SVG);
         surd.place(this.dx, rbox.h - sbox.h - t);
         base.toSVG(BASE);
@@ -81,8 +83,9 @@ export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<any, any,
      * @param {N} ROOT           The container for the root
      * @param {SVGWrapper} root  The wrapped MML root content
      * @param {BBox} sbox        The bounding box of the surd
+     * @param {number} H         The height of the root as a whole
      */
-    protected addRoot(ROOT: N, root: SVGWrapper<N, T, D>, sbox: BBox) {
+    protected addRoot(ROOT: N, root: SVGWrapper<N, T, D>, sbox: BBox, H: number) {
     }
 
 }


### PR DESCRIPTION
The height of the root was not taking the correct depth into account (it used the depth of the surd character, but that is being shifted vertically, so doesn't correspond to the actual baseline).  This required passing some more information to the functions that compute the information used in the bounding boxes, which accounts for most of the changes here.

Without this patch, `\sqrt[n]{\Rule{.5em}{.75em}{0em}}` will have its root too low, while `\sqrt[n]{\Rule{.5em}{0em}{1em}}` will be too high.

Resolves issue mathjax/MathJax#2347.