### PR TITLE
Fix handling of italic correction for munderover and msubsup combinations.

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -364,7 +364,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    * @param {CHTMLCharData} data     The bounding box data and options for the character
    */
   protected addCharStyles(styles: StyleList, vletter: string, n: number, data: CHTMLCharData) {
-    const [ , , w, options] = data as [number, number, number, CHTMLCharOptions];
+    const options = data[3] as CHTMLCharOptions;
     if (this.options.adaptiveCSS && !options.used) return;
     const letter = (options.f !== undefined ? options.f : vletter);
     const selector = 'mjx-c' + this.charSelector(n) + (letter ? '.TEX-' + letter : '');
@@ -372,11 +372,6 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
       padding: this.padding(data, 0, options.ic || 0),
       content: (options.c != null ? '"' + options.c + '"' : this.charContent(n))
     };
-    if (options.ic) {
-      styles['[noIC] ' + selector + ':last-child::before'] = {
-        'padding-right': this.em(w)
-      };
-    }
   }
 
   /***********************************************************************/

--- a/ts/output/chtml/Wrappers/mi.ts
+++ b/ts/output/chtml/Wrappers/mi.ts
@@ -42,14 +42,4 @@ CommonMiMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
    */
   public static kind = MmlMi.prototype.kind;
 
-  /**
-   * @override
-   */
-  public toCHTML(parent: N) {
-    super.toCHTML(parent);
-    if (this.noIC) {
-      this.adaptor.setAttribute(this.chtml, 'noIC', 'true');
-    }
-  }
-
 }

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -131,9 +131,6 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       this.getStretchedVariant([]);
     }
     let chtml = this.standardCHTMLnode(parent);
-    if (this.noIC) {
-      this.adaptor.setAttribute(chtml, 'noIC', 'true');
-    }
     if (stretchy && this.size < 0) {
       this.stretchHTML(chtml);
     } else {

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -127,18 +127,22 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
    * @override
    */
   public toCHTML(parent: N) {
+    const adaptor = this.adaptor;
     const chtml = this.standardCHTMLnode(parent);
     const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
     const [ , v, q] = this.getUVQ();
     const style = {'vertical-align': this.em(v)};
     base.toCHTML(chtml);
-    const stack = this.adaptor.append(chtml, this.html('mjx-script', {style})) as N;
+    const stack = adaptor.append(chtml, this.html('mjx-script', {style})) as N;
     sup.toCHTML(stack);
-    this.adaptor.append(stack, this.html('mjx-spacer', {style: {'margin-top': this.em(q)}}));
+    adaptor.append(stack, this.html('mjx-spacer', {style: {'margin-top': this.em(q)}}));
     sub.toCHTML(stack);
-    const corebox = this.baseCore.getBBox();
-    if (corebox.ic) {
-      this.adaptor.setStyle(sup.chtml, 'marginLeft', this.em(this.baseIc / sup.bbox.rscale));
+    const ic = this.getAdjustedIc();
+    if (ic) {
+      adaptor.setStyle(sup.chtml, 'marginLeft', this.em(ic / sup.bbox.rscale));
+    }
+    if (this.baseHasIc) {
+      adaptor.setStyle(stack, 'marginLeft', this.em(-this.baseIc));
     }
   }
 

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -47,11 +47,6 @@ CommonMsubMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any, an
    */
   public static kind = MmlMsub.prototype.kind;
 
-  /**
-   * don't include italic correction
-   */
-  public static useIC = false;
-
 }
 
 /*****************************************************************/
@@ -70,11 +65,6 @@ CommonMsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any, an
    * The msup wrapper
    */
   public static kind = MmlMsup.prototype.kind;
-
-  /**
-   * Use italic correction
-   */
-  public static useIC = true;
 
 }
 
