### PR TITLE
Reset the tex labels and ids when A11y changes force rerendering.  (mathjax/MathJax#2597)

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -941,6 +941,13 @@ export class Menu {
   protected rerender(start: number = STATE.TYPESET) {
     this.rerenderStart = Math.min(start, this.rerenderStart);
     if (!Menu.loading) {
+      if (this.rerenderStart <= STATE.COMPILED) {
+        for (const jax of this.document.inputJax) {
+          if (jax.name === 'TeX') {
+            (jax as any).parseOptions.tags.reset(0);
+          }
+        }
+      }
       this.document.rerender(this.rerenderStart);
       this.rerenderStart = STATE.LAST;
     }


### PR DESCRIPTION
This PR forces TeX to reset the tags when an A11Y menu item causes the page to re-render.

It may be good to abstract this so that the MathDocument has a `reset` method that can just be called, and that would call resets on the input jax (and output jax?), which would be empty for ones with no reset, but would do the TeX reset for the TeX input.

It may also be appropriate to save the expression labels and ids for each expression so that if it is re-rendered, it clear those labels and ids, and start auto-numbering at the right place.  That would allow proper rerendering without making assumptions about where the numbering starts on the page, or what labels need to be cleared.

Resolves issue mathjax/MathJax#2597