### PR TITLE
Use TeX algorithm for stretchy accents

### DIFF
--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -201,6 +201,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
     const variants = (this.constructor as typeof SerializedMmlVisitor).variants;
     variant && variants.hasOwnProperty(variant) && this.setDataAttribute(data, 'variant', variant);
     node.getProperty('variantForm') && this.setDataAttribute(data, 'alternate', '1');
+    node.getProperty('mathaccent') && this.setDataAttribute(data, 'accent', 'true');
     const texclass = node.getProperty('texClass') as number;
     if (texclass !== undefined) {
       let setclass = true;

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -162,6 +162,8 @@ export class MathMLCompile<N, T, D> {
         } else if (name === 'data-mjx-smallmatrix') {
           mml.setProperty('scriptlevel', 1);
           mml.setProperty('useHeight', false);
+        } else if (name === 'data-mjx-accent') {
+          mml.setProperty('mathaccent', value === 'true');
         }
       } else if (name !== 'class') {
         let val = value.toLowerCase();

--- a/ts/input/tex/NodeUtil.ts
+++ b/ts/input/tex/NodeUtil.ts
@@ -40,6 +40,7 @@ namespace NodeUtil {
     ['useHeight', true],
     ['variantForm', true],
     ['withDelims', true],
+    ['mathaccent', true],
     ['open', true],
     ['close', true]
   ]);

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -589,11 +589,9 @@ BaseMethods.Accent = function(parser: TexParser, name: string, accent: string, s
   // @test Vector
   const c = parser.ParseArg(name);
   // @test Vector Font
-  const def = ParseUtil.getFontDef(parser);
-  def['accent'] = true;
+  const def = {...ParseUtil.getFontDef(parser), accent: true, mathaccent: true};
   const entity = NodeUtil.createEntity(accent);
   const moNode = parser.create('token', 'mo', def, entity);
-  NodeUtil.setProperty(moNode, 'mathaccent', true);
   const mml = moNode;
   NodeUtil.setAttribute(mml, 'stretchy', stretchy ? true : false);
   // @test Vector Op, Vector

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -593,6 +593,7 @@ BaseMethods.Accent = function(parser: TexParser, name: string, accent: string, s
   def['accent'] = true;
   const entity = NodeUtil.createEntity(accent);
   const moNode = parser.create('token', 'mo', def, entity);
+  NodeUtil.setProperty(moNode, 'mathaccent', true);
   const mml = moNode;
   NodeUtil.setAttribute(mml, 'stretchy', stretchy ? true : false);
   // @test Vector Op, Vector

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -193,13 +193,15 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
         let D = this.getWH(WH);
         const min = this.getSize('minsize', 0);
         const max = this.getSize('maxsize', Infinity);
+        const mathaccent = this.node.getProperty('mathaccent');
         //
         //  Clamp the dimension to the max and min
-        //  then get the minimum size via TeX rules
+        //  then get the target size via TeX rules
         //
         D = Math.max(min, Math.min(max, D));
-        const m = (min || exact ? D : Math.max(D * this.font.params.delimiterfactor / 1000,
-                                               D - this.font.params.delimitershortfall));
+        const df = this.font.params.delimiterfactor / 1000;
+        const ds = this.font.params.delimitershortfall;
+        const m = (min || exact ? D : mathaccent ? Math.min(D / df, D + ds) :  Math.max(D * df, D - ds));
         //
         //  Look through the delimiter sizes for one that matches
         //
@@ -209,6 +211,9 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
         if (delim.sizes) {
           for (const d of delim.sizes) {
             if (d >= m) {
+              if (mathaccent && i) {
+                i--;
+              }
               this.variant = this.font.getSizeVariant(c, i);
               this.size = i;
               return;


### PR DESCRIPTION
This PR adjusts the algorithm used to stretch accents like those used in `\widehat` to better match the one used by TeX.  Prior to this, the accents used the horizontal stretchy character algorithm, which takes the smallest version that is larger than the needed size, but TeX's algorithm for accents uses the largest that is smaller than the width of the base.

Here, we mark math accents with a new `mathaccent` property, and when one is stretched, it uses the largest version that is smaller than the base.  We use the fudge-factors (`delimitershortfall` and `delimiterfactor`) as for other stretchy characters because we don't really have the proper italic corrections, and so the sizes turn out to not produce the desired result for the MathJax TeX fonts.  This fudge-factor allows the algorithm to work appropriately for both the MathJax fonts and the STIX2 fonts.

**This PR will be replaced by a new one soon, so don't review**