@@ -109,11 +99,6 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
   };
 
   /**
-   * Don't use italic correction
-   */
-  public static useIC = false;
-
-  /**
    * Make sure styles get output when called from munderover with movable limits
    *
    * @override
@@ -141,7 +126,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
     if (ic) {
       adaptor.setStyle(sup.chtml, 'marginLeft', this.em(ic / sup.bbox.rscale));
     }
-    if (this.baseHasIc) {
+    if (this.baseRemoveIc) {
       adaptor.setStyle(stack, 'marginLeft', this.em(-this.baseIc));
     }
   }

--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -92,7 +92,6 @@ CommonMunderMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsub<any, any, a
     this.adaptor.setStyle(under, 'paddingTop', this.em(k));
     this.setDeltaW([base, under], this.getDeltaW([basebox, underbox], [0, -delta]));
     this.adjustUnderDepth(under, underbox);
-    this.adjustBaseWidth();
   }
 
 }
@@ -148,7 +147,6 @@ CommonMoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsup<any, any, an
     this.adaptor.setStyle(over, 'paddingBottom', this.em(k));
     this.setDeltaW([base, over], this.getDeltaW([basebox, overbox], [0, delta]));
     this.adjustOverDepth(over, overbox);
-    this.adjustBaseWidth();
   }
 
 }
@@ -221,7 +219,6 @@ CommonMunderoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any,
                                   [0, this.isLineBelow ? 0 : -delta, this.isLineAbove ? 0 : delta]));
     this.adjustOverDepth(over, overbox);
     this.adjustUnderDepth(under, underbox);
-    this.adjustBaseWidth();
   }
 
 }

--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -48,11 +48,6 @@ CommonMunderMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsub<any, any, a
   public static kind = MmlMunder.prototype.kind;
 
   /**
-   * Include italic correction
-   */
-  public static useIC: boolean = true;
-
-  /**
    * @override
    */
   public static styles: StyleList = {
@@ -97,6 +92,7 @@ CommonMunderMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsub<any, any, a
     this.adaptor.setStyle(under, 'paddingTop', this.em(k));
     this.setDeltaW([base, under], this.getDeltaW([basebox, underbox], [0, -delta]));
     this.adjustUnderDepth(under, underbox);
+    this.adjustBaseWidth();
   }
 
 }
@@ -117,11 +113,6 @@ CommonMoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsup<any, any, an
    * The mover wrapper
    */
   public static kind = MmlMover.prototype.kind;
-
-  /**
-   * Include italic correction
-   */
-  public static useIC: boolean = true;
 
   /**
    * @override
@@ -157,6 +148,7 @@ CommonMoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsup<any, any, an
     this.adaptor.setStyle(over, 'paddingBottom', this.em(k));
     this.setDeltaW([base, over], this.getDeltaW([basebox, overbox], [0, delta]));
     this.adjustOverDepth(over, overbox);
+    this.adjustBaseWidth();
   }
 
 }
@@ -177,11 +169,6 @@ CommonMunderoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any,
    * The munderover wrapper
    */
   public static kind = MmlMunderover.prototype.kind;
