### PR TITLE
Fix LiteDOM comments and add support for DOCTYPE

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -36,6 +36,7 @@ export interface MinDocument<N, T> {
   head: N;
   body: N;
   title: string;
+  doctype: string;
   /* tslint:disable:jsdoc-require */
   createElement(kind: string): N;
   createElementNS(ns: string, kind: string): N;
@@ -226,6 +227,13 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    */
   public root(doc: D) {
     return doc.documentElement;
+  }
+
+  /**
+   * @override
+   */
+  public doctype(doc: D) {
+    return doc.doctype;
   }
 
   /**

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -36,7 +36,7 @@ export interface MinDocument<N, T> {
   head: N;
   body: N;
   title: string;
-  doctype: string;
+  doctype: {name: string};
   /* tslint:disable:jsdoc-require */
   createElement(kind: string): N;
   createElementNS(ns: string, kind: string): N;
@@ -233,7 +233,7 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public doctype(doc: D) {
-    return doc.doctype;
+    return `<!DOCTYPE ${doc.doctype.name}>`;
   }
 
   /**

--- a/ts/adaptors/lite/Document.ts
+++ b/ts/adaptors/lite/Document.ts
@@ -22,7 +22,6 @@
  */
 
 import {LiteElement} from './Element.js';
-import {LiteComment} from './Text.js';
 
 /************************************************************/
 /**

--- a/ts/adaptors/lite/Document.ts
+++ b/ts/adaptors/lite/Document.ts
@@ -22,6 +22,7 @@
  */
 
 import {LiteElement} from './Element.js';
+import {LiteComment} from './Text.js';
 
 /************************************************************/
 /**
@@ -42,6 +43,11 @@ export class LiteDocument {
   public body: LiteElement;
 
   /**
+   * the DOCTYPE comment
+   */
+  public type: string;
+
+  /**
    * The kind is always #document
    */
   public get kind() {
@@ -56,5 +62,6 @@ export class LiteDocument {
       this.head = new LiteElement('head'),
       this.body = new LiteElement('body')
     ]);
+    this.type = '<!DOCTYPE html>';
   }
 }

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -281,7 +281,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
       if (child === node) {
         break;
       }
-      if (child instanceof LiteComment && child.value.match(/^!DOCTYPE/)) {
+      if (child instanceof LiteComment && child.value.match(/^<!DOCTYPE/)) {
         root.type = child.value;
       }
     }

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -136,6 +136,13 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   /**
    * @override
    */
+  public doctype(doc: LiteDocument) {
+    return doc.type;
+  }
+
+  /**
+   * @override
+   */
   public tags(node: LiteElement, name: string, ns: string = null) {
     let stack = [] as LiteNode[];
     let tags = [] as LiteElement[];
@@ -402,7 +409,8 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
    * @override
    */
   public value(node: LiteNode | LiteText) {
-    return (node.kind === '#text' ? (node as LiteText).value : '');
+    return (node.kind === '#text' ? (node as LiteText).value :
+            node.kind === '#comment' ? (node as LiteComment).value.replace(/^<!(--)?((?:.|\n)*)\1>$/, '$2') : '');
   }
 
   /**

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -97,6 +97,12 @@ export interface DOMAdaptor<N, T, D> {
   root(doc: D): N;
 
   /**
+   * @paramn {D} doc    The document whose doctype is to be obtained
+   * @return {string}   The DOCTYPE comment
+   */
+  doctype(doc: D): string;
+
+  /**
    * @param {N} node        The node to search for tags
    * @param {string} name   The name of the tag to search for
    * @param {string} ns     The namespace to search in (or null for no namespace)
@@ -435,6 +441,11 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * @override
    */
   public abstract root(doc: D): N;
+
+  /**
+   * @override
+   */
+  public abstract doctype(doc: D): string;
 
   /**
    * @override

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -97,7 +97,7 @@ export interface DOMAdaptor<N, T, D> {
   root(doc: D): N;
 
   /**
-   * @paramn {D} doc    The document whose doctype is to be obtained
+   * @param {D} doc     The document whose doctype is to be obtained
    * @return {string}   The DOCTYPE comment
    */
   doctype(doc: D): string;


### PR DESCRIPTION
I ran into this while updating the node demos.  It turns out that comments were not being output properly from the LiteDOM.  I also wanted to be able to preserve the `DOCTYPE` comment so that the full-page node commands can retain it in their output.  So this PR fixes the comment problem, and adds the `DOCTYPE` support.
