### PR TITLE
Add exported configuration constant (mathjax/MathJax#2623)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -93,7 +93,7 @@ function internalMath(parser: TexParser, text: string, level?: number | string, 
 //
 //  The textmacros package configuration
 //
-Configuration.create('textmacros', {
+export const TextMacrosConfiguration = Configuration.create('textmacros', {
   /**
    * @param {ParserConfiguration} config   The configuration object we are being configured within
    * @param {TeX<any,any,any>} jax         The TeX input jax in which we are running


### PR DESCRIPTION
This PR exports the `textmacros` configuration (as per @pkra's request).

Resolves issue mathjax/MathJax#2623.