### PR TITLE
Allow MathML verification options to be specified in the input jax.

### DIFF
--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -45,17 +45,12 @@ export class MathMLCompile<N, T, D> {
   public static OPTIONS: OptionList = {
     MmlFactory: null,                   // The MmlFactory to use (defaults to a new MmlFactory)
     fixMisplacedChildren: true,         // True if we want to use heuristics to try to fix
-    //   problems with the tree based on HTML not handling
-    //   self-closing tags properly
-    verify: {},                         // Options to pass to verifyTree() controlling MathML verification
+                                        //   problems with the tree based on HTML not handling
+                                        //   self-closing tags properly
+    verify: {                           // Options to pass to verifyTree() controlling MathML verification
+      ...AbstractMmlNode.verifyDefaults
+    },
     translateEntities: true             // True means translate entities in text nodes
-  };
-
-  /**
-   *  The default values for the verify option
-   */
-  public static VERIFY: OptionList = {
-    ...AbstractMmlNode.verifyDefaults
   };
 
   /**
@@ -81,9 +76,6 @@ export class MathMLCompile<N, T, D> {
   constructor(options: OptionList = {}) {
     const Class = this.constructor as typeof MathMLCompile;
     this.options = userOptions(defaultOptions({}, Class.OPTIONS), options);
-    if (this.options['verify']) {
-      this.options['verify'] = userOptions(defaultOptions({}, Class.VERIFY), this.options['verify']);
-    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes a problem where the `verify` options for the MathML input jax could not be specified in the `mml` block of the MathJax configuration object.  The solution is simpler than the original, which is nice.  (I found this will updating documentation for v3.1.)