### PR TITLE
Add configuration options to noundefined extension

### DIFF
--- a/ts/input/tex/noundefined/NoUndefinedConfiguration.ts
+++ b/ts/input/tex/noundefined/NoUndefinedConfiguration.ts
@@ -33,11 +33,28 @@ import TexParser from '../TexParser.js';
  */
 function noUndefined(parser: TexParser, name: string) {
   const textNode = parser.create('text', '\\' + name);
-  parser.Push(parser.create('node', 'mtext', [], {mathcolor: 'red'}, textNode));
+console.log(parser.options);
+  const options = parser.options.noundefined || {};
+  const def = {} as {[name: string]: string};
+  for (const id of ['color', 'background', 'size']) {
+    if (options[id]) {
+      def['math' + id] = options[id];
+    }
+  }
+  parser.Push(parser.create('node', 'mtext', [], def, textNode));
 }
 
 export const NoUndefinedConfiguration = Configuration.create(
-  'noundefined', {fallback: {macro: noUndefined}}
+  'noundefined', {
+    fallback: {macro: noUndefined},
+    options: {
+      noundefined: {
+        color: 'red',
+        background: '',
+        size: ''
+      }
+    }
+  }
 );
 
 

--- a/ts/input/tex/noundefined/NoUndefinedConfiguration.ts
+++ b/ts/input/tex/noundefined/NoUndefinedConfiguration.ts
@@ -33,7 +33,6 @@ import TexParser from '../TexParser.js';
  */
 function noUndefined(parser: TexParser, name: string) {
   const textNode = parser.create('text', '\\' + name);
-console.log(parser.options);
   const options = parser.options.noundefined || {};
   const def = {} as {[name: string]: string};
   for (const id of ['color', 'background', 'size']) {


### PR DESCRIPTION
This PR adds the ability to configure the `noundefined` extension's colors and size.  This brings it in line with the v2 version of the extension.