### PR TITLE
Improve multi-glyph stretchy characters in Chrome.  (mathjax/MathJax#2311)

### DIFF
--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -50,7 +50,8 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<any, any, a
             width: 0
         },
         'mjx-stretchy-h > * > mjx-c': {
-            display: 'inline-block'
+            display: 'inline-block',
+            transform: 'scalex(1.0000001)'        // improves blink positioning
         },
         'mjx-stretchy-h > * > mjx-c::before': {
             padding: '.001em 0',                  // for blink
@@ -86,7 +87,7 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<any, any, a
             display: 'block'
         },
         'mjx-stretchy-v > * > mjx-c': {
-            transform: 'scale(1)',                // improves Firefox positioning
+            transform: 'scaley(1.0000001)',       // improves Firefox and blink positioning
             'transform-origin': 'left center',
             overflow: 'hidden'
         },


### PR DESCRIPTION
MathJax CHTML output uses a scaling transform to stretch the extenders in multi-character stretchy delimiters.  Chrome (and Firefox) don't align these with unstretched ending characters as well as they should.  Adding a scale transform (with an insignificant scaling factor) improves the results in these browsers.  The factor must be other than 1 in Chrome to make a difference.

Resolves issue mathjax/MathJax#2311.