### PR TITLE
Use the correct parser for noundefined (mathjax/MathJax#2622)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -62,7 +62,7 @@ export const textBase = Configuration.local({
       if (macro && macro._func !== TextMacrosMethods.Macro) {
         parser.Error('MathMacro', '%1 is only supported in math mode', '\\' + name);
       }
-      texParser.parse('macro', [macro ? parser : texParser, name]);
+      texParser.parse('macro', [parser, name]);
     }
   },
   items: {


### PR DESCRIPTION
This PR corrects the problem mentioned in mathjax/MathJax#2622:  that any undefined macros used in text mode when textmacros is in effect will end up being placed before the text material, regardless of where the undefined macro appears.