### PR TITLE
Fix mapping of \ncong (mathjax/MathJax#2497)

### DIFF
--- a/ts/input/tex/ams/AmsMappings.ts
+++ b/ts/input/tex/ams/AmsMappings.ts
@@ -357,7 +357,7 @@ new sm.CharacterMap('AMSsymbols-mathchar0m0', ParseMethods.mathchar0mo, {
   precnapprox:            '\u2AB9',
   succnapprox:            '\u2ABA',
   nsim:                   '\u2241',
-  ncong:                  '\u2246',
+  ncong:                  '\u2247',
   nshortmid:              ['\u2224', {variantForm: true}],
   nshortparallel:         ['\u2226', {variantForm: true}],
   nmid:                   '\u2224',


### PR DESCRIPTION
This PR fixes the `\ncong` macro to map to U+2247 instead of (the incorrect) U+2246.  Version 3 fixes the incorrect font mapping from version 2, but we didn't change the macro to correspond to that.

Resolves the first issue from mathjax/MathJax#2497.