### PR TITLE
Handle appending of inferred rows in MmlNode.appendChild() (mathjax/MathJax#2554)

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -448,9 +448,7 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
       //  (just add its children).
       //
       if (this.arity === Infinity) {
-        for (const node of child.childNodes) {
-          super.appendChild(node);
-        }
+        child.childNodes.forEach((node) => super.appendChild(node));
         return child;
       }
       //

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -443,10 +443,26 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
       return child;
     }
     if (child.isInferred) {
-      for (const node of child.childNodes) {
-        super.appendChild(node);
+      //
+      //  If we can have arbitrary children, remove the inferred mrow
+      //  (just add its children).
+      //
+      if (this.arity === Infinity) {
+        for (const node of child.childNodes) {
+          super.appendChild(node);
+        }
+        return child;
       }
-      return child;
+      //
+      //  Otherwise, convert the inferred mrow to an explicit mrow
+      //
+      const original = child;
+      child = this.factory.create('mrow');
+      child.setChildren(original.childNodes);
+      child.attributes = original.attributes;
+      for (const name of original.getPropertyNames()) {
+        child.setProperty(name, original.getProperty(name));
+      }
     }
     return super.appendChild(child);
   }

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -226,7 +226,7 @@ export interface MmlNodeClass extends NodeClass {
  */
 
 export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
-  protected texclass: number = null;
+
   /**
    * The properties common to all MathML nodes
    */
@@ -307,6 +307,11 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
    * The node factory is an MmlFactory
    */
   public readonly factory: MmlFactory;
+
+  /**
+   * The TeX class of this node (obtained via texClass below)
+   */
+  protected texclass: number = null;
 
   /**
    *  Create an MmlNode:
@@ -427,13 +432,20 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
     return super.setChildren(children);
   }
   /**
-   * If there is an inferred row, append to that instead
+   * If there is an inferred row, append to that instead.
+   * If a child is inferred, append its children instead.
    *
    * @override
    */
   public appendChild(child: MmlNode) {
     if (this.arity < 0) {
       this.childNodes[0].appendChild(child);
+      return child;
+    }
+    if (child.isInferred) {
+      for (const node of child.childNodes) {
+        super.appendChild(node);
+      }
       return child;
     }
     return super.appendChild(child);

--- a/ts/input/tex/NodeFactory.ts
+++ b/ts/input/tex/NodeFactory.ts
@@ -70,30 +70,7 @@ export class NodeFactory {
                            children: MmlNode[] = [], def: any = {},
                            text?: TextNode): MmlNode {
     const node = factory.mmlFactory.create(kind);
-    // If infinity or -1 remove inferred mrow
-    //
-    // In all other cases replace inferred mrow with a regular mrow, before adding
-    // children.
-    const arity = node.arity;
-    if (arity === Infinity || arity === -1) {
-      if (children.length === 1 && children[0].isInferred) {
-        node.setChildren(NodeUtil.getChildren(children[0]));
-      } else {
-        node.setChildren(children);
-      }
-    } else {
-      let cleanChildren = [];
-      for (let i = 0, child; child = children[i]; i++) {
-        if (child.isInferred) {
-          let mrow = factory.mmlFactory.create('mrow', {}, NodeUtil.getChildren(child));
-          NodeUtil.copyAttributes(child, mrow);
-          cleanChildren.push(mrow);
-        } else {
-          cleanChildren.push(child);
-        }
-      }
-      node.setChildren(cleanChildren);
-    }
+    node.setChildren(children);
     if (text) {
       node.appendChild(text);
     }

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -136,14 +136,7 @@ namespace ParseUtil {
                      {fence: true, stretchy: true, symmetric: true, texClass: TEXCLASS.OPEN},
                      openNode);
     }
-    NodeUtil.appendChildren(mrow, [mo]);
-    if (NodeUtil.isType(mml, 'mrow') && NodeUtil.isInferred(mml)) {
-      // @test Fenced, Middle
-      NodeUtil.appendChildren(mrow, NodeUtil.getChildren(mml));
-    } else {
-      // @test Fenced3
-      NodeUtil.appendChildren(mrow, [mml]);
-    }
+    NodeUtil.appendChildren(mrow, [mo, mml]);
     if (big) {
       mo = new TexParser('\\' + big + 'r' + close, configuration.parser.stack.env, configuration).mml();
     } else {

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -149,7 +149,7 @@ export class TextParser extends TexParser {
         NodeUtil.setAttribute(mml, name, env[name]);
       }
     }
-    if (mml.isKind('inferredMrow')) {
+    if (mml.isInferred) {
       mml = this.create('node', 'mrow', mml.childNodes);
     }
     this.nodes.push(mml);


### PR DESCRIPTION
Inferred mrows are used to hold multiple MathML nodes in situations where a single node is expected (e.g., they act as MathML fragments).  For example, the TexParser's `ParseArg()` function can return an inferred mrow.  These should not appear as children of normal MathML elements, and so historically the code had to be careful to check the return value of such functions in order to handle inferred mrows as a special case.  While this was done in many places, some situations still slipped through.  An unexpected inferred mrow did not affect CHTML output, but it does cause problems for SVG output, with mathjax/MathJax#2554, mathjax/MathJax#2624, and mathjax/MathJax#2577 being examples.

Rather than try to patch each new occurrence as it appears, this PR resolves it at the lowest lever:  the MmlNode's `appendChild()` function.  In the event that an inferred mrow is appended to an element, the mrow's children are appended instead.  This catches the problem in `setChildren()` as well, since that uses `appendChild()` internally.

This PR removes some of the special-casing that was done in NodeFactory and ParseUtil, since appending the children now handles the inferred mrows directly.  (There is one difference, which is that NodeFactory would turn the inferred mrows into actual mrows, but that should not be necessary.  It will mean some tests will probably have to be updated, though.)

This PR also moves the `texclass` property to below the static properties to make `tslint` happy.

Resolves issues mathjax/MathJax#2554 and mathjax/MathJax#2624.

Note that this means that PR #585 is no longer needed, as this PR is a better solution.