### PR TITLE
Sre issue 462

### DIFF
--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -76,7 +76,7 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
     //
     const sub = this.combinePrePost(data.sub, data.psub);
     const sup = this.combinePrePost(data.sup, data.psup);
-    const [u, v] = this.getUVQ(data.base, sub, sup);
+    const [u, v] = this.getUVQ((this as any).getRealBaseChild().getBBox(), sub, sup);
     //
     //  Place the pre-scripts, then the base, then the post-scripts
     //

--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -76,7 +76,7 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
     //
     const sub = this.combinePrePost(data.sub, data.psub);
     const sup = this.combinePrePost(data.sup, data.psup);
-    const [u, v] = this.getUVQ((this as any).getRealBaseChild().getBBox(), sub, sup);
+    const [u, v] = this.getUVQ(this.getRealBaseChild().getBBox(), sub, sup);
     //
     //  Place the pre-scripts, then the base, then the post-scripts
     //

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -129,7 +129,8 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
   public toCHTML(parent: N) {
     const chtml = this.standardCHTMLnode(parent);
     const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
-    const [ , v, q] = this.getUVQ(base.getBBox(), sub.getBBox(), sup.getBBox());
+    let baseBox = (this as any).getRealBaseChild().getBBox();
+    const [ , v, q] = this.getUVQ(baseBox, sub.getBBox(), sup.getBBox());
     const x = this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0;
     const style = {'vertical-align': this.em(v)};
     base.toCHTML(chtml);

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -129,7 +129,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
   public toCHTML(parent: N) {
     const chtml = this.standardCHTMLnode(parent);
     const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
-    let baseBox = (this as any).getRealBaseChild().getBBox();
+    let baseBox = this.getRealBaseChild().getBBox();
     const [ , v, q] = this.getUVQ(baseBox, sub.getBBox(), sup.getBBox());
     const x = this.baseCore.bbox.ic ? this.coreIC() * this.coreScale() : 0;
     const style = {'vertical-align': this.em(v)};

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -60,7 +60,12 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
    */
   public toCHTML(parent: N) {
     this.chtml = this.standardCHTMLnode(parent);
-    const [x, v] = this.getOffset(this.baseChild.getBBox(), this.script.getBBox());
+    let baseChild = this.baseChild;
+    if ((this as any).chtml.dataset &&
+      (this as any).chtml.dataset.semanticFencepointer !== undefined) {
+      baseChild = this.childNodes[this.childNodes.length - 1];
+    }
+    const [x, v] = this.getOffset(baseChild.getBBox(), this.script.getBBox());
     const style: StyleData = {'vertical-align': this.em(v)};
     if (x) {
       style['margin-left'] = this.em(x);

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -60,11 +60,7 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
    */
   public toCHTML(parent: N) {
     this.chtml = this.standardCHTMLnode(parent);
-    let baseChild = this.baseChild;
-    if ((this as any).chtml.dataset &&
-      (this as any).chtml.dataset.semanticFencepointer !== undefined) {
-      baseChild = this.childNodes[this.childNodes.length - 1];
-    }
+    let baseChild = (this as any).getRealBaseChild();
     const [x, v] = this.getOffset(baseChild.getBBox(), this.script.getBBox());
     const style: StyleData = {'vertical-align': this.em(v)};
     if (x) {

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -60,7 +60,7 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
    */
   public toCHTML(parent: N) {
     this.chtml = this.standardCHTMLnode(parent);
-    let baseChild = (this as any).getRealBaseChild();
+    let baseChild = this.getRealBaseChild();
     const [x, v] = this.getOffset(baseChild.getBBox(), this.script.getBBox());
     const style: StyleData = {'vertical-align': this.em(v)};
     if (x) {

--- a/ts/output/common/Wrappers/mmultiscripts.ts
+++ b/ts/output/common/Wrappers/mmultiscripts.ts
@@ -338,6 +338,20 @@ export function CommonMmultiscriptsMixin<
       return this.UVQ;
     }
 
+
+    /**
+     * @override
+     */
+    public isCharBase(): boolean {
+      let base = this.getRealBaseChild();
+      while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) && base.childNodes.length === 1) {
+        base = base.childNodes[0];
+      }
+      return ((base.node.isKind('mo') || base.node.isKind('mi') || base.node.isKind('mn')) &&
+              base.bbox.rscale === 1 && Array.from(base.getText()).length === 1 &&
+              !base.node.attributes.get('largeop'));
+    }
+
   };
 
 }

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -266,8 +266,7 @@ export function CommonScriptbaseMixin<
      * @override
      */
     public computeBBox(bbox: BBox, recompute: boolean = false) {
-      const baseChild = this.getRealBaseChild();
-      const basebox = baseChild.getBBox();
+      const basebox = this.baseChild.getBBox();
       const scriptbox = this.script.getBBox();
       const [x, y] = this.getOffset(basebox, scriptbox);
       bbox.append(basebox);

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -302,7 +302,7 @@ export function CommonScriptbaseMixin<
      * @return {boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
      */
     public isCharBase(): boolean {
-      let base = this.getRealBaseChild();
+      let base = this.baseChild;
       while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) && base.childNodes.length === 1) {
         base = base.childNodes[0];
       }

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -241,7 +241,11 @@ export function CommonScriptbaseMixin<
      * @override
      */
     public computeBBox(bbox: BBox, recompute: boolean = false) {
-      const basebox = this.baseChild.getBBox();
+      let basebox = this.baseChild.getBBox();
+      if ((this as any).chtml.dataset &&
+        (this as any).chtml.dataset.semanticFencepointer !== undefined) {
+        basebox = this.baseChild.childNodes[this.baseChild.childNodes.length - 1].getBBox();
+      }
       const scriptbox = this.script.getBBox();
       const [x, y] = this.getOffset(basebox, scriptbox);
       bbox.append(basebox);
@@ -327,6 +331,7 @@ export function CommonScriptbaseMixin<
      * @return {number}     The vertical offset for the script
      */
     public getU(bbox: BBox, sbox: BBox): number {
+      console.log(8);
       const tex = this.font.params;
       const attr = this.node.attributes.getList('displaystyle', 'superscriptshift');
       const prime = this.node.getProperty('texprimestyle');

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -152,6 +152,12 @@ export interface CommonScriptbase<W extends AnyWrapper> extends AnyWrapper {
    */
   stretchChildren(): void;
 
+  /**
+   * Computes the base fence in case of a fencepointer on an enriched element.
+   * @return{W} The base child fence.
+   */
+  getRealBaseChild(): W;
+
 }
 
 export interface CommonScriptbaseClass extends AnyWrapperClass {
@@ -234,7 +240,13 @@ export function CommonScriptbaseMixin<
       }
     }
 
-    private getBaseFence(fence: any, id: string): any {
+    /**
+     * Recursively retrieves an element for a given fencepointer.
+     * @param {W} fence The potential fence.
+     * @param {string} id The fencepointer id.
+     * @return {W} The original fence the scripts belong to.
+     */
+    private getBaseFence(fence: W, id: string): W {
       if (!fence || !fence.node.attributes) {
         return null;
       }
@@ -250,6 +262,9 @@ export function CommonScriptbaseMixin<
       return null;
     }
 
+    /**
+     * @override
+     */
     public getRealBaseChild() {
       let pointer = this.node.attributes.getExplicit('data-semantic-fencepointer') as string;
       if (pointer === undefined) {

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -302,7 +302,7 @@ export function CommonScriptbaseMixin<
      * @return {boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
      */
     public isCharBase(): boolean {
-      let base = this.baseChild;
+      let base = this.getRealBaseChild();
       while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) && base.childNodes.length === 1) {
         base = base.childNodes[0];
       }

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -25,7 +25,7 @@
  */
 
 import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
-import {CommonScriptbaseMixin} from '../../common/Wrappers/scriptbase.js';
+import {CommonScriptbaseMixin, CommonScriptbase} from '../../common/Wrappers/scriptbase.js';
 
 /*****************************************************************/
 /**
@@ -60,7 +60,7 @@ CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(
     const svg = this.standardSVGnode(parent);
     const bbox = this.baseChild.getBBox();
     const sbox = this.script.getBBox();
-    const [x, v] = this.getOffset(bbox, sbox);
+    const [x, v] = this.getOffset((this as any).getRealBaseChild().getBBox(), sbox);
     this.baseChild.toSVG(svg);
     this.script.toSVG(svg);
     this.script.place(bbox.w * bbox.rscale + x, v);

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -60,7 +60,7 @@ CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(
     const svg = this.standardSVGnode(parent);
     const bbox = this.baseChild.getBBox();
     const sbox = this.script.getBBox();
-    const [x, v] = this.getOffset((this as any).getRealBaseChild().getBBox(), sbox);
+    const [x, v] = this.getOffset(this.getRealBaseChild().getBBox(), sbox);
     this.baseChild.toSVG(svg);
     this.script.toSVG(svg);
     this.script.place(bbox.w * bbox.rscale + x, v);

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -25,7 +25,7 @@
  */
 
 import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
-import {CommonScriptbaseMixin, CommonScriptbase} from '../../common/Wrappers/scriptbase.js';
+import {CommonScriptbaseMixin} from '../../common/Wrappers/scriptbase.js';
 
 /*****************************************************************/
 /**


### PR DESCRIPTION
This is a step towards a solution of the rendering discrepancies caused by enrichment (see issue SRE https://github.com/zorkow/speech-rule-engine/issues/462). The basic idea is to follow the `fencepointer` to the node with the corresponding semantic `id` and take that to compute the base bound box.

* It currently only works for the `chtml` renderer.  
* Not implemented for `msubsup` or `mmultiscript` nodes.

__This is a draft PR. Do not merge!__