### PR TITLE
Update texClass to texclass for tsc v4.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/ts/core/MmlTree/MmlNodes/mspace.ts
@@ -45,7 +45,7 @@ export class MmlMspace extends AbstractMmlTokenNode {
   /**
    * TeX class is ORD
    */
-  public texClass = TEXCLASS.NONE;
+  protected texclass = TEXCLASS.NONE;
 
   /**
    * @override


### PR DESCRIPTION
This PR fixes the mspace internal node to work with Tyepscript v4.  This would have been part of #560, except the addition of the `texclass` was created before that, but merged after that, so it was not part of that PR.

This should allow `mspace` to compile properly now.