### PR TITLE
Handle classList when elements don't have it. (mathjax/MathJax#2411)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -64,6 +64,7 @@ export interface MinHTMLElement<N, T> {
   offsetHeight: number;
 
   attributes: AttributeData[] | NamedNodeMap;
+  className: string;
   classList: DOMTokenList;
   style: OptionList;
 
@@ -426,21 +427,32 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public addClass(node: N, name: string) {
-    node.classList.add(name);
+    if (node.classList) {
+      node.classList.add(name);
+    } else {
+      node.className = (node.className + ' ' + name).trim();
+    }
   }
 
   /**
    * @override
    */
   public removeClass(node: N, name: string) {
-    return node.classList.remove(name);
+    if (node.classList) {
+      node.classList.remove(name);
+    } else {
+      node.className = node.className.split(/ /).filter((c) => c !== name).join(' ');
+    }
   }
 
   /**
    * @override
    */
   public hasClass(node: N, name: string) {
-    return node.classList.contains(name);
+    if (node.classList) {
+      return node.classList.contains(name);
+    }
+    return node.className.split(/ /).indexOf(name) >= 0;
   }
 
   /**

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -282,7 +282,7 @@ export interface DOMAdaptor<N, T, D> {
    * @param {string} name   The class to test
    * @return {boolean}      True if the node has the given class
    */
-  hasClass(node: N, name: string): void;
+  hasClass(node: N, name: string): boolean;
 
   /**
    * @param {N} node        The HTML node whose class list is needed


### PR DESCRIPTION
This uses manipulations of `className` in place of `classList` when elements don't have a class list (e.g., IE11 SVG elements).  It also fixes an incorrect return type for `hasClass()` in the interface, and no longer (incorrectly) returns a value for `removeClass()`.

Resolves issue mathjax/MathJax#2411.