### PR TITLE
Correct menu name being disabled.  (mathjax/MathJax-demos-node#10)

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -558,7 +558,7 @@ export class Menu {
                     menu.findID('Settings', 'Renderer', name).disable();
                 }
             }
-            menu.findID('Accessibility', 'Explorer').disable();
+            menu.findID('Accessibility', 'Activate').disable();
             menu.findID('Accessibility', 'AutoCollapse').disable();
             menu.findID('Accessibility', 'Collapsible').disable();
         }


### PR DESCRIPTION
Fix name of menu to disable when components aren't being used, now that Explorer menu has been condensed.

Resolves issue mathjax/MathJax-demos-node#10.