### PR TITLE
Show all modules during packing

### DIFF
--- a/components/bin/makeAll
+++ b/components/bin/makeAll
@@ -126,7 +126,7 @@ function webpackLib(dir) {
   const wd = process.cwd();
   try {
     process.chdir(dir);
-    const result = execSync('npx webpack --stats-modules');
+    const result = execSync('npx webpack --display-modules');
     console.info('    ' + String(result).replace(/\n/g, '\n    ')
                  .replace(/ \.\.\//g, ' ' + path.dirname(path.resolve(dir)) + '/')
                  .replace(compRE, '[components]')


### PR DESCRIPTION
Not sure why this was changed, but I used the full list to check that everything is packing from the proper locations.  If that is a problem, perhaps we need to make a command-line option to control it.