### PR TITLE
Use consistent characters for \overline and \underline, and treat them both as accents

### DIFF
--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -455,8 +455,8 @@ new sm.CommandMap('macros', {
   limits:            ['Limits', 1],
   nolimits:          ['Limits', 0],
 
-  overline:            ['UnderOver', '00AF', null, 1],
-  underline:           ['UnderOver', '005F'],
+  overline:            ['UnderOver', '2015'],
+  underline:           ['UnderOver', '2015'],
   overbrace:           ['UnderOver', '23DE', 1],
   underbrace:          ['UnderOver', '23DF', 1],
   overparen:           ['UnderOver', '23DC'],


### PR DESCRIPTION
This PR changes the character used for `\overline` and `\underline` to be U+2015 (HORIZTONAL LINE) and makes them both have `accent="true"` (only `\overline` had that originally) so that the results for both are consistent both in spacing and thickness.

**This PR will be replaced by a new one soon, so don't review**