### PR TITLE
Add a remove() method to AbstractParseMaps, and remove subclass from autoload.

### DIFF
--- a/ts/input/tex/SymbolMap.ts
+++ b/ts/input/tex/SymbolMap.ts
@@ -202,10 +202,18 @@ export abstract class AbstractParseMap<K> extends AbstractSymbolMap<K> {
   /**
    * Sets mapping for a symbol.
    * @param {string} symbol The symbol to map.
-   * @param {T} object The symbols value in the mapping's codomain.
+   * @param {K} object The symbols value in the mapping's codomain.
    */
   public add(symbol: string, object: K) {
     this.map.set(symbol, object);
+  }
+
+  /**
+   * Removes a symbol from the map
+   * @param {string} symbol The symbol to remove
+   */
+  public remove(symbol: string) {
+    this.map.delete(symbol);
   }
 
 }

--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -32,17 +32,6 @@ import {RequireLoad, RequireConfiguration} from '../require/RequireConfiguration
 import {Package} from '../../../components/package.js';
 import {expandable, defaultOptions} from '../../../util/Options.js';
 
-/**
- * A CommandMap class that allows removal of macros
- */
-export class AutoloadCommandMap extends CommandMap {
-  /**
-   * @param{string} name   The command to be removed
-   */
-  public remove(name: string) {
-    (this as any).map.delete(name);
-  }
-}
 
 /**
  * Autoload an extension when the first macro for it is encountered
@@ -128,8 +117,8 @@ function configAutoload(config: Configuration, jax: TeX<any, any, any>) {
 /**
  * The command and environment maps for the macros that autoload extensions
  */
-const AutoloadMacros = new AutoloadCommandMap('autoload-macros', {}, {});
-const AutoloadEnvironments = new AutoloadCommandMap('autoload-environments', {}, {});
+const AutoloadMacros = new CommandMap('autoload-macros', {}, {});
+const AutoloadEnvironments = new CommandMap('autoload-environments', {}, {});
 
 
 /**


### PR DESCRIPTION
This PR adds a `remove()` method to `AbstractParseMap` so that a symbol can be removed, if needed.  The autoload function needs that in order to remove the macros that cause the extensions to be loaded once they have caused one to load.   The extension had used a subclass to do it, but it really should be in the base class.