-
-  /**
-   * Include italic correction
-   */
-  public static useIC: boolean = true;
 
   /**
    * @override
@@ -234,6 +221,7 @@ CommonMunderoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any,
                                   [0, this.isLineBelow ? 0 : -delta, this.isLineAbove ? 0 : delta]));
     this.adjustOverDepth(over, overbox);
     this.adjustUnderDepth(under, underbox);
+    this.adjustBaseWidth();
   }
 
 }

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -105,4 +105,14 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
     adaptor.append(adaptor.firstChild(under) as N, box);
   }
 
+  /**
+   * Add base italic correction, if needed
+   */
+  protected adjustBaseWidth() {
+    const w = this.baseWidthAdjust();
+    if (w) {
+      this.adaptor.setStyle(this.chtml, 'paddingRight', this.em(w));
+    }
+  }
+
 }

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -48,11 +48,6 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
   public static kind = 'scriptbase';
 
   /**
-   * Set to true for munderover/munder/mover/msup (Appendix G 13)
-   */
-  public static useIC: boolean = false;
-
-  /**
    * This gives the common output for msub and msup.  It is overridden
    * for all the others (msubsup, munder, mover, munderover).
    *
@@ -103,16 +98,6 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
       adaptor.append(box, child);
     }
     adaptor.append(adaptor.firstChild(under) as N, box);
-  }
-
-  /**
-   * Add base italic correction, if needed
-   */
-  protected adjustBaseWidth() {
-    const w = this.baseWidthAdjust();
-    if (w) {
-      this.adaptor.setStyle(this.chtml, 'paddingRight', this.em(w));
-    }
   }
 
 }

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -56,9 +56,10 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
   public toCHTML(parent: N) {
     this.chtml = this.standardCHTMLnode(parent);
     const [x, v] = this.getOffset();
+    const dx = x - (this.baseRemoveIc ? this.baseIc : 0);
     const style: StyleData = {'vertical-align': this.em(v)};
-    if (x) {
-      style['margin-left'] = this.em(x);
+    if (dx) {
+      style['margin-left'] = this.em(dx);
     }
     this.baseChild.toCHTML(this.chtml);
     this.scriptChild.toCHTML(this.adaptor.append(this.chtml, this.html('mjx-script', {style})) as N);

--- a/ts/output/common/Wrappers/mi.ts
+++ b/ts/output/common/Wrappers/mi.ts
@@ -29,10 +29,6 @@ import {BBox} from '../../../util/BBox.js';
  * The CommonMi interface
  */
 export interface CommonMi extends AnyWrapper {
-  /**
-   * True if no italic correction should be used
-   */
-  noIC: boolean;
 }
 
 /**
@@ -51,19 +47,11 @@ export function CommonMiMixin<T extends WrapperConstructor>(Base: T): MiConstruc
   return class extends Base {
 
     /**
-     * True if no italic correction should be used
-     */
-    public noIC: boolean = false;
-
-    /**
      * @override
      */
     public computeBBox(bbox: BBox, _recompute: boolean = false) {
       super.computeBBox(bbox);
       this.copySkewIC(bbox);
-      if (this.noIC) {
-        bbox.w -= bbox.ic;
-      }
     }
   };
 

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -41,10 +41,6 @@ export const DirectionVH: {[n: number]: string} = {
  * The CommonMo interface
  */
 export interface CommonMo extends AnyWrapper {
-  /**
-   * True if no italic correction should be used
-   */
-  noIC: boolean;
 
   /**
    * The font size that a stretched operator uses.
@@ -128,11 +124,6 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
   return class extends Base {
 
     /**
-     * True if no italic correction should be used
-     */
-    public noIC: boolean = false;
-
-    /**
      * The font size that a stretched operator uses.
      * If -1, then stretch arbitrarily, and bbox gives the actual height, depth, width
      */
@@ -181,9 +172,6 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
       if (stretchy && this.size < 0) return;
       super.computeBBox(bbox);
       this.copySkewIC(bbox);
-      if (this.noIC) {
-        bbox.w -= bbox.ic;
-      }
     }
 
     /**

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -70,7 +70,7 @@ export function CommonMsubMixin<
      * @override
      */
     public getOffset() {
-      return [0, -this.getV()];
+      return [this.baseHasIc ? -this.baseIc : 0, -this.getV()];
     }
 
   };
@@ -120,8 +120,8 @@ export function CommonMsupMixin<
      * @override
      */
     public getOffset() {
-      const x = (this.baseCore.bbox.ic ? .05 * this.baseCore.bbox.ic + .05 : 0);
-      return [x * this.baseScale, this.getU()];
+      const x = this.getAdjustedIc() - this.baseIc;
+      return [x, this.getU()];
     }
 
   };
@@ -211,10 +211,11 @@ export function CommonMsubsupMixin<
       const [subbox, supbox] = [this.subChild.getBBox(), this.supChild.getBBox()];
       bbox.empty();
       bbox.append(basebox);
-      const w = bbox.w;
+      const w = this.getBaseWidth();
+      const x = this.getAdjustedIc();
       const [u, v] = this.getUVQ();
       bbox.combine(subbox, w, v);
-      bbox.combine(supbox, w + this.baseIc, u);
+      bbox.combine(supbox, w + x, u);
       bbox.w += this.font.params.scriptspace;
       bbox.clean();
       this.setChildPWidths(recompute);
@@ -236,8 +237,7 @@ export function CommonMsubsupMixin<
       const tex = this.font.params;
       const t = 3 * tex.rule_thickness;
       const subscriptshift = this.length2em(this.node.attributes.get('subscriptshift'), tex.sub2);
