### PR TITLE
Handle AsciiMath configuration properly, in particular, displaystyle.  (mathjax/MathJax#2520)

### DIFF
--- a/components/src/input/asciimath/asciimath.js
+++ b/components/src/input/asciimath/asciimath.js
@@ -3,7 +3,6 @@ import './lib/asciimath.js';
 import {AsciiMath} from '../../../../js/input/asciimath.js';
 
 if (MathJax.startup) {
-  MathJax.Hub.Config({AsciiMath: MathJax.config.asciimath || {}});
   MathJax.startup.registerConstructor('asciimath', AsciiMath);
   MathJax.startup.useInput('asciimath');
 }

--- a/ts/input/asciimath.ts
+++ b/ts/input/asciimath.ts
@@ -61,7 +61,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
    * @override
    */
   constructor(options: OptionList) {
-    let [am, find] = separateOptions(options, FindAsciiMath.OPTIONS);
+    let [ , find, am] = separateOptions(options, FindAsciiMath.OPTIONS, AsciiMath.OPTIONS);
     super(am);
     this.findAsciiMath = this.options['FindAsciiMath'] || new FindAsciiMath(find);
   }

--- a/ts/input/asciimath/mathjax2/input/AsciiMath.js
+++ b/ts/input/asciimath/mathjax2/input/AsciiMath.js
@@ -1,5 +1,12 @@
 MathJax = Object.assign(global.MathJax || {}, require("../legacy/MathJax.js").MathJax);
 
+//
+//  Load component-based configuration, if any
+//
+if (MathJax.config && MathJax.config.asciimath) {
+  MathJax.Hub.Config({AsciiMath: MathJax.config.asciimath});
+}
+
 MathJax.Ajax.Preloading(
   "[MathJax]/jax/input/AsciiMath/config.js",
   "[MathJax]/jax/input/AsciiMath/jax.js",
@@ -18,12 +25,12 @@ var factory = new MmlFactory();
 exports.LegacyAsciiMath = {
   Compile: function (am,display) {
     var script = {
-      type:"math/asciimath",
+      type: "math/asciimath",
       innerText: am,
       MathJax: {}
     };
     var node = MathJax.InputJax.AsciiMath.Translate(script).root.toMmlNode(factory);
-    node.setInheritedAttributes();
+    node.setInheritedAttributes({}, display, 0, false);
     return node;
   },
   Translate: function (am,display) {

--- a/ts/input/asciimath/mathjax2/legacy/jax/element/MmlNode.js
+++ b/ts/input/asciimath/mathjax2/legacy/jax/element/MmlNode.js
@@ -58,6 +58,7 @@
         if (copy[names[i]] === 1 && !defaults.hasOwnProperty(names[i])) continue;
         value = (this.attr||{})[names[i]];
         if (value == null) value = this[names[i]];
+        if (value === 'true' || value === 'false') value = (value === 'true');
         if (value != null) node.attributes.set(names[i],value);
       }
     },


### PR DESCRIPTION
This PR fixes two issues with AsciiMath:

1.  The AsciiMath component configuration was not properly handled (it was being processed too late, after AsciiMath had already been configured, and the AsciiMath parameters were being flagged as having no default value (they are only defined in the legacy code, not the new Typescript code).

2.  The conversion from the legacy internal format was not properly handling boolean values, which caused the `displaystyle` configuration option to be always treated as false.

Resolves issue mathjax/MathJax#2520.