### PR TITLE
Fix sre source location to work in lab as well as node-main and components

### DIFF
--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -31,7 +31,7 @@ export const dependencies = {
 
 export const paths = {
   tex: '[mathjax]/input/tex/extensions',
-  sre: '[mathjax]/sre/sre_browser'
+  sre: '[mathjax]/sre/' + (typeof window === 'undefined' ? 'sre-node' : 'sre_browser')
 };
 
 const allPackages = [

--- a/components/src/node-main/node-main.js
+++ b/components/src/node-main/node-main.js
@@ -11,7 +11,6 @@ const {dependencies, paths, provides} = require('../dependencies.js');
 /*
  * Set up the initial configuration
  */
-paths.sre = '[mathjax]/sre/sre-node';
 combineDefaults(MathJax.config, 'loader', {
   require: eval('require'),      // use node's require() to load files
   failed: (err) => {throw err}   // pass on error message to init()'s catch function

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -41,7 +41,8 @@ export const source = {
   'a11y/semantic-enrich': `${src}/a11y/semantic-enrich/semantic-enrich.js`,
   'a11y/complexity': `${src}/a11y/complexity/complexity.js`,
   'a11y/explorer': `${src}/a11y/explorer/explorer.js`,
-  '[sre]': `${src}/../../js/a11y/sre-node.js`,
+  '[sre]': (typeof window === 'undefined' ? `${src}/../../js/a11y/sre-node.js` :
+            `${src}/../../node_modules/speech-rule-engine/lib/sre_browser.js`),
   'ui/menu': `${src}/ui/menu/menu.js`,
   'mml-chtml': `${src}/mml-chtml/mml-chtml.js`,
   'mml-svg': `${src}/mml-svg/mml-svg.js`,


### PR DESCRIPTION
This PR fixes the issue with the lab where the enrichment wasn't loading properly, while still allowing `node-main` to load it.