### PR TITLE
Improve xarrow spacing, and fix CHTML output for short extensible arrows.

### DIFF
--- a/ts/input/tex/ams/AmsMappings.ts
+++ b/ts/input/tex/ams/AmsMappings.ts
@@ -1,3 +1,4 @@
+
 /*************************************************************
  *
  *  Copyright (c) 2017 The MathJax Consortium
@@ -102,8 +103,8 @@ new sm.CommandMap('AMSmath-macros', {
   shoveleft:  ['HandleShove', TexConstant.Align.LEFT],
   shoveright: ['HandleShove', TexConstant.Align.RIGHT],
 
-  xrightarrow: ['xArrow', 0x2192, 5, 6],
-  xleftarrow:  ['xArrow', 0x2190, 7, 3]
+  xrightarrow: ['xArrow', 0x2192, 5, 12],
+  xleftarrow:  ['xArrow', 0x2190, 10, 5]
 }, AmsMethods);
 
 

--- a/ts/input/tex/ams/AmsMappings.ts
+++ b/ts/input/tex/ams/AmsMappings.ts
@@ -103,7 +103,7 @@ new sm.CommandMap('AMSmath-macros', {
   shoveleft:  ['HandleShove', TexConstant.Align.LEFT],
   shoveright: ['HandleShove', TexConstant.Align.RIGHT],
 
-  xrightarrow: ['xArrow', 0x2192, 5, 12],
+  xrightarrow: ['xArrow', 0x2192, 7, 12],
   xleftarrow:  ['xArrow', 0x2190, 10, 5]
 }, AmsMethods);
 

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -229,13 +229,15 @@ AmsMethods.xArrow = function(parser: TexParser, name: string,
     'mo', {stretchy: true, texClass: TEXCLASS.REL}, String.fromCodePoint(chr));
   let mml = parser.create('node', 'munderover', [arrow]) as MmlMunderover;
   let mpadded = parser.create('node', 'mpadded', [first], def);
-  NodeUtil.setAttribute(mpadded, 'voffset', '.15em');
+  NodeUtil.setAttribute(mpadded, 'voffset', '-.25em');
+  NodeUtil.setAttribute(mpadded, 'height', '-.25em');
   NodeUtil.setChild(mml, mml.over, mpadded);
   if (bot) {
     // @test Above Below Left Arrow, Above Below Right Arrow
     let bottom = new TexParser(bot, parser.stack.env, parser.configuration).mml();
     mpadded = parser.create('node', 'mpadded', [bottom], def);
-    NodeUtil.setAttribute(mpadded, 'voffset', '-.24em');
+    NodeUtil.setAttribute(mpadded, 'voffset', '.15em');
+    NodeUtil.setAttribute(mpadded, 'depth', '-.15em');
     NodeUtil.setChild(mml, mml.under, mpadded);
   }
   // @test Above Left Arrow, Above Right Arrow, Above Left Arrow in Context,

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -225,17 +225,20 @@ AmsMethods.xArrow = function(parser: TexParser, name: string,
   let def = {width: '+' + ParseUtil.Em((l + r) / 18), lspace: ParseUtil.Em(l / 18)};
   let bot = parser.GetBrackets(name);
   let first = parser.ParseArg(name);
+  let dstrut = parser.create('node', 'mspace', [], {depth: '.25em'});
   let arrow = parser.create('token',
     'mo', {stretchy: true, texClass: TEXCLASS.REL}, String.fromCodePoint(chr));
+  arrow = parser.create('node', 'mstyle', [arrow], {scriptlevel: 0});
   let mml = parser.create('node', 'munderover', [arrow]) as MmlMunderover;
-  let mpadded = parser.create('node', 'mpadded', [first], def);
-  NodeUtil.setAttribute(mpadded, 'voffset', '-.25em');
-  NodeUtil.setAttribute(mpadded, 'height', '-.25em');
+  let mpadded = parser.create('node', 'mpadded', [first, dstrut], def);
+  NodeUtil.setAttribute(mpadded, 'voffset', '-.2em');
+  NodeUtil.setAttribute(mpadded, 'height', '-.2em');
   NodeUtil.setChild(mml, mml.over, mpadded);
   if (bot) {
     // @test Above Below Left Arrow, Above Below Right Arrow
     let bottom = new TexParser(bot, parser.stack.env, parser.configuration).mml();
-    mpadded = parser.create('node', 'mpadded', [bottom], def);
+    let bstrut = parser.create('node', 'mspace', [], {height: '.75em'});
+    mpadded = parser.create('node', 'mpadded', [bottom, bstrut], def);
     NodeUtil.setAttribute(mpadded, 'voffset', '.15em');
     NodeUtil.setAttribute(mpadded, 'depth', '-.15em');
     NodeUtil.setChild(mml, mml.under, mpadded);

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -74,7 +74,7 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       transform: 'scalex(500)'
     },
     'mjx-stretchy-h > mjx-ext > mjx-c': {
-      width: '100%'
+      width: 0
     },
     'mjx-stretchy-h > mjx-beg > mjx-c': {
       'margin-right': '-.1em'


### PR DESCRIPTION
This PR improves the positioning of the content above and below stretchy arrows generated by xArrows to make it match TeX positioning better.  It also adjusts the bounding box to accommodate the `voffset` amounts (in the past, elements could fall outside the bounding box).

This also fixes a regression with short stretchy arrows in CHTML caused by #571 (the extensible piece ends up with a minimum size of the size of the extension character, so would not "overlap" the end piece to make short extensions).  For example, without this fix, `\xrightarrow{xx}` would be too long in CHTML (on the develop branch).  This puts back the pre-571 handling of the size of the extension.