### PR TITLE
Add missing support for \ref and \eqref in textmacros.  (mathjax/MathJax#2528)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -280,7 +280,8 @@ export const TextMacrosMethods = {
   Spacer: BaseMethods.Spacer,
   Hskip: BaseMethods.Hskip,
   rule: BaseMethods.rule,
-  Rule: BaseMethods.Rule
+  Rule: BaseMethods.Rule,
+  HandleRef: BaseMethods.HandleRef
 
 };
 

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -66,6 +66,13 @@ export class TextParser extends TexParser {
 
   /**
    * @override
+   */
+  public get tags() {
+    return this.texParser.tags;
+  }
+
+  /**
+   * @override
    * @constructor
    */
   constructor(text: string, env: EnvList, configuration: ParseOptions, level?: number | string) {


### PR DESCRIPTION
This PR adds missing support for `\ref` and `\eqref` in the `textmacros` extension.  The macros were mapped, but the method for them was missing, and the `TextParser` needed to use the `tags` object from the original `TexParser` in order to be able access the correct tagging data.

Resolves issue mathjax/MathJax#2528.