### PR TITLE
Add TeX error as data-mjx-error, similar to compile/typeset errors

### DIFF
--- a/ts/input/tex/NodeFactory.ts
+++ b/ts/input/tex/NodeFactory.ts
@@ -140,7 +140,7 @@ export class NodeFactory {
   public static createError(factory: NodeFactory, message: string): MmlNode  {
     let text = factory.create('text', message);
     let mtext = factory.create('node', 'mtext', [], {}, text);
-    let error = factory.create('node', 'merror', [mtext]);
+    let error = factory.create('node', 'merror', [mtext], {'data-mjx-error': message});
     return error;
   }
 


### PR DESCRIPTION
This PR adds a `data-mjx-error` attribute (like the one for compile/typeset errors and like the `no errors` extension) that contains the error message.  This makes the error message consistently available via the `data-mjx-error` attribute of the `merror` element, for easier error processing later.  (E.g., the contextual menu could use this to report the error.)
