### PR TITLE
Fix MathML spacing rules for mo elements.  (mathjax/MathJax#2392)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -150,7 +150,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     let math = this.factory.getNodeClass('math');
     while (parent && parent.isEmbellished && parent.coreMO() === this && !(parent instanceof math)) {
       embellished = parent;
-      parent = (parent as MmlNode).Parent;
+      parent = (parent as MmlNode).parent;
     }
     return embellished;
   }

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -533,20 +533,11 @@ export class CommonWrapper<
                    Math.max(0, this.length2em(attributes.get('rspace'))) :
                    MathMLSpace(isScript, node.rspace));
     //
-    // Remove lspace if we are first in the mrow, and rspace if last
-    //
-    const n = parent.childIndex(child);
-    if (n === 0) {
-      this.bbox.L = 0;
-      return;
-    }
-    if (n === parent.childNodes.length - 1) {
-      this.bbox.R = 0;
-    }
-    //
     // If there are two adjacent <mo>, use enough left space to make it
     //   the maximum of the rspace of the first and lspace of the second
     //
+    const n = parent.childIndex(child);
+    if (n === 0) return;
     const prev = parent.childNodes[n - 1] as AbstractMmlNode;
     if (!prev.isEmbellished) return;
     const bbox = this.jax.nodeMap.get(prev).getBBox();

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -515,6 +515,15 @@ export class CommonWrapper<
    */
   protected getMathMLSpacing() {
     const node = this.node.coreMO() as MmlMo;
+    //
+    // If the mo is not within a multi-node mrow, don't add space
+    //
+    const child = node.coreParent();
+    const parent = child.parent;
+    if (!parent || !parent.isKind('mrow') || parent.childNodes.length === 1) return;
+    //
+    // Get the lspace and rspace
+    //
     const attributes = node.attributes;
     const isScript = (attributes.get('scriptlevel') > 0);
     this.bbox.L = (attributes.isSet('lspace') ?
@@ -523,6 +532,27 @@ export class CommonWrapper<
     this.bbox.R = (attributes.isSet('rspace') ?
                    Math.max(0, this.length2em(attributes.get('rspace'))) :
                    MathMLSpace(isScript, node.rspace));
+    //
+    // Remove lspace if we are first in the mrow, and rspace if last
+    //
+    const n = parent.childIndex(child);
+    if (n === 0) {
+      this.bbox.L = 0;
+      return;
+    }
+    if (n === parent.childNodes.length - 1) {
+      this.bbox.R = 0;
+    }
+    //
+    // If there are two adjacent <mo>, use enough left space to make it
+    //   the maximum of the rspace of the first and lspace of the second
+    //
+    const prev = parent.childNodes[n - 1] as AbstractMmlNode;
+    if (!prev.isEmbellished) return;
+    const bbox = this.jax.nodeMap.get(prev).getBBox();
+    if (bbox.R) {
+      this.bbox.L = Math.max(0, this.bbox.L - bbox.R);
+    }
   }
 
   /**
@@ -555,7 +585,7 @@ export class CommonWrapper<
    */
   protected isTopEmbellished(): boolean {
     return (this.node.isEmbellished &&
-            !(this.node.Parent && this.node.Parent.isEmbellished));
+            !(this.node.parent && this.node.parent.isEmbellished));
   }
 
   /*******************************************************************/


### PR DESCRIPTION
This PR modifies the MathML spacing rules for `<mo>` (and embellished `<mo>`) to correspond to Neil's explanation of the rules in mathjax/MathJax#2392.  This means that space is only added when the (embellished) operator is inside an mrow (or inferred mrow) that has more than one element.  This also makes the spacing between two successive `<mo>` elements be the maximum of the `rspace` of the first and the `lspace` of the second (as opposed to the sum of the two, as in the past). 

This only affects when MathML spacing has been selected for the output jax, not the TeX spacing.

Finally, this also fixes the `coreParent()` function, which used to skip over `<mstyle>` elements, and so would incorrectly report the parent for `<mstyle><mo>+</mo></mstyle>` as the `<mo>` element rather than the `<mstyle>`.  Similarly, the `isTopEmbellished()` function incorrectly reported the `<mo>` as the top embellished operator.

Resolve issue mathjax/MathJax#2392.