### PR TITLE
Adapts Menu entry to new reduced number of ChromeVox styles in SRE.

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -471,8 +471,7 @@ export class Menu {
                                 ['clearspeak-default', 'Auto']
                             ])),
                             this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechRules', [
-                                ['default-default', 'Verbose'],
-                                ['default-short', 'Short'],
+                                ['default-default', 'Standard'],
                                 ['default-alternative', 'Alternative']
                             ]))
                         ]),


### PR DESCRIPTION
SRE now only offers two styles for ChromeVox speech rules:
* `default` (here called Standard) which used to be `short`, and was always the default setting.
* `alternative` that gives alternative readings to some characters and rules. As before.