### PR TITLE
Add bolding data for the -tex-mathit variant (mathjax/MathJax#2502)

### DIFF
--- a/ts/input/tex/boldsymbol/BoldsymbolConfiguration.ts
+++ b/ts/input/tex/boldsymbol/BoldsymbolConfiguration.ts
@@ -40,6 +40,7 @@ BOLDVARIANT[TexConstant.Variant.SCRIPT]    = TexConstant.Variant.BOLDSCRIPT;
 BOLDVARIANT[TexConstant.Variant.SANSSERIF] = TexConstant.Variant.BOLDSANSSERIF;
 BOLDVARIANT['-tex-calligraphic']   = '-tex-bold-calligraphic';
 BOLDVARIANT['-tex-oldstyle']       = '-tex-bold-oldstyle';
+BOLDVARIANT['-tex-mathit']         = TexConstant.Variant.BOLDITALIC;
 
 
 // Namespace


### PR DESCRIPTION
This PR adds data so that `\boldsymbol` will interact properly with `\mathit`.  So `\boldsymbol{\mathit{1}}` should produce `<mi mathvariant="bold-italic">1</mi>`.  Note, however, that the MathJax TeX fonts only include bold-italic alphabetic characters, so this will still not show a bold-italic 1.  That would require a font with more bold-italic coverage, such as STIX2.

Resolves issue mathjax/MathJax#2502