### PR TITLE
Ignore * in \\* and \\*[...] constructions.  (mathjax/MathJax#2433)

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1221,16 +1221,21 @@ BaseMethods.Cr = function(parser: TexParser, name: string) {
  */
 BaseMethods.CrLaTeX = function(parser: TexParser, name: string, nobrackets: boolean = false) {
   let n: string;
-  if (!nobrackets && parser.string.charAt(parser.i) === '[') {
-    let dim = parser.GetBrackets(name, '');
-    let [value, unit, ] = ParseUtil.matchDimen(dim);
-    // @test Custom Linebreak
-    if (dim && !value) {
-      // @test Dimension Error
-      throw new TexError('BracketMustBeDimension',
-                          'Bracket argument to %1 must be a dimension', parser.currentCS);
+  if (!nobrackets) {
+    if (parser.string.charAt(parser.i) === '*') {  // The * controls page breaking, so ignore it
+      parser.i++;
     }
-    n = value + unit;
+    if (parser.string.charAt(parser.i) === '[') {
+      let dim = parser.GetBrackets(name, '');
+      let [value, unit, ] = ParseUtil.matchDimen(dim);
+      // @test Custom Linebreak
+      if (dim && !value) {
+        // @test Dimension Error
+        throw new TexError('BracketMustBeDimension',
+                           'Bracket argument to %1 must be a dimension', parser.currentCS);
+      }
+      n = value + unit;
+    }
   }
   parser.Push(
     parser.itemFactory.create('cell').setProperties({isCR: true, name: name, linebreak: true}) );

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1222,6 +1222,8 @@ BaseMethods.Cr = function(parser: TexParser, name: string) {
 BaseMethods.CrLaTeX = function(parser: TexParser, name: string, nobrackets: boolean = false) {
   let n: string;
   if (!nobrackets) {
+    // TODO: spaces before * and [ are not allowed in AMS environments like align, but
+    //       should be allowed in array and eqnarray.  This distinction should be honored here.
     if (parser.string.charAt(parser.i) === '*') {  // The * controls page breaking, so ignore it
       parser.i++;
     }


### PR DESCRIPTION
This PR causes the `\\` command to ignore a following asterisk, if there is one.  (The asterisk is for controlling page breaks, but it makes sense for MathJax to just ignore it.)

Resolves issue mathjax/MathJax#2433.