### PR TITLE
Handle accents more like TeX does (better sizes and placement) (mathjax/MathJax#712, mathjax/MathJax#2474)

### DIFF
--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -201,6 +201,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
     const variants = (this.constructor as typeof SerializedMmlVisitor).variants;
     variant && variants.hasOwnProperty(variant) && this.setDataAttribute(data, 'variant', variant);
     node.getProperty('variantForm') && this.setDataAttribute(data, 'alternate', '1');
+    node.getProperty('mathaccent') && this.setDataAttribute(data, 'accent', 'true');
     const texclass = node.getProperty('texClass') as number;
     if (texclass !== undefined) {
       let setclass = true;

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -162,6 +162,8 @@ export class MathMLCompile<N, T, D> {
         } else if (name === 'data-mjx-smallmatrix') {
           mml.setProperty('scriptlevel', 1);
           mml.setProperty('useHeight', false);
+        } else if (name === 'data-mjx-accent') {
+          mml.setProperty('mathaccent', value === 'true');
         }
       } else if (name !== 'class') {
         let val = value.toLowerCase();

--- a/ts/input/tex/NodeUtil.ts
+++ b/ts/input/tex/NodeUtil.ts
@@ -40,6 +40,7 @@ namespace NodeUtil {
     ['useHeight', true],
     ['variantForm', true],
     ['withDelims', true],
+    ['mathaccent', true],
     ['open', true],
     ['close', true]
   ]);

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -589,8 +589,7 @@ BaseMethods.Accent = function(parser: TexParser, name: string, accent: string, s
   // @test Vector
   const c = parser.ParseArg(name);
   // @test Vector Font
-  const def = ParseUtil.getFontDef(parser);
-  def['accent'] = true;
+  const def = {...ParseUtil.getFontDef(parser), accent: true, mathaccent: true};
   const entity = NodeUtil.createEntity(accent);
   const moNode = parser.create('token', 'mo', def, entity);
   const mml = moNode;

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -143,6 +143,10 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
           this.adaptor.setStyle(chtml, 'verticalAlign', u);
         }
       }
+      if (this.node.getProperty('mathaccent')) {
+        this.adaptor.setStyle(chtml, 'width', '0');
+        this.adaptor.setStyle(chtml, 'margin-left', this.em(this.getAccentOffset()));
+      }
       for (const child of this.childNodes) {
         child.toCHTML(chtml);
       }

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -519,6 +519,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public params: FontParameters;
 
   /**
+   * Factor to multiply italic correction by for delta computations for munderover
+   */
+  public skewIcFactor: number = .75;
+
+  /**
    * Any styles needed for the font
    */
   protected _styles: StyleList;

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -519,7 +519,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public params: FontParameters;
 
   /**
-   * Factor to multiply italic correction by for delta computations for munderover
+   * Factor by which to multiply italic correction for computation of delta in munderover
    */
   public skewIcFactor: number = .75;
 

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -25,6 +25,7 @@
 import {AnyWrapper, Constructor} from '../Wrapper.js';
 import {CommonScriptbase, ScriptbaseConstructor} from './scriptbase.js';
 import {MmlMunderover, MmlMunder, MmlMover} from '../../../core/MmlTree/MmlNodes/munderover.js';
+import {CommonMo} from './mo.js';
 import {BBox} from '../../../util/BBox.js';
 
 /*****************************************************************/
@@ -142,6 +143,10 @@ export function CommonMoverMixin<
      */
     constructor(...args: any[]) {
       super(...args);
+      if (this.baseCore && 'noIC' in this.baseCore && this.isCharBase() &&
+          this.scriptChild.node.getProperty('mathaccent')) {
+        (this.baseCore as undefined as CommonMo).noIC = true;
+      }
       this.stretchChildren();
     }
 

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -64,11 +64,10 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
     if (stretchy && this.size < 0) {
       this.stretchSVG();
     } else {
-      if (symmetric || attributes.get('largeop')) {
-        const u = this.fixed(this.getCenterOffset());
-        if (u !== '0') {
-          this.adaptor.setAttribute(svg, 'transform', 'translate(0 ' + u + ')');
-        }
+      const u = (symmetric || attributes.get('largeop') ? this.fixed(this.getCenterOffset()) : '0');
+      const v = (this.node.getProperty('mathaccent') ? this.fixed(this.getAccentOffset()) : '0');
+      if (u !== '0' || v !== '0') {
+        this.adaptor.setAttribute(svg, 'transform', 'translate(' + v + ' ' + u + ')');
       }
       this.addChildren(svg);
     }

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -67,7 +67,7 @@ CommonMoMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
       const u = (symmetric || attributes.get('largeop') ? this.fixed(this.getCenterOffset()) : '0');
       const v = (this.node.getProperty('mathaccent') ? this.fixed(this.getAccentOffset()) : '0');
       if (u !== '0' || v !== '0') {
-        this.adaptor.setAttribute(svg, 'transform', 'translate(' + v + ' ' + u + ')');
+        this.adaptor.setAttribute(svg, 'transform', `translate(${v} ${u})`);
       }
       this.addChildren(svg);
     }


### PR DESCRIPTION
This PR combines what was the `tex-accents` and `stretchy-accents` into one, based on the `sre-fences` branch.

It adjusts the algorithm used to stretch accents like those used in `\widehat` to better match the one used by TeX. Prior to this, the accents used the horizontal stretchy character algorithm, which takes the smallest version that is larger than the needed size, but TeX's algorithm for accents uses the largest that is smaller than the width of the base.

Here, we mark math accents with a new `mathaccent` property, and when one is stretched, it uses the largest version that is smaller than the base. We use the fudge-factors (`delimitershortfall` and `delimiterfactor`) as for other stretchy characters because we don't really have the proper italic corrections, and so the sizes turn out to not produce the desired result for the MathJax TeX fonts (it also turns out that the wide hat and wide tilde delimiter data is wrong in the files, but that will be fixed in a separate PR). This fudge-factor allows the algorithm to work appropriately for both the MathJax fonts and the STIX2 fonts.

Also, when the base is a single character, TeX does not add the italic correction, and the width of the accent does not affect the resulting width (so if the accent is too large, it extends beyond the bounding box of the character below it). This PR implements those two features in MathJax as well.  The latter is done by making the accent zero width, and offset to the left by half its natural width.

In addition, the handling of the skew values is updated (to work with the STIX2 font). In the past, MathJax did not have proper skew values, so it uses the italic correction to compute a skew value, which is not needed for STIX2, which has proper skew values.
