### PR TITLE
Jsdoc lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjax-full",
-  "version": "3.0.1",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -136,7 +136,7 @@ export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
 /**
  * The mixin for adding assistive MathML to MathDocuments
  *
- * @param {B} BaseMathDocument         The MathDocument class to be extended
+ * @param {B} BaseDocument         The MathDocument class to be extended
  * @return {AssistiveMMlMathDocument}  The Assistive MathML MathDocument class
  *
  * @template N  The HTMLElement node class

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -127,7 +127,7 @@ export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
   /**
    * Add assistive MathML to the MathItems in the MathDocument
    *
-   * @return {AssisiitveMmlMathDocument}   The MathDocument (so calls can be chained)
+   * @return {AssistiveMmlMathDocument}   The MathDocument (so calls can be chained)
    */
   assistiveMml(): AssistiveMmlMathDocument<N, T, D>;
 
@@ -137,7 +137,7 @@ export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
  * The mixin for adding assistive MathML to MathDocuments
  *
  * @param {B} BaseDocument         The MathDocument class to be extended
- * @return {AssistiveMMlMathDocument}  The Assistive MathML MathDocument class
+ * @return {AssistiveMmlMathDocument}  The Assistive MathML MathDocument class
  *
  * @template N  The HTMLElement node class
  * @template T  The Text node class

--- a/ts/a11y/complexity.ts
+++ b/ts/a11y/complexity.ts
@@ -60,7 +60,7 @@ newState('COMPLEXITY', 40);
 export interface ComplexityMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
 
   /**
-   * @param {ComplexityMathDocument} docuemnt   The MathDocument for the MathItem
+   * @param {ComplexityMathDocument} document   The MathDocument for the MathItem
    */
   complexity(document: ComplexityMathDocument<N, T, D>): void;
 
