### PR TITLE
Use mrow rather than inferredMrow if text mode produces more than one. (mathjax/MathJax#2577)

### DIFF
--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -88,7 +88,7 @@ export class TextParser extends TexParser {
   public mml() {
     return (this.level != null ?
             this.create('node', 'mstyle', this.nodes, {displaystyle: false, scriptlevel: this.level}) :
-            this.nodes.length === 1 ? this.nodes[0] : this.create('node', 'inferredMrow', this.nodes));
+            this.nodes.length === 1 ? this.nodes[0] : this.create('node', 'mrow', this.nodes));
   }
 
   /**


### PR DESCRIPTION
This PR prevents an unwanted inferredMrow from being used for the content of text-mode material that produces more than one element.  This prevents overlaps in the rendering in SVG.

Resolves issue mathjax/MathJax#2577.