### PR TITLE
Make unitless linethickness be a multiple of the default size.  (mathjax/MathJax#2381)

### DIFF
--- a/ts/output/chtml/Wrappers/mfrac.ts
+++ b/ts/output/chtml/Wrappers/mfrac.ts
@@ -140,7 +140,7 @@ export class CHTMLmfrac<N, T, D> extends CommonMfracMixin<CHTMLConstructor<any, 
         if (bevelled) {
             this.makeBevelled(display);
         } else {
-            const thickness = this.length2em(String(linethickness));
+            const thickness = this.length2em(String(linethickness), .06);
             if (thickness === 0) {
                 this.makeAtop(display);
             } else {

--- a/ts/output/common/Wrappers/mfrac.ts
+++ b/ts/output/common/Wrappers/mfrac.ts
@@ -133,7 +133,7 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
             if (bevelled) {
                 this.getBevelledBBox(bbox, display);
             } else {
-                const thickness = this.length2em(String(linethickness));
+                const thickness = this.length2em(String(linethickness), .06);
                 w = -2 * this.pad;
                 if (thickness === 0) {
                     this.getAtopBBox(bbox, display);

--- a/ts/output/svg/Wrappers/mfrac.ts
+++ b/ts/output/svg/Wrappers/mfrac.ts
@@ -52,7 +52,7 @@ export class SVGmfrac<N, T, D> extends CommonMfracMixin<SVGConstructor<any, any,
         if (bevelled) {
             this.makeBevelled(display);
         } else {
-            const thickness = this.length2em(String(linethickness));
+            const thickness = this.length2em(String(linethickness), .06);
             if (thickness === 0) {
                 this.makeAtop(display);
             } else {


### PR DESCRIPTION
This provides the default size when converting the `linethickness` to ems so that unitless lengths will be multiples of the default.

Resolves issue mathjax/MathJax#2381.