### PR TITLE
Fix issues with munderover/msubsup when base is scaled  (mathjax/MathJax#2317)

### DIFF
--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -114,7 +114,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
         sub.toCHTML(stack);
         const corebox = this.baseCore.bbox;
         if (corebox.ic) {
-            this.adaptor.setStyle(sup.chtml, 'marginLeft', this.em(this.coreIC() / sup.bbox.rscale));
+            this.adaptor.setStyle(sup.chtml, 'marginLeft', this.em(this.coreIC() * base.bbox.rscale / sup.bbox.rscale));
         }
     }
 

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -106,7 +106,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
         const chtml = this.standardCHTMLnode(parent);
         const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
         const [u, v, q] = this.getUVQ(base.getBBox(), sub.getBBox(), sup.getBBox());
-        const x = (this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0);
+        const x = this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0;
         const style = {'vertical-align': this.em(v)};
         base.toCHTML(chtml);
         const stack = this.adaptor.append(chtml, this.html('mjx-script', {style})) as N;

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -106,6 +106,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
         const chtml = this.standardCHTMLnode(parent);
         const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
         const [u, v, q] = this.getUVQ(base.getBBox(), sub.getBBox(), sup.getBBox());
+        const x = (this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0);
         const style = {'vertical-align': this.em(v)};
         base.toCHTML(chtml);
         const stack = this.adaptor.append(chtml, this.html('mjx-script', {style})) as N;
@@ -114,7 +115,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
         sub.toCHTML(stack);
         const corebox = this.baseCore.bbox;
         if (corebox.ic) {
-            this.adaptor.setStyle(sup.chtml, 'marginLeft', this.em(this.coreIC() * base.bbox.rscale / sup.bbox.rscale));
+            this.adaptor.setStyle(sup.chtml, 'marginLeft', this.em(x / sup.bbox.rscale));
         }
     }
 

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -114,8 +114,8 @@ export function CommonMsupMixin<W extends AnyWrapper,
          * @override
          */
         public getOffset(bbox: BBox, sbox: BBox) {
-            const x = (this.baseCore.bbox.ic ? .2 * this.baseCore.bbox.ic + .05 : 0);
-            return [x, this.getU(bbox, sbox)];
+            const x = (this.baseCore.bbox.ic ? .05 * this.baseCore.bbox.ic + .05 : 0);
+            return [x * bbox.rscale, this.getU(bbox, sbox)];
         }
 
     };
@@ -207,7 +207,7 @@ export function CommonMsubsupMixin<W extends AnyWrapper,
             const w = bbox.w;
             const [u, v, q] = this.getUVQ(basebox, subbox, supbox);
             bbox.combine(subbox, w, v);
-            bbox.combine(supbox, w + this.coreIC(), u);
+            bbox.combine(supbox, w + this.coreIC() * basebox.rscale, u);
             bbox.w += this.font.params.scriptspace;
             bbox.clean();
             this.setChildPWidths(recompute);
@@ -226,7 +226,7 @@ export function CommonMsubsupMixin<W extends AnyWrapper,
             const tex = this.font.params;
             const t = 3 * tex.rule_thickness;
             const subscriptshift = this.length2em(this.node.attributes.get('subscriptshift'), tex.sub2);
-            const drop = (this.isCharBase() ? 0 : basebox.d + tex.sub_drop * subbox.rscale);
+            const drop = (this.isCharBase() ? 0 : basebox.d * basebox.rscale + tex.sub_drop * subbox.rscale);
             //
             // u and v are the veritcal shifts of the scripts, initially set to minimum values and then adjusted
             //

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -115,7 +115,7 @@ export function CommonMsupMixin<W extends AnyWrapper,
          */
         public getOffset(bbox: BBox, sbox: BBox) {
             const x = (this.baseCore.bbox.ic ? .05 * this.baseCore.bbox.ic + .05 : 0);
-            return [x * bbox.rscale, this.getU(bbox, sbox)];
+            return [x * this.coreScale(), this.getU(bbox, sbox)];
         }
 
     };
@@ -206,8 +206,9 @@ export function CommonMsubsupMixin<W extends AnyWrapper,
             bbox.append(basebox);
             const w = bbox.w;
             const [u, v, q] = this.getUVQ(basebox, subbox, supbox);
+            const x = (this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0);
             bbox.combine(subbox, w, v);
