### PR TITLE
Remove ids from assistive MathML to avoid duplicates

### DIFF
--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -29,6 +29,22 @@ import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 import {OptionList, expandable} from '../util/Options.js';
 import {StyleList} from '../util/StyleList.js';
 
+/*==========================================================================*/
+
+export class LimitedMmlVisitor extends SerializedMmlVisitor {
+
+  /**
+   * @override
+   */
+  protected getAttributes(node: MmlNode): string {
+    /**
+     * Remove id from attribute output
+     */
+    return super.getAttributes(node).replace(/ ?id=".*?"/, '');
+  }
+
+}
+
 /**
  * Generic constructor for Mixins
  */
@@ -198,7 +214,7 @@ B extends MathDocumentConstructor<AbstractMathDocument<N, T, D>>>(
     /**
      * Visitor used for serializing internal MathML nodes
      */
-    protected visitor: SerializedMmlVisitor;
+    protected visitor: LimitedMmlVisitor;
 
     /**
      * Augment the MathItem class used for this MathDocument, and create the serialization visitor.
@@ -213,7 +229,7 @@ B extends MathDocumentConstructor<AbstractMathDocument<N, T, D>>>(
       if (!ProcessBits.has('assistive-mml')) {
         ProcessBits.allocate('assistive-mml');
       }
-      this.visitor = new SerializedMmlVisitor(this.mmlFactory);
+      this.visitor = new LimitedMmlVisitor(this.mmlFactory);
       this.options.MathItem =
         AssistiveMmlMathItemMixin<N, T, D, Constructor<AbstractMathItem<N, T, D>>>(
           this.options.MathItem


### PR DESCRIPTION
This PR resolves a problem with the assistive MathML.  If there are IDs in the MathML (e.g., from `\tag` or `\cssId` macros, or explicit tags in MathML input), those IDs will appear in the CHTML or SVG output, but also in the hidden MathML from the assitive-mml extension.  Here, we subclass the `SerilaizeMmlVisitor` to remove them in the hidden MathML.

See [this post](https://groups.google.com/forum/?fromgroups#!topic/mathjax-users/uRmJsN-LYX0) for the original complaint.