### PR TITLE
Add tagFormat to AllPackes, and update the preloaded list.  (mathjax/MathJax#2328)

### DIFF
--- a/ts/input/tex/AllPackages.ts
+++ b/ts/input/tex/AllPackages.ts
@@ -41,6 +41,7 @@ import './newcommand/NewcommandConfiguration.js';
 import './noerrors/NoErrorsConfiguration.js';
 import './noundefined/NoUndefinedConfiguration.js';
 import './physics/PhysicsConfiguration.js';
+import './tag_format/TagFormatConfiguration.js';
 import './unicode/UnicodeConfiguration.js';
 import './verb/VerbConfiguration.js';
 
@@ -56,6 +57,7 @@ if (typeof MathJax !== 'undefined' && MathJax.loader) {
         '[tex]/bussproofs',
         '[tex]/cancel',
         '[tex]/color',
+        '[tex]/color_v2',
         '[tex]/enclose',
         '[tex]/extpfeil',
         '[tex]/html',
@@ -66,7 +68,8 @@ if (typeof MathJax !== 'undefined' && MathJax.loader) {
         '[tex]/physics',
         '[tex]/unicode',
         '[tex]/verb',
-        '[tex]/configMacros'
+        '[tex]/configMacros',
+        '[tex]/tagFormat'
     );
 }
 
@@ -78,6 +81,7 @@ export const AllPackages: string[] = [
     'bbox',
     'boldsymbol',
     'braket',
+    'bussproofs',
     'cancel',
     'color',
     'enclose',
@@ -89,5 +93,6 @@ export const AllPackages: string[] = [
     'noundefined',
     'unicode',
     'verb',
-    'configMacros'
+    'configMacros',
+    'tagFormat'
 ];

--- a/ts/input/tex/tag_format/TagFormatConfiguration.ts
+++ b/ts/input/tex/tag_format/TagFormatConfiguration.ts
@@ -61,7 +61,7 @@ export function tagFormatConfig(config: Configuration, jax: TeX<any, any, any>) 
      * methods don't have access to the input jax, and hence to its options.
      * If they did, we would use a common configTags class instead.
      */
-    class Tagformat extends TagClass {
+    class TagFormat extends TagClass {
 
         /**
          * @override
@@ -102,14 +102,14 @@ export function tagFormatConfig(config: Configuration, jax: TeX<any, any, any>) 
     //
     // Register the tag class
     //
-    TagsFactory.add(tagName, Tagformat);
+    TagsFactory.add(tagName, TagFormat);
     jax.parseOptions.options.tags = tagName;
 }
 
 /**
  * The configuration object for configTags
  */
-export const TagformatConfiguration = Configuration.create(
+export const TagFormatConfiguration = Configuration.create(
     'tagFormat', {
         config: tagFormatConfig,
         configPriority: 10,


### PR DESCRIPTION
This PR adds `tagFormat` to the AllPackages file, and updates the preloaded list to include it (and and `color_v2`, which was loaded but missing from the list.  Also, it adds `bussproofs` to the package list.

Resolves issue mathjax/MathJax#2328.
