### PR TITLE
Have HTMLDomStrings skip node types that it can't process. (mathjax/MathJax#2662)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -53,6 +53,7 @@ export interface MinDocument<N, T> {
  * @template T  The Text node class
  */
 export interface MinHTMLElement<N, T> {
+  nodeType: number;
   nodeName: string;
   nodeValue: string;
   textContent: string;
@@ -99,6 +100,7 @@ export interface MinHTMLElement<N, T> {
  * @template T  The Text node class
  */
 export interface MinText<N, T> {
+  nodeType: number;
   nodeName: string;
   nodeValue: string;
   parentNode: N | Node;
@@ -365,7 +367,8 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public kind(node: N | T) {
-    return node.nodeName.toLowerCase();
+    const n = node.nodeType;
+    return (n === 1 || n === 3 || n === 8 ? node.nodeName.toLowerCase() : '');
   }
 
   /**

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -242,7 +242,7 @@ export class HTMLDomStrings<N, T, D> {
   }
 
   /**
-   * Handle an unknown node type (nodeType other than 1, 3, 7)
+   * Handle an unknown node type (nodeType other than 1, 3, 8)
    *
    * @param {N} node           The node to process
    * @param {boolean} ignore   Whether we are currently ignoring content

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -242,6 +242,18 @@ export class HTMLDomStrings<N, T, D> {
   }
 
   /**
+   * Handle an unknown node type (nodeType other than 1, 3, 7)
+   *
+   * @param {N} node           The node to process
+   * @param {boolean} ignore   Whether we are currently ignoring content
+   * @return {N|T}             The next element to process
+   */
+  protected handleOther(node: N, _ignore: boolean): N | T {
+    this.pushString();
+    return this.adaptor.next(node);
+  }
+
+  /**
    * Find the strings for a given DOM element:
    *   Initialize the state
    *   Get the element where we stop processing
@@ -266,12 +278,15 @@ export class HTMLDomStrings<N, T, D> {
     let include = this.options['includeHtmlTags'];
 
     while (node && node !== stop) {
-      if (this.adaptor.kind(node) === '#text') {
+      const kind = this.adaptor.kind(node);
+      if (kind === '#text') {
         node = this.handleText(node as T, ignore);
-      } else if (include[this.adaptor.kind(node)] !== undefined) {
+      } else if (include.hasOwnProperty(kind)) {
         node = this.handleTag(node as N, ignore);
-      } else {
+      } else if (kind) {
         [node, ignore] = this.handleContainer(node as N, ignore);
+      } else {
+        node = this.handleOther(node as N, ignore);
       }
       if (!node && this.stack.length) {
         this.pushString();


### PR DESCRIPTION
This PR arranges for the HTMLDomStrings object to skip node types that it doesn't recognize (it can handle text, comments, and Elements).  This fixes the problem reported in mathjax/MathJax#2662 where ProcessingInstructions would cause MathJax to crash.


Resolves issue mathjax/MathJax#2662.