### PR TITLE
Make mspace elements have TEXCLASS.NONE (mathjax/MathJax#2576)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/ts/core/MmlTree/MmlNodes/mspace.ts
@@ -22,7 +22,7 @@
  */
 
 import {PropertyList} from '../../Tree/Node.js';
-import {AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
+import {MmlNode, AbstractMmlTokenNode, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
 /**
@@ -45,7 +45,14 @@ export class MmlMspace extends AbstractMmlTokenNode {
   /**
    * TeX class is ORD
    */
-  public texClass = TEXCLASS.ORD;
+  public texClass = TEXCLASS.NONE;
+
+  /**
+   * @override
+   */
+  public setTeXclass(prev: MmlNode): MmlNode {
+    return prev;
+  }
 
   /**
    * @override


### PR DESCRIPTION
Currently, `mspace` elements have `TEXCLASS.ORD`, but this causes spacing issues in some instances, for example `A=\!=B`.  This PR sets the `texClass` to `TEXCLASS.NONE` and overrides `setTeXclass()` so that the spacing will be based on the elements surrounding the space, as it is in actual TeX.

Resolves issue mathjax/MathJax#2576.