### PR TITLE
Add setTeXclass support for mroot elements.  (mathjax/MathJax#2630)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mroot.ts
+++ b/ts/core/MmlTree/MmlNodes/mroot.ts
@@ -22,7 +22,7 @@
  */
 
 import {PropertyList} from '../../Tree/Node.js';
-import {AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
+import {MmlNode, AbstractMmlNode, AttributeList, TEXCLASS} from '../MmlNode.js';
 
 /*****************************************************************/
 /**
@@ -56,6 +56,19 @@ export class MmlMroot extends AbstractMmlNode {
    */
   public get arity() {
     return 2;
+  }
+
+  /**
+   * Set the TeX class for the content of the root and the root separately.
+   * Return ourself as the previous item.
+   *
+   * @override
+   */
+  public setTeXclass(prev: MmlNode) {
+    this.getPrevClass(prev);
+    this.childNodes[0].setTeXclass(null);
+    this.childNodes[1].setTeXclass(null);
+    return this;
   }
 
   /**


### PR DESCRIPTION
This PR implements the `setTeXclass()` method for `mroot` elements, which was missing (argh!).

Resolves issue mathjax/MathJax#2630.