### PR TITLE
Fix problems with texClass

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -218,7 +218,6 @@ export class MmlMo extends AbstractMmlTokenNode {
     let {form, fence} = this.attributes.getList('form', 'fence') as {form: string, fence: string};
     if (this.getProperty('texClass') === undefined &&
         (this.attributes.isSet('lspace') || this.attributes.isSet('rspace'))) {
-      this.texClass = TEXCLASS.NONE;
       return null;
     }
     if (fence && this.texClass === TEXCLASS.REL) {

--- a/ts/core/MmlTree/MmlNodes/mrow.ts
+++ b/ts/core/MmlTree/MmlNodes/mrow.ts
@@ -154,7 +154,7 @@ export class MmlMrow extends AbstractMmlNode {
    */
   public setTeXclass(prev: MmlNode) {
     if ((this.getProperty('open') != null || this.getProperty('close') != null) &&
-        (!prev || prev.getProperty('fnOp') != null)) {
+        (!prev || prev.getProperty('fnOP') != null)) {
       //
       // <mrow> came from \left...\right
       //   so treat as subexpression (TeX class INNER).


### PR DESCRIPTION
Fix issues with texClass reported by Volker.

* When an `<mo>` has `lspace` or `rspace` set, the class was changed to `NONE`, but that is not necessary (as long as `setTeXclass()` returns `null`).

* When `\left...\right` follows an operator, the `<mrow>` is being changed to `OPEN` rather than being `INNER`.  This was due to a capitalization problem.