### PR TITLE
Update string handling to handle SMP unicode blocks better.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -371,10 +371,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     if (!mo.match(/^[\uD800-\uDBFF]?.$/)) {
       return null;
     }
-    let n = mo.charCodeAt(0);
-    if (mo.length === 2) {
-      n = (n - 0xD800) * 0x400 + mo.charCodeAt(1) - 0xDC00 + 0x10000;
-    }
+    let n = mo.codePointAt(0);
     let ranges = (this.constructor as typeof MmlMo).RANGES;
     for (const range of ranges) {
       if (range[0] <= n && n <= range[1]) {

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -29,6 +29,8 @@ import {MmlMi} from './MmlNodes/mi.js';
 
 export const DATAMJX = 'data-mjx-';
 
+export const toEntity = (c: string) => '&#x' + c.codePointAt(0).toString(16).toUpperCase() + ';';
+
 type PropertyList = {[name: string]: string};
 
 
@@ -233,13 +235,8 @@ export class SerializedMmlVisitor extends MmlVisitor {
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;').replace(/>/g, '&gt;')
       .replace(/\"/g, '&quot;')
-      .replace(/([\uD800-\uDBFF].)/g, (_m, c) => {
-        return '&#x' + ((c.charCodeAt(0) - 0xD800) * 0x400 +
-                        (c.charCodeAt(1) - 0xDC00) + 0x10000).toString(16).toUpperCase() + ';';
-      })
-      .replace(/([\u0080-\uD7FF\uE000-\uFFFF])/g, (_m, c) => {
-        return '&#x' + c.charCodeAt(0).toString(16).toUpperCase() + ';';
-      });
+      .replace(/[\uD800-\uDBFF]./g, toEntity)
+      .replace(/[\u0080-\uD7FF\uE000-\uFFFF]/g, toEntity);
   }
 
 }

--- a/ts/input/tex/NodeUtil.ts
+++ b/ts/input/tex/NodeUtil.ts
@@ -51,7 +51,7 @@ namespace NodeUtil {
    * @return {string} The newly created entity.
    */
   export function createEntity(code: string): string  {
-    return String.fromCharCode(parseInt(code, 16));
+    return String.fromCodePoint(parseInt(code, 16));
   }
 
 

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -181,10 +181,8 @@ export default class TexParser {
    */
   public Parse() {
     let c: string;
-    let n: number;
     while (this.i < this.string.length) {
-      n = this.string.codePointAt(this.i);
-      c = String.fromCodePoint(n);
+      c = this.getCodePoint();
       this.i += c.length;
       this.parse('character', [this, c]);
     }
@@ -244,6 +242,13 @@ export default class TexParser {
   }
 
   /**
+   * @return {string}   Get the next unicode character in the string
+   */
+  public getCodePoint(): string {
+    return String.fromCodePoint(this.string.codePointAt(this.i));
+  }
+
+  /**
    * @return {boolean} True if the next character to parse is a space.
    */
   public nextIsSpace(): boolean {
@@ -257,7 +262,7 @@ export default class TexParser {
     while (this.nextIsSpace()) {
       this.i++;
     }
-    return String.fromCodePoint(this.string.codePointAt(this.i));
+    return this.getCodePoint();
   }
 
   /**
@@ -315,7 +320,7 @@ export default class TexParser {
       // @test MissingCloseBrace
       throw new TexError('MissingCloseBrace', 'Missing close brace');
     }
-    const c = String.fromCodePoint(this.string.codePointAt(this.i));
+    const c = this.getCodePoint();
     this.i += c.length;
     return c;
   }

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -225,7 +225,7 @@ AmsMethods.xArrow = function(parser: TexParser, name: string,
   let bot = parser.GetBrackets(name);
   let first = parser.ParseArg(name);
   let arrow = parser.create('token',
-    'mo', {stretchy: true, texClass: TEXCLASS.REL}, String.fromCharCode(chr));
+    'mo', {stretchy: true, texClass: TEXCLASS.REL}, String.fromCodePoint(chr));
   let mml = parser.create('node', 'munderover', [arrow]) as MmlMunderover;
   let mpadded = parser.create('node', 'mpadded', [first], def);
   NodeUtil.setAttribute(mpadded, 'voffset', '.15em');

--- a/ts/input/tex/physics/PhysicsMethods.ts
+++ b/ts/input/tex/physics/PhysicsMethods.ts
@@ -232,7 +232,7 @@ function createVectorToken(factory: NodeFactory, kind: string,
                            def: any, text: string): MmlNode  {
   let parser = factory.configuration.parser;
   let token = NodeFactory.createToken(factory, kind, def, text);
-  let code: number = text.charCodeAt(0);
+  let code: number = text.codePointAt(0);
   if (text.length === 1 && !parser.stack.env.font &&
       parser.stack.env.vectorFont &&
       (inRange(code, latinCap) || inRange(code, latinSmall) ||

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -158,7 +158,7 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
    * @param {N} chtml  The parent element in which to put the delimiter
    */
   protected stretchHTML(chtml: N) {
-    const c = this.getText().charCodeAt(0);
+    const c = this.getText().codePointAt(0);
     const delim = this.stretch;
     delim.used = true;
     const stretch = delim.stretch;

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -176,8 +176,8 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
       const attributes = this.node.attributes;
       if (!attributes.get('stretchy')) return false;
       const c = this.getText();
-      if (c.length !== 1) return false;
-      const delim = this.font.getDelimiter(c.charCodeAt(0));
+      if (Array.from(c).length !== 1) return false;
+      const delim = this.font.getDelimiter(c.codePointAt(0));
       this.stretch = (delim && delim.dir === direction ? delim : NOSTRETCH);
       return this.stretch.dir !== DIRECTION.None;
     }
@@ -204,7 +204,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
         //  Look through the delimiter sizes for one that matches
         //
         const delim = this.stretch;
-        const c = delim.c || this.getText().charCodeAt(0);
+        const c = delim.c || this.getText().codePointAt(0);
         let i = 0;
         if (delim.sizes) {
           for (const d of delim.sizes) {

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -282,7 +282,7 @@ export function CommonScriptbaseMixin<
         base = base.childNodes[0];
       }
       return ((base.node.isKind('mo') || base.node.isKind('mi') || base.node.isKind('mn')) &&
-              base.bbox.rscale === 1 && base.getText().length === 1 &&
+              base.bbox.rscale === 1 && Array.from(base.getText()).length === 1 &&
               !base.node.attributes.get('largeop'));
     }
 

--- a/ts/util/Entities.ts
+++ b/ts/util/Entities.ts
@@ -515,17 +515,5 @@ export function numeric(entity: string): string {
   let n = (entity.charAt(0) === 'x' ?
            parseInt(entity.slice(1), 16) :
            parseInt(entity));
-  //
-  // For BMP only one character needed
-  //
-  if (n < 0x10000) {
-    return String.fromCharCode(n);
-  }
-  //
-  // Use surrogate pair for values outside the BMP0
-  //
-  n -= 0x10000;
-  const hi = (n >> 10) + 0xD800;
-  const lo = (n & 0x3FF) + 0xDC00;
-  return String.fromCharCode(hi, lo);
+  return String.fromCodePoint(n);
 }

--- a/ts/util/string.ts
+++ b/ts/util/string.ts
@@ -50,15 +50,7 @@ export function quotePattern(text: string): string {
  * @return {number[]}  Array of numbers representing the string's unicode character positions
  */
 export function unicodeChars(text: string): number[] {
-  let unicode: number[] = [];
-  for (let i = 0, m = text.length; i < m; i++) {
-    let n = text.charCodeAt(i);
-    if (n >= 0xD800 && n < 0xDBFF) {
-      n = (((n - 0xD800) << 10) + (text.charCodeAt(++i) - 0xDC00)) + 0x10000;
-    }
-    unicode.push(n);
-  }
-  return unicode;
+  return Array.from(text).map((c) => c.codePointAt(0));
 }
 
 /**


### PR DESCRIPTION
This PR updates the string-handling functions to take advantage of some ES6 string functions (`fromCodePoint()`, `codePointAt()`, and the fact that `Array.from()` splits a string into an array of unicode characters).  It also enhances the TeX parser string handling to handle unicode characters better.  E.g., you can use a (single) unicode character as a macro name (e.g., `\α`) or as an argument (e.g. `\sqrt α`) or in macro definition templates (e.g., `\def\x #1α{[#1]}` so that `\x abcα` will produce `[abc]`), and so on.