### PR TITLE
Add support for setting the unknown character family for output jax

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -25,7 +25,6 @@ import {CharMap, CharOptions, CharData, VariantData, DelimiterData, FontData, DI
 import {StringMap} from './Wrapper.js';
 import {StyleList, StyleData} from '../../util/StyleList.js';
 import {em} from '../../util/lengths.js';
-import {OptionList, defaultOptions, userOptions} from '../../util/Options.js';
 
 export * from '../common/FontData.js';
 
@@ -71,6 +70,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    * Default options
    */
   public static OPTIONS = {
+    ...FontData.OPTIONS,
     fontURL: 'js/output/chtml/fonts/tex-woff-v2'
   };
 
@@ -105,11 +105,6 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
   };
 
   /**
-   * The font options
-   */
-  protected options: OptionList;
-
-  /**
    * @override
    */
   public static charOptions(font: CHTMLCharMap, n: number) {
@@ -117,18 +112,6 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
   }
 
   /***********************************************************************/
-
-  /**
-   * @param {OptionList} options   The options for this font
-   *
-   * @override
-   * @constructor
-   */
-  constructor(options: OptionList = null) {
-    super();
-    let CLASS = (this.constructor as CHTMLFontDataClass);
-    this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
-  }
 
   /**
    * @param {boolean} adapt   Whether to use adaptive CSS or not

--- a/ts/output/svg/fonts/tex.ts
+++ b/ts/output/svg/fonts/tex.ts
@@ -24,6 +24,7 @@
 import {SVGFontData, SVGFontDataClass, SVGCharOptions, SVGVariantData, SVGDelimiterData,
         DelimiterMap, CharMapMap} from '../FontData.js';
 import {CommonTeXFontMixin} from '../../common/fonts/tex.js';
+import {OptionList} from '../../../util/Options.js';
 
 import {boldItalic} from './tex/bold-italic.js';
 import {bold} from './tex/bold.js';
@@ -127,8 +128,8 @@ CommonTeXFontMixin<SVGCharOptions, SVGVariantData, SVGDelimiterData, SVGFontData
   /**
    * @override
    */
-  constructor() {
-    super();
+  constructor(options: OptionList = null) {
+    super(options);
     //
     //  Add the cacheIDs to the variants
     //
@@ -139,4 +140,3 @@ CommonTeXFontMixin<SVGCharOptions, SVGVariantData, SVGDelimiterData, SVGFontData
   }
 
 }
-


### PR DESCRIPTION
This PR provides a new output jax parameter that specifies the font family to use for unknown characters (it defaults to `serif` as int eh past, but makes it easier to change the default to `monospace` when the LiteAdaptor is used.

This required moving support for `FontData` options from `chtml/FontData.ts` into `common/FontData.ts`, and making sure all the constructors passed the options on properly.