### PR TITLE
Disables SRE cache on all explorers to avoid interaction.

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -395,7 +395,7 @@ let allExplorers: {[options: string]: ExplorerInit} = {
     let [domain, style] = doc.options.a11y.speechRules.split('-');
     explorer.speechGenerator.setOptions({
       locale: doc.options.a11y.locale, domain: domain,
-      style: style, modality: 'speech'});
+      style: style, modality: 'speech', cache: false});
     explorer.showRegion = 'subtitles';
     return explorer;
   },

--- a/ts/a11y/sre_browser.d.ts
+++ b/ts/a11y/sre_browser.d.ts
@@ -84,7 +84,8 @@ declare namespace SRE {
     style?: string,
     markup?: string,
     speech?: string,
-    semantics?: boolean
+    semantics?: boolean,
+    cache?: boolean
   };
   export function toEnriched(mml: string): void;
   export function setupEngine(obj: config): void;


### PR DESCRIPTION
There is some unwelcome interaction with SRE's cache when changing rule sets on the fly. The cache is aimed to avoid recomputing speech values for elements that have already been recursively traversed. But for the time being it is best to disable it completely in MathJax.

The cache was originally a solution to bring computation time down before speech rules were indexed in a trie. As is it only results in minimal run-time improvement. I either have to make it smarter on the SRE side or deprecate it.