### PR TITLE
Fully clear tagging on equation start.  (mathjax/MathJax#2643)

### DIFF
--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -404,7 +404,7 @@ export class AbstractTags implements Tags {
   public clearTag() {
     this.label = '';
     this.tag(null, true);
-    this.currentTag.tagId = '';
+    this.currentTag = new TagInfo('', undefined, undefined);
   }
 
 
@@ -453,6 +453,9 @@ export class AbstractTags implements Tags {
    * @override
    */
   public startEquation(math: MathItem<any, any, any>) {
+    this.history = [];
+    this.stack = [];
+    this.clearTag();
     this.labels = {};
     this.ids = {};
     this.counter = this.allCounter;


### PR DESCRIPTION
This PR resolves an issue where the tagging information was not fully cleared when an equation begins.  This caused a problem if there were TagInfo objects on the stack when an extension is autoloaded (causing the equation to be rerendered).  The extra TagInfo would end up setting the initial `currentTag` item when the *next* equation is processed.  See the example at mathjax/MathJax#2643.