### PR TITLE
 Fix issue with textmacros in SVG mode. (mathjax/MathJax#2524)

### DIFF
--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -144,7 +144,11 @@ export class TextParser extends TexParser {
         NodeUtil.setAttribute(mml, name, env[name]);
       }
     }
-    this.nodes.push(mml);
+    if (mml.isKind('inferredMrow')) {
+      mml.childNodes.forEach(child => this.nodes.push(child as MmlNode));
+    } else {
+      this.nodes.push(mml);
+    }
   }
 
   /**

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -145,10 +145,9 @@ export class TextParser extends TexParser {
       }
     }
     if (mml.isKind('inferredMrow')) {
-      mml.childNodes.forEach(child => this.nodes.push(child as MmlNode));
-    } else {
-      this.nodes.push(mml);
+      mml = this.create('node', 'mrow', mml.childNodes);
     }
+    this.nodes.push(mml);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a problem where inferred mrows were being improperly included in the contexts of `text{}` when mathematics is also within the text.  This issue affected SVG output primarily.  The fix is to convert the inferred mrow into a real mrow.

Resolves issue mathjax/MathJax#2524.