### PR TITLE
Fix prime display issue for AsciiMath input, svg output

### DIFF
--- a/ts/input/asciimath/mathjax2/legacy/jax/input/AsciiMath/jax.js
+++ b/ts/input/asciimath/mathjax2/legacy/jax/input/AsciiMath/jax.js
@@ -1043,7 +1043,18 @@ function AMparseExpr(str,rightbracket) {
     node = result[0];
     str = result[1];
     symbol = AMgetSymbol(str);
-    if (symbol.ttype == INFIX && symbol.input == "/") {
+    if (symbol.input == "'") { // Speciall handle for prime
+      node = createMmlNode("msup",node);
+      var childNode = createMmlNode(symbol.tag);
+      do {
+        childNode.appendChild(document.createTextNode(symbol.output));
+        str = AMremoveCharsAndBlanks(str,symbol.input.length);
+        symbol = AMgetSymbol(str);
+      } while (symbol.input == "'");
+      node.appendChild(childNode);
+      newFrag.appendChild(node);
+    }
+    else if (symbol.ttype == INFIX && symbol.input == "/") {
       str = AMremoveCharsAndBlanks(str,symbol.input.length);
       result = AMparseIexpr(str);
       if (result[0] == null) // show box in place of missing argument


### PR DESCRIPTION
For AsciiMath notation:
```
h'x'''(x) = g'(h(x)')
```
Before fix:

![image](https://user-images.githubusercontent.com/1261574/98891350-dedee580-2452-11eb-8cf9-2d198c5e7a15.png)

After fix:

![image](https://user-images.githubusercontent.com/1261574/98891191-860f4d00-2452-11eb-9ec5-48bfafadc57a.png)
