### PR TITLE
Convert mu to em in CD environment.  (mathjax/MathJax#2513)

### DIFF
--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -116,7 +116,7 @@ AmsCdMethods.arrow = function(parser: TexParser, name: string) {
         a = '\\kern ' + top.getProperty('minw');
       } // minsize needs work
       if (a || b) {
-        let pad: EnvList = {width: '+11mu', lspace: '6mu'};
+        let pad: EnvList = {width: '.67em', lspace: '.33em'};
         mml = parser.create('node', 'munderover', [mml]) as MmlMunderover;
         if (a) {
           let nodeA = new TexParser(a, parser.stack.env, parser.configuration).mml();


### PR DESCRIPTION
This PR changes two uses of `mu` units for their corresponding `em` units, so that `mu` units don't end up in the internal MathML.