### PR TITLE
Fix webpack.common.js to handle windows paths correctly (mathjax/MathJax-demos-web#30)

### DIFF
--- a/components/bin/pack
+++ b/components/bin/pack
@@ -32,11 +32,11 @@ const {execSync} = require('child_process');
 /**
  * Regular expressions for the components directory and the MathJax .js location
  */
-const compRE = new RegExp(path.dirname(__dirname).replace(/([\\.{}[\]()?*^$])/g, '\$1'), 'g');
+const compRE = new RegExp(path.dirname(__dirname).replace(/([\\.{}[\]()?*^$])/g, '\\$1'), 'g');
 const rootRE = new RegExp(path.join(path.dirname(path.dirname(__dirname)), 'js')
-                          .replace(/([\\.{}[\]()?*^$])/g, '\$1'), 'g');
+                          .replace(/([\\.{}[\]()?*^$])/g, '\\$1'), 'g');
 const nodeRE = new RegExp(path.join(path.dirname(path.dirname(__dirname)), 'node_modules')
-                          .replace(/([\\.{}[\]()?*^$])/g, '\$1'), 'g');
+                          .replace(/([\\.{}[\]()?*^$])/g, '\\$1'), 'g');
 
 /**
  * Run webpack if there is a configuration file for it

--- a/components/webpack.common.js
+++ b/components/webpack.common.js
@@ -33,7 +33,7 @@ const TerserPlugin = require('terser-webpack-plugin');
  * @return {string}        The string with regex special characters escaped
  */
 function quoteRE(string) {
-  return string.replace(/([\\.{}[\]()?*^$])/g, '\$1')
+  return string.replace(/([\\.{}[\]()?*^$])/g, '\\$1')
 }
 
 /**
@@ -46,10 +46,10 @@ function quoteRE(string) {
  */
 const PLUGINS = function (mathjax, libs, dir) {
   const mjdir = path.resolve(dir, mathjax);
-  const mjRE = new RegExp('^' + quoteRE(mjdir + '/'));
+  const mjRE = new RegExp('^' + quoteRE(mjdir + path.sep));
   const root = path.dirname(mjdir);
-  const rootRE = new RegExp('^' + quoteRE(root + '/'));
-  const nodeRE = new RegExp('^' + quoteRE(path.dirname(root) + '/'));
+  const rootRE = new RegExp('^' + quoteRE(root + path.sep));
+  const nodeRE = new RegExp('^' + quoteRE(path.dirname(root) + path.sep));
 
   const plugins = [];
   if (libs.length) {
@@ -63,7 +63,7 @@ const PLUGINS = function (mathjax, libs, dir) {
           const request = path.resolve(resource.context, resource.request);
           if (!request.match(mjRE)) return;
           for (const lib of libs) {
-            const file = request.replace(mjRE, path.join(root, lib) + '/');
+            const file = request.replace(mjRE, path.join(root, lib) + path.sep);
             if (fs.existsSync(file)) {
               resource.request = file;
               break;
@@ -82,7 +82,7 @@ const PLUGINS = function (mathjax, libs, dir) {
       function (resource) {
         const request = path.resolve(resource.context, resource.request);
         if (request.match(rootRE) || !request.match(nodeRE) || fs.existsSync(request)) return;
-        const file = request.replace(nodeRE, path.join(root, 'node_modules') + '/');
+        const file = request.replace(nodeRE, path.join(root, 'node_modules') + path.sep);
         if (fs.existsSync(file)) {
           resource.request = file;
         }
@@ -107,8 +107,8 @@ const MODULE = function (dir) {
   return {
     // NOTE: for babel transpilation
     rules: [{
-      test: new RegExp(dirRE + '\\/.*\\.js$'),
-      exclude: new RegExp(quoteRE(path.dirname(__dirname)) + '\\/es5\\/'),
+      test: new RegExp(dirRE + quoteRE(path.sep) + '.*\\.js$'),
+      exclude: new RegExp(quoteRE(path.join(path.dirname(__dirname), 'es5') + path.sep)),
       use: {
         loader: 'babel-loader',
         options: {


### PR DESCRIPTION
The webpack configuration didn't handle Windows path separators properly, which caused the building of components to fail on windows.  This PR resolves the issues by using `path.sep` and fixing `quoteRE()` to properly quote the special characters like `\`.

Resolves issue mathjax/MathJax-demos-web#30.