### PR TITLE
Don't mark mrows as fences if the parens aren't stretchy

### DIFF
--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -302,8 +302,8 @@ export class MathMLCompile<N, T, D> {
     if (mml.isKind('mrow') && !mml.isInferred && mml.childNodes.length >= 2) {
       let first = mml.childNodes[0] as MmlNode;
       let last = mml.childNodes[mml.childNodes.length - 1] as MmlNode;
-      if (first.isKind('mo') && first.attributes.get('fence') &&
-          last.isKind('mo') && last.attributes.get('fence')) {
+      if (first.isKind('mo') && first.attributes.get('fence') && first.attributes.get('stretchy') &&
+          last.isKind('mo') && last.attributes.get('fence') && last.attributes.get('stretchy')) {
         if (first.childNodes.length) {
           mml.setProperty('open', (first as AbstractMmlTokenNode).getText());
         }


### PR DESCRIPTION
This PR resolves an issue reported by Peter where enrichment causes spacing differences with parentheses following a function, e.g. `f(x)` gets treated like `f\left(x\right)` after enrichment.  This is due to the extra `<mrow>` that is put around the `(x)`, which in turn is treated by the MathML input jax as a fenced group, which gets `texClass` of `INNER`, and so gets extra space.

This PR changes the heuristic for marking fenced groups so that they are marked only if the fences are actually stretchy (e.g., could have come from `\left...\right`), and not otherwise.  That should preserve the spacing from TeX output that gets enhanced.  It might still alter MathML output unless it is marked carefully, but that was the case in the past as well, since putting the `<mrow>` around the parentheses might prevent the parentheses from stretching to match larger content in the rest of the expression.  That is a good thing.