### PR TITLE
Fix problem with initial/trailing spaces in textmacros extension.  (#531)

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -350,7 +350,7 @@ namespace ParseUtil {
    * @param {EnvList} def The attributes of the text node.
    * @return {MmlNode} The text node.
    */
-  function internalText(parser: TexParser, text: string, def: EnvList): MmlNode {
+  export function internalText(parser: TexParser, text: string, def: EnvList): MmlNode {
     // @test Label, Fbox, Hbox
     text = text.replace(/^\s+/, entities.nbsp).replace(/\s+$/, entities.nbsp);
     let textNode = parser.create('text', text);

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -25,6 +25,7 @@
 import TexParser from '../TexParser.js';
 import TexError from '../TexError.js';
 import ParseOptions from '../ParseOptions.js';
+import ParseUtil from '../ParseUtil.js';
 import {StackItem} from '../StackItem.js';
 import {MmlNode, AbstractMmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {EnvList} from '../StackItem.js';
@@ -98,7 +99,7 @@ export class TextParser extends TexParser {
    */
   public saveText() {
     if (this.text) {
-      const text = this.create('token', 'mtext', {}, this.text);
+      const text = ParseUtil.internalText(this, this.text, {});
       if (this.stack.env.mathvariant) {
         NodeUtil.setAttribute(text, 'mathvariant', this.stack.env.mathvariant);
       }


### PR DESCRIPTION
Initial and trailing spaces were not being preserved by the new `textmacros` extension, so that `\text{ and }` would produce the equivalent of `\text{and}`.  This PR fixes the problem by calling the `ParseUtil.initialText()` macro, which does the quoting of those spaces.

Resolves issue #531.