### PR TITLE
This PR corrects errors in the horizontal stretchy data for several characters.

### DIFF
--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -134,7 +134,7 @@ export type DelimiterData = {
   stretch?: number[];   // The unicode code points for the parts of multi-character versions [beg, ext, end, mid?]
   stretchv?: number[];  // the variants to use for the stretchy characters (index into variant name array)
   HDW?: number[];       // [h, d, w] (for vertical, h and d are the normal size, w is the multi-character width,
-  //            for horizontal, h and d are the multi-character ones, w is for the normal size).
+                        //            for horizontal, h and d are the multi-character ones, w is for the normal size).
   min?: number;         // The minimum size a multi-character version can be
   c?: number;           // The character number (for aliased delimiters)
 };

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -256,6 +256,9 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
               }
               this.variant = this.font.getSizeVariant(c, i);
               this.size = i;
+              if (delim.schar && delim.schar[i]) {
+                this.stretch.c = delim.schar[i];
+              }
               return;
             }
             i++;

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -76,7 +76,7 @@ export function CommonTeXFontMixin<
     /**
      *  The default variants for the standard stretchy sizes
      */
-    protected static defaultSizeVariants = ['normal', '-smallop', '-largeop', '-size3', '-size4'];
+    protected static defaultSizeVariants = ['normal', '-smallop', '-largeop', '-size3', '-size4', '-tex-variant'];
 
     /**
      *  The default variants for the standard stretchy assmebly parts

--- a/ts/output/common/fonts/tex/delimiters.ts
+++ b/ts/output/common/fonts/tex/delimiters.ts
@@ -37,10 +37,10 @@ const DELIM21D2 = {c: 0x21D2, dir: H, sizes: [1], stretch: [0, 0x3D, 0x21D2], HD
 const DELIM21D4 = {c: 0x21D4, dir: H, sizes: [1], stretch: [0x21D0, 0x3D, 0x21D2], HDW: HDW3};
 const DELIM2212 = {c: 0x2212, dir: H, sizes: [.778], stretch: [0, 0x2212], HDW: HDW3};
 const DELIM2223 = {c: 0x2223, dir: V, sizes: [1], stretch: [0, 0x2223], HDW: [.627, .015, .333]};
-const DELIM23DC = {c: 0x23DC, dir: H, sizes: [.778, 1], schar: [0x2322, 0x2322], stretch: [0xE150, 0xE154, 0xE151],
-                   HDW: [.32, .2, .5]};
-const DELIM23DD = {c: 0x23DD, dir: H, sizes: [.778, 1], schar: [0x2323, 0x2323], stretch: [0xE152, 0xE154, 0xE153],
-                   HDW: [.32, .2, .5]};
+const DELIM23DC = {c: 0x23DC, dir: H, sizes: [.778, 1], schar: [0x2322, 0x2322], variants: [5, 0],
+                   stretch: [0xE150, 0xE154, 0xE151], HDW: [.32, .2, .5]};
+const DELIM23DD = {c: 0x23DD, dir: H, sizes: [.778, 1], schar: [0x2323, 0x2323], variants: [5, 0],
+                   stretch: [0xE152, 0xE154, 0xE153], HDW: [.32, .2, .5]};
 const DELIM23DE = {c: 0x23DE, dir: H, stretch: [0xE150, 0xE154, 0xE151, 0xE155], HDW: [.32, .2, .5], min: 1.8};
 const DELIM23DF = {c: 0x23DF, dir: H, stretch: [0xE152, 0xE154, 0xE153, 0xE156], HDW: [.32, .2, .5], min: 1.8};
 const DELIM27E8 = {c: 0x27E8, dir: V, sizes: VSIZES};
@@ -74,7 +74,7 @@ export const delimiters: DelimiterMap<DelimiterData> = {
   0x2013: DELIM2013,
   0x2014: DELIM2013,
   0x2015: DELIM2013,
-  0x2016: {dir: V, sizes: [.602, 1], schar: [0, 0x2225], stretch: [0, 0x2225], HDW: [.602, 0, .556]},
+  0x2016: {dir: V, sizes: [.602, 1], schar: [0, 0x2225], variants: [1, 0], stretch: [0, 0x2225], HDW: [.602, 0, .556]},
   0x2017: DELIM2013,
   0x203E: DELIMAF,
   0x20D7: DELIM2192,
@@ -128,7 +128,7 @@ export const delimiters: DelimiterMap<DelimiterData> = {
   0x23B1: {dir: V, sizes: [.989], stretch: [0x23AB, 0x23AA, 0x23A9], HDW: [.75, .25, .889]},
   0x23B4: {dir: H, stretch: [0x250C, 0x2212, 0x2510], HDW: HDW3, min: 1},
   0x23B5: {dir: H, stretch: [0x2514, 0x2212, 0x2518], HDW: HDW3, min: 1},
-  0x23D0: {dir: V, sizes: [.602, 1], schar: [0, 0x2223], stretch: [0, 0x2223], HDW: [.602, 0, .333]},
+  0x23D0: {dir: V, sizes: [.602, 1], schar: [0, 0x2223], variants: [1, 0], stretch: [0, 0x2223], HDW: [.602, 0, .333]},
   0x23DC: DELIM23DC,
   0x23DD: DELIM23DD,
   0x23DE: DELIM23DE,

--- a/ts/output/common/fonts/tex/delimiters.ts
+++ b/ts/output/common/fonts/tex/delimiters.ts
@@ -23,9 +23,9 @@ export const HDW3 = [.583, .082, .5];
 export const VSIZES = [1, 1.2, 1.8, 2.4, 3];
 
 const DELIM2F = {c: 0x2F, dir: V, sizes: VSIZES};
-const DELIMAF = {c: 0xAF, dir: H, sizes: [.59], stretch: [0, 0xAF], HDW: [.59, -0.544, .5]};
-const DELIM2C6 = {c: 0x2C6, dir: H, sizes: [.517, .817, 1.335, 1.777, 1.909]};
-const DELIM2DC = {c: 0x2DC, dir: H, sizes: [.583, .805, 1.33, 1.773, 1.887]};
+const DELIMAF = {c: 0xAF, dir: H, sizes: [.5], stretch: [0, 0xAF], HDW: [.59, -0.544, .5]};
+const DELIM2C6 = {c: 0x2C6, dir: H, sizes: [.5, .556, 1, 1.444, 1.889]};
+const DELIM2DC = {c: 0x2DC, dir: H, sizes: [.5, .556, 1, 1.444, 1.889]};
 const DELIM2013 = {c: 0x2013, dir: H, sizes: [.5], stretch: [0, 0x2013], HDW: [.285, -0.248, .5]};
 const DELIM2190 = {c: 0x2190, dir: H, sizes: [1], stretch: [0x2190, 0x2212], HDW: HDW3};
 const DELIM2192 = {c: 0x2192, dir: H, sizes: [1], stretch: [0, 0x2212, 0x2192], HDW: HDW3};
@@ -54,7 +54,7 @@ export const delimiters: DelimiterMap<DelimiterData> = {
   0x29: {dir: V, sizes: VSIZES, stretch: [0x239E, 0x239F, 0x23A0], HDW: [.85, .349, .875]},
   0x2D: DELIM2212,
   0x2F: DELIM2F,
-  0x3D: {dir: H, sizes: [.767], stretch: [0, 0x3D], HDW: HDW3},
+  0x3D: {dir: H, sizes: [.778], stretch: [0, 0x3D], HDW: HDW3},
   0x5B: {dir: V, sizes: VSIZES, stretch: [0x23A1, 0x23A2, 0x23A3], HDW: HDW2},
   0x5C: {dir: V, sizes: VSIZES},
   0x5D: {dir: V, sizes: VSIZES, stretch: [0x23A4, 0x23A5, 0x23A6], HDW: HDW2},


### PR DESCRIPTION
This PR fixes the stretchy data for several characters where it was incorrectly translated from the v2 data.  In particular, this fixes the data for `\widehat` and `\widetilde`, as well as U+00AF (MACRON) and U+003D (EQUAL SIGN).

See also the comment below for additional changes that were added in a second commit.