### PR TITLE
Add ability to specify additional textmacros packages.

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -105,7 +105,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @return {Configuration} The configuration object.
    */
   protected static configure(packages: (string | [string, number])[]): ParserConfiguration {
-    let configuration = new ParserConfiguration(packages);
+    let configuration = new ParserConfiguration(packages, ['tex']);
     configuration.init();
     return configuration;
   }

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -74,6 +74,7 @@ export class Configuration {
                                   init?: ProtoProcessor<InitMethod>,
                                   config?: ProtoProcessor<ConfigMethod>,
                                   priority?: number,
+                                  parser?: string,
                                  } = {}): Configuration {
     let priority = config.priority || PrioritizedList.DEFAULTPRIORITY;
     let init = config.init ? this.makeProcessor(config.init, priority) : null;
@@ -82,6 +83,7 @@ export class Configuration {
       pre => this.makeProcessor(pre, priority));
     let postprocessors = (config.postprocessors || []).map(
       post => this.makeProcessor(post, priority));
+    let parser = config.parser || 'tex';
     return new Configuration(
       name,
       config.handler || {},
@@ -90,7 +92,8 @@ export class Configuration {
       config.tags || {},
       config.options || {},
       config.nodes || {},
-      preprocessors, postprocessors, init, conf, priority
+      preprocessors, postprocessors, init, conf, priority,
+      parser
     );
   }
 
@@ -113,6 +116,7 @@ export class Configuration {
    *  * _init_ init method and optionally its priority.
    *  * _config_ config method and optionally its priority.
    *  * _priority_ default priority of the configuration.
+   *  * _parser_ the name of the parser that this configuration targets.
    * @return {Configuration} The newly generated configuration.
    */
   public static create(name: string,
@@ -127,6 +131,7 @@ export class Configuration {
                                 init?: ProtoProcessor<InitMethod>,
                                 config?: ProtoProcessor<ConfigMethod>,
                                 priority?: number,
+                                parser?: string,
                                } = {}): Configuration {
     let configuration = Configuration._create(name, config);
     ConfigurationHandler.set(name, configuration);
@@ -150,6 +155,7 @@ export class Configuration {
                               init?: ProtoProcessor<InitMethod>,
                               config?: ProtoProcessor<ConfigMethod>,
                               priority?: number,
+                              parser?: string,
                              } = {}): Configuration {
     return Configuration._create('', config);
   }
@@ -169,7 +175,8 @@ export class Configuration {
                       readonly postprocessors: ProcessorList = [],
                       readonly initMethod: Processor<InitMethod> = null,
                       readonly configMethod: Processor<ConfigMethod> = null,
-                      public priority: number
+                      public priority: number,
+                      readonly parser: string
                      ) {
     this.handler = Object.assign(
       {character: [], delimiter: [], macro: [], environment: []}, handler);
@@ -255,6 +262,11 @@ export class ParserConfiguration {
   protected configurations: PrioritizedList<Configuration> = new PrioritizedList();
 
   /**
+   * The list of parsers this configuration targets
+   */
+  protected parsers: string[] = [];
+
+  /**
    * The subhandlers for this configuration.
    * @type {SubHandlers}
    */
@@ -284,13 +296,14 @@ export class ParserConfiguration {
    */
   public nodes: {[key: string]: any}  = {};
 
-
   /**
    * @constructor
    * @param {(string|[string,number])[]} packages A list of packages with
    *     optional priorities.
+   * @parm {string[]} parsers   The names of the parsers this package targets
    */
-  constructor(packages: (string | [string, number])[]) {
+  constructor(packages: (string | [string, number])[], parsers: string[] = ['tex']) {
+    this.parsers = parsers;
     for (const pkg of packages.slice().reverse()) {
       this.addPackage(pkg);
     }
@@ -323,22 +336,20 @@ export class ParserConfiguration {
    */
   public addPackage(pkg: (string | [string, number])) {
     const name = typeof pkg === 'string' ? pkg : pkg[0];
-    let conf = ConfigurationHandler.get(name);
-    if (conf) {
-      this.configurations.add(
-        conf, typeof pkg === 'string' ? conf.priority : pkg[1]);
-    }
+    const conf = this.getPackage(name);
+    conf && this.configurations.add(conf, typeof pkg === 'string' ? conf.priority : pkg[1]);
   }
 
   /**
    * Adds a configuration after the input jax is created.  (Used by \require.)
    * Sets items, nodes and runs configuration method explicitly.
    *
-   * @param {Configuration} config   The configuration to be registered in this one
+   * @param {string} name            The name of the package to add
    * @param {TeX} jax                The TeX jax where it is being registered
    * @param {OptionList=} options    The options for the configuration.
    */
-  public add(config: Configuration, jax: TeX<any, any, any>, options: OptionList = {}) {
+  public add(name: string, jax: TeX<any, any, any>, options: OptionList = {}) {
+    const config = this.getPackage(name);
     this.append(config);
     this.configurations.add(config, config.priority);
     this.init();
@@ -356,6 +367,19 @@ export class ParserConfiguration {
     }
   }
 
+ /**
+  * Find a package and check that it is for the targeted parser
+  *
+  * @param {string} name       The name of the package to check
+  * @return {Configuration}    The configuration for the package
+  */
+  protected getPackage(name: string): Configuration {
+    const config = ConfigurationHandler.get(name);
+    if (config && this.parsers.indexOf(config.parser) < 0) {
+      throw Error(`Package ${name} doesn't target the proper parser`);
+    }
+    return config;
+  }
 
   /**
    * Appends a configuration to the overall configuration object.

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -72,7 +72,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
       //
       //  Register the extension with the jax's configuration
       //
-      (jax as any).configuration.add(handler, jax, options);
+      (jax as any).configuration.add(extension, jax, options);
       //
       // If there are preprocessors, restart so that they run
       // (we don't have access to the document or MathItem needed to call

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -37,7 +37,7 @@ import './TextMacrosMappings.js';
 /**
  *  The base text macro configuration (used in the TextParser)
  */
-export const textBase = Configuration.local({
+export const textBase = Configuration.create('text-base', {
   handler: {
     character: ['command', 'text-special'],
     macro: ['text-macros']
@@ -103,8 +103,7 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
     //  Create the configuration and parseOptions objects for the
     //    internal TextParser and add the textBase configuration.
     //
-    const textConf = new ParserConfiguration([]);
-    textConf.append(textBase);
+    const textConf = new ParserConfiguration(jax.parseOptions.options.textmacros.packages);
     textConf.init();
     const parseOptions = new ParseOptions(textConf, []);
     parseOptions.options = jax.parseOptions.options;      // share the TeX options
@@ -129,5 +128,10 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
     //
     const config = data.data.packageData.get('textmacros');
     config.parseOptions.nodeFactory.setMmlFactory(config.jax.mmlFactory);
-  }]
+  }],
+  options: {
+    textmacros: {
+      packages: ['text-base']    // textmacro packages to load
+    }
+  }
 });

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -37,7 +37,8 @@ import './TextMacrosMappings.js';
 /**
  *  The base text macro configuration (used in the TextParser)
  */
-export const textBase = Configuration.create('text-base', {
+export const TextBaseConfiguration = Configuration.create('text-base', {
+  parser: 'text',
   handler: {
     character: ['command', 'text-special'],
     macro: ['text-macros']
@@ -103,7 +104,7 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
     //  Create the configuration and parseOptions objects for the
     //    internal TextParser and add the textBase configuration.
     //
-    const textConf = new ParserConfiguration(jax.parseOptions.options.textmacros.packages);
+    const textConf = new ParserConfiguration(jax.parseOptions.options.textmacros.packages, ['tex', 'text']);
     textConf.init();
     const parseOptions = new ParseOptions(textConf, []);
     parseOptions.options = jax.parseOptions.options;      // share the TeX options


### PR DESCRIPTION
This PR adds the ability to specify additional packages to be loaded in the textmacros text parser.  Use

``` javascript
MathJax = {
  tex: {
    textmacros: {
      packages: {'[+]', [...]}
    }
  }
}
```

to specify the packages to include, e.g., `textmacros: {packages: {'[+]': ['bbox']}` to allow `\bbox` inside '\text{}`.

This also makes the main `textBase` configuration a named one rather than a local one, so that it can be included in the package list (as `text-base`, just like `base` for the main TeX base package).   That means it will show up as a package in the Lab package list, so `v3-lab.js` should probably be modified to not create a checkbox for it, since it is not appropriate outside of `\text{}`.