### PR TITLE
Trim TeX and annotations before copying to clipboard.  (mathjax/MathJax#2574)

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -957,14 +957,14 @@ export class Menu {
    * Copy the original form to the clipboard
    */
   protected copyOriginal() {
-    this.copyToClipboard(this.menu.mathItem.math);
+    this.copyToClipboard(this.menu.mathItem.math.trim());
   }
 
   /**
    * Copy the original annotation text to the clipboard
    */
   public copyAnnotation() {
-    this.copyToClipboard(this.menu.annotation);
+    this.copyToClipboard(this.menu.annotation.trim());
   }
 
   /**


### PR DESCRIPTION
This PR trims TeX code and annotations before copying to the clipboard.

Resolves issue mathjax/MathJax#2574.