### PR TITLE
Make sure configuration renaming is performed for *-full components. (mathjax/MathJax#2516)

### DIFF
--- a/components/src/input/tex-full/tex-full.js
+++ b/components/src/input/tex-full/tex-full.js
@@ -1,6 +1,7 @@
 import './lib/tex-full.js';
 
 import {registerTeX} from '../tex/register.js';
+import {rename} from '../tex/extensions/rename.js';
 import {Loader} from '../../../../js/components/loader.js';
 import {AllPackages} from '../../../../js/input/tex/AllPackages.js';
 import '../../../../js/input/tex/require/RequireConfiguration.js';
@@ -12,3 +13,7 @@ Loader.preLoad(
 );
 
 registerTeX(['require',...AllPackages]);
+rename('amsCd', 'amscd', true);
+rename('colorV2', 'colorv2', false);
+rename('configMacros', 'configmacros', false);
+rename('tagFormat', 'tagformat', true);


### PR DESCRIPTION
This PR makes sure the configuration blocks for the renamed TeX extensions are renamed in the components ending in `-full` (the individual components did the renaming, but in the `-full` files, the components aren't loaded, the original source code is).

Resolve issue mathjax/MathJax#2516.