### PR TITLE
Allow TeX extensions to store data that is local to the TeX input jax.

### DIFF
--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -67,6 +67,12 @@ export default class ParseOptions {
    */
   public tags: Tags;
 
+  /**
+   * Storage area for parser-specific package data (indexed by package name)
+   * @type {{[name: string]: any}}
+   */
+  public packageData: {[name: string]: any} = {};
+
   // Fields for ephemeral options, i.e., options that will be cleared for each
   // run of the parser.
   /**

--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -69,9 +69,9 @@ export default class ParseOptions {
 
   /**
    * Storage area for parser-specific package data (indexed by package name)
-   * @type {{[name: string]: any}}
+   * @type {Map<string, any>}
    */
-  public packageData: {[name: string]: any} = {};
+  public packageData: Map<string, any> = new Map();
 
   // Fields for ephemeral options, i.e., options that will be cleared for each
   // run of the parser.

--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -120,7 +120,7 @@ function configAutoload(config: Configuration, jax: TeX<any, any, any>) {
   //
   //  Check if the require extension needs to be configured
   //
-  if (!parser.options.require.jax) {
+  if (!parser.packageData.require) {
     RequireConfiguration.config(config, jax);
   }
 }

--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -120,7 +120,7 @@ function configAutoload(config: Configuration, jax: TeX<any, any, any>) {
   //
   //  Check if the require extension needs to be configured
   //
-  if (!parser.packageData.require) {
+  if (!parser.packageData.get('require')) {
     RequireConfiguration.config(config, jax);
   }
 }

--- a/ts/input/tex/color/ColorConfiguration.ts
+++ b/ts/input/tex/color/ColorConfiguration.ts
@@ -22,13 +22,13 @@
  */
 
 
-import { CommandMap } from '../SymbolMap.js';
-import { Configuration } from '../Configuration.js';
+import {CommandMap} from '../SymbolMap.js';
+import {Configuration} from '../Configuration.js';
 
-import { ColorMethods } from './ColorMethods.js';
-import { ColorModel } from './ColorUtil.js';
+import {ColorMethods} from './ColorMethods.js';
+import {ColorModel} from './ColorUtil.js';
 
-import { TeX } from '../../tex.js';
+import {TeX} from '../../tex.js';
 
 /**
  * The color macros
@@ -48,7 +48,7 @@ new CommandMap('color', {
  * @param {TeX} jax              The TeX jax having that configuration
  */
 const config = function(_config: Configuration, jax: TeX<any, any, any>) {
-  jax.parseOptions.options.color.model = new ColorModel();
+  jax.parseOptions.packageData.color = {model: new ColorModel()};
 };
 
 /**

--- a/ts/input/tex/color/ColorConfiguration.ts
+++ b/ts/input/tex/color/ColorConfiguration.ts
@@ -48,7 +48,7 @@ new CommandMap('color', {
  * @param {TeX} jax              The TeX jax having that configuration
  */
 const config = function(_config: Configuration, jax: TeX<any, any, any>) {
-  jax.parseOptions.packageData.color = {model: new ColorModel()};
+  jax.parseOptions.packageData.set('color', {model: new ColorModel()});
 };
 
 /**

--- a/ts/input/tex/color/ColorMethods.ts
+++ b/ts/input/tex/color/ColorMethods.ts
@@ -23,12 +23,12 @@
 
 
 import NodeUtil from '../NodeUtil.js';
-import { ParseMethod } from '../Types.js';
-import { PropertyList } from '../../../core/Tree/Node.js';
+import {ParseMethod} from '../Types.js';
+import {PropertyList} from '../../../core/Tree/Node.js';
 import ParseUtil from '../ParseUtil.js';
 import TexParser from '../TexParser.js';
 
-import { ColorModel } from './ColorUtil.js';
+import {ColorModel} from './ColorUtil.js';
 
 
 /**
@@ -62,7 +62,7 @@ export const ColorMethods: Record<string, ParseMethod> = {};
 ColorMethods.Color = function (parser: TexParser, name: string) {
   const model = parser.GetBrackets(name, '');
   const colorDef = parser.GetArgument(name);
-  const colorModel: ColorModel = parser.options.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.color.model;
   const color = colorModel.getColor(model, colorDef);
 
   const style = parser.itemFactory.create('style')
@@ -82,7 +82,7 @@ ColorMethods.Color = function (parser: TexParser, name: string) {
 ColorMethods.TextColor = function (parser: TexParser, name: string) {
   const model = parser.GetBrackets(name, '');
   const colorDef = parser.GetArgument(name);
-  const colorModel: ColorModel = parser.options.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.color.model;
   const color = colorModel.getColor(model, colorDef);
   const old = parser.stack.env['color'];
 
@@ -95,7 +95,7 @@ ColorMethods.TextColor = function (parser: TexParser, name: string) {
     delete parser.stack.env['color'];
   }
 
-  const node = parser.create('node', 'mstyle', [math], { mathcolor: color });
+  const node = parser.create('node', 'mstyle', [math], {mathcolor: color});
   parser.Push(node);
 };
 
@@ -110,7 +110,7 @@ ColorMethods.DefineColor = function (parser: TexParser, name: string) {
   const model = parser.GetArgument(name);
   const def = parser.GetArgument(name);
 
-  const colorModel: ColorModel = parser.options.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.color.model;
   colorModel.defineColor(model, cname, def);
 };
 
@@ -123,14 +123,13 @@ ColorMethods.DefineColor = function (parser: TexParser, name: string) {
 ColorMethods.ColorBox = function (parser: TexParser, name: string) {
   const cname = parser.GetArgument(name);
   const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
-  const options = parser.options.color;
-  const colorModel: ColorModel = options.model;
+  const colorModel: ColorModel = parser.configuration.packageData.color.model;
 
   const node = parser.create('node', 'mpadded', math, {
     mathbackground: colorModel.getColor('named', cname)
   });
 
-  NodeUtil.setProperties(node, padding(options.padding));
+  NodeUtil.setProperties(node, padding(parser.options.color.padding));
   parser.Push(node);
 };
 
@@ -145,7 +144,7 @@ ColorMethods.FColorBox = function (parser: TexParser, name: string) {
   const cname = parser.GetArgument(name);
   const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
   const options = parser.options.color;
-  const colorModel: ColorModel = options.model;
+  const colorModel: ColorModel = parser.configuration.packageData.color.model;
 
   const node = parser.create('node', 'mpadded', math, {
     mathbackground: colorModel.getColor('named', cname),

--- a/ts/input/tex/color/ColorMethods.ts
+++ b/ts/input/tex/color/ColorMethods.ts
@@ -62,7 +62,7 @@ export const ColorMethods: Record<string, ParseMethod> = {};
 ColorMethods.Color = function (parser: TexParser, name: string) {
   const model = parser.GetBrackets(name, '');
   const colorDef = parser.GetArgument(name);
-  const colorModel: ColorModel = parser.configuration.packageData.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.get('color').model;
   const color = colorModel.getColor(model, colorDef);
 
   const style = parser.itemFactory.create('style')
@@ -82,7 +82,7 @@ ColorMethods.Color = function (parser: TexParser, name: string) {
 ColorMethods.TextColor = function (parser: TexParser, name: string) {
   const model = parser.GetBrackets(name, '');
   const colorDef = parser.GetArgument(name);
-  const colorModel: ColorModel = parser.configuration.packageData.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.get('color').model;
   const color = colorModel.getColor(model, colorDef);
   const old = parser.stack.env['color'];
 
@@ -110,7 +110,7 @@ ColorMethods.DefineColor = function (parser: TexParser, name: string) {
   const model = parser.GetArgument(name);
   const def = parser.GetArgument(name);
 
-  const colorModel: ColorModel = parser.configuration.packageData.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.get('color').model;
   colorModel.defineColor(model, cname, def);
 };
 
@@ -123,7 +123,7 @@ ColorMethods.DefineColor = function (parser: TexParser, name: string) {
 ColorMethods.ColorBox = function (parser: TexParser, name: string) {
   const cname = parser.GetArgument(name);
   const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
-  const colorModel: ColorModel = parser.configuration.packageData.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.get('color').model;
 
   const node = parser.create('node', 'mpadded', math, {
     mathbackground: colorModel.getColor('named', cname)
@@ -144,7 +144,7 @@ ColorMethods.FColorBox = function (parser: TexParser, name: string) {
   const cname = parser.GetArgument(name);
   const math = ParseUtil.internalMath(parser, parser.GetArgument(name));
   const options = parser.options.color;
-  const colorModel: ColorModel = parser.configuration.packageData.color.model;
+  const colorModel: ColorModel = parser.configuration.packageData.get('color').model;
 
   const node = parser.create('node', 'mpadded', math, {
     mathbackground: colorModel.getColor('named', cname),

--- a/ts/input/tex/color/ColorUtil.ts
+++ b/ts/input/tex/color/ColorUtil.ts
@@ -23,7 +23,7 @@
 
 
 import TexError from '../TexError.js';
-import { COLORS } from './ColorConstants.js';
+import {COLORS} from './ColorConstants.js';
 
 type ColorModelProcessor = (def: string) => string;
 const ColorModelProcessors: Map<string, ColorModelProcessor> = new Map<string, ColorModelProcessor>();

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -48,9 +48,10 @@ const MJCONFIG = MathJax.config;
  */
 function RegisterExtension(jax: TeX<any, any, any>, name: string) {
   const require = jax.parseOptions.options.require;
+  const required = jax.parseOptions.packageData.require.required as string[];
   const extension = name.substr(require.prefix.length);
-  if (require.required.indexOf(extension) < 0) {
-    require.required.push(extension);
+  if (required.indexOf(extension) < 0) {
+    required.push(extension);
     //
     //  Register any dependencies that were loaded to handle this one
     //
@@ -77,8 +78,9 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
       // (we don't have access to the document or MathItem needed to call
       //  the preprocessors from here)
       //
-      if (handler.preprocessors.length && !handler.options.configured) {
-        handler.options.configured = true;
+      const configured = jax.parseOptions.packageData.require.configured;
+      if (handler.preprocessors.length && !configured.has(extension)) {
+        configured.set(extension, true);
         mathjax.retryAfter(Promise.resolve());
       }
     }
@@ -116,7 +118,7 @@ export function RequireLoad(parser: TexParser, name: string) {
     throw new TexError('BadRequire', 'Extension "%1" is now allowed to be loaded', extension);
   }
   if (Package.packages.has(extension)) {
-    RegisterExtension(options.jax, extension);
+    RegisterExtension(parser.configuration.packageData.require.jax, extension);
   } else {
     mathjax.retryAfter(Loader.load(extension));
   }
@@ -126,9 +128,12 @@ export function RequireLoad(parser: TexParser, name: string) {
  * Save the jax so that it can be used when \require{} is processed.
  */
 function config(_config: Configuration, jax: TeX<any, any, any>) {
+  jax.parseOptions.packageData.require = {
+    jax: jax,                             // \require needs access to this
+    required: [...jax.options.packages],  // stores the names of the packages that have been added
+    configured: new Map()                 // stores the packages that have been configured
+  };
   const options = jax.parseOptions.options.require;
-  options.jax = jax;                             // \require needs access to this
-  options.required = [...jax.options.packages];  // stores the names of the packages that have been added
   const prefix = options.prefix;
   if (prefix.match(/[^_a-zA-Z0-9]/)) {
     throw Error('Illegal characters used in \\require prefix');

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -48,7 +48,7 @@ const MJCONFIG = MathJax.config;
  */
 function RegisterExtension(jax: TeX<any, any, any>, name: string) {
   const require = jax.parseOptions.options.require;
-  const required = jax.parseOptions.packageData.require.required as string[];
+  const required = jax.parseOptions.packageData.get('require').required as string[];
   const extension = name.substr(require.prefix.length);
   if (required.indexOf(extension) < 0) {
     required.push(extension);
@@ -78,7 +78,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
       // (we don't have access to the document or MathItem needed to call
       //  the preprocessors from here)
       //
-      const configured = jax.parseOptions.packageData.require.configured;
+      const configured = jax.parseOptions.packageData.get('require').configured;
       if (handler.preprocessors.length && !configured.has(extension)) {
         configured.set(extension, true);
         mathjax.retryAfter(Promise.resolve());
@@ -118,7 +118,7 @@ export function RequireLoad(parser: TexParser, name: string) {
     throw new TexError('BadRequire', 'Extension "%1" is now allowed to be loaded', extension);
   }
   if (Package.packages.has(extension)) {
-    RegisterExtension(parser.configuration.packageData.require.jax, extension);
+    RegisterExtension(parser.configuration.packageData.get('require').jax, extension);
   } else {
     mathjax.retryAfter(Loader.load(extension));
   }
@@ -128,11 +128,11 @@ export function RequireLoad(parser: TexParser, name: string) {
  * Save the jax so that it can be used when \require{} is processed.
  */
 function config(_config: Configuration, jax: TeX<any, any, any>) {
-  jax.parseOptions.packageData.require = {
+  jax.parseOptions.packageData.set('require', {
     jax: jax,                             // \require needs access to this
     required: [...jax.options.packages],  // stores the names of the packages that have been added
     configured: new Map()                 // stores the packages that have been configured
-  };
+  });
   const options = jax.parseOptions.options.require;
   const prefix = options.prefix;
   if (prefix.match(/[^_a-zA-Z0-9]/)) {


### PR DESCRIPTION
This PR provides a storage area for TeX extensions to keep information that is local to the TeX input jax instance in which they are operating.  The `color` extension uses that to handle information about defined colors, and the `require` and `autoload` extensions use it to track the extensions that are loaded and configured.

In the past, this data was stored in the configurations `options` object, as the only available location, but that muddles the meaning of the `options` object, which was the default options with the user-supplied options merged in.  This PR separates out the data storage from the option specifications.