### PR TITLE
Add functions to manage math items within a given container. (#351)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -74,6 +74,7 @@ export interface MinHTMLElement<N, T> {
   /* tslint:disable:jsdoc-require */
   getElementsByTagName(name: string): N[] | HTMLCollectionOf<Element>;
   getElementsByTagNameNS(ns: string, name: string): N[] | HTMLCollectionOf<Element>;
+  contains(child: N | T): boolean;
   appendChild(child: N | T): N | T | Node;
   removeChild(child: N | T): N | T  | Node;
   replaceChild(nnode: N | T, onode: N | T): N | T  | Node;
@@ -252,6 +253,13 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
       }
     }
     return containers;
+  }
+
+  /**
+   * @override
+   */
+  public contains(container: N, node: N | T) {
+    return container.contains(node);
   }
 
   /**

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -238,6 +238,16 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   /**
    * @override
    */
+  public contains(container: LiteNode, node: LiteNode | LiteText) {
+    while (node && node !== container) {
+      node = this.parent(node);
+    }
+    return !!node;
+  }
+
+  /**
+   * @override
+   */
   public parent(node: LiteNode) {
     return node.parent;
   }
@@ -295,6 +305,8 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     const i = this.childIndex(onode);
     if (i >= 0) {
       onode.parent.children[i] = nnode;
+      nnode.parent = onode.parent;
+      onode.parent = null;
     }
     return onode;
   }

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -327,19 +327,26 @@ export namespace Startup {
    * TypeseClear() clears all the MathItems from the document.
    */
   export function makeTypesetMethods() {
-    MathJax.typeset = (elements: any = null) => {
+    MathJax.typeset = (elements: any[] = null) => {
       document.options.elements = elements;
       document.reset();
       document.render();
     };
-    MathJax.typesetPromise = (elements: any = null) => {
+    MathJax.typesetPromise = (elements: any[] = null) => {
       document.options.elements = elements;
       document.reset();
       return mathjax.handleRetriesFor(() => {
         document.render();
       });
     };
-    MathJax.typesetClear = () => document.clear();
+    MathJax.typesetClear = (elements: any[] = null) => {
+      if (elements) {
+        document.reset();
+        document.clearMathItemsWithin(elements);
+      } else {
+        document.clear();
+      }
+    };
   }
 
   /**

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -115,6 +115,15 @@ export interface DOMAdaptor<N, T, D> {
   getElements(nodes: (string | N | N[])[], document: D): N[];
 
   /**
+   * Determine if a container node contains a given node in somewhere in its DOM tree
+   *
+   * @param {N} container  The container to search
+   * @param {N|T} node     The node to look for
+   * @return {boolean}     True if the node is in the container's DOM tree
+   */
+  contains(container: N, node: N | T): boolean;
+
+  /**
    * @param {N|T} node  The HTML node whose parent is to be obtained
    * @return {N}        The parent node of the given one
    */
@@ -430,6 +439,11 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * @override
    */
   public abstract getElements(nodes: (string | N | N[])[], document: D): N[];
+
+  /**
+   * @override
+   */
+  public abstract contains(container: N, node: N | T): boolean;
 
   /**
    * @override

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -115,7 +115,7 @@ export interface DOMAdaptor<N, T, D> {
   getElements(nodes: (string | N | N[])[], document: D): N[];
 
   /**
-   * Determine if a container node contains a given node in somewhere in its DOM tree
+   * Determine if a container node contains a given node is somewhere in its DOM tree
    *
    * @param {N} container  The container to search
    * @param {N|T} node     The node to look for

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -437,6 +437,24 @@ export interface MathDocument<N, T, D> {
    */
   concat(list: MathList<N, T, D>): MathDocument<N, T, D>;
 
+  /**
+   * Clear the typeset MathItems that are within the given container
+   *   from the document's MathList.  (E.g., when the content of the
+   *   container has been updated and you want to remove the
+   *   associated MathItems)
+   *
+   * @param {ContainerList<N>} elements   The container DOM elements whose math items are to be removed
+   */
+  clearMathItemsWithin(containers: ContainerList<N>): void;
+
+  /**
+   * Get the typeset MathItems that are within a given container.
+   *
+   * @param {ContainerList<N>} elements   The container DOM elements whose math items are to be found
+   * @return {MathItem<N,T,D>[]}          The list of MathItems within that container
+   */
+  getMathItemsWithin(elements: ContainerList<N>): MathItem<N, T, D>[];
+
 }
 
 /*****************************************************************/
@@ -867,24 +885,16 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
   }
 
   /**
-   * Clear the typeset MathItems that are within the given container
-   *   from the document's MathList.  (E.g., when the content of the
-   *   container has been updated and you want to remove the
-   *   associated MathItems)
-   *
-   * @param {ContainerList<N>} elements   The container DOM elements whose math items are to be removed
+   * @override
    */
   public clearMathItemsWithin(containers: ContainerList<N>) {
     this.math.remove(...this.getMathItemsWithin(containers));
   }
 
   /**
-   * Get the typeset MathItems that are within a given container.
-   *
-   * @param {ContainerList<N>} elements   The container DOM elements whose math items are to be found
-   * @return {MathItem<N,T,D>[]}          The list of MathItems within that container
+   * @override
    */
-  public getMathItemsWithin(elements: ContainerList<N>): MathItem<N, T, D>[] {
+  public getMathItemsWithin(elements: ContainerList<N>) {
     if (!Array.isArray(elements)) {
       elements = [elements];
     }

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -857,6 +857,35 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     return this;
   }
 
+  /**
+   * Clear the typeset MathItems that are within the given container
+   *   from the document's MathList.  (E.g., when the content of the
+   *   container has been updated and you want to remove the
+   *   associated MathItems)
+   *
+   * @param {N} container   The container DOM element whose math items are to be removed
+   */
+  public clearMathItemsWithin(container: N) {
+    this.math.remove(...this.getMathItemsWithin(container));
+  }
+
+  /**
+   * Get the typeset MathItems that are within a given container.
+   *
+   * @param {N} container          The container DOM element whose math items are to be found
+   * @return {MathItem<N,T,D>[]}   The list of MathItems within that container
+   */
+  public getMathItemsWithin(container: N): MathItem<N, T, D>[] {
+    const adaptor = this.adaptor;
+    const items = [] as MathItem<N, T, D>[];
+    for (const item of this.math) {
+      if (item.start.node && adaptor.contains(container, item.start.node)) {
+        items.push(item);
+      }
+    }
+    return items;
+  }
+
 }
 
 /**

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -901,7 +901,8 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     const adaptor = this.adaptor;
     const items = [] as MathItem<N, T, D>[];
     const containers = adaptor.getElements(elements, this.document);
-    ITEMS: for (const item of this.math) {
+    ITEMS:
+    for (const item of this.math) {
       for (const container of containers) {
         if (item.start.node && adaptor.contains(container, item.start.node)) {
           items.push(item);

--- a/ts/util/LinkedList.ts
+++ b/ts/util/LinkedList.ts
@@ -26,7 +26,7 @@
  *  A symbol used to mark the special node used to indicate
  *  the start and end of the list.
  */
-const END = Symbol();
+export const END = Symbol();
 
 /**
  * Shorthand type for the functions used to sort the data items
@@ -188,6 +188,28 @@ export class LinkedList<DataClass> {
     item.next.prev = this.list;
     item.next = item.prev = null;
     return item.data as DataClass;
+  }
+
+  /**
+   * Remove items from the list
+   *
+   * @param {DataClass[]} items   The items to remove
+   */
+  public remove(...items: DataClass[]) {
+    const map = new Map<DataClass, boolean>();
+    for (const item of items) {
+      map.set(item, true);
+    }
+    let item = this.list.next;
+    while (item.data !== END) {
+      const next = item.next;
+      if (map.has(item.data as DataClass)) {
+        item.prev.next = item.next;
+        item.next.prev = item.prev;
+        item.next = item.prev = null;
+      }
+      item = next;
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds API calls to allow managing of math items with container elements in the DOM.  For example, if you are updating a portion of the DOM (by setting its `innerHTML` for example) and typeset math is removed, you want to be able to remove the associated MathItems from the list of MathItems held in the MathDocument.  Previously there was no API for that.

There two new main calls added to the base MathDocument class:  `clearMathItemsWithin()` and `getMathItemsWithin()`.  Both take a container element; the first removes the MathItems from the MathList that are found within the container, and the second returns an array of MathItems found within the container.

There is also a new LinkedList method, `remove()` for removing an item from the list.

Finally, there is a new DOMAdaptor method (`contains()`) to determine if an element is contained in another element.

This PR also fixes a bug in the liteAdaptor's `replace()` call where the parent elements weren't being set for the new nodes being inserted into the LiteDOM.

Resolves issue #351.
