### PR TITLE
Fix problem with \| being stretchy when it shouldn't be.  (mathjax/MathJax#2632)

### DIFF
--- a/ts/core/MmlTree/OperatorDictionary.ts
+++ b/ts/core/MmlTree/OperatorDictionary.ts
@@ -1271,7 +1271,3 @@ export const OPTABLE: {[form: string]: OperatorList} = {
 //
 OPTABLE['infix']['^'] = MO.WIDEREL;
 OPTABLE['infix']['_'] = MO.WIDEREL;
-OPTABLE['prefix']['\u2223'] = MO.OPEN;
-OPTABLE['prefix']['\u2225'] = MO.OPEN;
-OPTABLE['postfix']['\u2223'] = MO.CLOSE;
-OPTABLE['postfix']['\u2225'] = MO.CLOSE;

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -220,8 +220,6 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   times:        '\u00D7',
   star:         '\u22C6',
 
-  Vert:         ['\u2225', {texClass: TEXCLASS.ORD}],
-  '|':          ['\u2225', {texClass: TEXCLASS.ORD}],
 
   // Relations
   propto:       '\u221D',

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -220,6 +220,9 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   times:        '\u00D7',
   star:         '\u22C6',
 
+  Vert:         ['\u2225', {texClass: TEXCLASS.ORD}],
+  '|':          ['\u2225', {texClass: TEXCLASS.ORD}],
+
   // Relations
   propto:       '\u221D',
   sqsubseteq:   '\u2291',
@@ -361,8 +364,8 @@ new sm.DelimiterMap('delimiter', ParseMethods.delimiter, {
   '\\arrowvert':      '\u23D0',
   '\\Arrowvert':      '\u2016',
   '\\bracevert':      '\u23AA',  // non-standard
-  '\\Vert':           ['\u2225', {texClass: TEXCLASS.ORD}],
-  '\\|':              ['\u2225', {texClass: TEXCLASS.ORD}],
+  '\\Vert':           ['\u2016', {texClass: TEXCLASS.ORD}],
+  '\\|':              ['\u2016', {texClass: TEXCLASS.ORD}],
   '\\vert':           ['|', {texClass: TEXCLASS.ORD}],
   '\\uparrow':        '\u2191',
   '\\downarrow':      '\u2193',


### PR DESCRIPTION
Semantic enrichment together with certain TeX input can cause `\|` to be stretchy when it shouldn't.  For example, `\|X^X\|_x,` can cause the problem.  This is due to the fact that `\|` produces U+2225, which normally is not stretchy, but should be when used as delimiters with `\left` and `\right`.  In order to accommodate that, the operator dictionary added U+2225 in prefix and postfix positions with `stretchy="true"`, making the stretchy attribute different in infix from the other positions.

Because the TeX input jax removes attributes that are the defaults for the given nodes, the expression `\|X^X\|_x,` has `\|_x` in infix position (as an embellished operator), and so the U+2225 has `stretchy="false"` and `fence="false"` as defaults, and so these attributes that had been added explicitly by `\|` are removed in the `cleanAttributes` post-filter (that is not the case for the initial one, since it is in prefix position, where the defaults are `true` for those attributes).  But when enriched, the result is that `\|X^X\|_x` is placed in an mrow (with the comma outside), and so the `\|_x` is now in prefix position, where it defaults to being a stretchy fence.

The basis of the problem is the different stretchability for infix versus pre- and postfix positions, which was due to an addition to the table to make the poor TeX mapping of the delimiter `\|` to U+2225 work.  This PR resolves the problem by removing the changes to the operator dictionary for U+2225, and instead, having the delimiters `\|` and `\Vert` map to U+2016.

Resolves issue mathjax/MathJax#2632.