-      const scale = this.baseScale;
-      const drop = (this.baseIsChar && scale === 1 ? 0 : basebox.d * scale + tex.sub_drop * subbox.rscale);
+      const drop = this.baseCharZero(basebox.d * this.baseScale + tex.sub_drop * subbox.rscale);
       //
       // u and v are the veritcal shifts of the scripts, initially set to minimum values and then adjusted
       //

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -75,7 +75,7 @@ export function CommonMsubMixin<
      * @override
      */
     public getOffset() {
-      return [this.baseRemoveIc ? -this.baseIc : 0, -this.getV()];
+      return [0, -this.getV()];
     }
 
   };
@@ -125,7 +125,7 @@ export function CommonMsupMixin<
      * @override
      */
     public getOffset() {
-      const x = this.getAdjustedIc() - this.baseIc;
+      const x = this.getAdjustedIc() - (this.baseRemoveIc ? 0 : this.baseIc);
       return [x, this.getU()];
     }
 

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -58,6 +58,11 @@ export function CommonMsubMixin<
   return class extends Base {
 
     /**
+     * Do not include italic correction
+     */
+    public static useIC: boolean = false;
+
+    /**
      * @override
      */
     public get scriptChild() {
@@ -70,7 +75,7 @@ export function CommonMsubMixin<
      * @override
      */
     public getOffset() {
-      return [this.baseHasIc ? -this.baseIc : 0, -this.getV()];
+      return [this.baseRemoveIc ? -this.baseIc : 0, -this.getV()];
     }
 
   };
@@ -182,6 +187,11 @@ export function CommonMsubsupMixin<
 >(Base: T): MsubsupConstructor<W> & T {
 
   return class extends Base {
+
+    /**
+     * Do not include italic correction
+     */
+    public static useIC: boolean = false;
 
     /**
      *  Cached values for the script offsets and separation (so if they are

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -58,11 +58,6 @@ export function CommonMunderMixin<
   return class extends Base {
 
     /**
-     * Do include italic correction
-     */
-    public static useIC: boolean = true;
-
-    /**
      * @override
      */
     public get scriptChild() {
@@ -95,7 +90,6 @@ export function CommonMunderMixin<
       bbox.combine(basebox, bw, 0);
       bbox.combine(underbox, uw, v);
       bbox.d += this.font.params.big_op_spacing5;
-      bbox.w += this.baseWidthAdjust();
       bbox.clean();
       this.setChildPWidths(recompute);
     }
@@ -135,11 +129,6 @@ export function CommonMoverMixin<
   return class extends Base {
 
     /**
-     * Do include italic correction
-     */
-    public static useIC: boolean = true;
-
-    /**
      * @override
      */
     public get scriptChild() {
@@ -172,7 +161,6 @@ export function CommonMoverMixin<
       bbox.combine(basebox, bw, 0);
       bbox.combine(overbox, ow, u);
       bbox.h += this.font.params.big_op_spacing5;
-      bbox.w += this.baseWidthAdjust();
       bbox.clean();
     }
 
@@ -220,11 +208,6 @@ export function CommonMunderoverMixin<
 >(Base: T): MunderoverConstructor<W> & T {
 
   return class extends Base {
-
-    /**
-     * Do include italic correction
-     */
-    public static useIC: boolean = true;
 
     /*
      * @return {W}   The wrapped under node
@@ -290,7 +273,6 @@ export function CommonMunderoverMixin<
       const z = this.font.params.big_op_spacing5;
       bbox.h += z;
       bbox.d += z;
-      bbox.w += this.baseWidthAdjust();
       bbox.clean();
     }
 

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -25,7 +25,6 @@
 import {AnyWrapper, Constructor} from '../Wrapper.js';
 import {CommonScriptbase, ScriptbaseConstructor} from './scriptbase.js';
 import {MmlMunderover, MmlMunder, MmlMover} from '../../../core/MmlTree/MmlNodes/munderover.js';
-import {CommonMo} from './mo.js';
 import {BBox} from '../../../util/BBox.js';
 
 /*****************************************************************/
@@ -57,6 +56,11 @@ export function CommonMunderMixin<
 >(Base: T): MunderConstructor<W> & T {
 
   return class extends Base {
+
+    /**
+     * Do include italic correction
+     */
+    public static useIC: boolean = true;
 
     /**
      * @override
@@ -91,6 +95,7 @@ export function CommonMunderMixin<
       bbox.combine(basebox, bw, 0);
       bbox.combine(underbox, uw, v);
       bbox.d += this.font.params.big_op_spacing5;
+      bbox.w += this.baseWidthAdjust();
       bbox.clean();
       this.setChildPWidths(recompute);
     }
@@ -130,6 +135,11 @@ export function CommonMoverMixin<
   return class extends Base {
 
     /**
+     * Do include italic correction
+     */
+    public static useIC: boolean = true;
+
+    /**
      * @override
      */
     public get scriptChild() {
@@ -142,10 +152,6 @@ export function CommonMoverMixin<
      */
     constructor(...args: any[]) {
       super(...args);
-      if (this.baseCore && 'noIC' in this.baseCore && this.isCharBase() &&
-          this.scriptChild.node.getProperty('mathaccent')) {
-        (this.baseCore as undefined as CommonMo).noIC = true;
-      }
       this.stretchChildren();
     }
 
@@ -166,6 +172,7 @@ export function CommonMoverMixin<
       bbox.combine(basebox, bw, 0);
       bbox.combine(overbox, ow, u);
       bbox.h += this.font.params.big_op_spacing5;
+      bbox.w += this.baseWidthAdjust();
       bbox.clean();
     }
 
@@ -213,6 +220,11 @@ export function CommonMunderoverMixin<
 >(Base: T): MunderoverConstructor<W> & T {
 
   return class extends Base {
+
+    /**
+     * Do include italic correction
+     */
+    public static useIC: boolean = true;
 
     /*
      * @return {W}   The wrapped under node
@@ -278,6 +290,7 @@ export function CommonMunderoverMixin<
       const z = this.font.params.big_op_spacing5;
       bbox.h += z;
       bbox.d += z;
+      bbox.w += this.baseWidthAdjust();
       bbox.clean();
     }
 

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -505,9 +505,10 @@ export function CommonScriptbaseMixin<
      * @override
      */
     public computeBBox(bbox: BBox, recompute: boolean = false) {
+      const w = this.getBaseWidth();
       const [x, y] = this.getOffset();
       bbox.append(this.baseChild.getBBox());
-      bbox.combine(this.scriptChild.getBBox(), bbox.w + x, y);
+      bbox.combine(this.scriptChild.getBBox(), w + x, y);
       bbox.w += this.font.params.scriptspace;
       bbox.clean();
       this.setChildPWidths(recompute);
@@ -632,7 +633,7 @@ export function CommonScriptbaseMixin<
     public getDeltaW(boxes: BBox[], delta: number[] = [0, 0, 0]): number[] {
       const align = this.node.attributes.get('align');
       const widths = boxes.map(box => box.w * box.rscale);
-      widths[0] -= (this.baseRemoveIc ? this.baseIc : 0);
+      widths[0] -= (this.baseRemoveIc && !this.baseCore.node.attributes.get('largeop') ? this.baseIc : 0);
       const w = Math.max(...widths);
       const dw = [];
       let m = 0;

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -105,15 +105,16 @@ CommonMsubsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any
   public toSVG(parent: N) {
     const svg = this.standardSVGnode(parent);
     const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
-    const bbox = base.getBBox();
+    const w = this.getBaseWidth();
+    const x = this.getAdjustedIc();
     const [u, v] = this.getUVQ();
 
     base.toSVG(svg);
     sup.toSVG(svg);
     sub.toSVG(svg);
 
-    sub.place(bbox.w * bbox.rscale, v);
-    sup.place(bbox.w * bbox.rscale + this.baseIc, u);
+    sub.place(w, v);
+    sup.place(w + x, u);
   }
 
 }

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -46,11 +46,6 @@ CommonMsubMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any, a
    */
   public static kind = MmlMsub.prototype.kind;
 
-  /**
-   * Don't include italic correction
-   */
-  public static useIC = false;
-
 }
 
 /*****************************************************************/
@@ -70,11 +65,6 @@ CommonMsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any, a
    */
   public static kind = MmlMsup.prototype.kind;
 
-  /**
-   * Do include italic correction
-   */
-  public static useIC = true;
-
 }
 
 /*****************************************************************/
@@ -93,11 +83,6 @@ CommonMsubsupMixin<SVGWrapper<any, any, any>, Constructor<SVGscriptbase<any, any
    * The msubsup wrapper
    */
   public static kind = MmlMsubsup.prototype.kind;
-
-  /**
-   * Don't use italic correction
-   */
-  public static useIC = false;
 
   /**
    * @override

--- a/ts/output/svg/Wrappers/munderover.ts
+++ b/ts/output/svg/Wrappers/munderover.ts
@@ -47,11 +47,6 @@ CommonMunderMixin<SVGWrapper<any, any, any>, Constructor<SVGmsub<any, any, any>>
   public static kind = MmlMunder.prototype.kind;
 
   /**
-   * Do include italic correction
-   */
-  public static useIC: boolean = true;
-
-  /**
    * @override
    */
   public toSVG(parent: N) {
@@ -95,11 +90,6 @@ CommonMoverMixin<SVGWrapper<any, any, any>, Constructor<SVGmsup<any, any, any>>>
   public static kind = MmlMover.prototype.kind;
 
   /**
-   * Do include italic correction
-   */
-  public static useIC: boolean = true;
-
-  /**
    * @override
    */
   public toSVG(parent: N) {
@@ -140,11 +130,6 @@ CommonMunderoverMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, any
    * The munderover wrapper
    */
   public static kind = MmlMunderover.prototype.kind;
-
-  /**
-   * Do include italic correction
-   */
-  public static useIC: boolean = true;
 
   /**
    * @override

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -59,10 +59,11 @@ CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(
   public toSVG(parent: N) {
     const svg = this.standardSVGnode(parent);
     const bbox = this.baseChild.getBBox();
+    const w = bbox.w * bbox.rscale;
     const [x, v] = this.getOffset();
     this.baseChild.toSVG(svg);
     this.scriptChild.toSVG(svg);
-    this.scriptChild.place(bbox.w * bbox.rscale + x, v);
+    this.scriptChild.place(w + x, v);
   }
 
 }

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -53,8 +53,7 @@ CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(
    */
   public toSVG(parent: N) {
     const svg = this.standardSVGnode(parent);
-    const bbox = this.baseChild.getBBox();
-    const w = bbox.w * bbox.rscale;
+    const w = this.getBaseWidth();
     const [x, v] = this.getOffset();
     this.baseChild.toSVG(svg);
     this.scriptChild.toSVG(svg);

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -46,11 +46,6 @@ CommonScriptbaseMixin<SVGWrapper<any, any, any>, SVGConstructor<any, any, any>>(
   public static kind = 'scriptbase';
 
   /**
-   * Set to true for munderover/munder/mover/msup (Appendix G 13)
-   */
-  public static useIC: boolean = false;
-
-  /**
    * This gives the common output for msub and msup.  It is overridden
    * for all the others (msubsup, munder, mover, munderover).
    *


### PR DESCRIPTION
This PR refactors some fo the previous accent code to better handle the italic correction differences in the bases of some constructs (`msub`, `msubsup`, and math-accent `munderover` nodes).  The previous code included some hacks that were competing with each other, and caused complications in handling the interactions between `munderover` and `msubsup` nodes.  This refactors some of the code to make that work more reliably, and moves more to the common wrappers so that the specific output routines are more uniform.

In the past, the italic correction was removed from the base character when it was output, and had to be added back in later, which made for complicated checking of whether the italic correction needs to be taken into account and when it needs to be added again.  The new approach is to always include the italic correction in the base and then compensate for it when subscripts are added, or when math accents are placed.  This makes for fewer cases, and allows the CHTML CSS to be reduced by removing the need for the `noIC` selector cases.

This PR also moves the `useIC` properties to the common wrappers (since they are inherited), and switches the default to `true` since that makes for fewer cases that need to be overridden (just `msub` and `msubsup`).