### PR TITLE
Don't remap stretchy characters (mathjax/MathJax#2497)

### DIFF
--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -73,8 +73,7 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       const font = this.jax.getFontData(this.parent.styles);
       adaptor.append(parent, this.jax.unknownText(text, variant, font));
     } else {
-      const c = this.parent.stretch.c;
-      const chars = c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant));
+      const chars = this.remappedText(text, variant);
       for (const n of chars) {
         const data = this.getVariantChar(variant, n)[3];
         const font = (data.f ? ' TEX-' + data.f : '');

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -74,7 +74,7 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       adaptor.append(parent, this.jax.unknownText(text, variant, font));
     } else {
       const c = this.parent.stretch.c;
-      const chars = this.parent.remapChars(c ? [c] : this.unicodeChars(text, variant));
+      const chars = c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant));
       for (const n of chars) {
         const data = this.getVariantChar(variant, n)[3];
         const font = (data.f ? ' TEX-' + data.f : '');

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -30,6 +30,12 @@ import {TextNode} from '../../../core/MmlTree/MmlNode.js';
  * The CommonTextNode interface
  */
 export interface CommonTextNode extends AnyWrapper {
+  /**
+   * @param {string} text     The text to remap
+   * @param {string} variant  The variant for the character
+   * @return {number[]}       The unicode points for the (remapped) text
+   */
+  remappedText(text: string, variant: string): number[];
 }
 
 /**
@@ -63,8 +69,7 @@ export function CommonTextNodeMixin<T extends WrapperConstructor>(Base: T): Text
         bbox.d = d;
         bbox.w = w;
       } else {
-        const c = this.parent.stretch.c;
-        const chars = c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant));
+        const chars = this.remappedText(text, variant);
         bbox.empty();
         //
         // Loop through the characters and add them in one by one
@@ -94,6 +99,16 @@ export function CommonTextNodeMixin<T extends WrapperConstructor>(Base: T): Text
         }
         bbox.clean();
       }
+    }
+
+    /**
+     * @param {string} text     The text to remap
+     * @param {string} variant  The variant for the character
+     * @return {number[]}       The unicode points for the (remapped) text
+     */
+    public remappedText(text: string, variant: string): number[] {
+      const c = this.parent.stretch.c;
+      return (c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant)));
     }
 
     /******************************************************/

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -64,7 +64,7 @@ export function CommonTextNodeMixin<T extends WrapperConstructor>(Base: T): Text
         bbox.w = w;
       } else {
         const c = this.parent.stretch.c;
-        const chars = this.parent.remapChars(c ? [c] : this.unicodeChars(text, variant));
+        const chars = c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant));
         bbox.empty();
         //
         // Loop through the characters and add them in one by one

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -61,8 +61,7 @@ CommonTextNodeMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
     if (variant === '-explicitFont') {
       this.adaptor.append(parent, this.jax.unknownText(text, variant));
     } else {
-      const c = this.parent.stretch.c;
-      const chars = c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant));
+      const chars = this.remappedText(text, variant);
       let x = 0;
       for (const n of chars) {
         x += this.placeChar(n, x, 0, parent, variant);

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -62,7 +62,7 @@ CommonTextNodeMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
       this.adaptor.append(parent, this.jax.unknownText(text, variant));
     } else {
       const c = this.parent.stretch.c;
-      const chars = this.parent.remapChars(c ? [c] : this.unicodeChars(text, variant));
+      const chars = c ? [c] : this.parent.remapChars(this.unicodeChars(text, variant));
       let x = 0;
       for (const n of chars) {
         x += this.placeChar(n, x, 0, parent, variant);


### PR DESCRIPTION
The PR fixes a problem where a stretchy delimiter that turns out to be rendered as a single character might be remapped to another character inadvertently.  Stretchy characters should not be remapped, which is handled here by moving the test for the stretchy character to outside the remapping.

Resolves the second part of mathjax/MathJax#2497.