### PR TITLE
Make path resolving more flexible, and don't fail when loading entity files. (mathjax/MathJax#2650)

### DIFF
--- a/components/src/input/mml/mml.js
+++ b/components/src/input/mml/mml.js
@@ -6,3 +6,13 @@ if (MathJax.startup) {
   MathJax.startup.registerConstructor('mml', MathML);
   MathJax.startup.useInput('mml');
 }
+if (MathJax.loader) {
+  //
+  // Install a path-filter to cause loading of an entity file to load all entities,
+  //   since the individual files don't have individual components.
+  //
+  MathJax.loader.pathFilters.add((data) => {
+    data.name = data.name.replace(/\/util\/entities\/.*?\.js/, '/input/mml/entities.js');
+    return true;
+  });
+}

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -30,11 +30,19 @@ import {Package, PackageError, PackageReady, PackageFailed} from './package.js';
 export {Package, PackageError, PackageReady, PackageFailed} from './package.js';
 export {MathJaxLibrary} from './global.js';
 
+import {FunctionList} from '../util/FunctionList.js';
+
 /*
  * The current directory (for webpack), and the browser document (if any)
  */
 declare var __dirname: string;
 declare var document: Document;
+
+/**
+ * Function used to determine path to a given package.
+ */
+export type PathFilterFunction = (data: {name: string, original: string, addExtension: boolean}) => boolean;
+export type PathFilterList = {[name: string]: PathFilterFunction};
 
 /**
  * Update the configuration structure to include the loader configuration
@@ -65,9 +73,52 @@ export interface MathJaxObject extends MJObject {
     preLoad: (...names: string[]) => void;            // Indicate that packages are already loaded by hand
     defaultReady: () => void;                         // The function performed when all packages are loaded
     getRoot: () => string;                            // Find the root URL for the MathJax files
+    pathFilters: PathFilterList;                      // the filters to use for looking for package paths
   };
   startup?: any;
 }
+
+/**
+ * Functions to used to filter the path to a package
+ */
+export const PathFilters: {[name: string]: PathFilterFunction} = {
+  /**
+   * Look up the path in the configuration's source list
+   */
+  source: (data) => {
+    if (CONFIG.source.hasOwnProperty(data.name)) {
+      data.name = CONFIG.source[data.name];
+    }
+    return true;
+  },
+
+  /**
+   * Add [mathjax] before any relative path, and add .js if needed
+   */
+  normalize: (data) => {
+    const name = data.name;
+    if (!name.match(/^(?:[a-z]+:\/)?\/|[a-z]:\\|\[/i)) {
+      data.name = '[mathjax]/' + name.replace(/^\.\//, '');
+    }
+    if (data.addExtension && !name.match(/\.[^\/]+$/)) {
+      data.name += '.js';
+    }
+    return true;
+  },
+
+  /**
+   * Revursively replace path prefixes (e.g., [mathjax], [tex], etc.)
+   */
+  prefix: (data) => {
+    let match;
+    while ((match = data.name.match(/^\[([^\]]*)\]/))) {
+      if (!CONFIG.paths.hasOwnProperty(match[1])) break;
+      data.name = CONFIG.paths[match[1]] + data.name.substr(match[0].length);
+    }
+    return true;
+  }
+};
+
 
 /**
  * The implementation of the dynamic loader
@@ -157,6 +208,17 @@ export namespace Loader {
     return root;
   }
 
+  /**
+   * The filters to use to modify the paths used to obtain the packages
+   */
+  export const pathFilters = new FunctionList();
+
+  /**
+   * The default filters to use.
+   */
+  pathFilters.add(PathFilters.source, 1);
+  pathFilters.add(PathFilters.normalize, 2);
+  pathFilters.add(PathFilters.prefix, 5);
 }
 
 /**

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -79,7 +79,7 @@ export interface MathJaxObject extends MJObject {
 }
 
 /**
- * Functions to used to filter the path to a package
+ * Functions used to filter the path to a package
  */
 export const PathFilters: {[name: string]: PathFilterFunction} = {
   /**
@@ -107,7 +107,7 @@ export const PathFilters: {[name: string]: PathFilterFunction} = {
   },
 
   /**
-   * Revursively replace path prefixes (e.g., [mathjax], [tex], etc.)
+   * Recursively replace path prefixes (e.g., [mathjax], [tex], etc.)
    */
   prefix: (data) => {
     let match;


### PR DESCRIPTION
This PR adds a function list to use for resolving the path to a component file (i.e., package), and populates it with several default filters (the ones that were in the original `resolvePath()` method).  This allows extensions to add or remove the filters as needed, and is used by the MathML input component to handle loading entity files when needed.

In the past, the Entities object would try to load entity definitions when an entity wasn't found in its default table.  That works for node applications, but for in-browser use, which requires components, not just files, that caused MathJax to fail.  (Fortunately, the browser usually handles the entities, but it could cause problems with entities not known in the browser, and in some other edge cases).

This PR resolves that problem by adding a filter to remap attempts to load an entity file to instead load the "all entities" component.

Resolves issue mathjax/MathJax#2650.