### PR TITLE
Fix positions of superscripts in "cramped" style.  (mathjax/MathJax#2395)

### DIFF
--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -325,8 +325,9 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          */
         public getU(bbox: BBox, sbox: BBox) {
             const tex = this.font.params;
-            const attr = this.node.attributes.getList('displaystyle', 'texprimestyle', 'superscriptshift');
-            const p = (attr.displaystyle ? tex.sup1 : attr.texprimestyle ? tex.sup3 : tex.sup2);
+            const attr = this.node.attributes.getList('displaystyle', 'superscriptshift', 'scriptlevel');
+            const prime = this.node.getProperty('texprimestyle');
+            const p = (prime ? tex.sup3 : attr.displaystyle ? tex.sup1 : tex.sup2);
             const superscriptshift = this.length2em(attr.superscriptshift, p);
             return Math.max(
                 this.isCharBase() ? 0 : bbox.h * bbox.rscale - tex.sup_drop * sbox.rscale,

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -325,7 +325,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
          */
         public getU(bbox: BBox, sbox: BBox) {
             const tex = this.font.params;
-            const attr = this.node.attributes.getList('displaystyle', 'superscriptshift', 'scriptlevel');
+            const attr = this.node.attributes.getList('displaystyle', 'superscriptshift');
             const prime = this.node.getProperty('texprimestyle');
             const p = (prime ? tex.sup3 : attr.displaystyle ? tex.sup1 : tex.sup2);
             const superscriptshift = this.length2em(attr.superscriptshift, p);

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -327,7 +327,7 @@ export function CommonScriptbaseMixin<W extends AnyWrapper,
             const tex = this.font.params;
             const attr = this.node.attributes.getList('displaystyle', 'superscriptshift');
             const prime = this.node.getProperty('texprimestyle');
-            const p = (prime ? tex.sup3 : attr.displaystyle ? tex.sup1 : tex.sup2);
+            const p = prime ? tex.sup3 : (attr.displaystyle ? tex.sup1 : tex.sup2);
             const superscriptshift = this.length2em(attr.superscriptshift, p);
             return Math.max(
                 this.isCharBase() ? 0 : bbox.h * bbox.rscale - tex.sup_drop * sbox.rscale,


### PR DESCRIPTION
Get `texprimestyle` from the property list, not the attribute list.  Also, fix the handling of D' style (display prime), which should also be cramped.

Resolves issue mathjax/MathJax#2395.