### PR TITLE
General improvements to input/output errors

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -735,7 +735,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
    */
   public compileError(math: MathItem<N, T, D>, err: Error) {
     math.root = this.mmlFactory.create('math', null, [
-      this.mmlFactory.create('merror', {'data-mjx-error': err.message}, [
+      this.mmlFactory.create('merror', {'data-mjx-error': err.message, title: err.message}, [
         this.mmlFactory.create('mtext', null, [
           (this.mmlFactory.create('text') as TextNode).setText('Math input error')
         ])
@@ -744,6 +744,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     if (math.display) {
       math.root.attributes.set('display', 'block');
     }
+    math.inputData.error = err.message;
   }
 
   /**
@@ -774,10 +775,32 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
    * @param {Error} err      The Error object for the error
    */
   public typesetError(math: MathItem<N, T, D>, err: Error) {
-    math.typesetRoot = this.adaptor.node('span',
-                                         {'data-mjx-error': err.message},
-                                         [this.adaptor.text('Math output error')]);
-    math.isEscaped = true;
+    math.typesetRoot = this.adaptor.node('mjx-container', {
+      class: 'MathJax mjx-output-error',
+      jax: this.outputJax.name,
+    }, [
+      this.adaptor.node('span', {
+        'data-mjx-error': err.message,
+        title: err.message,
+        style: {
+          color: 'red',
+          'background-color': 'yellow',
+          'line-height': 'normal'
+        }
+      }, [
+        this.adaptor.text('Math output error')
+      ])
+    ]);
+    if (math.display) {
+      this.adaptor.setAttributes(math.typesetRoot, {
+        style: {
+          display: 'block',
+          margin: '1em 0',
+          'text-align': 'center'
+        }
+      });
+    }
+    math.outputData.error = err.message;
   }
 
   /**

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -173,7 +173,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @override
    */
   public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode {
-xxx();
     this.parseOptions.clear();
     this.executeFilters(this.preFilters, math, document, this.parseOptions);
     let display = math.display;

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -173,6 +173,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @override
    */
   public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode {
+xxx();
     this.parseOptions.clear();
     this.executeFilters(this.preFilters, math, document, this.parseOptions);
     let display = math.display;

--- a/ts/input/tex/noerrors/NoErrorsConfiguration.ts
+++ b/ts/input/tex/noerrors/NoErrorsConfiguration.ts
@@ -35,7 +35,7 @@ import {NodeFactory} from '../NodeFactory.js';
 function noErrors(factory: NodeFactory,
                   message: string, _id: string, expr: string) {
   let mtext = factory.create('token', 'mtext', {}, expr.replace(/\n/g, ' '));
-  let error = factory.create('node', 'merror', [mtext], {'data-mjx-error': message});
+  let error = factory.create('node', 'merror', [mtext], {'data-mjx-error': message, title: message});
   return error;
 }
 

--- a/ts/output/svg/Wrappers/merror.ts
+++ b/ts/output/svg/Wrappers/merror.ts
@@ -60,13 +60,13 @@ export class SVGmerror<N, T, D> extends SVGWrapper<N, T, D> {
   public toSVG(parent: N) {
     const svg = this.standardSVGnode(parent);
     const {h, d, w} = this.getBBox();
-    const rect = this.adaptor.append(this.element, this.svg('rect', {
+    this.adaptor.append(this.element, this.svg('rect', {
       'data-background': true,
       width: this.fixed(w), height: this.fixed(h + d), y: this.fixed(-d)
     }));
     const title = this.node.attributes.get('title') as string;
     if (title) {
-      this.adaptor.append(rect, this.svg('title', {}, [this.adaptor.text(title)]));
+      this.adaptor.append(this.element, this.svg('title', {}, [this.adaptor.text(title)]));
     }
     this.addChildren(svg);
   }

--- a/ts/output/svg/Wrappers/merror.ts
+++ b/ts/output/svg/Wrappers/merror.ts
@@ -60,10 +60,14 @@ export class SVGmerror<N, T, D> extends SVGWrapper<N, T, D> {
   public toSVG(parent: N) {
     const svg = this.standardSVGnode(parent);
     const {h, d, w} = this.getBBox();
-    this.adaptor.append(this.element, this.svg('rect', {
+    const rect = this.adaptor.append(this.element, this.svg('rect', {
       'data-background': true,
       width: this.fixed(w), height: this.fixed(h + d), y: this.fixed(-d)
     }));
+    const title = this.node.attributes.get('title') as string;
+    if (title) {
+      this.adaptor.append(rect, this.svg('title', {}, [this.adaptor.text(title)]));
+    }
     this.addChildren(svg);
   }
 


### PR DESCRIPTION
This PR improves the formatting of 'Math output error' messages (to make them display like other errors, and to allow the contextual menu to be used, and to not cause errors with assistive-mml).  The message is also stored in the `inputData`/`outputData` object for easier retrieval, if needed.

It also adds tooltips to the input and output errors to give the message for the error that occurred, and adds a similar tooltip to the `noerrors` output so that it is easier to get the TeX error that caused the problem.  The SVG output jax's `merror` wrapper is modified to move the message to a `<title>` element where it will be displayed by the browser as a tool tip.

For `noerrors` output, it would be nice to be able to save the message in the MathItem's `inputData` object, but since the TeX input jax's `formatError()` method doesn't have access to the MathItem, that can't be done.  It would be nice to change that (see #483).