### PR TITLE
Fix CHTML handling of MJXZERO font prefix

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -23,7 +23,7 @@
 
 import {CommonOutputJax} from './common/OutputJax.js';
 import {CommonWrapper} from './common/Wrapper.js';
-import {StyleList, Styles} from '../util/Styles.js';
+import {StyleList} from '../util/Styles.js';
 import {StyleList as CssStyleList} from './common/CssStyles.js';
 import {OptionList} from '../util/Options.js';
 import {MathDocument} from '../core/MathDocument.js';
@@ -32,7 +32,6 @@ import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {CHTMLWrapper} from './chtml/Wrapper.js';
 import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
 import {CHTMLFontData} from './chtml/FontData.js';
-import {CssFontData} from './common/FontData.js';
 import {TeXFont} from './chtml/fonts/tex.js';
 import * as LENGTHS from '../util/lengths.js';
 import {unicodeChars} from '../util/string.js';
@@ -230,23 +229,5 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
     adaptor.remove(node);
     return {w: w, h: .75, d: .2};
   }
-
-  /**
-   * @override
-   */
-  public getFontData(styles: Styles) {
-    const font = super.getFontData(styles);
-    font[0] = 'MJXZERO, ' + font[0];
-    return font;
-  }
-
-  /**
-   * @override
-   */
-  public cssFontStyles(font: CssFontData, styles: StyleList = {}) {
-    font[0] = 'MJXZERO, ' + font[0];
-    return super.cssFontStyles(font, styles);
-  }
-
 
 }

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -715,6 +715,14 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   }
 
   /**
+   * @param {string} family   The font camily to use
+   * @return {string}         The family with the css prefix
+   */
+  public getFamily(family: string): string {
+    return (this.cssFamilyPrefix ? this.cssFamilyPrefix + ', ' + family : family);
+  }
+
+  /**
    * @param {string} name   The name of the map to query
    * @param {number} c      The character to remap
    * @return {string}       The remapped character (or the original)

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -608,7 +608,7 @@ export abstract class CommonOutputJax<
    */
   public cssFontStyles(font: CssFontData, styles: StyleList = {}): StyleList {
     const [family, italic, bold] = font;
-    styles['font-family'] = this.font.cssFamilyPrefix + ', ' + family;
+    styles['font-family'] = this.font.getFamily(family);
     if (italic) styles['font-style'] = 'italic';
     if (bold) styles['font-weight'] = 'bold';
     return styles;
@@ -622,7 +622,7 @@ export abstract class CommonOutputJax<
     if (!styles) {
       styles = new Styles();
     }
-    return [styles.get('font-family'),
+    return [this.font.getFamily(styles.get('font-family')),
             styles.get('font-style') === 'italic',
             styles.get('font-weight') === 'bold'] as CssFontData;
   }


### PR DESCRIPTION
Removes CHTML overrides that cause MJXZERO to be added repeatedly to the font family of unknown characters, and creates a service routine in FontData to ad the prefix, if any.  (This is why the comma was part of the prefix originally, because the SVG output doesn't have one, and we don't want the extra comma in that case.)