### PR TITLE
Don't replace stylesheet unnecessarily. (mathjax/MathJax#2454)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -127,6 +127,11 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   public factory: CHTMLWrapperFactory<N, T, D>;
 
   /**
+   * The CHTML stylesheet, once it is constructed
+   */
+  public chtmlStyles: N = null;
+
+  /**
    * @override
    * @constructor
    */
@@ -147,7 +152,10 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
    * @override
    */
   public styleSheet(html: MathDocument<N, T, D>) {
-    const sheet = super.styleSheet(html);
+    if (this.chtmlStyles && !this.options.adaptiveCSS) {
+      return null;  // stylesheet is already added to the document
+    }
+    const sheet = this.chtmlStyles = super.styleSheet(html);
     this.adaptor.setAttribute(sheet, 'id', CHTML.STYLESHEETID);
     return sheet;
   }

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -112,7 +112,12 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
   /**
    * The container element for the math
    */
-  public container: N;
+  public container: N = null;
+
+  /**
+   * The SVG stylesheet, once it is constructed
+   */
+  public svgStyles: N = null;
 
   /**
    * @override
@@ -160,7 +165,10 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
    * @override
    */
   public styleSheet(html: MathDocument<N, T, D>) {
-    const sheet = super.styleSheet(html);
+    if (this.svgStyles) {
+      return null;  // stylesheet is already added to the document
+    }
+    const sheet = this.svgStyles = super.styleSheet(html);
     this.adaptor.setAttribute(sheet, 'id', SVG.STYLESHEETID);
     return sheet;
   }


### PR DESCRIPTION
This PR prevents the stylesheet from being replaced when it doesn't have to be, namely in the SVG output jax (since it doesn't change) and in CHTML when `adaptiveCSS` is false.

Resolves issue mathjax/MathJax#2454.