### PR TITLE
Updates needed to support STIX2 fonts

### DIFF
--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -24,7 +24,6 @@
 import {CHTMLWrapper, CHTMLConstructor, StringMap} from '../Wrapper.js';
 import {CommonMoMixin, DirectionVH} from '../../common/Wrappers/mo.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
-import {BBox} from '../../../util/BBox.js';
 import {StyleList} from '../../../util/StyleList.js';
 import {DIRECTION} from '../FontData.js';
 
@@ -139,9 +138,7 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       this.stretchHTML(chtml);
     } else {
       if (symmetric || attributes.get('largeop')) {
-        const bbox = BBox.empty();
-        super.computeBBox(bbox);
-        const u = this.em((bbox.d - bbox.h) / 2 + this.font.params.axis_height);
+        const u = this.em(this.getCenterOffset());
         if (u !== '0') {
           this.adaptor.setStyle(chtml, 'verticalAlign', u);
         }

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -132,6 +132,7 @@ export type DelimiterData = {
   variants?: number[];  // The variants in which the different sizes can be found (if not the default)
   schar?: number[];     // The character number to use for each size (if different from the default)
   stretch?: number[];   // The unicode code points for the parts of multi-character versions [beg, ext, end, mid?]
+  stretchv?: number[];  // the variants to use for the stretchy characters (index into variant name array)
   HDW?: number[];       // [h, d, w] (for vertical, h and d are the normal size, w is the multi-character width,
   //            for horizontal, h and d are the multi-character ones, w is for the normal size).
   min?: number;         // The minimum size a multi-character version can be
@@ -468,6 +469,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   protected static defaultSizeVariants: string[] = [];
 
   /**
+   * The default variants for the assembly parts for stretchy delimiters
+   */
+  protected static defaultStretchVariants: string[] = [];
+
+  /**
    * The font options
    */
   protected options: OptionList;
@@ -476,14 +482,22 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * The actual variant information for this font
    */
   protected variant: VariantMap<C, V> = {};
+
   /**
    * The actual delimiter information for this font
    */
   protected delimiters: DelimiterMap<D> = {};
+
   /**
-   * The actual size information for this font
+   * The actual size variants to use for this font
    */
   protected sizeVariants: string[];
+
+  /**
+   * The actual stretchy variants to use for this font
+   */
+  protected stretchVariants: string[];
+
   /**
    * The data to use to make variants to default fonts and css for unknown characters
    */
@@ -534,6 +548,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     this.params = {...CLASS.defaultParams};
     this.sizeVariants = [...CLASS.defaultSizeVariants];
+    this.stretchVariants = [...CLASS.defaultStretchVariants];
     this.cssFontMap = {...CLASS.defaultCssFonts};
     for (const name of Object.keys(this.cssFontMap)) {
       if (this.cssFontMap[name][0] === 'unknown') {
@@ -717,6 +732,15 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
       i = this.delimiters[n].variants[i];
     }
     return this.sizeVariants[i];
+  }
+
+  /**
+   * @param {number} n  The delimiter character number whose variant is needed
+   * @param {number} i  The index in the stretch array of the part whose variant is needed
+   * @return {string}   The variant of the i-th part for delimiter n
+   */
+  public getStretchVariant(n: number, i: number): string {
+    return this.stretchVariants[this.delimiters[n].stretchv ? this.delimiters[n].stretchv[i] : 0];
   }
 
   /**

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -58,6 +58,12 @@ export interface CommonMo extends AnyWrapper {
   isAccent: boolean;
 
   /**
+   * @param {BBox} bbox   The bbox to center, or null to compute the bbox
+   * @return {number}     The offset to move the glyph to center it
+   */
+  getCenterOffset(bbox?: BBox): number;
+
+  /**
    * Determint variant for vertically/horizontally stretched character
    *
    * @param {number[]} WH  size to stretch to, either [W] or [H, D]
@@ -149,10 +155,22 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
       }
       if (this.node.attributes.get('symmetric') &&
           this.stretch.dir !== DIRECTION.Horizontal) {
-        const d = ((bbox.h + bbox.d) / 2 + this.font.params.axis_height) - bbox.h;
+        const d = this.getCenterOffset(bbox);
         bbox.h += d;
         bbox.d -= d;
       }
+    }
+
+    /**
+     * @param {BBox} bbox   The bbox to center, or null to compute the bbox
+     * @return {number}     The offset to move the glyph to center it
+     */
+    public getCenterOffset(bbox: BBox = null): number {
+      if (!bbox) {
+        bbox = BBox.empty();
+        super.computeBBox(bbox);
+      }
+      return ((bbox.h + bbox.d) / 2 + this.font.params.axis_height) - bbox.h;
     }
 
     /**

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -79,6 +79,11 @@ export function CommonTeXFontMixin<
     protected static defaultSizeVariants = ['normal', '-smallop', '-largeop', '-size3', '-size4'];
 
     /**
+     *  The default variants for the standard stretchy assmebly parts
+     */
+    protected static defaultStretchVariants = ['-size4'];
+
+    /**
      * @override
      */
     protected getDelimiterData(n: number) {

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -236,7 +236,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     //
     const g = this.svg('g', {
       stroke: 'currentColor', fill: 'currentColor',
-      'stroke-width': 0, transform: 'matrix(1 0 0 -1 0 0)'
+      'stroke-width': 0, transform: 'scale(1,-1)'
     }) as N;
     //
     //  The svg element with its viewBox, size and alignment
@@ -262,9 +262,9 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
       adaptor.setStyle(svg, 'min-width', this.ex(W));
       adaptor.setAttribute(svg, 'width', pwidth);
       adaptor.removeAttribute(svg, 'viewBox');
-      const scale = wrapper.metrics.ex / (this.font.params.x_height * 1000);
-      adaptor.setAttribute(g, 'transform', 'matrix(1 0 0 -1 0 0) scale(' +
-                           this.fixed(scale, 6) + ') translate(0, ' + this.fixed(-h * 1000, 1) + ')');
+      const scale = this.fixed(wrapper.metrics.ex / (this.font.params.x_height * 1000), 6);
+      adaptor.setAttribute(g, 'transform', 'scale(' + scale + ',-' + scale + ') '
+                            + 'translate(0, ' + this.fixed(-h * 1000, 1) + ')');
     }
     if (this.options.fontCache !== 'none') {
       adaptor.setAttribute(svg, 'xmlns:xlink', XLINKNS);
@@ -346,7 +346,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
     const scale = this.font.params.x_height / metrics.ex * metrics.em * 1000;
     const svg = this.svg('text', {
       'data-variant': variant,
-      transform: 'matrix(1 0 0 -1 0 0)', 'font-size': this.fixed(scale, 1) + 'px'
+      transform: 'scale(1,-1)', 'font-size': this.fixed(scale, 1) + 'px'
     }, [this.text(text)]);
     const adaptor = this.adaptor;
     if (variant !== '-explicitFont') {

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -263,8 +263,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
       adaptor.setAttribute(svg, 'width', pwidth);
       adaptor.removeAttribute(svg, 'viewBox');
       const scale = this.fixed(wrapper.metrics.ex / (this.font.params.x_height * 1000), 6);
-      adaptor.setAttribute(g, 'transform', 'scale(' + scale + ',-' + scale + ') '
-                            + 'translate(0, ' + this.fixed(-h * 1000, 1) + ')');
+      adaptor.setAttribute(g, 'transform', `scale(${scale},-${scale}) translate(0, ${this.fixed(-h * 1000, 1)})`);
     }
     if (this.options.fontCache !== 'none') {
       adaptor.setAttribute(svg, 'xmlns:xlink', XLINKNS);

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -1,3 +1,4 @@
+
 /*************************************************************
  *
  *  Copyright (c) 2018 The MathJax Consortium
@@ -205,13 +206,13 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
     });
     this.addGlyph(n, v, 0, 0, svg);
     const glyph = adaptor.lastChild(svg);
-    adaptor.setAttribute(glyph, 'transform', 'scale(1,' + this.jax.fixed(s) + ')');
+    adaptor.setAttribute(glyph, 'transform', 'scale(1,${this.jax.fixed(s)})');
     adaptor.append(this.element, svg);
   }
 
   /**
    * @param {number} n    The character number for the bottom glyph
-   * @param {srting} v    The variant for the bottom glyph
+   * @param {string} v    The variant for the bottom glyph
    * @param {number} D    The depth of the stretched delimiter
    * @param {number} W    The width of the stretched delimiter
    * @return {number}     The total height of the bottom glyph
@@ -225,7 +226,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n    The character number for the middle glyph
-   * @param {srting} v    The variant for the middle glyph
+   * @param {string} v    The variant for the middle glyph
    * @param {number} W    The width of the stretched delimiter
    * @return {[number, number]}   The top and bottom positions of the middle glyph
    */
@@ -241,7 +242,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n   The character number for the left glyph of the stretchy character
-   * @param {srting} v   The variant for the left glyph
+   * @param {string} v   The variant for the left glyph
    * @return {number}    The width of the left glyph
    */
   protected addLeft(n: number, v: string): number {
@@ -250,7 +251,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n   The character number for the extender glyph of the stretchy character
-   * @param {srting} v   The variant for the extender glyph
+   * @param {string} v   The variant for the extender glyph
    * @param {number} W   The width of the stretched character
    * @param {number} L   The width of the left glyph of the stretchy character
    * @param {number} R   The width of the right glyph of the stretchy character
@@ -280,7 +281,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n   The character number for the right glyph of the stretchy character
-   * @param {srting} v   The variant for the right glyph
+   * @param {string} v   The variant for the right glyph
    * @param {number} W   The width of the stretched character
    * @return {number}    The width of the right glyph
    */
@@ -292,7 +293,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n   The character number for the middle glyph of the stretchy character
-   * @param {srting} v   The variant for the middle glyph
+   * @param {string} v   The variant for the middle glyph
    * @param {number} W   The width of the stretched character
    * @return {[number, number]}  The positions of the left and right edges of the middle glyph
    */

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -166,7 +166,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n    The character number for the top glyph
-   * @param {srting} v    The variant for the top glyph
+   * @param {string} v    The variant for the top glyph
    * @param {number} H    The height of the stretched delimiter
    * @param {number} W    The width of the stretched delimiter
    * @return {number}     The total height of the top glyph
@@ -180,7 +180,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
    * @param {number} n    The character number for the extender glyph
-   * @param {srting} v    The variant for the extender glyph
+   * @param {string} v    The variant for the extender glyph
    * @param {number} H    The height of the stretched delimiter
    * @param {number} D    The depth of the stretched delimiter
    * @param {number} T    The height of the top glyph in the delimiter

--- a/ts/util/Styles.ts
+++ b/ts/util/Styles.ts
@@ -406,7 +406,7 @@ export class Styles {
 
   /**
    * @param {string} name   The name of the style to set
-   * @param {srting|number|boolean} value The value to set it to
+   * @param {string|number|boolean} value The value to set it to
    */
   public set(name: string, value: string | number | boolean) {
     name = this.normalizeName(name);


### PR DESCRIPTION
This PR includes changes needed to support the STIX2 fonts.  (It is cherry-picked from the first commit on the `stix2` branch, but is needed for other changes that will be made in a separate PR.  The `stix2` branch can be rebased off this branch, if needed, when we make the PR for stix2.)

Most of the changes here are to allow specifying the variant to use for stretchy characters, so there are a lot of places where a variant needs to be passed into a function that was not the case before.  There is also some refactoring of some duplicate code into `getCenterOffset()`, and simplification of of scaling transforms (e.g., `matrix(1 0 0 0 -1 0)` is replaced by `scale(1,-1)` which does the same thing more transparently).  