### PR TITLE
Improve heights of successively larger multi-character surds. (mathjax/MathJax#2658)

### DIFF
--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -137,6 +137,8 @@ export type DelimiterData = {
   //            for horizontal, h and d are the multi-character ones, w is for the normal size).
   min?: number;         // The minimum size a multi-character version can be
   c?: number;           // The character number (for aliased delimiters)
+  fullExt?: [number, number]  // When present, extenders must be full sized, and the first number is
+                              //   the size of the extender, while the second is the total size of the ends
 };
 
 /**

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -106,6 +106,16 @@ export interface CommonMo extends AnyWrapper {
    * @return {number[]}        The height and depth for the vertically stretched delimiter
    */
   getBaseline(WHD: number[], HD: number, C: DelimiterData): number[];
+
+  /**
+   * Determine the size of the delimiter based on whether full extenders should be used or not.
+   *
+   * @param {number} D          The requested size of the delimiter
+   * @param {DelimiterData} C   The data for the delimiter
+   * @return {number}           The final size of the assembly
+   */
+  checkExtendedHeight(D: number, C: DelimiterData): number;
+
 }
 
 /**
@@ -268,7 +278,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
         if (delim.stretch) {
           this.size = -1;
           this.invalidateBBox();
-          this.getStretchBBox(WH, D, delim);
+          this.getStretchBBox(WH, this.checkExtendedHeight(D, delim), delim);
         } else {
           this.variant = this.font.getSizeVariant(c, i - 1);
           this.size = i - 1;
@@ -355,6 +365,22 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
         d = cd * (h / (ch + cd));
       }
       return [h - d, d];
+    }
+
+    /**
+     * Determine the size of the delimiter based on whether full extenders should be used or not.
+     *
+     * @param {number} D          The requested size of the delimiter
+     * @param {DelimiterData} C   The data for the delimiter
+     * @return {number}           The final size of the assembly
+     */
+    public checkExtendedHeight(D: number, C: DelimiterData): number {
+      if (C.fullExt) {
+        const [extSize, endSize] = C.fullExt;
+        const n = Math.ceil(Math.max(0, D - endSize) / extSize);
+        D = endSize + n * extSize;
+      }
+      return D;
     }
 
     /**

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -368,11 +368,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
     }
 
     /**
-     * Determine the size of the delimiter based on whether full extenders should be used or not.
-     *
-     * @param {number} D          The requested size of the delimiter
-     * @param {DelimiterData} C   The data for the delimiter
-     * @return {number}           The final size of the assembly
+     * @override
      */
     public checkExtendedHeight(D: number, C: DelimiterData): number {
       if (C.fullExt) {

--- a/ts/output/common/fonts/tex/delimiters.ts
+++ b/ts/output/common/fonts/tex/delimiters.ts
@@ -110,7 +110,7 @@ export const delimiters: DelimiterMap<DelimiterData> = {
   0x21DB: {dir: H, sizes: [1], stretch: [0, 0x2261, 0x21DB], HDW: [.464, -0.036, .5]},
   0x2212: DELIM2212,
   0x2215: DELIM2F,
-  0x221A: {dir: V, sizes: VSIZES, stretch: [0xE001, 0xE000, 0x23B7], HDW: [.85, .35, 1.056]},
+  0x221A: {dir: V, sizes: VSIZES, stretch: [0xE001, 0xE000, 0x23B7], fullExt: [.65, 2.3], HDW: [.85, .35, 1.056]},
   0x2223: DELIM2223,
   0x2225: {dir: V, sizes: [1], stretch: [0, 0x2225], HDW: [.627, .015, .556]},
   0x2308: {dir: V, sizes: VSIZES, stretch: [0x23A1, 0x23A2], HDW: HDW2},


### PR DESCRIPTION
This PR adds the ability to make stretchy multi-character assemblies only use the full size of the extenders.  In TeX, this is used by stretchy surds, for example, to make them grow at a standard rate.  E.g., 

``` latex
\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{1-x^2}}}}}}}}}}
```

now produces

<img width="353" alt="now" src="https://user-images.githubusercontent.com/432782/112161942-fb89e780-8bc1-11eb-825e-eb95c52f712f.png">

with this PR (which is consistent with LaTeX), but used to produce

<img width="352" alt="then" src="https://user-images.githubusercontent.com/432782/112162041-0f354e00-8bc2-11eb-8249-1dd2f6ac62c8.png">

without it (which is not consistent with LaTeX).

Resolves issue mathjax/MathJax#2658.