### PR TITLE
Fix autoloading when macro name is followed by a space.  (mathjax/MathJax#2580)

### DIFF
--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -58,7 +58,7 @@ function Autoload(parser: TexParser, name: string, extension: string, isMacro: b
     //
     //  Put back the macro or \begin and read it again
     //
-    parser.string = (isMacro ? name : '\\begin{' + name.slice(1) + '}' ) + parser.string.slice(parser.i);
+    parser.string = (isMacro ? name + ' ' : '\\begin{' + name.slice(1) + '}' ) + parser.string.slice(parser.i);
     parser.i = 0;
   }
   RequireLoad(parser, extension);


### PR DESCRIPTION
If an autoloading macro is followed by a space, the space is lost when the macro name is reprocessed, and so the macro can become incorrect if it is followed by other tex.  For example, `\ce C` ends up as `\ceC` after the autoload.  This PR replaces the missing space (that was removed during the initial parsing for the macro name, and will be removed again when it is re-parsed).

Resolves issue mathjax/MathJax#2580.