### PR TITLE
Updates to handle smallmatrix properly

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/ts/core/MmlTree/MmlNodes/mtable.ts
@@ -61,7 +61,7 @@ export class MmlMtable extends AbstractMmlNode {
    * Extra properties for this node
    */
   public properties = {
-    useHeight: 1
+    useHeight: true
   };
 
   /**
@@ -116,6 +116,7 @@ export class MmlMtable extends AbstractMmlNode {
           .appendChild(child);
       }
     }
+    level = this.getProperty('scriptlevel') as number || level;
     display = !!(this.attributes.getExplicit('displaystyle') || this.attributes.getDefault('displaystyle'));
     attributes = this.addInheritedAttributes(attributes, {
       columnalign: this.attributes.get('columnalign'),

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -210,6 +210,8 @@ export class SerializedMmlVisitor extends MmlVisitor {
       }
       setclass && this.setDataAttribute(data, 'texclass', texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass]);
     }
+    node.getProperty('scriptlevel') && node.getProperty('useHeight') === false &&
+      this.setDataAttribute(data, 'smallmatrix', 'true');
     return data;
   }
 

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -159,6 +159,9 @@ export class MathMLCompile<N, T, D> {
         } else if (name === 'data-mjx-variant') {
           mml.attributes.set('mathvariant', value);
           ignoreVariant = true;
+        } else if (name === 'data-mjx-smallmatrix') {
+          mml.setProperty('scriptlevel', 1);
+          mml.setProperty('useHeight', false);
         }
       } else if (name !== 'class') {
         let val = value.toLowerCase();

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -846,6 +846,9 @@ export class ArrayItem extends BaseItem {
       const scriptlevel = this.arraydef['scriptlevel'];
       delete this.arraydef['scriptlevel'];
       let mml = this.create('node', 'mtable', this.table, this.arraydef);
+      if (scriptlevel) {
+        mml.setProperty('scriptlevel', scriptlevel);
+      }
       if (this.frame.length === 4) {
         // @test Enclosed frame solid, Enclosed frame dashed
         NodeUtil.setAttribute(mml, 'frame', this.dashed ? 'dashed' : 'solid');
@@ -865,10 +868,6 @@ export class ArrayItem extends BaseItem {
           // @test Enclosed dashed column, Enclosed solid column
           NodeUtil.setAttribute(mml, 'padding', 0);
         }
-      }
-      if (scriptlevel) {
-        // @test Subarray, Small Matrix
-        mml = this.create('node', 'mstyle', [mml], {scriptlevel: scriptlevel});
       }
       if (this.getProperty('open') || this.getProperty('close')) {
         // @test Cross Product Formula

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -58,6 +58,9 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
       'position': 'relative',
       'box-sizing': 'border-box'
     },
+    'mjx-mstyle[size="s"] mjx-mtable': {
+      'vertical-align': '.354em'
+    },
     'mjx-labels': {
       position: 'absolute',
       left: 0,

--- a/ts/output/chtml/Wrappers/mtd.ts
+++ b/ts/output/chtml/Wrappers/mtd.ts
@@ -109,9 +109,12 @@ CommonMtdMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       this.adaptor.setStyle(this.chtml, 'textAlign', calign);
     }
     //
-    // Include a strut to force minimum height and depth
+    // If we are using minimum row heights,
+    //   Include a strut to force minimum height and depth
     //
-    this.adaptor.append(this.chtml, this.html('mjx-tstrut'));
+    if (this.parent.parent.node.getProperty('useHeight')) {
+      this.adaptor.append(this.chtml, this.html('mjx-tstrut'));
+    }
   }
 
 }

--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -102,7 +102,9 @@ export function CommonMrowMixin<T extends WrapperConstructor>(Base: T): MrowCons
         for (const child of this.childNodes) {
           const noStretch = (child.stretch.dir === DIRECTION.None);
           if (all || noStretch) {
-            const {h, d} = child.getBBox(noStretch);
+            let {h, d, rscale} = child.getBBox(noStretch);
+            h *= rscale;
+            d *= rscale;
             if (h > H) H = h;
             if (d > D) D = d;
           }

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -617,8 +617,16 @@ export function CommonMtableMixin<
      */
     public updateHDW(cell: C, i: number, j: number, H: number[], D: number[], W: number[] = null) {
       let {h, d, w} = cell.getBBox();
-      if (h < .75) h = .75;
-      if (d < .25) d = .25;
+      const scale = cell.parent.bbox.rscale;
+      if (cell.parent.bbox.rscale !== 1) {
+        h *= scale;
+        d *= scale;
+        w *= scale;
+      }
+      if (this.node.getProperty('useHeight')) {
+        if (h < .75) h = .75;
+        if (d < .25) d = .25;
+      }
       if (h > H[j]) H[j] = h;
       if (d > D[j]) D[j] = d;
       if (W && w > W[i]) W[i] = w;


### PR DESCRIPTION
This PR implements the proper table layout for the `smallmatrix` and `subarray` environments.  These use the `useHeight` property that is supposed to to change how the matrix is laid out (by not adding extra height and depth to make sure rows are full height, as usual).  That feature was not implemented, so this PR adds support for `useHeight`.

These environments are typeset in script style, which had been handled by adding an `mstyle` around the table with `scriptlevel="1"`, but this had the side-effect of making the math axis be the script-size math axis (too low).  So the script level is now set through an internal property instead (which causes the table to scale down its children).  That required handling the relative size change of children in the bounding box computations.

The MathML serializer was modified to expose the small matrix internal properties as data attributes, and the MathML input to read those and restore the internal properties.

Finally, the `mrow` stretchy operator heights didn't take scaled children into proper account when figuring the heights, so there is a fix there as well.  There should probably be a `getChildBBox()` function that computes a properly scaled version of the BBox, since that ends up being a common issue that has caused problems before.  (That will also be needed in order to handle borders, margins, and padding CSS, which v2 does, but v3 doesn't.)  I will make that a separate PR, as it will touch on lots of files.