### PR TITLE
Better selectors for SVG path widths.  (mathjax/MathJax#2618)

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -318,7 +318,7 @@ CommonWrapper<
    * @return {N}                The <use> node for the glyph
    */
   protected useNode(variant: string, C: string, path: string): N {
-    const use = this.svg('use');
+    const use = this.svg('use', {'data-c': C});
     const id = '#' + this.jax.fontCache.cachePath(variant, C, path);
     this.adaptor.setAttribute(use, 'href', id, XLINKNS);
     return use;

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -47,7 +47,7 @@ CommonTextNodeMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
    * @override
    */
   public static styles: StyleList = {
-    '.MathJax path': {
+    'mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c]': {
       'stroke-width': 3
     }
   };


### PR DESCRIPTION
This PR uses more specific CSS selectors for the SVG glyphs paths, and makes sure they apply to both `path` and `use` elements.

Resolves issue mathjax/MathJax#2618.