### PR TITLE
Fix problem with SVG output crashing when \not is used with a letter

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -247,7 +247,7 @@ CommonWrapper<
     const translate = 'translate(' + this.fixed(x) + ', ' + this.fixed(y) + ')';
     if (!element) {
       element = this.element;
-      if (this.node.attributes.get('href')) {
+      if (this.node.attributes && this.node.attributes.get('href')) {
         const rect = adaptor.previous(element);
         if (rect && adaptor.kind(rect) === 'rect' && adaptor.getAttribute(rect, 'data-hitbox')) {
           adaptor.setAttribute(rect, 'transform', translate);


### PR DESCRIPTION
This PR fixes a regression due to #589 that affects the SVG output when `\not` is followed by a letter, as in `\not a`.  This generates `<mi>a&#x338;</mi>`, and the contents of the `<mi>` is actually two text items, due to how the TeX input jax adds the U+0038.  The second text item needs to be placed with a non-zero *x* value, and causes the change from #589 to attempt to access the node's `attributes` value, which doesn't exist on a text node, causing an error.  This PR prevents that.