### PR TITLE
Improve startup.promise so it is always valid.  (mathjax/MathJax#2307)

### DIFF
--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -60,11 +60,11 @@ export interface MathJaxObject extends MJObject {
   _: MathJaxLibrary;
   config: MathJaxConfig;
   loader: {
-    ready: (...names: string[]) => Promise<void>;    // Get a promise for when all the named packages are loaded
-    load: (...names: string[]) => Promise<string>;   // Load the packages and return a promise for when ready
-    preLoad: (...names: string[]) => void;           // Indicate that packages are already loaded by hand
-    defaultReady: () => void;                        // The function performed when all packages are loaded
-    getRoot: () => string;                           // Find the root URL for the MathJax files
+    ready: (...names: string[]) => Promise<string[]>; // Get a promise for when all the named packages are loaded
+    load: (...names: string[]) => Promise<string>;    // Load the packages and return a promise for when ready
+    preLoad: (...names: string[]) => void;            // Indicate that packages are already loaded by hand
+    defaultReady: () => void;                         // The function performed when all packages are loaded
+    getRoot: () => string;                            // Find the root URL for the MathJax files
   };
   startup?: any;
 }

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -166,11 +166,32 @@ export namespace Startup {
   export let document: MATHDOCUMENT = null;
 
   /**
-   * The promise for the startup process (the initial typesetting).
-   * Initially, it is resolved when the page is loaded and ready to be processed,
-   *   but it is replaced by the pageReady() action in the ready() function.
+   * The function that resolves the first promise defined below
+   *   (called in the defaultReady() function when MathJax is finished with
+   *    its initial typesetting)
    */
-  export let promise: Promise<void> = new Promise<void>((resolve, _reject) => {
+  export let promiseResolve: () => void;
+  /**
+   * The function that rejects the first promise defined below
+   *   (called in the defaultReady() function when MathJax's initial
+   *    typesetting fails)
+   */
+  export let promiseReject: (reason: any) => void;
+
+  /**
+   * The promise for the startup process (the initial typesetting).
+   * It is resolves or rejected in the ready() function.
+   */
+  export let promise = new Promise<void>((resolve, reject) => {
+    promiseResolve = resolve;
+    promiseReject = reject;
+  });
+
+  /**
+   * A promise that is resolved when the page contents are available
+   * for processing.
+   */
+  export let pagePromise = new Promise<void>((resolve, _reject) => {
     const doc = global.document;
     if (!doc || !doc.readyState || doc.readyState === 'complete' || doc.readyState === 'interactive') {
       resolve();
@@ -260,7 +281,10 @@ export namespace Startup {
   export function defaultReady() {
     getComponents();
     makeMethods();
-    promise = promise.then(() => CONFIG.pageReady());  // usually the initial typesetting call
+    pagePromise
+      .then(() => CONFIG.pageReady())  // usually the initial typesetting call
+      .then(() => promiseResolve())
+      .catch((err) => promiseReject(err));
   }
 
   /**
@@ -270,7 +294,9 @@ export namespace Startup {
    * Setting Mathjax.startup.pageReady in the configuration will override this.
    */
   export function defaultPageReady() {
-    return (CONFIG.typeset && MathJax.typesetPromise ? MathJax.typesetPromise(CONFIG.elements) : null);
+    return (CONFIG.typeset && MathJax.typesetPromise ?
+            MathJax.typesetPromise(CONFIG.elements) as Promise<void> :
+            Promise.resolve());
   }
 
   /**


### PR DESCRIPTION
This PR adjusts how the `MathJax.startup.promise` is handled so that it is now possible to use it for synchronization outside of the `startup.ready()` function.

Originally, the startup promise was created as a promise for when the page is loaded, and then modified in the `ready()` function to be a promise that resolves when the initial typesetting was complete.  But people wanted to use it for that without waiting for the `ready()` function (and it wasn't well documented).

This PR allows for that latter behavior.  That requires an additional promise (for the page loading), leaving `startup.promise()` for when the typesetting is complete.  We need to retain the functions needed for resolving and rejecting `startup.promise` so that they can be called in the `pageReady()` function when the typesetting is done.  We also make sure `defaultPageReady()` always returns a promise (even when there is no initial typesetting to be done), so you can always use `MathJax.startup.defaultPageReady().then(...)` in your own `pageReady()` function.

This should be backward compatible, as long as people have followed the documented examples and have their `pageReady()` commands return the result of `defaultPageReady()`.  If not, the `startup.promise` will resolve too early.  But since the initial `startup.promise` wasn't hooked to the typeset promise anyway, no one was able to use that anyway, so it shouldn't matter.