### PR TITLE
Handle automatic tex class of OP better.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mi.ts
+++ b/ts/core/MmlTree/MmlNodes/mi.ts
@@ -82,7 +82,7 @@ export class MmlMi extends AbstractMmlTokenNode {
   public setTeXclass(prev: AbstractMmlNode) {
     this.getPrevClass(prev);
     let name = this.getText();
-    if (name.length > 1 && name.match(MmlMi.operatorName) && this.texClass === TEXCLASS.ORD) {
+    if (name.length > 1 && name.match(MmlMi.operatorName) && this.getProperty('texClass') === undefined) {
       this.texClass = TEXCLASS.OP;
       this.setProperty('autoOP', true);
     }

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -232,7 +232,7 @@ export class MmlMo extends AbstractMmlTokenNode {
       //
       //  Force previous node to be TEXCLASS.OP and skip this node
       //
-      if (prev) {
+      if (prev && prev.getProperty('texClass') === undefined) {
         prev.texClass = TEXCLASS.OP;
         prev.setProperty('fnOP', true);
       }

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -232,7 +232,8 @@ export class MmlMo extends AbstractMmlTokenNode {
       //
       //  Force previous node to be TEXCLASS.OP and skip this node
       //
-      if (prev && prev.getProperty('texClass') === undefined) {
+      if (prev && prev.getProperty('texClass') === undefined &&
+          prev.attributes.get('mathvariant') !== 'italic') {
         prev.texClass = TEXCLASS.OP;
         prev.setProperty('fnOP', true);
       }

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -131,8 +131,10 @@ export class MathMLCompile<N, T, D> {
       mml.setProperty('movesupsub', true);
       mml.attributes.setInherited('movablelimits', true);
     }
-    mml.texClass = (TEXCLASS as {[name: string]: number})[texClass];
-    mml.setProperty('texClass', mml.texClass);
+    if (texClass) {
+      mml.texClass = (TEXCLASS as {[name: string]: number})[texClass];
+      mml.setProperty('texClass', mml.texClass);
+    }
     this.addAttributes(mml, node);
     this.checkClass(mml, node);
     this.addChildren(mml, node);

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -150,8 +150,8 @@ export class MathMLCompile<N, T, D> {
     for (const attr of this.adaptor.allAttributes(node)) {
       let name = attr.name;
       let value = this.filterAttribute(name, attr.value);
-      if (value === null) {
-        return;
+      if (value === null || name === 'xmlns') {
+        continue;
       }
       if (name.substr(0, 9) === 'data-mjx-') {
         if (name === 'data-mjx-alternate') {

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -127,12 +127,12 @@ export class MathMLCompile<N, T, D> {
     }
     this.factory.getNodeClass(type) || this.error('Unknown node type "' + type + '"');
     let mml = this.factory.create(type);
-    if (type === 'TeXAtom') {
-      this.texAtom(mml, texClass, limits);
-    } else if (texClass) {
-      mml.texClass = (TEXCLASS as {[name: string]: number})[texClass];
-      mml.setProperty('texClass', mml.texClass);
+    if (type === 'TeXAtom' && texClass === 'OP' && !limits) {
+      mml.setProperty('movesupsub', true);
+      mml.attributes.setInherited('movablelimits', true);
     }
+    mml.texClass = (TEXCLASS as {[name: string]: number})[texClass];
+    mml.setProperty('texClass', mml.texClass);
     this.addAttributes(mml, node);
     this.checkClass(mml, node);
     this.addChildren(mml, node);
@@ -275,22 +275,6 @@ export class MathMLCompile<N, T, D> {
    */
   protected fixCalligraphic(variant: string): string {
     return variant.replace(/caligraphic/, 'calligraphic');
-  }
-
-  /**
-   * Handle the properties of a TeXAtom
-   *
-   * @param {MmlNode} mml      The node to be updated
-   * @param {string} texClass  The texClass indicated in the MJX class identifier
-   * @param {boolean} limits   Whether MJX-fixedlimits was found in the class list
-   */
-  protected texAtom(mml: MmlNode, texClass: string, limits: boolean) {
-    mml.texClass = (TEXCLASS as {[name: string]: number})[texClass];
-    mml.setProperty('texClass', mml.texClass);
-    if (texClass === 'OP' && !limits) {
-      mml.setProperty('movesupsub', true);
-      mml.attributes.setInherited('movablelimits', true);
-    }
   }
 
   /**


### PR DESCRIPTION
This PR improves the assignment of TeX class OP to multi-character `mi` elements, and to elements followed by invisible apply.  This improves spacing of enriched content where invisible apply has been inserted after a single-character identifier (e.g., `fR(s)`).

It also refactors the MathML input to not need the `texAtom()` method, and to remove `xmlns` attributes that appear on serialized MathML from SRE.