### PR TITLE
Properly inherit scriptminsize and scriptsizemultiplier

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -254,6 +254,16 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
       mtable: {groupalign: true}
     }
   };
+
+  /**
+   * This lists the attributes that should always be inherited,
+   *   even when there is no default value for the attribute.
+   */
+  public static alwaysInherit: {[name: string]: boolean} = {
+    scriptminsize: true,
+    scriptsizemultiplier: true
+  };
+
   /**
    * This is the list of options for the verifyTree() method
    */
@@ -552,7 +562,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
                                 display: boolean = false, level: number = 0, prime: boolean = false) {
     let defaults = this.attributes.getAllDefaults();
     for (const key of Object.keys(attributes)) {
-      if (defaults.hasOwnProperty(key)) {
+      if (defaults.hasOwnProperty(key) || AbstractMmlNode.alwaysInherit.hasOwnProperty(key)) {
         let [node, value] = attributes[key];
         let noinherit = (AbstractMmlNode.noInherit[node] || {})[this.kind] || {};
         if (!noinherit[key]) {


### PR DESCRIPTION
This PR allows `scriptminsize` and `scriptsizemultiplier` to be inherited to any element, since these values are used in computing the scaling factor for any element.  Currently, these attributes have no effect because they are not being inherited properly.