### PR TITLE
Update AsciiMath to current v2 version. (mathjax/MathJax#2640)

### DIFF
--- a/ts/input/asciimath/mathjax2/legacy/jax/input/AsciiMath/jax.js
+++ b/ts/input/asciimath/mathjax2/legacy/jax/input/AsciiMath/jax.js
@@ -24,7 +24,7 @@
  *  
  *  ---------------------------------------------------------------------
  *  
- *  Copyright (c) 2012-2017 The MathJax Consortium
+ *  Copyright (c) 2012-2020 The MathJax Consortium
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ THE SOFTWARE.
 //(function(){
 var mathcolor = "blue";        // change it to "" (to inherit) or another color
 //var mathfontsize = "1em";      // change to e.g. 1.2em for larger math
-var mathfontfamily = "serif";  // change to "" to inherit (works in IE) 
+//var mathfontfamily = "serif";  // change to "" to inherit (works in IE) 
                                // or another family (e.g. "arial")
 //var automathrecognize = false; // writing "amath" on page makes this true
 //var checkForMathML = true;     // check if browser can display MathML
@@ -390,7 +390,7 @@ function newsymbol(symbolobj) {
 }
 
 // character lists for Mozilla/Netscape fonts
-var AMcal = ["\uD835\uDC9C","\u212C","\uD835\uDC9E","\uD835\uDC9F","\u2130","\u2131","\uD835\uDCA2","\u210B","\u2110","\uD835\uDCA5","\uD835\uDCA6","\u2112","\u2133","\uD835\uDCA9","\uD835\uDCAA","\uD835\uDCAB","\uD835\uDCAC","\u211B","\uD835\uDCAE","\uD835\uDCAF","\uD835\uDCB0","\uD835\uDCB1","\uD835\uDCB2","\uD835\uDCB3","\uD835\uDCB4","\uD835\uDCB5","\uD835\uDCB6","\uD835\uDCB7","\uD835\uDCB8","\uD835\uDCB9","\u212F","\uD835\uDCBB","\u210A","\uD835\uDCBD","\uD835\uDCBE","\uD835\uDCBF","\uD835\uDCC0","\uD835\uDCC1","\uD835\uDCC2","\uD835\uDCC3","\u2134","\uD835\uDCC5","\uD835\uDCC6","\uD835\uDCC7","\uD835\uDCC8","\uD835\uDCC9","\uD835\uDCCA","\uD835\uDCCB","\uD835\uDCCC","\uD835\uDCCD","\uD835\uDCCE","\uD835\uDCCF"]; 
+var AMcal = ["\uD835\uDC9C","\u212C","\uD835\uDC9E","\uD835\uDC9F","\u2130","\u2131","\uD835\uDCA2","\u210B","\u2110","\uD835\uDCA5","\uD835\uDCA6","\u2112","\u2133","\uD835\uDCA9","\uD835\uDCAA","\uD835\uDCAB","\uD835\uDCAC","\u211B","\uD835\uDCAE","\uD835\uDCAF","\uD835\uDCB0","\uD835\uDCB1","\uD835\uDCB2","\uD835\uDCB3","\uD835\uDCB4","\uD835\uDCB5","\uD835\uDCB6","\uD835\uDCB7","\uD835\uDCB8","\uD835\uDCB9","\u212F","\uD835\uDCBB","\u210A","\uD835\uDCBD","\uD835\uDCBE","\uD835\uDCBF","\uD835\uDCC0","\uD835\uDCC1","\uD835\uDCC2","\uD835\uDCC3","\u2134","\uD835\uDCC5","\uD835\uDCC6","\uD835\uDCC7","\uD835\uDCC8","\uD835\uDCC9","\uD835\uDCCA","\uD835\uDCCB","\uD835\uDCCC","\uD835\uDCCD","\uD835\uDCCE","\uD835\uDCCF"];
 
 var AMfrk = ["\uD835\uDD04","\uD835\uDD05","\u212D","\uD835\uDD07","\uD835\uDD08","\uD835\uDD09","\uD835\uDD0A","\u210C","\u2111","\uD835\uDD0D","\uD835\uDD0E","\uD835\uDD0F","\uD835\uDD10","\uD835\uDD11","\uD835\uDD12","\uD835\uDD13","\uD835\uDD14","\u211C","\uD835\uDD16","\uD835\uDD17","\uD835\uDD18","\uD835\uDD19","\uD835\uDD1A","\uD835\uDD1B","\uD835\uDD1C","\u2128","\uD835\uDD1E","\uD835\uDD1F","\uD835\uDD20","\uD835\uDD21","\uD835\uDD22","\uD835\uDD23","\uD835\uDD24","\uD835\uDD25","\uD835\uDD26","\uD835\uDD27","\uD835\uDD28","\uD835\uDD29","\uD835\uDD2A","\uD835\uDD2B","\uD835\uDD2C","\uD835\uDD2D","\uD835\uDD2E","\uD835\uDD2F","\uD835\uDD30","\uD835\uDD31","\uD835\uDD32","\uD835\uDD33","\uD835\uDD34","\uD835\uDD35","\uD835\uDD36","\uD835\uDD37"];
 
@@ -499,6 +499,7 @@ var AMsymbols = [
 {input:"-=",  tag:"mo", output:"\u2261", tex:"equiv", ttype:CONST},
 {input:"~=",  tag:"mo", output:"\u2245", tex:"cong", ttype:CONST},
 {input:"~~",  tag:"mo", output:"\u2248", tex:"approx", ttype:CONST},
+{input:"~",  tag:"mo", output:"\u223C", tex:"sim", ttype:CONST},
 {input:"prop", tag:"mo", output:"\u221D", tex:"propto", ttype:CONST},
 
 //logical symbols
@@ -516,13 +517,16 @@ var AMsymbols = [
 {input:"|==",  tag:"mo", output:"\u22A8", tex:"models", ttype:CONST},
 
 //grouping brackets
-{input:"(", tag:"mo", output:"(", tex:null, ttype:LEFTBRACKET},
-{input:")", tag:"mo", output:")", tex:null, ttype:RIGHTBRACKET},
-{input:"[", tag:"mo", output:"[", tex:null, ttype:LEFTBRACKET},
-{input:"]", tag:"mo", output:"]", tex:null, ttype:RIGHTBRACKET},
+{input:"(", tag:"mo", output:"(", tex:"left(", ttype:LEFTBRACKET},
+{input:")", tag:"mo", output:")", tex:"right)", ttype:RIGHTBRACKET},
+{input:"[", tag:"mo", output:"[", tex:"left[", ttype:LEFTBRACKET},
+{input:"]", tag:"mo", output:"]", tex:"right]", ttype:RIGHTBRACKET},
 {input:"{", tag:"mo", output:"{", tex:null, ttype:LEFTBRACKET},
 {input:"}", tag:"mo", output:"}", tex:null, ttype:RIGHTBRACKET},
 {input:"|", tag:"mo", output:"|", tex:null, ttype:LEFTRIGHT},
+{input:":|:", tag:"mo", output:"|", tex:null, ttype:CONST},
+{input:"|:", tag:"mo", output:"|", tex:null, ttype:LEFTBRACKET},
+{input:":|", tag:"mo", output:"|", tex:null, ttype:RIGHTBRACKET},
 //{input:"||", tag:"mo", output:"||", tex:null, ttype:LEFTRIGHT},
 {input:"(:", tag:"mo", output:"\u2329", tex:"langle", ttype:LEFTBRACKET},
 {input:":)", tag:"mo", output:"\u232A", tex:"rangle", ttype:RIGHTBRACKET},
@@ -541,6 +545,7 @@ var AMsymbols = [
 {input:"del",  tag:"mo", output:"\u2202", tex:"partial", ttype:CONST},
 {input:"grad", tag:"mo", output:"\u2207", tex:"nabla", ttype:CONST},
 {input:"+-",   tag:"mo", output:"\u00B1", tex:"pm", ttype:CONST},
+{input:"-+",   tag:"mo", output:"\u2213", tex:"mp", ttype:CONST},
 {input:"O/",   tag:"mo", output:"\u2205", tex:"emptyset", ttype:CONST},
 {input:"oo",   tag:"mo", output:"\u221E", tex:"infty", ttype:CONST},
 {input:"aleph", tag:"mo", output:"\u2135", tex:null, ttype:CONST},
@@ -606,6 +611,21 @@ var AMsymbols = [
 {input:"glb",  tag:"mo", output:"glb", tex:null, ttype:CONST},
 {input:"min",  tag:"mo", output:"min", tex:null, ttype:UNDEROVER},
 {input:"max",  tag:"mo", output:"max", tex:null, ttype:UNDEROVER},
+{input:"Sin",  tag:"mo", output:"Sin", tex:null, ttype:UNARY, func:true},
+{input:"Cos",  tag:"mo", output:"Cos", tex:null, ttype:UNARY, func:true},
+{input:"Tan",  tag:"mo", output:"Tan", tex:null, ttype:UNARY, func:true},
+{input:"Arcsin",  tag:"mo", output:"Arcsin", tex:null, ttype:UNARY, func:true},
+{input:"Arccos",  tag:"mo", output:"Arccos", tex:null, ttype:UNARY, func:true},
+{input:"Arctan",  tag:"mo", output:"Arctan", tex:null, ttype:UNARY, func:true},
+{input:"Sinh", tag:"mo", output:"Sinh", tex:null, ttype:UNARY, func:true},
+{input:"Cosh", tag:"mo", output:"Cosh", tex:null, ttype:UNARY, func:true},
+{input:"Tanh", tag:"mo", output:"Tanh", tex:null, ttype:UNARY, func:true},
+{input:"Cot",  tag:"mo", output:"Cot", tex:null, ttype:UNARY, func:true},
+{input:"Sec",  tag:"mo", output:"Sec", tex:null, ttype:UNARY, func:true},
+{input:"Csc",  tag:"mo", output:"Csc", tex:null, ttype:UNARY, func:true},
+{input:"Log",  tag:"mo", output:"Log", tex:null, ttype:UNARY, func:true},
+{input:"Ln",   tag:"mo", output:"Ln",  tex:null, ttype:UNARY, func:true},
+{input:"Abs",   tag:"mo", output:"abs",  tex:null, ttype:UNARY, notexcopy:true, rewriteleftright:["|","|"]},
 
 //arrows
 {input:"uarr", tag:"mo", output:"\u2191", tex:"uparrow", ttype:CONST},
@@ -636,12 +656,15 @@ var AMsymbols = [
 {input:"vec", tag:"mover", output:"\u2192", tex:null, ttype:UNARY, acc:true},
 {input:"dot", tag:"mover", output:".",      tex:null, ttype:UNARY, acc:true},
 {input:"ddot", tag:"mover", output:"..",    tex:null, ttype:UNARY, acc:true},
+{input:"overarc", tag:"mover", output:"\u23DC", tex:"overparen", ttype:UNARY, acc:true},
 {input:"ul", tag:"munder", output:"\u0332", tex:"underline", ttype:UNARY, acc:true},
 {input:"ubrace", tag:"munder", output:"\u23DF", tex:"underbrace", ttype:UNARYUNDEROVER, acc:true},
 {input:"obrace", tag:"mover", output:"\u23DE", tex:"overbrace", ttype:UNARYUNDEROVER, acc:true},
 {input:"text", tag:"mtext", output:"text", tex:null, ttype:TEXT},
 {input:"mbox", tag:"mtext", output:"mbox", tex:null, ttype:TEXT},
 {input:"color", tag:"mstyle", ttype:BINARY},
+{input:"id", tag:"mrow", ttype:BINARY},
+{input:"class", tag:"mrow", ttype:BINARY},
 {input:"cancel", tag:"menclose", output:"cancel", tex:null, ttype:UNARY},
 AMquote,
 {input:"bb", tag:"mstyle", atname:"mathvariant", atval:"bold", output:"bb", tex:null, ttype:UNARY},
@@ -670,7 +693,7 @@ function initSymbols() {
   var symlen = AMsymbols.length;
   for (i=0; i<symlen; i++) {
     if (AMsymbols[i].tex) {
-      AMsymbols.push({input:AMsymbols[i].tex, 
+      AMsymbols.push({input:AMsymbols[i].tex,
         tag:AMsymbols[i].tag, output:AMsymbols[i].output, ttype:AMsymbols[i].ttype,
         acc:(AMsymbols[i].acc||false)});
     }
@@ -692,14 +715,14 @@ function define(oldstr,newstr) {
 function AMremoveCharsAndBlanks(str,n) {
 //remove n characters and any following blanks
   var st;
-  if (str.charAt(n)=="\\" && str.charAt(n+1)!="\\" && str.charAt(n+1)!=" ") 
+  if (str.charAt(n)=="\\" && str.charAt(n+1)!="\\" && str.charAt(n+1)!=" ")
     st = str.slice(n+1);
   else st = str.slice(n);
   for (var i=0; i<st.length && st.charCodeAt(i)<=32; i=i+1);
   return st.slice(i);
 }
 
-function position(arr, str, n) { 
+function position(arr, str, n) {
 // return position >=n where str appears or would be inserted
 // assumes arr is sorted
   if (n==0) {
@@ -740,7 +763,7 @@ function AMgetSymbol(str) {
   AMpreviousSymbol=AMcurrentSymbol;
   if (match!=""){
     AMcurrentSymbol=AMsymbols[mk].ttype;
-    return AMsymbols[mk]; 
+    return AMsymbols[mk];
   }
 // if str[0] is a digit or - return maxsubstring of digits.digits
   AMcurrentSymbol=CONST;
@@ -770,7 +793,7 @@ function AMgetSymbol(str) {
     st = str.slice(0,1); //take 1 character
     tagst = (("A">st || st>"Z") && ("a">st || st>"z")?"mo":"mi");
   }
-  if (st=="-" && AMpreviousSymbol==INFIX) {
+  if (st=="-" && str.charAt(1)!==' ' && AMpreviousSymbol==INFIX) {
     AMcurrentSymbol = INFIX;  //trick "/" into recognizing "-" on second parse
     return {input:st, tag:tagst, output:st, ttype:UNARY, func:true};
   }
@@ -812,20 +835,20 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
     return [null,str];
   }
   if (symbol.ttype == DEFINITION) {
-    str = symbol.output+AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = symbol.output+AMremoveCharsAndBlanks(str,symbol.input.length);
     symbol = AMgetSymbol(str);
   }
   switch (symbol.ttype) {  case UNDEROVER:
   case CONST:
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     return [createMmlNode(symbol.tag,        //its a constant
                              document.createTextNode(symbol.output)),str];
   case LEFTBRACKET:   //read (expr+)
     AMnestingDepth++;
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     result = AMparseExpr(str,true);
     AMnestingDepth--;
-    if (typeof symbol.invisible == "boolean" && symbol.invisible) 
+    if (typeof symbol.invisible == "boolean" && symbol.invisible)
       node = createMmlNode("mrow",result[0]);
     else {
       node = createMmlNode("mo",document.createTextNode(symbol.output));
@@ -858,7 +881,7 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
       return [createMmlNode("mrow",newFrag),str];
   case UNARYUNDEROVER:
   case UNARY:
-      str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+      str = AMremoveCharsAndBlanks(str,symbol.input.length);
       result = AMparseSexpr(str);
       if (result[0]==null) return [createMmlNode(symbol.tag,
                              document.createTextNode(symbol.output)),str];
@@ -889,7 +912,16 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
 	return [node,result[1]];
       } else if (typeof symbol.acc == "boolean" && symbol.acc) {   // accent
         node = createMmlNode(symbol.tag,result[0]);
-        node.appendChild(createMmlNode("mo",document.createTextNode(symbol.output)));
+        var accnode = createMmlNode("mo",document.createTextNode(symbol.output));
+        if (symbol.input=="vec" && (
+		(result[0].nodeName=="mrow" && result[0].childNodes.length==1
+			&& result[0].firstChild.firstChild.nodeValue !== null
+			&& result[0].firstChild.firstChild.nodeValue.length==1) ||
+		(result[0].firstChild.nodeValue !== null
+			&& result[0].firstChild.nodeValue.length==1) )) {
+			accnode.setAttribute("stretchy",false);
+        }
+        node.appendChild(accnode);
         return [node,result[1]];
       } else {                        // font change command
         if (!isIE && typeof symbol.codes != "undefined") {
@@ -899,9 +931,9 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
                               result[0].childNodes[i].firstChild.nodeValue);
               var newst = [];
               for (var j=0; j<st.length; j++)
-		  if (st.charCodeAt(j)>64 && st.charCodeAt(j)<91) 
+		  if (st.charCodeAt(j)>64 && st.charCodeAt(j)<91)
 		  	newst = newst + symbol.codes[st.charCodeAt(j)-65];
-                else if (st.charCodeAt(j)>96 && st.charCodeAt(j)<123) 
+                else if (st.charCodeAt(j)>96 && st.charCodeAt(j)<123)
                 	newst = newst + symbol.codes[st.charCodeAt(j)-71];
                 else newst = newst + st.charAt(j);
               if (result[0].nodeName=="mi")
@@ -917,7 +949,7 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
         return [node,result[1]];
       }
   case BINARY:
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     result = AMparseSexpr(str);
     if (result[0]==null) return [createMmlNode("mo",
                            document.createTextNode(symbol.input)),str];
@@ -926,25 +958,33 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
     if (result2[0]==null) return [createMmlNode("mo",
                            document.createTextNode(symbol.input)),str];
     AMremoveBrackets(result2[0]);
-    if (symbol.input=="color") {
-	if (str.charAt(0)=="{") i=str.indexOf("}");
-        else if (str.charAt(0)=="(") i=str.indexOf(")");
-        else if (str.charAt(0)=="[") i=str.indexOf("]");
-	st = str.slice(1,i);
-	node = createMmlNode(symbol.tag,result2[0]);
-	node.setAttribute("mathcolor",st);
-	return [node,result2[1]];
+    if (['color', 'class', 'id'].indexOf(symbol.input) >= 0) {
+
+      // Get the second argument
+    	if (str.charAt(0)=="{") i=str.indexOf("}");
+      else if (str.charAt(0)=="(") i=str.indexOf(")");
+      else if (str.charAt(0)=="[") i=str.indexOf("]");
+    	st = str.slice(1,i);
+
+      // Make a mathml node
+    	node = createMmlNode(symbol.tag,result2[0]);
+
+      // Set the correct attribute
+      if (symbol.input === "color") node.setAttribute("mathcolor", st)
+      else if (symbol.input === "class") node.setAttribute("class", st)
+      else if (symbol.input === "id") node.setAttribute("id", st)
+   	return [node,result2[1]];
     }
-    if (symbol.input=="root" || symbol.output=="stackrel") 
+    if (symbol.input=="root" || symbol.output=="stackrel")
       newFrag.appendChild(result2[0]);
     newFrag.appendChild(result[0]);
     if (symbol.input=="frac") newFrag.appendChild(result2[0]);
     return [createMmlNode(symbol.tag,newFrag),result2[1]];
   case INFIX:
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     return [createMmlNode("mo",document.createTextNode(symbol.output)),str];
   case SPACE:
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     node = createMmlNode("mspace");
     node.setAttribute("width","1ex");
     newFrag.appendChild(node);
@@ -957,13 +997,13 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
   case LEFTRIGHT:
 //    if (rightvert) return [null,str]; else rightvert = true;
     AMnestingDepth++;
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     result = AMparseExpr(str,false);
     AMnestingDepth--;
     st = "";
     if (result[0].lastChild!=null)
       st = result[0].lastChild.firstChild.nodeValue;
-    if (st == "|") { // its an absolute value subterm
+    if (st == "|" && str.charAt(0)!==",") { // its an absolute value subterm
       node = createMmlNode("mo",document.createTextNode(symbol.output));
       node = createMmlNode("mrow",node);
       node.appendChild(result[0]);
@@ -975,7 +1015,7 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
     }
   default:
 //alert("default");
-    str = AMremoveCharsAndBlanks(str,symbol.input.length); 
+    str = AMremoveCharsAndBlanks(str,symbol.input.length);
     return [createMmlNode(symbol.tag,        //its a constant
                              document.createTextNode(symbol.output)),str];
   }
@@ -1016,14 +1056,15 @@ function AMparseIexpr(str) {
       }
     } else if (symbol.input == "^" && underover) {
     	node = createMmlNode("mover",node);
-        node.appendChild(result[0]);   
+        node.appendChild(result[0]);
     } else {
       node = createMmlNode(symbol.tag,node);
       node.appendChild(result[0]);
     }
     if (typeof sym1.func != 'undefined' && sym1.func) {
     	sym2 = AMgetSymbol(str);
-    	if (sym2.ttype != INFIX && sym2.ttype != RIGHTBRACKET) {
+    	if (sym2.ttype != INFIX && sym2.ttype != RIGHTBRACKET &&
+     	    (sym1.input.length>1 || sym2.ttype == LEFTBRACKET)) {
     		result = AMparseIexpr(str);
     		node = createMmlNode("mrow",node);
     		node.appendChild(result[0]);
@@ -1055,24 +1096,24 @@ function AMparseExpr(str,rightbracket) {
       node.appendChild(result[0]);
       newFrag.appendChild(node);
       symbol = AMgetSymbol(str);
-    } 
+    }
     else if (node!=undefined) newFrag.appendChild(node);
-  } while ((symbol.ttype != RIGHTBRACKET && 
+  } while ((symbol.ttype != RIGHTBRACKET &&
            (symbol.ttype != LEFTRIGHT || rightbracket)
            || AMnestingDepth == 0) && symbol!=null && symbol.output!="");
   if (symbol.ttype == RIGHTBRACKET || symbol.ttype == LEFTRIGHT) {
 //    if (AMnestingDepth > 0) AMnestingDepth--;
     var len = newFrag.childNodes.length;
-    if (len>0 && newFrag.childNodes[len-1].nodeName == "mrow" 
-            && newFrag.childNodes[len-1].lastChild
-            && newFrag.childNodes[len-1].lastChild.firstChild ) { //matrix
-      	    //removed to allow row vectors: //&& len>1 && 
+    if (len>0 && newFrag.childNodes[len-1].nodeName == "mrow"
+    	    && newFrag.childNodes[len-1].lastChild
+    	    && newFrag.childNodes[len-1].lastChild.firstChild ) { //matrix
+    	    //removed to allow row vectors: //&& len>1 &&
     	    //newFrag.childNodes[len-2].nodeName == "mo" &&
     	    //newFrag.childNodes[len-2].firstChild.nodeValue == ","
       var right = newFrag.childNodes[len-1].lastChild.firstChild.nodeValue;
       if (right==")" || right=="]") {
         var left = newFrag.childNodes[len-1].firstChild.firstChild.nodeValue;
-        if (left=="(" && right==")" && symbol.output != "}" || 
+        if (left=="(" && right==")" && symbol.output != "}" ||
             left=="[" && right=="]") {
         var pos = []; // positions of commas
         var matrix = true;
@@ -1080,18 +1121,19 @@ function AMparseExpr(str,rightbracket) {
         for (i=0; matrix && i<m; i=i+2) {
           pos[i] = [];
           node = newFrag.childNodes[i];
-          if (matrix) matrix = node.nodeName=="mrow" && 
-            (i==m-1 || node.nextSibling.nodeName=="mo" && 
+          if (matrix) matrix = node.nodeName=="mrow" &&
+            (i==m-1 || node.nextSibling.nodeName=="mo" &&
             node.nextSibling.firstChild.nodeValue==",")&&
             node.firstChild.firstChild.nodeValue==left &&
             node.lastChild.firstChild.nodeValue==right;
-          if (matrix) 
+          if (matrix)
             for (var j=0; j<node.childNodes.length; j++)
               if (node.childNodes[j].firstChild.nodeValue==",")
                 pos[i][pos[i].length]=j;
           if (matrix && i>1) matrix = pos[i].length == pos[i-2].length;
         }
         matrix = matrix && (pos.length>1 || pos[0].length>0);
+        var columnlines = [];
         if (matrix) {
           var row, frag, n, k, table = document.createDocumentFragment();
           for (i=0; i<m; i=i+2) {
@@ -1104,11 +1146,21 @@ function AMparseExpr(str,rightbracket) {
             for (j=1; j<n-1; j++) {
               if (typeof pos[i][k] != "undefined" && j==pos[i][k]){
                 node.removeChild(node.firstChild); //remove ,
+                if (node.firstChild.nodeName=="mrow" && node.firstChild.childNodes.length==1 &&
+         	  node.firstChild.firstChild.firstChild.nodeValue=="\u2223") {
+         	    //is columnline marker - skip it
+         	    if (i==0) { columnlines.push("solid"); }
+         	    node.removeChild(node.firstChild); //remove mrow
+         	    node.removeChild(node.firstChild); //remove ,
+         	    j+=2;
+         	    k++;
+            	} else if (i==0) { columnlines.push("none"); }
                 row.appendChild(createMmlNode("mtd",frag));
                 k++;
               } else frag.appendChild(node.firstChild);
             }
             row.appendChild(createMmlNode("mtd",frag));
+            if (i==0) { columnlines.push("none"); }
             if (newFrag.childNodes.length>2) {
               newFrag.removeChild(newFrag.firstChild); //remove <mrow>)</mrow>
               newFrag.removeChild(newFrag.firstChild); //remove <mo>,</mo>
@@ -1116,6 +1168,7 @@ function AMparseExpr(str,rightbracket) {
             table.appendChild(createMmlNode("mtr",row));
           }
           node = createMmlNode("mtable",table);
+          node.setAttribute("columnlines", columnlines.join(" "));
           if (typeof symbol.invisible == "boolean" && symbol.invisible) node.setAttribute("columnalign","left");
           newFrag.replaceChild(node,newFrag.firstChild);
         }
@@ -1138,11 +1191,18 @@ function parseMath(str,latex) {
   str = str.replace(/&nbsp;/g,"");
   str = str.replace(/&gt;/g,">");
   str = str.replace(/&lt;/g,"<");
-  str = str.replace(/(Sin|Cos|Tan|Arcsin|Arccos|Arctan|Sinh|Cosh|Tanh|Cot|Sec|Csc|Log|Ln|Abs)/g, function(v) { return v.toLowerCase(); });
   frag = AMparseExpr(str.replace(/^\s+/g,""),false)[0];
   node = createMmlNode("mstyle",frag);
   if (mathcolor != "") node.setAttribute("mathcolor",mathcolor);
-  if (mathfontfamily != "") node.setAttribute("fontfamily",mathfontfamily);
+  if (mathfontsize != "") {
+	  node.setAttribute("fontsize", mathfontsize);
+	  node.setAttribute("mathsize", mathfontsize);
+  }
+  if (mathfontfamily != "") {
+	  node.setAttribute("fontfamily", mathfontfamily);
+	  node.setAttribute("mathvariant", mathfontfamily);
+  }
+
   if (displaystyle) node.setAttribute("displaystyle","true");
   node = createMmlNode("math",node);
   if (showasciiformulaonhover)                      //fixed by djhsu so newline
@@ -1334,6 +1394,7 @@ asciimath.translate = translate;
 showasciiformulaonhover = false;
 mathfontfamily = "";
 mathcolor = "";
+mathfontsize = "";
 
 //
 //  Remove remapping of mathvariants to plane1 (MathJax handles that)


### PR DESCRIPTION
This PR brings the legacy AsciiMath input jax up to the version currently in MathJax v2 (adding missing commands, etc.).