### PR TITLE
Fix problems with mtextInheritFont, and provide new mtextFont option (mathjax/MathJax#2189)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -475,6 +475,14 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
   /**
    * @override
    */
+  public fontFamily(node: N) {
+    const style = this.window.getComputedStyle(node);
+    return style.fontFamily || '';
+  }
+
+  /**
+   * @override
+   */
   public nodeSize(node: N, em: number = 1, local: boolean = false) {
     if (local && node.getBBox) {
       let {width, height} = node.getBBox();

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -40,7 +40,8 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
    * The default options
    */
   public static OPTIONS: OptionList = {
-    fontSize: 16,      // we can't compute the font size, so always use this
+    fontSize: 16,        // We can't compute the font size, so always use this
+    fontFamily: 'Times'  // We can't compute the font family, so always use this
   };
 
   /**
@@ -533,6 +534,13 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
    */
   public fontSize(_node: LiteElement) {
     return this.options.fontSize;
+  }
+
+  /**
+   * @override
+   */
+  public fontFamily(_node: LiteElement) {
+    return this.options.fontFamily;
   }
 
   /**

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -317,6 +317,12 @@ export interface DOMAdaptor<N, T, D> {
   fontSize(node: N): number;
 
   /**
+   * @param {N} node        The HTML node whose font family is to be determined
+   * @return {string}       The font family
+   */
+  fontFamily(node: N): string;
+
+  /**
    * @param {N} node            The HTML node whose dimensions are to be determined
    * @param {number} em         The number of pixels in an em
    * @param {boolean} local     True if local coordinates are to be used in SVG elements
@@ -596,6 +602,11 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * @override
    */
   public abstract fontSize(node: N): number;
+
+  /**
+   * @override
+   */
+  public abstract fontFamily(node: N): string;
 
   /**
    * @override

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -36,11 +36,15 @@ import {StyleList as CssStyleList} from './CssStyles.js';
 
 /*****************************************************************/
 
+export interface ExtendedMetrics extends Metrics {
+  family: string;     // the font family for the surrounding text
+}
+
 /**
  * Maps linking a node to the test node it contains,
  *  and a map linking a node to the metrics within that node.
  */
-export type MetricMap<N> = Map<N, Metrics>;
+export type MetricMap<N> = Map<N, ExtendedMetrics>;
 type MetricDomMap<N> = Map<N, N>;
 
 /**
@@ -85,7 +89,9 @@ export abstract class CommonOutputJax<
     minScale: .5,                  // smallest scaling factor to use
     matchFontHeight: true,         // true to match ex-height of surrounding font
     mtextInheritFont: false,       // true to make mtext elements use surrounding font
-    merrorInheritFont: true,       // true to make merror text use surrounding font
+    merrorInheritFont: false,      // true to make merror text use surrounding font
+    mtextFont: '',                 // font to use for mtext, if not inheriting (empty means use MathJax fonts)
+    merrorFont: 'Times',           // font to use for merror, if not inheriting (empty means use MathJax fonts)
     mathmlSpacing: false,          // true for MathML spacing rules, false for TeX rules
     skipAttributes: {},            // RFDa and other attributes NOT to copy to the output
     exFactor: .5,                  // default size of ex in em units
@@ -286,8 +292,14 @@ export abstract class CommonOutputJax<
       const parent = adaptor.parent(math.start.node);
       if (math.state() < STATE.METRICS && parent) {
         const map = maps[math.display ? 1 : 0];
-        const {em, ex, containerWidth, lineWidth, scale} = map.get(parent);
+        const {em, ex, containerWidth, lineWidth, scale, family} = map.get(parent);
         math.setMetrics(em, ex, containerWidth, lineWidth, scale);
+        if (this.options.mtextInheritFont) {
+          math.outputData.mtextFamily = family;
+        }
+        if (this.options.merrorInheritFont) {
+          math.outputData.merrorFamily = family;
+        }
         math.state(STATE.METRICS);
       }
     }
@@ -298,9 +310,10 @@ export abstract class CommonOutputJax<
    * @param {boolean} display   True if the metrics are for displayed math
    * @return {Metrics}          Object containing em, ex, containerWidth, etc.
    */
-  public getMetricsFor(node: N, display: boolean): Metrics {
+  public getMetricsFor(node: N, display: boolean): ExtendedMetrics {
+    const getFamily = (this.options.mtextInheritFont || this.options.merrorInheritFont);
     const test = this.getTestElement(node, display);
-    const metrics = this.measureMetrics(test);
+    const metrics = this.measureMetrics(test, getFamily);
     this.adaptor.remove(test);
     return metrics;
   }
@@ -333,10 +346,11 @@ export abstract class CommonOutputJax<
     //
     // Measure the metrics for all the mapped elements
     //
+    const getFamily = this.options.mtextInheritFont || this.options.merrorInheritFont;
     const maps = [new Map() as MetricMap<N>, new Map() as MetricMap<N>];
     for (const i of maps.keys()) {
       for (const node of domMaps[i].keys()) {
-        maps[i].set(node, this.measureMetrics(domMaps[i].get(node)));
+        maps[i].set(node, this.measureMetrics(domMaps[i].get(node), getFamily));
       }
     }
     //
@@ -401,11 +415,13 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @param {N} node    The test node to measure
-   * @return {Metrics}  The metric data for the given node
+   * @param {N} node              The test node to measure
+   * @param {boolean} getFamily   True if font family of surroundings is to be determined
+   * @return {ExtendedMetrics}    The metric data for the given node
    */
-  protected measureMetrics(node: N): Metrics {
+  protected measureMetrics(node: N, getFamily: boolean): ExtendedMetrics {
     const adaptor = this.adaptor;
+    const family = (getFamily ? adaptor.fontFamily(node) : '');
     const em = adaptor.fontSize(node);
     const ex = (adaptor.nodeSize(adaptor.childNode(node, 1) as N)[1] / 60) || (em * this.options.exFactor);
     const containerWidth = (adaptor.getStyle(node, 'display') === 'table' ?
@@ -415,7 +431,7 @@ export abstract class CommonOutputJax<
     const scale = Math.max(this.options.minScale,
                            this.options.matchFontHeight ? ex / this.font.params.x_height / em : 1);
     const lineWidth = 1000000;      // no linebreaking (otherwise would be a percentage of cwidth)
-    return {em, ex, containerWidth, lineWidth, scale};
+    return {em, ex, containerWidth, lineWidth, scale, family};
   }
 
   /*****************************************************************/
@@ -547,21 +563,23 @@ export abstract class CommonOutputJax<
    * @param {string} chars   The string contained in the text node
    * @return {UnknownBBox}   The width, height and depth for the text
    */
-  public measureTextNodeWithCache(text: N, chars: string, variant: string,
-                                  font: CssFontData = ['', false, false]): UnknownBBox {
-                                    if (variant === '-explicitFont') {
-                                      variant = [font[0], font[1] ? 'T' : 'F', font[2] ? 'T' : 'F', ''].join('-');
-                                    }
-                                    if (!this.unknownCache.has(variant)) {
-                                      this.unknownCache.set(variant, new Map());
-                                    }
-                                    const map = this.unknownCache.get(variant);
-                                    const cached = map.get(chars);
-                                    if (cached) return cached;
-                                    const bbox = this.measureTextNode(text);
-                                    map.set(chars, bbox);
-                                    return bbox;
-                                  }
+  public measureTextNodeWithCache(
+    text: N, chars: string, variant: string,
+    font: CssFontData = ['', false, false]
+  ): UnknownBBox {
+    if (variant === '-explicitFont') {
+      variant = [font[0], font[1] ? 'T' : 'F', font[2] ? 'T' : 'F', ''].join('-');
+    }
+    if (!this.unknownCache.has(variant)) {
+      this.unknownCache.set(variant, new Map());
+    }
+    const map = this.unknownCache.get(variant);
+    const cached = map.get(chars);
+    if (cached) return cached;
+    const bbox = this.measureTextNode(text);
+    map.set(chars, bbox);
+    return bbox;
+  }
 
   /**
    * Measure the width of a text element by placing it in the page


### PR DESCRIPTION
This PR fixes the long-standing issues with `mtextInheritFont` (and the little-known `merrorInheritFont`) option.  To do so, we need to look up the font of the surrounding text, and so so during the process of getting the metrics of the surrounding font.  That requires an additional function for the DOMadaptor (`fontFamily()`).

Because looking up the font requires computing the styles for the container, which is expensive, new `mtextFont` and `merrorFont` options are also provided to specify an explicit font to use for `mtext` and `merror` elements, avoiding the need to look these up (this will need to be documented).  Originally, `merrorInheritFont` was set to `true`, but because of the added expense of looking up the font, this has been changed to `false`, and the `merrorFont` is set to `Times`.  The inherit options override the explicit font settings so that you can get inherited fonts for the errors without having to unset `merrorFont`.

There was some duplication of font data in the `INHERITFONT` object in the `mtext` wrapper and the `cssFontMap` object in the FontData class.  I have removed the data from `mtext`, and left only the four that are needed to allow the inherited font to override the `normal`, `italic`, `bold` and `bold-italic` mathvariants.

Finally, a function that was badly formatted is re-indented here.

Resolves issue mathjax/MathJax#2189