### PR TITLE
Fix \overbrace in SVG output. (mathjax/MathJax#2402)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -717,17 +717,18 @@ export class CommonWrapper<
   }
 
   /**
-   * @param {string} text     The text to turn into unicode locations
-   * @param {string} variant  The name of the variant for the characters
-   * @return {number[]}  Array of numbers represeting the string's unicode character positions
+   * @param {string} text   The text to turn into unicode locations
+   * @param {string} name   The name of the variant for the characters
+   * @return {number[]}     Array of numbers represeting the string's unicode character positions
    */
-  protected unicodeChars(text: string, variant: string = ''): number[] {
+  protected unicodeChars(text: string, name: string = this.variant): number[] {
     let chars = unicodeChars(text);
     //
     //  Remap to Math Alphanumerics block
     //
-    const map = this.font.getVariant(variant).chars;
-    if (map) {
+    const variant = this.font.getVariant(name);
+    if (variant && variant.chars) {
+      const map = variant.chars;
       //
       //  Is map[n] doesn't exist, (map[n] || []) still gives an CharData array.
       //  If the array doesn't have a CharOptions element use {} instead.

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -272,7 +272,7 @@ CommonWrapper<
       const g = this.adaptor.append(parent, this.svg('g', {'data-c': C}));
       this.place(x, y, g);
       x = 0;
-      for (const n of this.unicodeChars(data.c)) {
+      for (const n of this.unicodeChars(data.c, variant)) {
         x += this.placeChar(n, x, y, g, variant);
       }
     } else if (data.unknown) {


### PR DESCRIPTION
This is the redo for #477, which had conflicts due to the indenting changes in the `pretty-code` merge.  This makes for a clear merge.

Since it was already reviewed in #477, I am merging with no additional review.