### PR TITLE
Make sure hitbox is translated along with the hit-able element. (mathjax/MathJax#2530)

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -243,12 +243,19 @@ CommonWrapper<
    */
   public place(x: number, y: number, element: N = null) {
     if (!(x || y)) return;
+    const adaptor = this.adaptor;
+    const translate = 'translate(' + this.fixed(x) + ', ' + this.fixed(y) + ')';
     if (!element) {
       element = this.element;
+      if (this.node.attributes.get('href')) {
+        const rect = adaptor.previous(element);
+        if (rect && adaptor.kind(rect) === 'rect' && adaptor.getAttribute(rect, 'data-hitbox')) {
+          adaptor.setAttribute(rect, 'transform', translate);
+        }
+      }
     }
-    let transform = this.adaptor.getAttribute(element, 'transform') || '';
-    transform = 'translate(' + this.fixed(x) + ', ' + this.fixed(y) + ')' + (transform ? ' ' + transform : '');
-    this.adaptor.setAttribute(element, 'transform', transform);
+    let transform = adaptor.getAttribute(element, 'transform') || '';
+    adaptor.setAttribute(element, 'transform', translate + (transform ? ' ' + transform : ''));
   }
 
   /**


### PR DESCRIPTION
This PR resolves the issue with hit-boxes for the SVG output when an element in the middle of an `mrow` has an `href` attribute.  The hotbox was not placed properly, so this patch causes the box to be translated properly.

(I had fixed this some time ago, but apparently didn't push the branch or make the PR).

Resolves issue mathjax/MathJax#2530.