### PR TITLE
Fix problem with \rightarrow being converted to \vec in some cases.  (mathjax/MathJax#2380)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -130,12 +130,14 @@ export class MmlMo extends AbstractMmlTokenNode {
      *                    with this node as its core
      */
     public coreParent() {
-        let parent: MmlNode = this;
+        let embellished = this as MmlNode;
+        let parent = this as MmlNode;
         let math = this.factory.getNodeClass('math');
         while (parent && parent.isEmbellished && parent.coreMO() === this && !(parent instanceof math)) {
+            embellished = parent;
             parent = (parent as MmlNode).Parent;
         }
-        return parent;
+        return embellished;
     }
 
     /**
@@ -170,7 +172,7 @@ export class MmlMo extends AbstractMmlTokenNode {
      */
     get isAccent() {
         let accent = false;
-        const node = this.coreParent();
+        const node = this.coreParent().parent;
         if (node) {
             const key = (node.isKind('mover') ?
                             ((node.childNodes[(node as MmlMover).over] as MmlNode).coreMO() ?

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -498,7 +498,6 @@ export class CommonWrapper<
     protected getMathMLSpacing() {
         const node = this.node.coreMO() as MmlMo;
         const attributes = node.attributes;
-        const parent = this.jax.nodeMap.get(node.coreParent());
         const isScript = (attributes.get('scriptlevel') > 0);
         this.bbox.L = (attributes.isSet('lspace') ?
                        Math.max(0, this.length2em(attributes.get('lspace'))) :

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -316,9 +316,8 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
          */
         public remapChars(chars: number[]) {
             if (chars.length === 1) {
-                const parent = this.node.parent;
-                const isAccent = this.isAccent &&
-                    (parent === (this.node as MmlMo).coreParent() || parent.isEmbellished);
+                const parent = (this.node as MmlMo).coreParent().parent;
+                const isAccent = this.isAccent && !parent.isKind('mrow');
                 const map = (isAccent ? 'accent' : 'mo');
                 const text = this.font.getRemappedChar(map, chars[0]);
                 if (text) {


### PR DESCRIPTION
Fix `MmlMo.coreParent()` to produce the documented element, and fix accent mapping to only remap when the (possibly embellished) `mo` is the only element in the accent position.

Resolves issue mathjax/MathJax#2380.