### PR TITLE
Allow 'single-character' mi's to include trailing combining characters (mathjax/MathJax#2617)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mi.ts
+++ b/ts/core/MmlTree/MmlNodes/mi.ts
@@ -45,7 +45,8 @@ export class MmlMi extends AbstractMmlTokenNode {
   /**
    * Pattern for single-character texts
    */
-  public static singleCharacter: RegExp = /^[\uD800-\uDBFF]?.$/;
+  public static singleCharacter: RegExp =
+    /^[\uD800-\uDBFF]?.[\u0300-\u036F\u1AB0-\u1ABE\u1DC0-\u1DFF\u20D0-\u20EF]*$/;
 
   /**
    * TeX class is ORD


### PR DESCRIPTION
This PR doesn't sound combining characters when counting the length of the content of an `mi` element in order to determine the `mathvariant` to use.  This allows things like `\not a` to render as an italic "a" rather than an upright one.

Resolves issue mathjax/MathJax#2617.