### PR TITLE
Fix issue with \overbrace in SVG output (mathjax/MathJax#2402)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -699,17 +699,18 @@ export class CommonWrapper<
     }
 
     /**
-     * @param {string} text     The text to turn into unicode locations
-     * @param {string} variant  The name of the variant for the characters
-     * @return {number[]}  Array of numbers represeting the string's unicode character positions
+     * @param {string} text   The text to turn into unicode locations
+     * @param {string} name   The name of the variant for the characters
+     * @return {number[]}     Array of numbers represeting the string's unicode character positions
      */
-    protected unicodeChars(text: string, variant: string = '') {
+    protected unicodeChars(text: string, name: string = this.variant) {
         let chars = unicodeChars(text);
         //
         //  Remap to Math Alphanumerics block
         //
-        const map = this.font.getVariant(variant).chars;
-        if (map) {
+        const variant = this.font.getVariant(name);
+        if (variant && variant.chars) {
+            const map = variant.chars;
             //
             //  Is map[n] doesn't exist, (map[n] || []) still gives an CharData array.
             //  If the array doesn't have a CharOptions element use {} instead.

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -278,7 +278,7 @@ CommonWrapper<
             const g = this.adaptor.append(parent, this.svg('g', {'data-c': C}));
             this.place(x, y, g);
             x = 0;
-            for (const n of this.unicodeChars(data.c)) {
+            for (const n of this.unicodeChars(data.c, variant)) {
                 x += this.placeChar(n, x, y, g, variant);
             }
         } else if (data.unknown) {


### PR DESCRIPTION
This fixes a problem with not passing the variant name to `unicodeChars()` in the SVG `Wrapper.ts`, and also improves error checking in `unicodeChars()` to avoid similar problems in the future.

Resolves issue mathjax/MathJax#2402.