-            bbox.combine(supbox, w + this.coreIC() * basebox.rscale, u);
+            bbox.combine(supbox, w + x, u);
             bbox.w += this.font.params.scriptspace;
             bbox.clean();
             this.setChildPWidths(recompute);

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -248,7 +248,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          */
         public coreIC() {
             const corebox = this.baseCore.getBBox();
-            return (corebox.ic ? 1.2 * corebox.ic + .05 : 0);
+            return (corebox.ic ? 1.05 * corebox.ic + .05 : 0);
         }
 
         /**
@@ -256,7 +256,8 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          */
         public isCharBase() {
             let base = this.baseChild;
-            if ((base.node.isKind('mstyle') || base.node.isKind('mrow')) && base.childNodes.length === 1) {
+            while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) &&
+                   base.bbox.rscale === 1 && base.childNodes.length === 1) {
                 base = base.childNodes[0];
             }
             return ((base.node.isKind('mo') || base.node.isKind('mi') || base.node.isKind('mn')) &&
@@ -291,7 +292,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
             const tex = this.font.params;
             const subscriptshift = this.length2em(this.node.attributes.get('subscriptshift'), tex.sub1);
             return Math.max(
-                this.isCharBase() ? 0 : bbox.d + tex.sub_drop * sbox.rscale,
+                this.isCharBase() ? 0 : bbox.d * bbox.rscale + tex.sub_drop * sbox.rscale,
                 subscriptshift,
                 sbox.h * sbox.rscale - (4/5) * tex.x_height
             );
@@ -310,7 +311,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
             const p = (attr.displaystyle ? tex.sup1 : attr.texprimestyle ? tex.sup3 : tex.sup2);
             const superscriptshift = this.length2em(attr.superscriptshift, p);
             return Math.max(
-                this.isCharBase() ? 0 : bbox.h - tex.sup_drop * sbox.rscale,
+                this.isCharBase() ? 0 : bbox.h * bbox.rscale - tex.sup_drop * sbox.rscale,
                 superscriptshift,
                 sbox.d * sbox.rscale + (1/4) * tex.x_height
             );
@@ -397,7 +398,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
         public getDelta(noskew: boolean = false) {
             const accent = this.node.attributes.get('accent');
             const ddelta = (accent && !noskew ? this.baseChild.coreMO().bbox.sk : 0);
-            return DELTA * this.baseCore.bbox.ic / 2 + ddelta;
+            return (DELTA * this.baseCore.bbox.ic / 2 + ddelta) * this.baseChild.bbox.rscale;
         }
 
         /**

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -74,6 +74,11 @@ export interface CommonScriptbase<W extends AnyWrapper> extends AnyWrapper {
     coreIC(): number;
 
     /**
+     * @return {number}   The relative scaling of the base
+     */
+    coreScale(): number;
+
+    /**
      * Get the shift for the script (implemented in subclasses)
      *
      * @param {BBox} bbox   The bounding box of the base element
@@ -252,12 +257,25 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
         }
 
         /**
+         * @return {number}   The relative scaling of the base
+         */
+        public coreScale() {
+            let scale = this.baseChild.getBBox().rscale;
+            let base = this.baseChild;
+            while ((base.node.isKind('mstyle') || base.node.isKind('mrow') || base.node.isKind('TeXAtom'))
+                   && base.childNodes.length === 1) {
+                base = base.childNodes[0];
+                scale *= base.getBBox().rscale;
+            }
+            return scale;
+        }
+
+        /**
          * @return {boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
          */
         public isCharBase() {
             let base = this.baseChild;
-            while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) &&
-                   base.bbox.rscale === 1 && base.childNodes.length === 1) {
+            while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) && base.childNodes.length === 1) {
                 base = base.childNodes[0];
             }
             return ((base.node.isKind('mo') || base.node.isKind('mi') || base.node.isKind('mn')) &&
@@ -398,7 +416,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
         public getDelta(noskew: boolean = false) {
             const accent = this.node.attributes.get('accent');
             const ddelta = (accent && !noskew ? this.baseChild.coreMO().bbox.sk : 0);
-            return (DELTA * this.baseCore.bbox.ic / 2 + ddelta) * this.baseChild.bbox.rscale;
+            return (DELTA * this.baseCore.bbox.ic / 2 + ddelta) * this.coreScale();
         }
 
         /**

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -86,7 +86,7 @@ CommonMsubsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any
         const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
         const bbox = base.getBBox();
         const [u, v] = this.getUVQ(bbox, sub.getBBox(), sup.getBBox());
-        const x = (this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0);
+        const x = this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0;
 
         base.toSVG(svg);
         sup.toSVG(svg);

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -85,15 +85,15 @@ CommonMsubsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any
         const svg = this.standardSVGnode(parent);
         const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
         const bbox = base.getBBox();
-        const cbox = this.baseCore.bbox;
         const [u, v] = this.getUVQ(bbox, sub.getBBox(), sup.getBBox());
+        const x = (this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0);
 
         base.toSVG(svg);
         sup.toSVG(svg);
         sub.toSVG(svg);
 
         sub.place(bbox.w * bbox.rscale, v);
-        sup.place((bbox.w + this.coreIC()) * bbox.rscale, u);
+        sup.place(bbox.w * bbox.rscale + x, u);
     }
 
 }

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -92,8 +92,8 @@ CommonMsubsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any
         sup.toSVG(svg);
         sub.toSVG(svg);
 
-        sub.place(bbox.w, v);
-        sup.place(bbox.w + this.coreIC(), u);
+        sub.place(bbox.w * bbox.rscale, v);
+        sup.place((bbox.w + this.coreIC()) * bbox.rscale, u);
     }
 
 }

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -59,7 +59,7 @@ CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(
         const [x, v] = this.getOffset(bbox, sbox);
         this.baseChild.toSVG(svg);
         this.script.toSVG(svg);
-        this.script.place(bbox.w + x, v);
+        this.script.place(bbox.w * bbox.rscale + x, v);
     }
 
 }


### PR DESCRIPTION
This PR fixes a number of script placement issues with `munderover` and `msubsup` when the base is scaled via `<mstyle mathsize="...">`.

Resolves issue mathjax/MathJax#2317.