### PR TITLE
Fixes table walking by setting modifier key.

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -257,6 +257,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
    */
   public KeyDown(event: KeyboardEvent) {
     const code = event.keyCode;
+    this.walker.modifier = event.shiftKey;
     if (code === 27) {
       this.Stop();
       this.stopEvent(event);
@@ -380,6 +381,7 @@ export class Magnifier extends AbstractKeyExplorer<HTMLElement> {
    */
   public KeyDown(event: KeyboardEvent) {
     const code = event.keyCode;
+    this.walker.modifier = event.shiftKey;
     if (code === 27) {
       this.Stop();
       this.stopEvent(event);

--- a/ts/a11y/sre_browser.d.ts
+++ b/ts/a11y/sre_browser.d.ts
@@ -25,6 +25,7 @@ declare namespace sre {
   }
 
   interface Walker {
+    modifier: boolean;
     activate(): void;
     deactivate(): void;
     speech(): string;


### PR DESCRIPTION
Pass the shift key to the table walker as modifier. This allows table walking similar to v2.