### PR TITLE
Make sure bevelled fraction is symmertically placed (needed for STIX2 fonts)

### DIFF
--- a/ts/output/common/Wrappers/mfrac.ts
+++ b/ts/output/common/Wrappers/mfrac.ts
@@ -120,6 +120,7 @@ export function CommonMfracMixin<T extends WrapperConstructor>(Base: T): MfracCo
       if (this.node.attributes.get('bevelled')) {
         const {H} = this.getBevelData(this.isDisplay());
         const bevel = this.bevel = this.createMo('/') as CommonMo;
+        bevel.node.attributes.set('symmetric', true);
         bevel.canStretch(DIRECTION.Vertical);
         bevel.getStretchedVariant([H], true);
       }


### PR DESCRIPTION
This PR makes sure the `/` used for bevelled fractions is centered on the math axis.  This didn't matter with the MathJax TeX fonts, whose glyphs are centered already, but for STIX2, the slash isn't centered, so this makes a difference.