### PR TITLE
Handle math accents more like TeX.

### DIFF
--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -143,6 +143,10 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
           this.adaptor.setStyle(chtml, 'verticalAlign', u);
         }
       }
+      if (this.node.getProperty('mathaccent')) {
+        this.adaptor.setStyle(chtml, 'width', '0');
+        this.adaptor.setStyle(chtml, 'margin-left', this.em(this.getAccentOffset()));
+      }
       for (const child of this.childNodes) {
         child.toCHTML(chtml);
       }

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -520,6 +520,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public params: FontParameters;
 
   /**
+   * Non-zero means use IC to fake skew values, and this is a scaling factor for it.
+   */
+  public skewIcFactor: number = 0;
+
+  /**
    * Any styles needed for the font
    */
   protected _styles: StyleList;

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -520,9 +520,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public params: FontParameters;
 
   /**
-   * Non-zero means use IC to fake skew values, and this is a scaling factor for it.
+   * Factor to multiply italic correction by for delta computations for munderover
    */
-  public skewIcFactor: number = 0;
+  public skewIcFactor: number = .75;
 
   /**
    * Any styles needed for the font

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -473,6 +473,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    */
   protected static defaultStretchVariants: string[] = [];
 
+
   /**
    * The font options
    */

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -58,6 +58,18 @@ export interface CommonMo extends AnyWrapper {
   isAccent: boolean;
 
   /**
+   * Get the (unmodified) bbox of the contents (before centering or setting accents to width 0)
+   *
+   * @param {BBox} bbox   The bbox to fill
+   */
+  protoBBox(bbox: BBox): void;
+
+  /**
+   * @return {number}    Offset to the left by half the actual width of the accent
+   */
+  getAccentOffset(): number;
+
+  /**
    * @param {BBox} bbox   The bbox to center, or null to compute the bbox
    * @return {number}     The offset to move the glyph to center it
    */
@@ -143,6 +155,25 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
      * @override
      */
     public computeBBox(bbox: BBox, _recompute: boolean = false) {
+      this.protoBBox(bbox);
+      if (this.node.attributes.get('symmetric') &&
+          this.stretch.dir !== DIRECTION.Horizontal) {
+        const d = this.getCenterOffset(bbox);
+        bbox.h += d;
+        bbox.d -= d;
+      }
+      if (this.node.getProperty('mathaccent') &&
+          (this.stretch.dir === DIRECTION.None || this.size >= 0)) {
+        bbox.w = 0;
+      }
+    }
+
+    /**
+     * Get the (unmodified) bbox of the contents (before centering or setting accents to width 0)
+     *
+     * @param {BBox} bbox   The bbox to fill
+     */
+    public protoBBox(bbox: BBox) {
       const stretchy = (this.stretch.dir !== DIRECTION.None);
       if (stretchy && this.size === null) {
         this.getStretchedVariant([0]);
@@ -153,12 +184,15 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
       if (this.noIC) {
         bbox.w -= bbox.ic;
       }
-      if (this.node.attributes.get('symmetric') &&
-          this.stretch.dir !== DIRECTION.Horizontal) {
-        const d = this.getCenterOffset(bbox);
-        bbox.h += d;
-        bbox.d -= d;
-      }
+    }
+
+    /**
+     * @return {number}    Offset to the left by half the actual width of the accent
+     */
+    public getAccentOffset(): number {
+      const bbox = BBox.empty();
+      this.protoBBox(bbox);
+      return -bbox.w / 2;
     }
 
     /**

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -25,6 +25,7 @@
 import {AnyWrapper, Constructor} from '../Wrapper.js';
 import {CommonScriptbase, ScriptbaseConstructor} from './scriptbase.js';
 import {MmlMunderover, MmlMunder, MmlMover} from '../../../core/MmlTree/MmlNodes/munderover.js';
+import {CommonMo} from './mo.js';
 import {BBox} from '../../../util/BBox.js';
 
 /*****************************************************************/
@@ -142,6 +143,10 @@ export function CommonMoverMixin<
      */
     constructor(...args: any[]) {
       super(...args);
+      if (this.baseCore && 'noIC' in this.baseCore && this.isCharBase() &&
+          this.script.node.getProperty('mathaccent')) {
+        (this.baseCore as undefined as CommonMo).noIC = true;
+      }
       this.stretchChildren();
     }
 

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -30,11 +30,6 @@ import {MmlMsubsup} from '../../../core/MmlTree/MmlNodes/msubsup.js';
 import {BBox} from '../../../util/BBox.js';
 import {DIRECTION} from '../FontData.js';
 
-/*
- * Mutliply italic correction by this much (improve horizontal shift for italic characters)
- */
-const DELTA = 1.5;
-
 /*****************************************************************/
 /**
  * The CommonScriptbase interface
@@ -277,10 +272,7 @@ export function CommonScriptbaseMixin<
      * @return {boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of a single character
      */
     public isCharBase(): boolean {
-      let base = this.baseChild;
-      while ((base.node.isKind('mstyle') || base.node.isKind('mrow')) && base.childNodes.length === 1) {
-        base = base.childNodes[0];
-      }
+      let base = this.baseCore;
       return ((base.node.isKind('mo') || base.node.isKind('mi') || base.node.isKind('mn')) &&
               base.bbox.rscale === 1 && Array.from(base.getText()).length === 1 &&
               !base.node.attributes.get('largeop'));
@@ -419,8 +411,8 @@ export function CommonScriptbaseMixin<
      */
     public getDelta(noskew: boolean = false): number {
       const accent = this.node.attributes.get('accent');
-      const ddelta = (accent && !noskew ? this.baseChild.coreMO().bbox.sk : 0);
-      return (DELTA * this.baseCore.bbox.ic / 2 + ddelta) * this.coreScale();
+      const {sk, ic} = this.baseCore.bbox;
+      return (accent && !noskew ? sk + this.font.skewIcFactor * ic : 0) * this.coreScale();
     }
 
     /**

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -412,7 +412,7 @@ export function CommonScriptbaseMixin<
     public getDelta(noskew: boolean = false): number {
       const accent = this.node.attributes.get('accent');
       const {sk, ic} = this.baseCore.bbox;
-      return (accent && !noskew ? sk + this.font.skewIcFactor * ic : 0) * this.coreScale();
+      return ((accent && !noskew ? sk : 0) + this.font.skewIcFactor * ic) * this.coreScale();
     }
 
     /**

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -84,11 +84,6 @@ export function CommonTeXFontMixin<
     protected static defaultStretchVariants = ['-size4'];
 
     /**
-     * The factor to use for computing skews from italic correction
-     */
-    public skewIcFactor = .75;
-
-    /**
      * @override
      */
     protected getDelimiterData(n: number) {

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -84,6 +84,11 @@ export function CommonTeXFontMixin<
     protected static defaultStretchVariants = ['-size4'];
 
     /**
+     * The factor to use for computing skews from italic correction
+     */
+    public skewIcFactor = .75;
+
+    /**
      * @override
      */
     protected getDelimiterData(n: number) {

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -64,11 +64,10 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
     if (stretchy && this.size < 0) {
       this.stretchSVG();
     } else {
-      if (symmetric || attributes.get('largeop')) {
-        const u = this.fixed(this.getCenterOffset());
-        if (u !== '0') {
-          this.adaptor.setAttribute(svg, 'transform', 'translate(0 ' + u + ')');
-        }
+      const u = (symmetric || attributes.get('largeop') ? this.fixed(this.getCenterOffset()) : '0');
+      const v = (this.node.getProperty('mathaccent') ? this.fixed(this.getAccentOffset()) : '0');
+      if (u !== '0' || v !== '0') {
+        this.adaptor.setAttribute(svg, 'transform', 'translate(' + v + ' ' + u + ')');
       }
       this.addChildren(svg);
     }


### PR DESCRIPTION
This PR handles math accents more like TeX does:  when the base is a single character, the italic correction is not added, and the width of the accent does not affect the resulting width (so if the accent is too large, it extends beyond the bounding box of the character below it).  The latter is done by making the accent zero width, and offset to the left by half its natural width.

In addition, the handling of the skew values is updated (to work with the STIX2 font).  In the past, MathJax did not have proper skew values, so it uses the italic correction to compute a skew value, which is not needed for STIX2, which has proper skew values.

**This PR will be replaced by a new one soon, so don't review**