### PR TITLE
Allow MathML to mark mathaccents, so output is the same as TeX input.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/TeXAtom.ts
+++ b/ts/core/MmlTree/MmlNodes/TeXAtom.ts
@@ -65,7 +65,7 @@ export class TeXAtom extends AbstractMmlBaseNode {
    * @override
    */
   public get notParent() {
-    return true;
+    return this.childNodes[0].childNodes.length === 1;
   }
 
   /**

--- a/ts/core/MmlTree/MmlNodes/TeXAtom.ts
+++ b/ts/core/MmlTree/MmlNodes/TeXAtom.ts
@@ -65,7 +65,7 @@ export class TeXAtom extends AbstractMmlBaseNode {
    * @override
    */
   public get notParent() {
-    return this.childNodes[0].childNodes.length === 1;
+    return this.childNodes[0] && this.childNodes[0].childNodes.length === 1;
   }
 
   /**

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -478,7 +478,7 @@ export class MmlMo extends AbstractMmlTokenNode {
   }
 
   /**
-   * Determine if the mo consists of primes, and remap them if so.
+   * Determine whether the mo consists of primes, and remap them if so.
    *
    * @param {string} mo   The test of the mo element
    */
@@ -491,7 +491,7 @@ export class MmlMo extends AbstractMmlTokenNode {
   }
 
   /**
-   * Determine if the mo is a mathaccent character
+   * Determine whether the mo is a mathaccent character
    *
    * @param {string} mo   The test of the mo element
    */

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -496,7 +496,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    * @param {string} mo   The test of the mo element
    */
   protected checkMathAccent(mo: string) {
-    if (this.getProperty('mathaccent') !== undefined && !this.Parent.isKind('munderover')) return;
+    if (this.getProperty('mathaccent') !== undefined || !this.Parent.isKind('munderover')) return;
     const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
     if (mo.match(MATHACCENT)) {
       this.setProperty('mathaccent', true);

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -121,7 +121,25 @@ export class MmlMo extends AbstractMmlTokenNode {
      0x201D: 0x2033,   // close double quote
      0x201E: 0x2033,   // low open double quote
      0x201F: 0x2036,   // reversed open double quote
-   };
+  };
+
+  protected static mathaccents = new RegExp([
+    '^[',
+    '\u00B4\u0301\u02CA',  // acute
+    '\u0060\u0300\u02CB',  // grave
+    '\u00A8\u0308',        // ddot
+    '\u007E\u0303\u02DC',  // tilde
+    '\u00AF\u0304\u02C9',  // bar
+    '\u02D8\u0306',        // breve
+    '\u02C7\u030C',        // check
+    '\u005E\u0302\u02C6',  // hat
+    '\u2192\u20D7',        // vec
+    '\u02D9\u0307',        // dot
+    '\u02DA\u030A',        // mathring
+    '\u20DB',              // dddot
+    '\u20DC',              // ddddot
+    ']$'
+  ].join(''));
 
   /**
    * The internal TeX class of the node (for use with getter/setter below)
@@ -348,6 +366,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     this.checkOperatorTable(mo);
     this.checkPseudoScripts(mo);
     this.checkPrimes(mo);
+    this.checkMathAccent(mo);
   }
 
   /**
@@ -469,6 +488,19 @@ export class MmlMo extends AbstractMmlTokenNode {
     if (!mo.match(PRIMES)) return;
     const primes = unicodeString(unicodeChars(mo).map(c => REMAP[c]));
     this.setProperty('primes', primes);
+  }
+
+  /**
+   * Determine of the mo is a mathaccent character
+   *
+   * @param {string} mo   The test of the mo element
+   */
+  protected checkMathAccent(mo: string) {
+    if (this.getProperty('mathaccent') !== undefined && !this.Parent.isKind('munderover')) return;
+    const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
+    if (mo.match(MATHACCENT)) {
+      this.setProperty('mathaccent', true);
+    }
   }
 
 }

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -478,7 +478,7 @@ export class MmlMo extends AbstractMmlTokenNode {
   }
 
   /**
-   * Determine of the mo consists of primes, and remap them if so.
+   * Determine if the mo consists of primes, and remap them if so.
    *
    * @param {string} mo   The test of the mo element
    */
@@ -491,7 +491,7 @@ export class MmlMo extends AbstractMmlTokenNode {
   }
 
   /**
-   * Determine of the mo is a mathaccent character
+   * Determine if the mo is a mathaccent character
    *
    * @param {string} mo   The test of the mo element
    */

--- a/ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -58,7 +58,7 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
    * @override
    */
   public get notParent() {
-    return this.childNodes[0].childNodes.length === 1;
+    return this.childNodes[0] && this.childNodes[0].childNodes.length === 1;
   }
 
   /**

--- a/ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -58,7 +58,7 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
    * @override
    */
   public get notParent() {
-    return true;
+    return this.childNodes[0].childNodes.length === 1;
   }
 
   /**

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -202,7 +202,6 @@ export class SerializedMmlVisitor extends MmlVisitor {
     variant && variants.hasOwnProperty(variant) && this.setDataAttribute(data, 'variant', variant);
     node.getProperty('variantForm') && this.setDataAttribute(data, 'alternate', '1');
     node.getProperty('pseudoscript') && this.setDataAttribute(data, 'pseudoscript', 'true');
-    node.getProperty('mathaccent') && this.setDataAttribute(data, 'accent', 'true');
     const texclass = node.getProperty('texClass') as number;
     if (texclass !== undefined) {
       let setclass = true;


### PR DESCRIPTION
This PR allows the `MmlMo` object to mark itself as having a math-accent so that MathML input will display the same as TeX input for these accents, without the need for the `data-mjx-accent="true"` attribute.  That attribute is no longer applied in serialized MathML output, but you can still use it on MathML input to control this internal setting (either to prevent an accent from getting it, or to force one that isn't usually marked that way).

This also fixes a problem with the `TeXAtom` and `mstyle` element's `notParent()` methods to have them not be parents only if they contain a single element (otherwise, they ARE the parent, effectively as an `mrow`).  Without this, something like `\lim_{n\to\infty}` would incorrectly mark the arrow as a mathaccent, as the group `n\to\infty` is in a `TeXAtom` and so the parent would incorrectly be the `munder`.