### PR TITLE
Remove role='presentation' attributes.  (mathjax/MathJax#2608)

### DIFF
--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -109,13 +109,12 @@ export function AssistiveMmlMathItemMixin<N, T, D, B extends Constructor<Abstrac
         // Create a container for the hidden MathML
         //
         const node = adaptor.node('mjx-assistive-mml', {
-          role: 'presentation', unselectable: 'on', display: (this.display ? 'block' : 'inline')
+          unselectable: 'on', display: (this.display ? 'block' : 'inline')
         }, [mmlNodes]);
         //
         // Hide the typeset math from assistive technology and append the MathML that is visually
         //   hidden from other users
         //
-        adaptor.setAttribute(this.typesetRoot, 'role', 'presentation');
         adaptor.setAttribute(adaptor.firstChild(this.typesetRoot) as N, 'aria-hidden', 'true');
         adaptor.setStyle(this.typesetRoot, 'position', 'relative');
         adaptor.append(this.typesetRoot, node);


### PR DESCRIPTION
This PR removes the unneeded `role="presentation"` attributes that are inserted by the assistive MathML extension.  Since these were being applied to custom element that had no role to begin with, there is no need for these.

Resolves issue mathjax/MathJax#2608.