### PR TITLE
 Remove role application on detach only if active.

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -130,8 +130,8 @@ export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> impleme
       this.node.tabIndex = this.oldIndex;
       this.oldIndex = null;
       this.node.removeAttribute('role');
-      super.Detach();
     }
+    super.Detach();
   }
 
   /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -126,10 +126,12 @@ export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> impleme
    * @override
    */
   public Detach() {
-    this.node.tabIndex = this.oldIndex;
-    this.oldIndex = null;
-    this.node.removeAttribute('role');
-    super.Detach();
+    if (this.active) {
+      this.node.tabIndex = this.oldIndex;
+      this.oldIndex = null;
+      this.node.removeAttribute('role');
+      super.Detach();
+    }
   }
 
   /**


### PR DESCRIPTION
Problem: 
When only one `KeyExplorer` attaches itself, one of the others might remove the `role="application"` attribute.

Solution:
`KeyExplorer` only alters attributes during detachment when they are active.