### PR TITLE
Fix handling of mrows that look like \left...\right to be texClass INNER.  (mathjax/Mathjax#2584)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mrow.ts
+++ b/ts/core/MmlTree/MmlNodes/mrow.ts
@@ -153,10 +153,9 @@ export class MmlMrow extends AbstractMmlNode {
    * @override
    */
   public setTeXclass(prev: MmlNode) {
-    if ((this.getProperty('open') != null || this.getProperty('close') != null) &&
-        (!prev || prev.getProperty('fnOP') != null)) {
+    if (this.getProperty('open') != null || this.getProperty('close') != null) {
       //
-      // <mrow> came from \left...\right
+      // <mrow> looks like it came from \left...\right
       //   so treat as subexpression (TeX class INNER).
       // Use prev = null for the initial element in the
       //   delimiters, since there is nothing previous to


### PR DESCRIPTION
This PR removes the check that there either be no previous element or that it be marked as `fnOP` in order for an `mrow` to be marked as `TEXCLASS.INNER`.  That was incorrectly preventing `\left...\right` constructs from being treated as the correct class.

With this PR, `f\left(x\right)` will be spaced as it is in actual TeX (with a bit of extra space between the `f` and the open parenthesis).  It also means that 

``` xml
<math>
  <mi>f</mi>
  <mrow>
    <mo>(</mo>
    <mi>x</mi>
    <mo>)</mo>
  </mrow>
</math>
```

will also be spaced the same way.  Some may object to that.  There are several ways to prevent it.  One would be to set the `mathMLSpacing` property to `true` on the output jax.  Alternatively, you can modify the input to be

``` xml
<math>
  <mi>f</mi>
  <mrow data-mjx-texclass="ORD">
    <mo>(</mo>
    <mi>x</mi>
    <mo>)</mo>
  </mrow>
</math>
```

or

``` xml
<math>
  <mi>f</mi>
  <mo rspace="0">&#x2061;</mo>
  <mrow>
    <mo>(</mo>
    <mi>x</mi>
    <mo>)</mo>
  </mrow>
</math>
```

One could also write a MathML input jax post-filter to add the `data-mjx-texclass="ORD"` to recover the earlier behavior.

Resolves issue mathjax/Mathjax#2584.