### PR TITLE
Add 'smart quote' version of acute and grave accents. (mathjax/MathJax#2526)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -65,7 +65,9 @@ new CommandMap('text-macros', {
   '\\':         'SelfQuote',
 
   '\'':         ['Accent', '\u00B4'],
+  '\u2019':     ['Accent', '\u00B4'],
   '`':          ['Accent', '\u0060'],
+  '\u2018':     ['Accent', '\u0060'],
   '^':          ['Accent', '^'],
   '\"':         ['Accent', '\u00A8'],
   '~':          ['Accent', '~'],


### PR DESCRIPTION
This PR adds two macros to `textmacros`: `\’` and `\‘` that mirror the `\'` and `` \` `` macros, but with "smart quote" characters (U+2019 and U+2018) rather than the usual ascii characters.  The is because some content-management systems do automatic substitution of smart quotes, and would convert `\'` to `\’`, perhaps without the user's knowledge.

Resolves issue mathjax/MathJax#2526.