### PR TITLE
A11y menu update

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -489,8 +489,8 @@ export class Menu {
               ['clearspeak-default', 'Auto']
             ])),
             this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechRules', [
-              ['default-default', 'Standard'],
-              ['default-alternative', 'Alternative']
+              ['chromevox-default', 'Standard'],
+              ['chromevox-alternative', 'Alternative']
             ]))
           ]),
           this.submenu('Highlight', 'Highlight', [


### PR DESCRIPTION
Updates menu entry to reflect renaming of ChromeVox rule set in SRE (>= v3.2.0-beta.1).