### PR TITLE
Only ignore space following alphabetic control sequences.  (mathjax/MathJax#2527)

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -269,7 +269,7 @@ export default class TexParser {
    * @return {string} Get and return a control-sequence name
    */
   public GetCS(): string {
-    let CS = this.string.slice(this.i).match(/^([a-z]+|[\uD800-\uDBFF].|.) ?/i);
+    let CS = this.string.slice(this.i).match(/^([a-z]+ ?|[\uD800-\uDBFF].|.)/i);
     if (CS) {
       this.i += CS[0].length;
       return CS[1];


### PR DESCRIPTION
In `textmacros`, the spacing counts, so we need to follow LaTeX rules poperly:  only skip a space after an alphabetic control sequence, not ones that are a single special character.

Resolves issue mathjax/MathJax#2527.