### PR TITLE
Fix autoload to handle macro or \begin followed by spaces.  (mathjax/MathJax#2511)

### DIFF
--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -55,7 +55,11 @@ function Autoload(parser: TexParser, name: string, extension: string, isMacro: b
     for (const env of envs) {
       AutoloadEnvironments.remove(env);
     }
-    parser.i -= name.length + (isMacro ? 0 : 7);  // back up and read the macro or \begin again
+    //
+    //  Put back the macro or \begin and read it again
+    //
+    parser.string = (isMacro ? name : '\\begin{' + name.slice(1) + '}' ) + parser.string.slice(parser.i);
+    parser.i = 0;
   }
   RequireLoad(parser, extension);
 }


### PR DESCRIPTION
This PR fixes a problem with the `autoload` extension when the auto-loaded macro or `\begin` is followed by spaces.

Resolves issue mathjax/MathJax#2511.