### PR TITLE
Add the entities needed by TeX into the main entities table.

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -30,7 +30,6 @@ import NodeUtil from './NodeUtil.js';
 import TexParser from './TexParser.js';
 import TexError from './TexError.js';
 import {entities} from '../../util/Entities.js';
-import '../../util/entities/n.js';
 
 
 namespace ParseUtil {

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -36,9 +36,6 @@ import {MmlMsubsup} from '../../../core/MmlTree/MmlNodes/msubsup.js';
 import {MmlMunderover} from '../../../core/MmlTree/MmlNodes/munderover.js';
 import {Label} from '../Tags.js';
 import {entities} from '../../../util/Entities.js';
-import '../../../util/entities/n.js';
-import '../../../util/entities/p.js';
-import '../../../util/entities/r.js';
 
 
 // Namespace
@@ -235,7 +232,7 @@ BaseMethods.Prime = function(parser: TexParser, c: string) {
   do {
     // @test Prime, PrimeSup, Double Prime, PrePrime
     sup += entities.prime; parser.i++, c = parser.GetNext();
-  } while (c === '\'' || c === entities.rquote);
+  } while (c === '\'' || c === entities.rsquo);
   sup = ['', '\u2032', '\u2033', '\u2034', '\u2057'][sup.length] || sup;
   const node = parser.create('token', 'mo', {}, sup);
   parser.Push(

--- a/ts/util/Entities.ts
+++ b/ts/util/Entities.ts
@@ -445,7 +445,13 @@ export const entities: EntityList = {
   xi: '\u03BE',
   yen: '\u00A5',
   zeta: '\u03B6',
-  zigrarr: '\u21DD'
+  zigrarr: '\u21DD',
+
+  //
+  //  Needed by TeX input jax
+  nbsp: '\u00A0',
+  rsquo: '\u2019',
+  lsquo: '\u2018'
 };
 
 /**


### PR DESCRIPTION
This PR adds the few entities needed by the TeX input jax into the main entity table so that we don't have to load the auxiliary tables for just one or two entities.  Also, replace the undefined `rquote` entity with `rsquo`.