### PR TITLE
Update TeXAtom to save the texClass in the property list, so it appears in MathML output.  (mathjax/MathJax#2585)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/TeXAtom.ts
+++ b/ts/core/MmlTree/MmlNodes/TeXAtom.ts
@@ -70,6 +70,14 @@ export class TeXAtom extends AbstractMmlBaseNode {
   /**
    * @override
    */
+  constructor(node: any, properties: any, children: any) {
+    super(node, properties, children);
+    this.setProperty('texClass', this.texClass);   // needed for serialization to include the texClass
+  }
+
+  /**
+   * @override
+   */
   public setTeXclass(prev: MmlNode) {
     this.childNodes[0].setTeXclass(null);
     return this.adjustTeXclass(prev);

--- a/ts/core/MmlTree/MmlNodes/TeXAtom.ts
+++ b/ts/core/MmlTree/MmlNodes/TeXAtom.ts
@@ -21,6 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import {MmlFactory} from '../MmlFactory.js';
 import {PropertyList} from '../../Tree/Node.js';
 import {AbstractMmlBaseNode, MmlNode, TEXCLASS} from '../MmlNode.js';
 import {MmlMo} from './mo.js';
@@ -70,8 +71,8 @@ export class TeXAtom extends AbstractMmlBaseNode {
   /**
    * @override
    */
-  constructor(node: any, properties: any, children: any) {
-    super(node, properties, children);
+  constructor(factory: MmlFactory, attributes: PropertyList, children: MmlNode[]) {
+    super(factory, attributes, children);
     this.setProperty('texClass', this.texClass);   // needed for serialization to include the texClass
   }
 


### PR DESCRIPTION
This PR adjusts the TeXAtom node to save the node's TeX class in the property list so that it will be included in the `data-mjx-texclass` attribute when serialized MathML is generated, even if the TeX class is just the default `ORD` class.  This allows the serialized MathML to preserve the TeXAtom even when the property was not set explicitly.

For example, `f{\left(x\right)}` currently produces

``` xml
<math xmlns="http://www.w3.org/1998/Math/MathML">
  <mi>f</mi>
  <mrow>
    <mrow data-mjx-texclass="INNER">
      <mo data-mjx-texclass="OPEN">(</mo>
      <mi>x</mi>
      <mo data-mjx-texclass="CLOSE">)</mo>
    </mrow>
  </mrow>
</math>
```

and since the outer `<mrow>` does not include a TeX class, the spacing is that of `INNER` when this MathML is read into MathJax (but the spacing is `ORD` when the TeX input is processed).

This PR causes the serialized MathML to be

``` xml
<math xmlns="http://www.w3.org/1998/Math/MathML">
  <mi>f</mi>
  <mrow data-mjx-texclass="ORD">
    <mrow data-mjx-texclass="INNER">
      <mo data-mjx-texclass="OPEN">(</mo>
      <mi>x</mi>
      <mo data-mjx-texclass="CLOSE">)</mo>
    </mrow>
  </mrow>
</math>
```

which gives the same output as the TeX does.

Note that this PR probably will require changes to the test suite, since braced groups will now show `data-mix-texclass="ORD"` explicitly in situations where it didn't before.  (E.g., `x^{-4}`).

Resolves issue mathjax/MathJax#2585.