### PR TITLE
Add a small separation between base and scripts.  (mathjax/MathJax#2406)

### DIFF
--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -91,7 +91,8 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
   public static styles: StyleList = {
     'mjx-script': {
       display: 'inline-block',
-      'padding-right': '.05em'   // scriptspace
+      'padding-right': '.05em',  // scriptspace
+      'padding-left': '.033em'   // extra_ic
     },
     'mjx-script > *': {
       display: 'block'

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -218,7 +218,8 @@ export type FontParameters = {
   delimitershortfall: number,
 
   min_rule_thickness: number,
-  separation_factor: number
+  separation_factor: number,
+  extra_ic: number
 };
 
 /****************************************************************************/
@@ -453,7 +454,8 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     delimitershortfall:   .3,
 
     min_rule_thickness:  1.25,     // in pixels
-    separation_factor:   1.75      // expansion factor for spacing e.g. between accents and base
+    separation_factor:   1.75,     // expansion factor for spacing e.g. between accents and base
+    extra_ic:            .033      // extra spacing for scripts (compensate for not having actual ic values)
   };
 
   /**

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -90,7 +90,6 @@ export interface CommonScriptbase<W extends AnyWrapper> extends AnyWrapper {
   /**
    * The script element's wrapper (overridden in subclasses)
    */
-
   readonly scriptChild: W;
 
   /***************************************************************************/

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -90,6 +90,7 @@ export interface CommonScriptbase<W extends AnyWrapper> extends AnyWrapper {
   /**
    * The script element's wrapper (overridden in subclasses)
    */
+
   readonly scriptChild: W;
 
   /***************************************************************************/
@@ -147,15 +148,15 @@ export interface CommonScriptbase<W extends AnyWrapper> extends AnyWrapper {
    */
   isLineAccent(script: W): boolean;
 
-  /**
-   * @return {number}    The base child's width adjusted for the base italic correction
-   */
-  getBaseWidth(): number;
-
   /***************************************************************************/
   /*
    *  Methods for sub-sup nodes
    */
+
+  /**
+   * @return {number}    The base child's width adjusted for the base italic correction
+   */
+  getBaseWidth(): number;
 
   /**
    * Get the shift for the script (implemented in subclasses)
@@ -490,12 +491,17 @@ export function CommonScriptbaseMixin<
       return (node.isToken && (node as MmlMo).getText() === '\u2015');
     }
 
+    /***************************************************************************/
+    /*
+     *  Methods for sub-sup nodes
+     */
+
     /**
      * @return {number}   The base child's width adjusted for the base italic correction
      */
     public getBaseWidth(): number {
       const bbox = this.baseChild.getBBox();
-      return bbox.w * bbox.rscale - (this.baseRemoveIc ? this.baseIc : 0);
+      return bbox.w * bbox.rscale - (this.baseRemoveIc ? this.baseIc : 0) + this.font.params.extra_ic;
     }
 
     /**
@@ -513,11 +519,6 @@ export function CommonScriptbaseMixin<
       bbox.clean();
       this.setChildPWidths(recompute);
     }
-
-    /***************************************************************************/
-    /*
-     *  Methods for sub-sup nodes
-     */
 
     /**
      * Get the shift for the script (implemented in subclasses)


### PR DESCRIPTION
This PR modifies the super- and subscript positions to leave a small amount of space between the base and the scripts.  In TeX, this is handled by italic correction values (that are different for each character), but we don't have that information in the font tables.  We may be able to add that during the font update this summer, so this is a bit of a hack to improve the layout until then.  It's not perfect, but it helps.  See, for example `\beta^p` before and after:

Before:  <img width="58" alt="before" src="https://user-images.githubusercontent.com/432782/111667669-55b63180-87eb-11eb-9827-e57be81002f9.png">

After: <img width="54" alt="after" src="https://user-images.githubusercontent.com/432782/111667969-9c0b9080-87eb-11eb-9f18-a63cc08f4a5d.png">

I also moved the comments that identified what `scriptbase` functions are for `msub` and `msup`, which end up making it look like functions were moved.

Addresses issue mathjax/MathJax#2406.