@@ -84,7 +84,7 @@ EMItemC<N, T, D>>(BaseMathItem: B, computeComplexity: (node: MmlNode) => void): 
   return class extends BaseMathItem {
 
     /**
-     * @param {ComplexityMathDocument} docuemnt   The MathDocument for the MathItem
+     * @param {ComplexityMathDocument} document   The MathDocument for the MathItem
      */
     public complexity(document: ComplexityMathDocument<N, T, D>) {
       if (this.state() < STATE.COMPLEXITY && !this.isEscaped) {

--- a/ts/a11y/complexity.ts
+++ b/ts/a11y/complexity.ts
@@ -70,6 +70,7 @@ export interface ComplexityMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
  * The mixin for adding complexity to MathItems
  *
  * @param {B} BaseMathItem       The MathItem class to be extended
+ * @param {function(MmlNode): void} computeComplexity Method of complexity computation.
  * @return {ComplexityMathItem}  The complexity MathItem class
  *
  * @template N  The HTMLElement node class
@@ -118,8 +119,7 @@ export interface ComplexityMathDocument<N, T, D> extends EnrichedMathDocument<N,
 /**
  * The mixin for adding complexity to MathDocuments
  *
- * @param {B} BaseMathDocument     The MathDocument class to be extended
- * @param {MathML} MmlJax          The MathML input jax used to convert the enriched MathML
+ * @param {B} BaseDocument     The MathDocument class to be extended
  * @return {EnrichedMathDocument}  The enriched MathDocument class
  *
  * @template N  The HTMLElement node class

--- a/ts/a11y/complexity/visitor.ts
+++ b/ts/a11y/complexity/visitor.ts
@@ -270,7 +270,7 @@ export class ComplexityVisitor extends MmlVisitor {
     /**
      * For enclose, use sum of child complexities plus some for the enclose
      *
-     * @Param {MmlNode} node   The node whose complixity is being computed
+     * @param {MmlNode} node   The node whose complixity is being computed
      * @param {boolean} save   True if the complexity is to be saved or just returned
      */
     protected visitMencloseNode(node: MmlNode, save: boolean) {

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -220,7 +220,7 @@ export interface ExplorerMathDocument extends HTMLDOCUMENT {
 /**
  * The mixin for adding the Explorer to MathDocuments
  *
- * @param {B} BaseMathDocument      The MathDocument class to be extended
+ * @param {B} BaseDocument      The MathDocument class to be extended
  * @returns {ExplorerMathDocument}  The extended MathDocument class
  */
 export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTMLDOCUMENT>>(

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -214,7 +214,7 @@ export interface EnrichedMathDocument<N, T, D> extends AbstractMathDocument<N, T
 /**
  * The mixin for adding enrichment to MathDocuments
  *
- * @param {B} BaseMathDocument     The MathDocument class to be extended
+ * @param {B} BaseDocument     The MathDocument class to be extended
  * @param {MathML} MmlJax          The MathML input jax used to convert the enriched MathML
  * @return {EnrichedMathDocument}  The enriched MathDocument class
  *

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -272,7 +272,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
    * full documents and still get a valid document.
    *
    * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
-   * @param {LiteDocuemnt} root    The document being checked
+   * @param {LiteDocument} root    The document being checked
    */
   protected checkDocument(adaptor: LiteAdaptor, root: LiteDocument) {
     let node = this.getOnlyChild(adaptor, adaptor.body(root));

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -159,7 +159,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   }
 
   /**
-   * @param {LiteELement} node   The node to be searched
+   * @param {LiteElement} node   The node to be searched
    * @param {string} id          The id of the node to look for
    * @return {LiteElement}       The child node having the given id
    */
@@ -182,7 +182,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   }
 
   /**
-   * @param {LiteELement} node   The node to be searched
+   * @param {LiteElement} node   The node to be searched
    * @param {string} name        The name of the class to find
    * @return {LiteElement[]}     The nodes with the given class
    */

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -390,7 +390,7 @@ export namespace Startup {
    *   returns the resulting promise.
    *
    * @param {string} name     The name of the input jax
-   * @param {input} INPUTJAX  The input jax itself
+   * @param {INPUTJAX} input  The input jax itself
    */
   export function makeMmlMethods(name: string, input: INPUTJAX) {
     const STATE = MathJax._.core.MathItem.STATE;
@@ -414,7 +414,7 @@ export namespace Startup {
    * The texReset() method clears the equation numbers and labels
    *
    * @param {string} name     The name of the input jax
-   * @param {input} INPUTJAX  The input jax itself
+   * @param {INPUTJAX} input  The input jax itself
    */
   export function makeResetMethod(name: string, input: INPUTJAX) {
     if (name === 'tex') {

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -66,7 +66,7 @@ export interface DOMAdaptor<N, T, D> {
   /**
    * @param {string} kind      The tag name of the HTML node to be created
    * @param {OptionList} def   The properties to set for the created node
-   * @param {(N|T)[]} content  The child nodes for the created HTML node
+   * @param {(N|T)[]} children The child nodes for the created HTML node
    * @param {string} ns        The namespace in which to create the node
    * @return {N}               The generated HTML tree
    */
@@ -293,7 +293,7 @@ export interface DOMAdaptor<N, T, D> {
   /**
    * @param {N} node        The HTML node whose style is to be changed
    * @param {string} name   The style to be set
-   * @param {string} name   The new value of the style
+   * @param {string} value  The new value of the style
    */
   setStyle(node: N, name: string, value: string): void;
 

--- a/ts/core/InputJax.ts
+++ b/ts/core/InputJax.ts
@@ -71,12 +71,12 @@ export interface InputJax<N, T, D> {
   mmlFactory: MmlFactory;
 
   /**
-   * @param {DOMAdaptor}  The adaptor to use in this jax
+   * @param {DOMAdaptor} adaptor The adaptor to use in this jax
    */
   setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
 
   /**
-   * @param {MmlFactory}  The MmlFactory to use in this jax
+   * @param {MmlFactory} mmlFactory The MmlFactory to use in this jax
    */
   setMmlFactory(mmlFactory: MmlFactory): void;
 
@@ -99,6 +99,7 @@ export interface InputJax<N, T, D> {
    * Convert the math in a math item into the internal format
    *
    * @param {MathItem} math  The MathItem whose math content is to processed
+   * @param {MathDocument} document The MathDocument for this input jax.
    * @return {MmlNode}       The resulting internal node tree for the math
    */
   compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode;

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -109,7 +109,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
   /**
    * Creates a new RenderList from an initial list of rendering actions
    *
-   * @param {RenderActions}   The list of actions to take during render(), rerender(), and convert() calls
+   * @param {RenderActions} actions The list of actions to take during render(), rerender(), and convert() calls
    * @returns {RenderList}    The newly created prioritied list
    */
   public static create<N, T, D>(actions: RenderActions<N, T, D>): RenderList<N, T, D> {
@@ -389,6 +389,7 @@ export interface MathDocument<N, T, D> {
    * Set the state of the document (allowing you to roll back
    *  the state to a previous one, if needed).
    *
+   * @param {number} state     The new state of the document
    * @param {boolean} restore  True if the original math should be put
    *                            back into the document during the rollback
    * @return {MathDocument}    The math document instance

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -182,7 +182,7 @@ export interface MathItem<N, T, D> {
    * Removes the typeset version from the document, optionally replacing the original
    * form of the expression and its delimiters.
    *
-   * @param {boolena} restore  True if the original version is to be restored
+   * @param {boolean} restore  True if the original version is to be restored
    */
   removeFromDocument(restore: boolean): void;
 

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -698,6 +698,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
    *
    * @param {string} message         The error message to use
    * @param {PropertyList} options   The options telling how much to verify
+   * @param {boolean} short          True means use just the kind if not using full errors
    */
   public mError(message: string, options: PropertyList, short: boolean = false) {
     if (this.parent && this.parent.isKind('merror')) {
@@ -1083,7 +1084,6 @@ export abstract class AbstractMmlEmptyNode extends AbstractEmptyNode implements 
   /**
    * No children or attributes, so ignore this call.
    *
-   * @param {MmlNode} node          The node tree to be checked
    * @param {PropertyList} options  The opritons for the check
    */
   public verifyTree(_options: PropertyList) {}
@@ -1171,6 +1171,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
 
   /**
    * @param {object} xml  The XML content to be saved
+   * @param {DOMAdaptor} adaptor DOM adaptor for the content
    * @return {XMLNode}  The XML node (for chaining of method calls)
    */
   public setXML(xml: Object, adaptor: DOMAdaptor<any, any, any> = null): XMLNode {

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -165,7 +165,7 @@ export interface MmlNode extends Node {
    *                                    from which they came)
    * @param {boolean} display           The displaystyle to inherit
    * @param {number} level              The scriptlevel to inherit
-   * @param {bookean} prime             The TeX prime style to inherit (T vs. T', etc).
+   * @param {boolean} prime             The TeX prime style to inherit (T vs. T', etc).
    */
   setInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean): void;
 
@@ -596,7 +596,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
    *                                    from which they came)
    * @param {boolean} display           The displaystyle to inherit
    * @param {number} level              The scriptlevel to inherit
-   * @param {bookean} prime             The TeX prime style to inherit (T vs. T', etc).
+   * @param {boolean} prime             The TeX prime style to inherit (T vs. T', etc).
    */
   protected setChildInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {
     for (const child of this.childNodes) {

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -137,7 +137,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
    *   Add the end tag with proper spacing (empty tags have the close tag following directly)
    *
    * @param {MmlNode} node    The node to visit
-   * @param {Element} parent  The DOM parent to which this node should be added
+   * @param {string} space    The number of spaces to use for indentation
    * @return {string}         The serialization of the given node
    */
   public visitDefault(node: MmlNode, space: string): string {
@@ -212,7 +212,9 @@ export class SerializedMmlVisitor extends MmlVisitor {
   }
 
   /**
+   * @param {PropertyList} data  The class attribute list
    * @param {string} name    The name for the data-mjx-name attribute
+   * @param {string} value   The value of the attribute
    */
   protected setDataAttribute(data: PropertyList, name: string, value: string) {
     data[DATAMJX + name] = value;

--- a/ts/core/MmlTree/TestMmlVisitor.ts
+++ b/ts/core/MmlTree/TestMmlVisitor.ts
@@ -44,7 +44,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
    *   Add the end tag with proper spacing (empty tags have the close tag following directly)
    *
    * @param {MmlNode} node  The node to visit
-   * @param {Element} parent  The DOM parent to which this node should be added
+   * @param {string} space    The number of spaces to use for indentation
    */
   public visitDefault(node: MmlNode, space: string) {
     let kind = node.kind;

--- a/ts/core/OutputJax.ts
+++ b/ts/core/OutputJax.ts
@@ -57,7 +57,7 @@ export interface OutputJax<N, T, D> {
   adaptor: DOMAdaptor<N, T, D>;
 
   /**
-   * @param {DOMAdaptor}  The adaptor to use in this jax
+   * @param {DOMAdaptor} adaptor The adaptor to use in this jax
    */
   setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
 

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -167,7 +167,7 @@ export class HTMLDomStrings<N, T, D> {
    * Add more text to the current string, and record the
    * node and its position in the string.
    *
-   * @param {T} node        The node to be pushed
+   * @param {N|T} node        The node to be pushed
    * @param {string} text   The text to be added (it may not be the actual text
    *                         of the node, if it is one of the nodes that gets
    *                         translated to text, like <br> to a newline).

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -278,7 +278,7 @@ export class MathMLCompile<N, T, D> {
    *
    * @param {MmlNode} mml      The node to be updated
    * @param {string} texClass  The texClass indicated in the MJX class identifier
-   * @param {boolena} limits   Whether MJX-fixedlimits was found in the class list
+   * @param {boolean} limits   Whether MJX-fixedlimits was found in the class list
    */
   protected texAtom(mml: MmlNode, texClass: string, limits: boolean) {
     mml.texClass = (TEXCLASS as {[name: string]: number})[texClass];

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -200,6 +200,7 @@ export class Configuration {
    *
    * @param {Configuration} config   The configuration to be registered in this one
    * @param {TeX} jax                The TeX jax where it is being registered
+   * @param {OptionList=} options    The options for the configuration.
    */
   public register(config: Configuration, jax: TeX<any, any, any>, options: OptionList = {}) {
     this.append(config);
@@ -251,7 +252,8 @@ export namespace ConfigurationHandler {
   /**
    * Adds a new configuration to the handler overwriting old ones.
    *
-   * @param {SymbolConfiguration} map Registers a new symbol map.
+   * @param {string} name The name of the configuration.
+   * @param {Configuration} map The configuration mapping.
    */
   export let set = function(name: string, map: Configuration): void {
     maps.set(name, map);
@@ -262,7 +264,7 @@ export namespace ConfigurationHandler {
    * Looks up a configuration.
    *
    * @param {string} name The name of the configuration.
-   * @return {SymbolConfiguration} The configuration with the given name or null.
+   * @return {Configuration} The configuration with the given name or null.
    */
   export let get = function(name: string): Configuration {
     return maps.get(name);

--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -35,8 +35,8 @@ namespace FilterUtil {
    * Visitor to set stretchy attributes to false on <mo> elements, if they are
    * not used as delimiters. Also wraps non-stretchy infix delimiters into a
    * TeXAtom.
-   * @param {MmlNode} node The node to rewrite.
-   * @param {ParseOptions} options The parse options.
+   * @param {MmlNode} math The node to rewrite.
+   * @param {ParseOptions} data The parse options.
    */
   export let cleanStretchy = function(arg: {math: any, data: ParseOptions}) {
     let options = arg.data;
@@ -62,8 +62,7 @@ namespace FilterUtil {
    * Visitor that removes superfluous attributes from nodes. I.e., if a node has
    * an attribute, which is also an inherited attribute it will be removed. This
    * is necessary as attributes are set bottom up in the parser.
-   * @param {MmlNode} mml The node to clean.
-   * @param {ParseOptions} options The parse options.
+   * @param {ParseOptions} data The parse options.
    */
   export let cleanAttributes = function(arg: {data: ParseOptions}) {
     let node = arg.data.root as MmlNode;
@@ -84,8 +83,7 @@ namespace FilterUtil {
   /**
    * Combine adjacent <mo> elements that are relations (since MathML treats the
    * spacing very differently)
-   * @param {MmlNode} mml The node in which to combine relations.
-   * @param {ParseOptions} options The parse options.
+   * @param {ParseOptions} data The parse options.
    */
   export let combineRelations = function(arg: {data: ParseOptions}) {
     for (let mo of arg.data.getList('mo')) {
@@ -259,7 +257,7 @@ namespace FilterUtil {
    * Visitor that rewrites in-line munderover elements with movablelimits but bases
    * that are not mo's into explicit msubsup elements.
    *
-   * @param {{data:ParseOptions}} arg   The parse options to use
+   * @param {ParseOptions} data  The parse options to use
    */
   export let moveLimits = function (arg: {data: ParseOptions}) {
     const options = arg.data;

--- a/ts/input/tex/MapHandler.ts
+++ b/ts/input/tex/MapHandler.ts
@@ -80,6 +80,7 @@ export class SubHandler {
    * @constructor
    * @param {Array.<string>} maps Names of the maps included in this
    *     configuration.
+   * @param {ParseMethod} fallback A fallback method if no map is found.
    */
   constructor(maps: string[], private _fallback: ParseMethod) {
     for (const name of maps) {
@@ -195,7 +196,7 @@ export class SubHandlers {
 
   /**
    * Sets a new configuration for the map handler.
-   * @param {Configuration} configuration A setting for the map handler.
+   * @param {Configuration} config A setting for the map handler.
    */
   constructor(config: Configuration) {
     for (const key of Object.keys(config.handler)) {

--- a/ts/input/tex/NodeUtil.ts
+++ b/ts/input/tex/NodeUtil.ts
@@ -150,7 +150,7 @@ namespace NodeUtil {
   /**
    * Returns the attribute of a node.
    * @param {MmlNode} node The node.
-   * @param {string} attribute A attribute name.
+   * @param {string} attr A attribute name.
    * @return {Property} Value of the attribute.
    */
   export function getAttribute(node: MmlNode, attr: string): Property  {

--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -127,7 +127,7 @@ namespace ParseMethods {
   /**
    * Handle delimiter.
    * @param {TexParser} parser The current tex parser.
-   * @param {Symbol} mchar The parsed symbol.
+   * @param {Symbol} delim The parsed delimiter symbol.
    */
   export function delimiter(parser: TexParser, delim: Symbol) {
     let def = delim.attributes || {};

--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -99,8 +99,8 @@ export default class ParseOptions {
 
   /**
    * @constructor
-   * @param {{[key: string]: (string|boolean)}} setting A list of option
-   *     settings. Those are added to the default options.
+   * @param {Configuration} configuration Configuration object of the current
+   *     TeX parser.
    * @param {OptionList[]} options   [TeX options, Tag options, {packages}]
    */
   public constructor(configuration: Configuration, options: OptionList[] = []) {

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -211,7 +211,7 @@ namespace ParseUtil {
    * is an <mo>, precede it by an empty <mi> to force the <mo> to
    * be infix.
    * @param {ParseOptions} configuration The current parse options.
-   * @param {MmlNodep[]} nodes The row of nodes to scan for an initial <mo>
+   * @param {MmlNode[]} nodes The row of nodes to scan for an initial <mo>
    */
   export function fixInitialMO(configuration: ParseOptions, nodes: MmlNode[]) {
     for (let i = 0, m = nodes.length; i < m; i++) {

--- a/ts/input/tex/Stack.ts
+++ b/ts/input/tex/Stack.ts
@@ -44,6 +44,7 @@ export default class Stack {
 
   /**
    * @constructor
+   * @param {StackItemFactory} factory The stack item factory.
    * @param {EnvList} _env The environment.
    * @param {boolean} inner True if parser has been called recursively.
    */

--- a/ts/input/tex/Stack.ts
+++ b/ts/input/tex/Stack.ts
@@ -45,7 +45,7 @@ export default class Stack {
   /**
    * @constructor
    * @param {StackItemFactory} factory The stack item factory.
-   * @param {EnvList} _env The environment.
+   * @param {EnvList} env The environment.
    * @param {boolean} inner True if parser has been called recursively.
    */
   constructor(private _factory: StackItemFactory,

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -100,7 +100,7 @@ export abstract class MmlStack implements NodeStack {
   /**
    * @constructor
    * @extends {NodeStack}
-   * @param {MmlNode[]} _nodes An initial list of nodes to put on the stack.
+   * @param {MmlNode[]} nodes An initial list of nodes to put on the stack.
    */
   constructor(private _nodes: MmlNode[]) { }
 

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -386,8 +386,7 @@ export abstract class BaseItem extends MmlStack implements StackItem {
   }
 
   /**
-   * Get the private environment
-   * @return {EnvList}
+   * @return {EnvList} Get the private environment
    */
   public get env(): EnvList {
     return this._env;
@@ -395,7 +394,7 @@ export abstract class BaseItem extends MmlStack implements StackItem {
 
   /**
    * Set the private environment
-   * @param {EnvList} value
+   * @param {EnvList} value New private environemt.
    */
   public set env(value: EnvList) {
     this._env = value;

--- a/ts/input/tex/Symbol.ts
+++ b/ts/input/tex/Symbol.ts
@@ -33,7 +33,7 @@ export class Symbol {
   /**
    * @constructor
    * @param {string} _symbol The symbol parsed.
-   * @param {string} char The corresponding translation.
+   * @param {string} _char The corresponding translation.
    * @param {Attributes} _attributes The attributes for the translation.
    */
   constructor(private _symbol: string, private _char: string,

--- a/ts/input/tex/Symbol.ts
+++ b/ts/input/tex/Symbol.ts
@@ -32,9 +32,9 @@ export class Symbol {
 
   /**
    * @constructor
-   * @param {string} _symbol The symbol parsed.
-   * @param {string} _char The corresponding translation.
-   * @param {Attributes} _attributes The attributes for the translation.
+   * @param {string} symbol The symbol parsed.
+   * @param {string} char The corresponding translation.
+   * @param {Attributes} attributes The attributes for the translation.
    */
   constructor(private _symbol: string, private _char: string,
               private _attributes: Attributes) {
@@ -59,9 +59,9 @@ export class Macro {
 
   /**
    * @constructor
-   * @param {string} _symbol The symbol parsed
-   * @param {ParseMethod} _func The parsing function for that symbol.
-   * @param {Args[]} _args Additional arguments for the function.
+   * @param {string} symbol The symbol parsed
+   * @param {ParseMethod} func The parsing function for that symbol.
+   * @param {Args[]} args Additional arguments for the function.
    */
   constructor(private _symbol: string, private _func: ParseMethod,
               private _args: Args[] = []) {

--- a/ts/input/tex/SymbolMap.ts
+++ b/ts/input/tex/SymbolMap.ts
@@ -57,7 +57,7 @@ export interface SymbolMap {
 
   /**
    * @param {string} symbol A symbol to parse.
-   * @return {function(string): ParseResult} A parse method for the symbol.
+   * @return {ParseMethod} A parse method for the symbol.
    */
   parserFor(symbol: string): ParseMethod;
 
@@ -200,9 +200,9 @@ export abstract class AbstractParseMap<K> extends AbstractSymbolMap<K> {
   }
 
   /**
-   *
-   * @param {string} symbol
-   * @param {T} object
+   * Sets mapping for a symbol.
+   * @param {string} symbol The symbol to map.
+   * @param {T} object The symbols value in the mapping's codomain.
    */
   public add(symbol: string, object: K) {
     this.map.set(symbol, object);

--- a/ts/input/tex/SymbolMap.ts
+++ b/ts/input/tex/SymbolMap.ts
@@ -80,8 +80,8 @@ export abstract class AbstractSymbolMap<T> implements SymbolMap {
   /**
    * @constructor
    * @implements {SymbolMap}
-   * @param {string} _name Name of the mapping.
-   * @param {ParseMethod} _parser The parser for the mappiong.
+   * @param {string} name Name of the mapping.
+   * @param {ParseMethod} parser The parser for the mappiong.
    */
   constructor(private _name: string, private _parser: ParseMethod) {
     MapHandler.register(this);
@@ -150,7 +150,7 @@ export class RegExpMap extends AbstractSymbolMap<string> {
    * @extends {AbstractSymbolMap}
    * @param {string} name Name of the mapping.
    * @param {ParseMethod} parser The parser for the mappiong.
-   * @param {RegExp} _regexp The regular expression.
+   * @param {RegExp} regexp The regular expression.
    */
   constructor(name: string, parser: ParseMethod, private _regExp: RegExp) {
     super(name, parser);

--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -219,7 +219,7 @@ export interface Tags {
    * @param {string} tag The tag content.
    * @param {boolean} noFormat True if tag should not be formatted.
    */
-  tag(tag: string, format: boolean): void;
+  tag(tag: string, noFormat: boolean): void;
 
   /**
    * Call an explicit no tag.

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -36,7 +36,8 @@ export default class TexError {
 
   /**
    * The old MathJax processing function.
-   * @param {Array.<string>} input The input message.
+   * @param {string} str The basic error message.
+   * @param {Array[]} args The arguments to be replaced in the error message.
    * @return {string} The processed error string.
    */
   private static processString(str: string, args: string[]): string {
@@ -75,7 +76,7 @@ export default class TexError {
    * @constructor
    * @param{string} id        message id (for localization)
    * @param{string} message   text of English message
-   * @param{...string} rest   any substitution arguments
+   * @param{string[]=} rest   any substitution arguments
    */
   constructor(public id: string, message: string, ...rest: string[]) {
     this.message = TexError.processString(message, rest);

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -37,7 +37,7 @@ export default class TexError {
   /**
    * The old MathJax processing function.
    * @param {string} str The basic error message.
-   * @param {Array[]} args The arguments to be replaced in the error message.
+   * @param {string[]} args The arguments to be replaced in the error message.
    * @return {string} The processed error string.
    */
   private static processString(str: string, args: string[]): string {

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -71,7 +71,7 @@ export default class TexParser {
    * @param {string} _string The string to parse.
    * @param {EnvList} env The intial environment representing the current parse
    *     state of the overall expression translation.
-   * @param {ParseOptions=} config A parser configuration.
+   * @param {ParseOptions=} configuration A parser configuration.
    */
   constructor(private _string: string, env: EnvList,
               public configuration: ParseOptions) {
@@ -153,6 +153,7 @@ export default class TexParser {
   /**
    * Checks if a symbol is contained in one of the symbol mappings of the
    * specified kind.
+   * @param {HandlerType} kind Configuration name.
    * @param {string} symbol The symbol to parse.
    * @return {boolean} True if the symbol is contained in the given types of
    *     symbol mapping.

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -68,7 +68,7 @@ export default class TexParser {
 
   /**
    * @constructor
-   * @param {string} _string The string to parse.
+   * @param {string} string The string to parse.
    * @param {EnvList} env The intial environment representing the current parse
    *     state of the overall expression translation.
    * @param {ParseOptions=} configuration A parser configuration.

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1215,6 +1215,8 @@ BaseMethods.Cr = function(parser: TexParser, name: string) {
  * Handle newline outside array.
  * @param {TexParser} parser The calling parser.
  * @param {string} name The macro name.
+ * @param {boolean} nobrackets Flag indicating if newline is followed by
+ *     brackets.
  */
 BaseMethods.CrLaTeX = function(parser: TexParser, name: string, nobrackets: boolean = false) {
   let n: string;
@@ -1357,7 +1359,7 @@ BaseMethods.BeginEnd = function(parser: TexParser, name: string) {
  * @param {string} spacing Column spacing.
  * @param {string} vspacing Row spacing.
  * @param {string} style Display or text style.
- * @param {boolean} raggedHeight Does the height need to be adjusted.
+ * @param {boolean} raggedHeight Does the height need to be adjusted?
  */
 BaseMethods.Array = function(parser: TexParser, begin: StackItem,
                              open: string, close: string, align: string,

--- a/ts/input/tex/boldsymbol/BoldsymbolConfiguration.ts
+++ b/ts/input/tex/boldsymbol/BoldsymbolConfiguration.ts
@@ -85,8 +85,7 @@ export function createBoldToken(factory: NodeFactory, kind: string,
 
 /**
  * Postprocessor to rewrite token nodes to bold font, if possible.
- * @param {MmlNode} node The node to rewrite.
- * @param {ParseOptions} options The parse options.
+ * @param {ParseOptions} data The parse options.
  */
 export function rewriteBoldTokens(arg: {data: ParseOptions}) {
   for (let node of arg.data.getList('fixBold')) {

--- a/ts/input/tex/cancel/CancelConfiguration.ts
+++ b/ts/input/tex/cancel/CancelConfiguration.ts
@@ -54,7 +54,6 @@ CancelMethods.Cancel = function(parser: TexParser, name: string, notation: strin
  * Parse function implementing \cancelto{value}[attributes]{math}
  * @param {TexParser} parser The current tex parser.
  * @param {string} name The name of the calling macro.
- * @param {string} notation The type of cancel notation to use.
  */
 
 CancelMethods.CancelTo = function(parser: TexParser, name: string) {

--- a/ts/input/tex/physics/PhysicsMethods.ts
+++ b/ts/input/tex/physics/PhysicsMethods.ts
@@ -927,6 +927,7 @@ function makeDiagMatrix(elements: string[], anti: boolean) {
  * Closes an automatic fence if one was opened.
  * @param {TexParser} parser The calling parser.
  * @param {string} fence The fence.
+ * @param {number} texclass The TeX class.
  */
 PhysicsMethods.AutoClose = function(parser: TexParser, fence: string, _texclass: number) {
   const mo = parser.create('token', 'mo', {stretchy: false}, fence);

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -372,7 +372,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
 
   /**
    * @param {StyleList} styles  The style object to add styles to
-   * @param {string} vletter    The variant class string (e.g., .mjx-b) where this character is being defined
+   * @param {string} vletter    The variant class letter (e.g., `B`, `SS`) where this character is being defined
    * @param {number} n          The unicode character being defined
    * @param {CHTMLCharData} data     The bounding box data and options for the character
    */

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -354,6 +354,8 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    * @param {StyleList} styles  The style object to add styles to
    * @param {string} c          The vertical character whose part is being added
    * @param {string} part       The name of the part (beg, ext, end, mid) that is being added
+   * @param {number} n          The unicode character to use for the part
+   * @param {boolean} force     True if padding is always enforced
    */
   protected addDelimiterHPart(styles: StyleList, c: string, part: string, n: number, force: boolean = false) {
     if (!n) return;
@@ -370,9 +372,9 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
 
   /**
    * @param {StyleList} styles  The style object to add styles to
-   * @param {string} vclass     The variant class string (e.g., .mjx-b) where this character is being defined
+   * @param {string} vletter    The variant class string (e.g., .mjx-b) where this character is being defined
    * @param {number} n          The unicode character being defined
-   * @param {CharData} data     The bounding box data and options for the character
+   * @param {CHTMLCharData} data     The bounding box data and options for the character
    */
   protected addCharStyles(styles: StyleList, vletter: string, n: number, data: CHTMLCharData) {
     const [ , , w, options] = data as [number, number, number, CHTMLCharOptions];

--- a/ts/output/chtml/Notation.ts
+++ b/ts/output/chtml/Notation.ts
@@ -36,7 +36,7 @@ export type DEFPAIR<N, T, D> = Notation.DefPair<CHTMLmenclose<N, T, D>, N>;
  *
  * @param {string} name    The name of the element to create
  * @param {string} offset  The offset direction to adjust if thickness is non-standard
- * @return {Renderer}      The renderer function for the given element name
+ * @return {RENDERER}      The renderer function for the given element name
  */
 export const RenderElement = function<N, T, D>(name: string, offset: string = ''):  RENDERER<N, T, D> {
   return ((node, _child) => {
@@ -50,8 +50,8 @@ export const RenderElement = function<N, T, D>(name: string, offset: string = ''
 };
 
 /**
- * @param {string} side   The side on which a border should appear
- * @return {DefPair}      The notation definition for the notation having a line on the given side
+ * @param {Notation.Side} side   The side on which a border should appear
+ * @return {DEFPAIR}      The notation definition for the notation having a line on the given side
  */
 export const Border = function<N, T, D>(side: Notation.Side): DEFPAIR<N, T, D> {
   return Notation.CommonBorder<CHTMLmenclose<N, T, D>, N>((node, child) => {
@@ -62,9 +62,9 @@ export const Border = function<N, T, D>(side: Notation.Side): DEFPAIR<N, T, D> {
 
 /**
  * @param {string} name    The name of the notation to define
- * @param {string} side1   The first side to get a border
- * @param {string} side2   The second side to get a border
- * @return {DefPair}       The notation definition for the notation having lines on two sides
+ * @param {Notation.Side} side1   The first side to get a border
+ * @param {Notation.Side} side2   The second side to get a border
+ * @return {DEFPAIR}       The notation definition for the notation having lines on two sides
  */
 export const Border2 = function<N, T, D>(name: string, side1: Notation.Side, side2: Notation.Side): DEFPAIR<N, T, D> {
   return Notation.CommonBorder2<CHTMLmenclose<N, T, D>, N>((node, child) => {
@@ -77,7 +77,7 @@ export const Border2 = function<N, T, D>(name: string, side1: Notation.Side, sid
 /**
  * @param {string} name  The name of the diagonal strike to define
  * @param {number} neg   1 or -1 to use with the angle
- * @return {DefPair}     The notation definition for the diagonal strike
+ * @return {DEFPAIR}     The notation definition for the diagonal strike
  */
 export const DiagonalStrike = function<N, T, D>(name: string, neg: number): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalStrike<CHTMLmenclose<N, T, D>, N>((cname: string) => (node, _child) => {
@@ -94,7 +94,7 @@ export const DiagonalStrike = function<N, T, D>(name: string, neg: number): DEFP
 
 /**
  * @param {string} name   The name of the diagonal arrow to define
- * @return {DefPair}      The notation definition for the diagonal arrow
+ * @return {DEFPAIR}      The notation definition for the diagonal arrow
  */
 export const DiagonalArrow = function<N, T, D>(name: string): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalArrow<CHTMLmenclose<N, T, D>, N>((node, arrow) => {
@@ -104,7 +104,7 @@ export const DiagonalArrow = function<N, T, D>(name: string): DEFPAIR<N, T, D> {
 
 /**
  * @param {string} name   The name of the horizontal or vertical arrow to define
- * @return {DefPair}      The notation definition for the arrow
+ * @return {DEFPAIR}      The notation definition for the arrow
  */
 export const Arrow = function<N, T, D>(name: string): DEFPAIR<N, T, D> {
   return Notation.CommonArrow<CHTMLmenclose<N, T, D>, N>((node, arrow) => {

--- a/ts/output/common/Notation.ts
+++ b/ts/output/common/Notation.ts
@@ -211,15 +211,15 @@ export const CommonBorder = function<W extends Menclose, N>(render: Renderer<W, 
 
 /**
  * @param {Renderer} render                    The function for adding the borders to the node
- * @return {(sring,string,string) => DefPair}  The function returning the notation definition
+ * @return {(sring, Side, Side) => DefPair}    The function returning the notation definition
  *                                             for the notation having lines on two sides
  */
 export const CommonBorder2 = function<W extends Menclose, N>(render: Renderer<W, N>):
 (name: string, side1: Side, side2: Side) => DefPair<W, N> {
   /**
    * @param {string} name    The name of the notation to define
-   * @param {string} side1   The first side to get a border
-   * @param {string} side2   The second side to get a border
+   * @param {Side} side1   The first side to get a border
+   * @param {Side} side2   The second side to get a border
    * @return {DefPair}       The notation definition for the notation having lines on two sides
    */
   return (name: string, side1: Side, side2: Side) => {
@@ -259,7 +259,7 @@ export const CommonBorder2 = function<W extends Menclose, N>(render: Renderer<W,
 
 /**
  * @param {string => Renderer} render      The function for adding the strike to the node
- * @return {(string, number) => DefPair}   The function returning the notation definition for the diagonal strike
+ * @return {string => DefPair}   The function returning the notation definition for the diagonal strike
  */
 export const CommonDiagonalStrike = function<W extends Menclose, N>(render: (sname: string) => Renderer<W, N>):
 DefPairF<string, W, N> {

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -170,7 +170,8 @@ export abstract class CommonOutputJax<
    * Get the cssStyle and font objects
    *
    * @param {OptionList} options         The configuration options
-   * @param {FontDataClass} defaultFont  The default FontData constructor
+   * @param {CommonWrapperFactory} defaultFactory  The default wrapper factory
+   * @param {FC} defaultFont  The default FontData constructor
    * @constructor
    */
   constructor(options: OptionList = null,
@@ -478,7 +479,7 @@ export abstract class CommonOutputJax<
    * @param {string} type      The type of HTML node to create
    * @param {OptionList} def   The properties to set on the HTML node
    * @param {(N|T)[]} content  Array of child nodes to set for the HTML node
-   * @param {string}           The namespace for the element
+   * @param {string} ns        The namespace for the element
    * @return {N}               The newly created DOM tree
    */
   public html(type: string, def: OptionList = {}, content: (N | T)[] = [], ns?: string): N {
@@ -488,7 +489,7 @@ export abstract class CommonOutputJax<
   /**
    * @param {string} text  The text string for which to make a text node
    *
-   * @return {HTMLElement}  A text node with the given text
+   * @return {T}  A text node with the given text
    */
   public text(text: string): T {
     return this.adaptor.text(text);
@@ -517,7 +518,6 @@ export abstract class CommonOutputJax<
    *
    * @param {string} text        The text to be displayed
    * @param {string} variant     The name of the variant for the text
-   * @param {CssFontData} font   The style cssText string containing the font information
    * @return {N}                 The text element containing the text
    */
   public abstract unknownText(text: string, variant: string): N;
@@ -545,6 +545,8 @@ export abstract class CommonOutputJax<
    *
    * @param {N} text         The text element to measure
    * @param {string} chars   The string contained in the text node
+   * @param {string} variant     The variant for the text
+   * @param {CssFontData} font   The style cssText string containing the font information
    * @return {UnknownBBox}   The width, height and depth for the text
    */
   public measureTextNodeWithCache(text: N, chars: string, variant: string,

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -170,7 +170,7 @@ export abstract class CommonOutputJax<
    * Get the cssStyle and font objects
    *
    * @param {OptionList} options         The configuration options
-   * @param {CommonWrapperFactory} defaultFactory  The default wrapper factory
+   * @param {CommonWrapperFactory} defaultFactory  The default wrapper factory class
    * @param {FC} defaultFont  The default FontData constructor
    * @constructor
    */
@@ -546,7 +546,7 @@ export abstract class CommonOutputJax<
    * @param {N} text         The text element to measure
    * @param {string} chars   The string contained in the text node
    * @param {string} variant     The variant for the text
-   * @param {CssFontData} font   The style cssText string containing the font information
+   * @param {CssFontData} font   The family, italic, and bold data for explicit fonts
    * @return {UnknownBBox}   The width, height and depth for the text
    */
   public measureTextNodeWithCache(text: N, chars: string, variant: string,

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -51,7 +51,7 @@ const SMALLSIZE = 2/18;
 /**
  * @param {boolean} script   The scriptlevel
  * @param {number} size      The space size
- * @return {numner}          The size clamped to SMALLSIZE when scriptlevel > 0
+ * @return {number}          The size clamped to SMALLSIZE when scriptlevel > 0
  */
 function MathMLSpace(script: boolean, size: number): number {
   return (script ? size < SMALLSIZE ? 0 : SMALLSIZE : size);
@@ -334,6 +334,7 @@ export class CommonWrapper<
    *   container width (or the child width, if none was passed).
    *   Overriden for mtables in order to compute the width.
    *
+   * @param {boolean} recompute  True if we are recomputing due to changes in children
    * @param {(number|null)=} w   The width of the container (from which percentages are computed)
    * @param {boolean=} clear     True if pwidth marker is to be cleared
    * @return {boolean}           True if a percentage width was found

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -280,7 +280,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
      * @param {number[]} WHD     The [H, D] being requested from the parent mrow
      * @param {number} HD        The full height (including symmetry, etc)
      * @param {DelimiterData} C  The delimiter data for the stretchy character
-     * @return {number[]}        The height and depth for the vertically stretched delimiter
+     * @return {[number, number]}        The height and depth for the vertically stretched delimiter
      */
     public getBaseline(WHD: number[], HD: number, C: DelimiterData): [number, number] {
       const hasWHD = (WHD.length === 2 && WHD[0] + WHD[1] === HD);

--- a/ts/output/common/Wrappers/msqrt.ts
+++ b/ts/output/common/Wrappers/msqrt.ts
@@ -171,7 +171,7 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
 
     /**
      * @param {BBox} sbox  The bounding box for the surd character
-     * @return {number[]}  The p, q, and x values for the TeX layout computations
+     * @return {[number, number]}  The p, q, and x values for the TeX layout computations
      */
     public getPQ(sbox: BBox): [number, number] {
       const t = this.font.params.rule_thickness;
@@ -185,7 +185,8 @@ export function CommonMsqrtMixin<T extends WrapperConstructor>(Base: T): MsqrtCo
     /**
      * @param {BBox} sbox  The bounding box of the surd
      * @param {number} H   The height of the root as a whole
-     * @return {number[]}  The x offset of the surd, and the height, x offset, and scale of the root
+     * @return {[number, number, number, number]} The x offset of the surd, and
+     *     the height, x offset, and scale of the root
      */
     public getRootDimens(_sbox: BBox, _H: number): [number, number, number, number] {
       return [0, 0, 0, 0];

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -729,7 +729,7 @@ export function CommonMtableMixin<
 
     /**
      * @param {number} height   The total height of the table
-     * @return {number[]}       The [height, depth] for the aligned table
+     * @return {[number, number]}  The [height, depth] for the aligned table
      */
     public getBBoxHD(height: number): [number, number] {
       const [align, row] = this.getAlignmentRow();

--- a/ts/output/common/Wrappers/mtr.ts
+++ b/ts/output/common/Wrappers/mtr.ts
@@ -56,7 +56,7 @@ export interface CommonMtr<C extends AnyWrapper> extends AnyWrapper {
   childNodes: C[];
 
   /**
-   * @param {nunber} i   The index of the child to get (skipping labels)
+   * @param {number} i   The index of the child to get (skipping labels)
    * @return {C}         The ith child node wrapper
    */
   getChild(i: number): C;

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -296,7 +296,7 @@ export function CommonScriptbaseMixin<
      *
      * @param {BBox} bbox   The bounding box of the base element
      * @param {BBox} sbox   The bounding box of the script element
-     * @return {number[]}   The horizontal and vertical offsets for the script
+     * @return {[number, number]}   The horizontal and vertical offsets for the script
      */
     public getOffset(_bbox: BBox, _sbox: BBox): [number, number] {
       return [0, 0];
@@ -358,7 +358,7 @@ export function CommonScriptbaseMixin<
      *
      * @param {BBox} basebox  The bounding box of the base
      * @param {BBox} overbox  The bounding box of the overscript
-     * @return {number[]}     The separation between their boxes, and the offset of the overscript
+     * @return {[number, number]}     The separation between their boxes, and the offset of the overscript
      */
     public getOverKU(basebox: BBox, overbox: BBox): [number, number] {
       const accent = this.node.attributes.get('accent') as boolean;
@@ -375,7 +375,7 @@ export function CommonScriptbaseMixin<
      *
      * @param {BBox} basebox   The bounding box of the base
      * @param {BBox} underbox  The bounding box of the underscript
-     * @return {number[]}      The separation between their boxes, and the offset of the underscript
+     * @return {[number, number]}      The separation between their boxes, and the offset of the underscript
      */
     public getUnderKV(basebox: BBox, underbox: BBox): [number, number] {
       const accent = this.node.attributes.get('accentunder') as boolean;

--- a/ts/output/svg/FontData.ts
+++ b/ts/output/svg/FontData.ts
@@ -76,9 +76,9 @@ export type SVGFontDataClass = typeof SVGFontData;
 
 /**
  * @param {CharMap} font        The font to augment
- * @param {StringMap} paths     The path data to use for each character
- * @param {StringMap} content   The string to use for remapped characters
- * @return {CharMap}            The augmented font
+ * @param {CharStringMap} paths     The path data to use for each character
+ * @param {CharStringMap} content   The string to use for remapped characters
+ * @return {SVGCharMap}            The augmented font
  */
 export function AddPaths(font: SVGCharMap, paths: CharStringMap, content: CharStringMap): SVGCharMap {
   for (const c of Object.keys(paths)) {

--- a/ts/output/svg/Notation.ts
+++ b/ts/output/svg/Notation.ts
@@ -62,7 +62,7 @@ export const computeLineData = {
  * The data for a given line as two endpoints: [x1, y1, x2, y1]
  *
  * @param {Menclose} node   The node whose line is to be drawn
- * @param {LineName} line   The type of line to draw for the node
+ * @param {LineName} kind   The type of line to draw for the node
  * @return {[number, number, number, number]}   The coordinates of the two nedpoints
  */
 
@@ -76,8 +76,8 @@ export const lineData = function(node: Menclose, kind: LineName): [number, numbe
 /*******************************************************************/
 
 /**
- * @param {string} name    The name of the line to create
- * @return {Renderer}      The renderer function for the given line
+ * @param {LineName} line  The name of the line to create
+ * @return {RENDERER}      The renderer function for the given line
  */
 export const RenderLine = function<N, T, D>(line: LineName): RENDERER<N, T, D> {
   return ((node, _child) => {
@@ -88,8 +88,8 @@ export const RenderLine = function<N, T, D>(line: LineName): RENDERER<N, T, D> {
 /*******************************************************************/
 
 /**
- * @param {string} kind   The kind of line (side, diagonal, etc.)
- * @return {DefPair}      The notation definition for the notation having a line on the given side
+ * @param {Notation.Side} side   The kind of line (side, diagonal, etc.)
+ * @return {DEFPAIR}      The notation definition for the notation having a line on the given side
  */
 export const Border = function<N, T, D>(side: Notation.Side): DEFPAIR<N, T, D> {
   return Notation.CommonBorder<SVGmenclose<N, T, D>, N>((node, _child) => {
@@ -100,9 +100,9 @@ export const Border = function<N, T, D>(side: Notation.Side): DEFPAIR<N, T, D> {
 
 /**
  * @param {string} name    The name of the notation to define
- * @param {string} side1   The first side to get a border
- * @param {string} side2   The second side to get a border
- * @return {DefPair}       The notation definition for the notation having lines on two sides
+ * @param {Notation.Side} side1   The first side to get a border
+ * @param {Notation.Side} side2   The second side to get a border
+ * @return {DEFPAIR}       The notation definition for the notation having lines on two sides
  */
 export const Border2 = function<N, T, D>(name: string, side1: Notation.Side, side2: Notation.Side): DEFPAIR<N, T, D> {
   return Notation.CommonBorder2<SVGmenclose<N, T, D>, N>((node, _child) => {
@@ -115,7 +115,7 @@ export const Border2 = function<N, T, D>(name: string, side1: Notation.Side, sid
 
 /**
  * @param {LineName} name  The name of the diagonal strike to define
- * @return {DefPair}       The notation definition for the diagonal strike
+ * @return {DEFPAIR}       The notation definition for the diagonal strike
  */
 export const DiagonalStrike = function<N, T, D>(name: LineName): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalStrike<SVGmenclose<N, T, D>, N>((_cname: string) => (node, _child) => {
@@ -127,7 +127,7 @@ export const DiagonalStrike = function<N, T, D>(name: LineName): DEFPAIR<N, T, D
 
 /**
  * @param {string} name   The name of the diagonal arrow to define
- * @return {DefPair}      The notation definition for the diagonal arrow
+ * @return {DEFPAIR}      The notation definition for the diagonal arrow
  */
 export const DiagonalArrow = function<N, T, D>(name: string): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalArrow<SVGmenclose<N, T, D>, N>((node, arrow) => {
@@ -137,7 +137,7 @@ export const DiagonalArrow = function<N, T, D>(name: string): DEFPAIR<N, T, D> {
 
 /**
  * @param {string} name   The name of the horizontal or vertical arrow to define
- * @return {DefPair}      The notation definition for the arrow
+ * @return {DEFPAIR}      The notation definition for the arrow
  */
 export const Arrow = function<N, T, D>(name: string): DEFPAIR<N, T, D> {
   return Notation.CommonArrow<SVGmenclose<N, T, D>, N>((node, arrow) => {

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -255,7 +255,7 @@ CommonWrapper<
    * @param {number} n        The character number
    * @param {number} x        The x-position of the character
    * @param {number} y        The y-position of the character
-   * @param {N}               The container for the character
+   * @param {N} parent        The container for the character
    * @param {string} variant  The variant to use for the character
    * @return {number}         The width of the character
    */

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -208,7 +208,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
   /**
    * @param {number} n    The character number for the middle glyph
    * @param {number} W    The width of the stretched delimiter
-   * @return {number[]}   The top and bottom positions of the middle glyph
+   * @return {[number, number]}   The top and bottom positions of the middle glyph
    */
   protected addMidV(n: number, W: number): [number, number] {
     if (!n) return [0, 0];
@@ -270,7 +270,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
   /**
    * @param {number} n   The character number for the middle glyph of the stretchy character
    * @param {number} W   The width of the stretched character
-   * @return {number[]}  The positions of the left and right edges of the middle glyph
+   * @return {[number, number]}  The positions of the left and right edges of the middle glyph
    */
   protected addMidH(n: number, W: number): [number, number] {
     if (!n) return [0, 0];

--- a/ts/output/svg/Wrappers/mtd.ts
+++ b/ts/output/svg/Wrappers/mtd.ts
@@ -48,7 +48,7 @@ CommonMtdMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
    * @param {number} W    The width of the cell
    * @param {number} H    The height of the cell
    * @param {number} D    The depth of the cell
-   * @return {number[]}   The x and y offsets used
+   * @return {[number, number]}   The x and y offsets used
    */
   public placeCell(x: number, y: number, W: number, H: number, D: number): [number, number] {
     const bbox = this.getBBox();

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -862,7 +862,7 @@ export class Menu {
   }
 
   /**
-   * @param {MathItem} math   The MathItem to serialize as MathML
+   * @param {HTMLMATHITEM} math   The MathItem to serialize as MathML
    * @returns {string}        The serialized version of the internal MathML
    */
   protected toMML(math: HTMLMATHITEM): string {
@@ -877,7 +877,7 @@ export class Menu {
   /**
    * @param {MouseEvent|null} event   The event triggering the zoom (or null for from a menu pick)
    * @param {string} type             The type of event occurring (click, dblclick)
-   * @param {MathItem} math           The MathItem triggering the event
+   * @param {HTMLMATHITEM} math       The MathItem triggering the event
    */
   protected zoom(event: MouseEvent, type: string, math: HTMLMATHITEM) {
     if (!event || this.isZoomEvent(event, type)) {
@@ -963,7 +963,7 @@ export class Menu {
   /*======================================================================*/
 
   /**
-   * @param {MathItem} math   The math to attach the context menu and zoom triggers to
+   * @param {HTMLMATHITEM} math   The math to attach the context menu and zoom triggers to
    */
   public addMenu(math: HTMLMATHITEM) {
     const element = math.typesetRoot;

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -229,7 +229,7 @@ export interface MenuMathDocument extends ComplexityMathDocument<HTMLElement, Te
 /**
  * The mixin for adding context menus to MathDocuments
  *
- * @param {B} BaseMathDocument     The MathDocument class to be extended
+ * @param {B} BaseDocument     The MathDocument class to be extended
  * @return {MenuMathDocument}      The extended MathDocument class
  *
  * @template B  The MathDocument class to extend

--- a/ts/util/Styles.ts
+++ b/ts/util/Styles.ts
@@ -406,7 +406,7 @@ export class Styles {
 
   /**
    * @param {string} name   The name of the style to set
-   * @param {srting|number|boolean}  The value to set it to
+   * @param {srting|number|boolean} value The value to set it to
    */
   public set(name: string, value: string | number | boolean) {
     name = this.normalizeName(name);

--- a/ts/util/lengths.ts
+++ b/ts/util/lengths.ts
@@ -84,7 +84,7 @@ export const MATHSPACE: {[name: string]: number} = {
  * @param {string|number} length  A dimension (giving number and units) to be converted to ems
  * @param {number} size           The default size of the dimension (for percentage values)
  * @param {number} scale          The current scaling factor (to handle absolute units)
- * @param {number} ex             The size of an ex in pixels
+ * @param {number} em             The size of an em in pixels
  * @return {number}               The dimension converted to ems
  */
 export function length2em(length: string | number, size: number = 0, scale: number = 1, em: number = 16): number {

--- a/ts/util/string.ts
+++ b/ts/util/string.ts
@@ -25,7 +25,8 @@
 /**
  * Sort strings by length
  *
- * @param {string} a, b  The strings to be compared
+ * @param {string} a  First string to be compared
+ * @param {string} b  Second string to be compared
  * @return {number}  -1 id a < b, 0 of a === b, 1 if a > b
  */
 export function sortLength(a: string, b: string): number {


### PR DESCRIPTION
Lints the JSDoc to some extent. This is based on a crude emacs lisp function and eyeballing.
Things it definitely will not catch:
* Functions that take a parameter but have no `@param` element in JSDoc 
* Missing `return` statements.

Things that might be partially missed: 
* Incorrect or incomplete types (in particular if they contain templates).
* Missing parameters when parameter declaration block was broken over multiple lines.

Currently done for all modules expect `input` and `output`.


