### PR TITLE
Better handling of min height and width for SVG (so they don't disappear).

### DIFF
--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -73,7 +73,9 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
       direction: 'ltr'
     },
     'mjx-container[jax="SVG"] > svg': {
-      overflow: 'visible'
+      overflow: 'visible',
+      'min-height': '1px',
+      'min-width': '1px'
     },
     'mjx-container[jax="SVG"] > svg a': {
       fill: 'blue', stroke: 'blue'
@@ -229,8 +231,9 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
    */
   protected createRoot(wrapper: SVGWrapper<N, T, D>): [N, N] {
     const {w, h, d, pwidth} = wrapper.getBBox();
-    const W = Math.max(w, .001); // make sure we are at least one unit wide (needed for e.g. \llap)
-    const H = Math.max(h + d, .001); // make sure we are at least one unit tall (needed for e.g., \smash)
+    const px = wrapper.metrics.em / 1000;
+    const W = Math.max(w, px); // make sure we are at least one unitpx wide (needed for e.g. \llap)
+    const H = Math.max(h + d, px); // make sure we are at least one px tall (needed for e.g., \smash)
     //
     //  The container that flips the y-axis and sets the colors to inherit from the surroundings
     //


### PR DESCRIPTION
This PR attempts (again) to fix the problem with SVG element disappearing if they have 0 height or width.  This uses CSS `min-height` and `min-width` to make sure the SVG has some width and height, and also makes sure the `viewBox` has non-zero width and height (this time using the em-size to make it what should be one pixel minimum.