### PR TITLE
Allow stylesheet to be obtained even after it was created.  (mathjax/MathJax#2542)

### DIFF
--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -212,13 +212,14 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    */
   public addStyleSheet() {
     const sheet = this.documentStyleSheet();
-    if (sheet) {
-      const head = this.adaptor.head(this.document);
-      let styles = this.findSheet(head, this.adaptor.getAttribute(sheet, 'id'));
+    const adaptor = this.adaptor;
+    if (sheet && !adaptor.parent(sheet)) {
+      const head = adaptor.head(this.document);
+      let styles = this.findSheet(head, adaptor.getAttribute(sheet, 'id'));
       if (styles) {
-        this.adaptor.replace(sheet, styles);
+        adaptor.replace(sheet, styles);
       } else {
-        this.adaptor.append(head, sheet);
+        adaptor.append(head, sheet);
       }
     }
   }

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -153,7 +153,7 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
    */
   public styleSheet(html: MathDocument<N, T, D>) {
     if (this.chtmlStyles && !this.options.adaptiveCSS) {
-      return null;  // stylesheet is already added to the document
+      return this.chtmlStyles;  // stylesheet is already added to the document
     }
     const sheet = this.chtmlStyles = super.styleSheet(html);
     this.adaptor.setAttribute(sheet, 'id', CHTML.STYLESHEETID);

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -166,7 +166,7 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
    */
   public styleSheet(html: MathDocument<N, T, D>) {
     if (this.svgStyles) {
-      return null;  // stylesheet is already added to the document
+      return this.svgStyles;  // stylesheet is already added to the document
     }
     const sheet = this.svgStyles = super.styleSheet(html);
     this.adaptor.setAttribute(sheet, 'id', SVG.STYLESHEETID);


### PR DESCRIPTION
This PR allows the `MathJax.svgStyleSheet()` or `MathJax.chtmlStyleSheet()` functions to return the stylesheet properly even after it has been created already, while still preventing the stylesheet from being updated unnecessarily.

Resolves issue mathjax/MathJax#2542.