### PR TITLE
Fix problem with maction when the math is converted from a string.  (mathjax/MathJax#2490)

### DIFF
--- a/ts/output/chtml/Wrappers/maction.ts
+++ b/ts/output/chtml/Wrappers/maction.ts
@@ -105,7 +105,7 @@ CommonMactionMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, any>>
       // Add a click handler that changes the selection and rerenders the expression
       //
       node.setEventHandler('click', (event: Event) => {
-        if (!math.start.node) {
+        if (!math.end.node) {
           //
           // If the MathItem was created by hand, it might not have a node
           // telling it where to replace the existing math, so set it.

--- a/ts/output/svg/Wrappers/maction.ts
+++ b/ts/output/svg/Wrappers/maction.ts
@@ -104,7 +104,7 @@ CommonMactionMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(SVG
       // Add a click handler that changes the selection and rerenders the expression
       //
       node.setEventHandler('click', (event: Event) => {
-        if (!math.start.node) {
+        if (!math.end.node) {
           //
           // If the MathItem was created by hand, it might not have a node
           // telling it where to replace the existing math, so set it.


### PR DESCRIPTION
If an `maction` element is created by using the MathDocument's `convert()` function (as is done for `tex2chtml()`, etc.), which converts a string to DOM elements, rather than `render()`, which converts math in place in the document, then MathJax doesn't know where in the document the element may be placed, and sets its start node to the document body (so that it can use the body to do font measuring for characters that aren't in the MathJax fonts, for example), and leaves the end node `null`, indicating that the element isn't attached to the document yet.

The action item looks for this, but should check the end node instead of the start node (the start node being set to the body was changed after the `maction` code was written).

This PR fixes the CommonHTML and SVG output to look at the correct node to see if the element is attached, and changes them to the MathItem's root node so that it will re-render properly.

Resolve issue mathjax/MathJax#2490.