### PR TITLE
Fix problem with horizontal stretchy extenders.  (mathjax/MathJax#2400).

### DIFF
--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -54,6 +54,7 @@ export class CHTMLmo<N, T, D> extends CommonMoMixin<CHTMLConstructor<any, any, a
             transform: 'scalex(1.0000001)'        // improves blink positioning
         },
         'mjx-stretchy-h > * > mjx-c::before': {
+            display: 'inline-block',
             padding: '.001em 0',                  // for blink
             width: 'initial'
         },


### PR DESCRIPTION
The extenders were not being placed in the proper position because the display value had been checked to block, so set it explicitly to inline-block.

Resolves issue mathjax/MathJax#2400.