### PR TITLE
Make sure strechy character extenders have non-zero height in CHTML for Safari (mathjax/MathJax#2598)

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -327,6 +327,8 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
       css.padding = this.padding(data, dw);
     } else if (dw) {
       css['padding-left'] = this.em0(dw);
+    } else {
+      css.padding = '.1em 0';    // for Safari
     }
     styles['mjx-stretchy-v' + c + ' mjx-' + part + ' mjx-c::before'] = css;
     return data[0] + data[1];
@@ -364,6 +366,8 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
     const css: StyleData = {content: (options && options.c ? '"' + options.c + '"' : this.charContent(n))};
     if (part !== 'ext' || force) {
       css.padding = this.padding(data, 0, -data[2]);
+    } else {
+      css['padding-top'] = '1px';   // for Safari
     }
     styles['mjx-stretchy-h' + c + ' mjx-' + part + ' mjx-c::before'] = css;
   }

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -74,7 +74,7 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       transform: 'scalex(500)'
     },
     'mjx-stretchy-h > mjx-ext > mjx-c': {
-      width: 0
+      width: '100%'
     },
     'mjx-stretchy-h > mjx-beg > mjx-c': {
       'margin-right': '-.1em'


### PR DESCRIPTION
It turns out that the zero height boxes used for the characters in the stretchy horizontal extenders in CHTML are not placed properly in Safari (but are in Firefox and Chrome).  If the height is non-zero, they they are, so this PR forces a non-zero height.

Resolves issue mathjax/MathJax#2598.