### PR TITLE
Fixing SCRIPT mapping for 'I'

### DIFF
--- a/ts/output/chtml/fonts/tex/normal.ts
+++ b/ts/output/chtml/fonts/tex/normal.ts
@@ -72,7 +72,7 @@ export const normal: CHTMLCharMap = AddCSS(font, {
     0x210D: {c: 'H', f: 'A'},
     0x210E: {c: 'h', f: 'I'},
     0x210F: {f: 'A'},
-    0x2110: {c: 'J', f: 'SC'},
+    0x2110: {c: 'I', f: 'SC'},
     0x2111: {c: 'I', f: 'FR'},
     0x2112: {c: 'L', f: 'SC'},
     0x2115: {c: 'N', f: 'A'},


### PR DESCRIPTION
Fixes issue #2555:  \mathscr{I} renders incorrectly @mathjax /MathJax 