### PR TITLE
Change require() to import to avoid typescript/tslint warnings

### DIFF
--- a/ts/a11y/speech-rule-engine.d.ts
+++ b/ts/a11y/speech-rule-engine.d.ts
@@ -1,0 +1,3 @@
+declare module 'speech-rule-engine' {
+  export function engineReady(): boolean;
+}

--- a/ts/a11y/sre-node.ts
+++ b/ts/a11y/sre-node.ts
@@ -32,13 +32,12 @@ declare const global: any;
 global.SRE = SRE;
 global.sre = Object.create(SRE);
 global.sre.Engine = {
-    /**
-     * @return {boolean}   True when SRE is ready
-     */
-    isReady(): boolean {
-        return SRE.engineReady();
-    }
+  /**
+   * @return {boolean}   True when SRE is ready
+   */
+  isReady(): boolean {
+    return SRE.engineReady();
+  }
 };
 
 export {};
-

--- a/ts/a11y/sre-node.ts
+++ b/ts/a11y/sre-node.ts
@@ -22,15 +22,23 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-declare const require: (name: string) => any;
-
-const Sre = require('speech-rule-engine');
+import * as SRE from 'speech-rule-engine';
 
 declare const global: any;
 
 /**
  * The global sre with sre.Engine.isReady() and sre.toEnriched()
  */
-global.SRE = Sre;
-global.sre = Object.create(Sre);
-global.sre.Engine = {isReady() {return Sre.engineReady()}};
+global.SRE = SRE;
+global.sre = Object.create(SRE);
+global.sre.Engine = {
+    /**
+     * @return {boolean}   True when SRE is ready
+     */
+    isReady(): boolean {
+        return SRE.engineReady();
+    }
+};
+
+export {};
+

--- a/ts/util/asyncLoad/node.ts
+++ b/ts/util/asyncLoad/node.ts
@@ -22,11 +22,10 @@
  */
 
 import {mathjax} from '../../mathjax.js';
+import * as path from 'path';
 
 declare var require: (name: string) => any;
 declare var __dirname: string;
-
-const path = require('path');
 
 const root = path.dirname(path.dirname(__dirname));
 

--- a/ts/util/asyncLoad/node.ts
+++ b/ts/util/asyncLoad/node.ts
@@ -30,8 +30,7 @@ declare var __dirname: string;
 const root = path.dirname(path.dirname(__dirname));
 
 if (!mathjax.asyncLoad && typeof require !== 'undefined') {
-    mathjax.asyncLoad = (name: string) => {
-        return require(name.charAt(0) === '.' ? path.resolve(root, name) : name);
-    };
+  mathjax.asyncLoad = (name: string) => {
+    return require(name.charAt(0) === '.' ? path.resolve(root, name) : name);
+  };
 }
-

--- a/ts/util/asyncLoad/path.d.ts
+++ b/ts/util/asyncLoad/path.d.ts
@@ -1,0 +1,4 @@
+declare module 'path' {
+    export function dirname(dir: string): string;
+    export function resolve(root: string, name: string): string;
+}


### PR DESCRIPTION
This changes two node-specific files (`a11y/sre-node.ts` and `util/asyncLoad/node.js`) that had been using `require()` to using `import` instead (to avoid typescript/tslint warnings).  In order to make that work, this also adds minimal `.d.ts` files to clear the parts that we need.