### PR TITLE
Fix error with setting startup.elements in configuration.  (mathjax/MathJax#2371)

### DIFF
--- a/ts/components/global.ts
+++ b/ts/components/global.ts
@@ -46,6 +46,14 @@ export interface MathJaxObject {
 declare const global: {MathJax: MathJaxObject | MathJaxConfig};
 
 /**
+ * @param {any} x     An item to test if it is an object
+ * @return {boolean}  True if the item is a non-null object
+ */
+export function isObject(x: any) {
+    return typeof x === 'object' && x !== null;
+}
+
+/**
  * Combine user-produced configuration with existing defaults.  Values
  * from src will replace those in dst.
  *
@@ -56,7 +64,7 @@ declare const global: {MathJax: MathJaxObject | MathJaxConfig};
 export function combineConfig(dst: any, src: any) {
     for (const id of Object.keys(src)) {
         if (id === '__esModule') continue;
-        if (typeof dst[id] === 'object' && typeof src[id] === 'object' &&
+        if (isObject(dst[id]) && isObject(src[id]) &&
             !(src[id] instanceof Promise) /* needed for IE polyfill */) {
             combineConfig(dst[id], src[id]);
         } else if (src[id] !== null && src[id] !== undefined) {
@@ -82,7 +90,7 @@ export function combineDefaults(dst: any, name: string, src: any) {
     }
     dst = dst[name];
     for (const id of Object.keys(src)) {
-        if (typeof dst[id] === 'object' && typeof src[id] === 'object') {
+        if (isObject(dst[id]) && isObject(src[id])) {
             combineDefaults(dst, id, src[id]);
         } else if (dst[id] == null && src[id] != null) {
             dst[id] = src[id];

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -268,7 +268,7 @@ export namespace Startup {
      * Setting Mathjax.startup.pageReady in the configuration will override this.
      */
     export function defaultPageReady() {
-        return (CONFIG.typeset && MathJax.typesetPromise ? MathJax.typesetPromise() : null);
+        return (CONFIG.typeset && MathJax.typesetPromise ? MathJax.typesetPromise(CONFIG.elements) : null);
     };
 
     /**
@@ -335,7 +335,7 @@ export namespace Startup {
             document.reset();
             return mathjax.handleRetriesFor(() => {
                 document.render();
-            })
+            });
         };
         MathJax.typesetClear = () => document.clear();
     };

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -509,10 +509,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
             doc.typesetError(math, err);
         },
         renderActions: expandable({
-            find:    [STATE.FINDMATH, (document: MathDocument<any, any, any>) => {
-                const elements = document.options.elements;
-                document.findMath(elements ? {elements} : {});
-            }, () => {}, false],
+            find:    [STATE.FINDMATH, 'findMath', '', false],
             compile: [STATE.COMPILED],
             metrics: [STATE.METRICS, 'getMetrics', '', false],
             typeset: [STATE.TYPESET],
@@ -827,4 +824,4 @@ export interface MathDocumentConstructor<D extends MathDocument<any, any, any>> 
     OPTIONS: OptionList;
     ProcessBits: typeof BitField;
     new (...args: any[]): D;
-};
+}

--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -145,7 +145,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     public findMath(options: OptionList) {
         if (!this.processed.isSet('findMath')) {
             this.adaptor.document = this.document;
-            options = userOptions({elements: [this.adaptor.body(this.document)]}, options);
+            options = userOptions({elements: this.options.elements || [this.adaptor.body(this.document)]}, options);
             for (const container of this.adaptor.getElements(options['elements'], this.document)) {
                 let [strings, nodes] = [null, null] as [string[], HTMLNodeArray<N, T>];
                 for (const jax of this.inputJax) {

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -147,7 +147,7 @@ export abstract class CommonOutputJax<
      * Get the cssStyle and font objects
      *
      * @param {OptionList} options         The configuration options
-     * @param(FontDataClass} defaultFont  The default FontData constructor
+     * @param {FontDataClass} defaultFont  The default FontData constructor
      * @constructor
      */
     constructor(options: OptionList = null,


### PR DESCRIPTION
This PR fixes an error that occurs when the `startup` configuration block includes an `elements` array (intended to restrict the typesetting to a collection of containers).  WIthout this patch, MathJax throws an error.  (The problem was that `combineConfig()` tried to merge a `null` value into the array, thinking it was an object, since `typeof null === 'object'`).

It also turns out that the `elements` array was never used, even if specifying it didn't cause an error, so this also fixes that problem.

Finally, it simplifies the `findMath` render action, which was rather unpleasant to begin with.

Resolves issue mathjax/MathJax#2371.