### PR TITLE
Handle measuring of elements as in liteDOM, since jsdom doesn't do measurements.  (mathjax/MathJax#2550)

### DIFF
--- a/ts/adaptors/jsdomAdaptor.ts
+++ b/ts/adaptors/jsdomAdaptor.ts
@@ -36,7 +36,7 @@ export class JsdomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
   };
 
   /**
-   * Pattern to identify CJK (.i.e., full-width) characters
+   * Pattern to identify CJK (i.e., full-width) characters
    */
   public static cjkPattern = new RegExp([
     '[',


### PR DESCRIPTION
This PR allows the jsdom adaptor to handle undefined characters and `mtextFontInherit` better (in the same way that the liteDOM does).  It also adds options for the jsdom adaptor so that you can specify the widths and heights to use for the unknown characters.

Resolves issue mathjax/MathJax#2550.