### PR TITLE
Fix processing of texClass for multi-character <mi> elements.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -255,8 +255,8 @@ export class MmlMo extends AbstractMmlTokenNode {
       return prev;
     }
     if (prev) {
-      if (prev.getProperty('autoOp') && (texClass === TEXCLASS.BIN || texClass === TEXCLASS.REL)) {
-        texClass = this.texClass = TEXCLASS.ORD;
+      if (prev.getProperty('autoOP') && (texClass === TEXCLASS.BIN || texClass === TEXCLASS.REL)) {
+        prevClass = prev.texClass = TEXCLASS.ORD;
       }
       prevClass = this.prevClass = (prev.texClass || TEXCLASS.ORD);
       this.prevLevel = this.attributes.getInherited('scriptlevel') as number;


### PR DESCRIPTION
When porting of `mo.adjustTeXClass()` to v3, I messed up these lines.  I used the wrong property, (it is capitalized in the two other places it is used), so the if-then was never satisfied.  But even if it had been, I set the wrong object's TeX class.  This fixes both issues and makes the results consistent with v2.