### PR TITLE
Make \underset explicitly turn off movablelimits.  (mathjax/MathJax#2460)

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -676,7 +676,7 @@ BaseMethods.Overset = function(parser: TexParser, name: string) {
 BaseMethods.Underset = function(parser: TexParser, name: string) {
   // @test Underset
   const bot = parser.ParseArg(name), base = parser.ParseArg(name);
-  if (NodeUtil.getAttribute(base, 'movablelimits') || NodeUtil.getProperty(base, 'movablelimits')) {
+  if (NodeUtil.isType(base, 'mo') || NodeUtil.getProperty(base, 'movablelimits')) {
     // @test Overline Sum
     NodeUtil.setProperties(base, {'movablelimits': false});
   }


### PR DESCRIPTION
This PR forces `movablelimits` to be false on an `<mo>` that is the base of an `\underset` command.  You can't determine the default value from the operator table because the inheritance hasn't occurred yet, so force the value on any `<mo>` explicitly.

Resolves issue mathjax/MathJax#2460.