### PR TITLE
Fix issues with placement of menclose notations. (mathjax/MathJax#2571)

### DIFF
--- a/ts/output/chtml/Notation.ts
+++ b/ts/output/chtml/Notation.ts
@@ -41,9 +41,12 @@ export type DEFPAIR<N, T, D> = Notation.DefPair<CHTMLmenclose<N, T, D>, N>;
 export const RenderElement = function<N, T, D>(name: string, offset: string = ''):  RENDERER<N, T, D> {
   return ((node, _child) => {
     const shape = node.adjustBorder(node.html('mjx-' + name));
-    if (offset && node.thickness !== Notation.THICKNESS) {
-      const transform = 'translate' + offset + '(' + node.em(node.thickness / 2) + ')';
-      node.adaptor.setStyle(shape, 'transform', transform);
+    if (offset) {
+      const d = node.getOffset(offset);
+      if (node.thickness !== Notation.THICKNESS || d)  {
+        const transform = `translate${offset}(${node.em(node.thickness / 2 - d)})`;
+        node.adaptor.setStyle(shape, 'transform', transform);
+      }
     }
     node.adaptor.append(node.chtml, shape);
   }) as Notation.Renderer<CHTMLmenclose<N, T, D>, N>;

--- a/ts/output/chtml/Wrappers/menclose.ts
+++ b/ts/output/chtml/Wrappers/menclose.ts
@@ -434,8 +434,7 @@ CommonMencloseMixin<
     if (!d) return;
     const transform = this.adaptor.getStyle(arrow, 'transform');
     this.adaptor.setStyle(
-      arrow, 'transform',
-      `translate${offset}(${this.em(-d)})` + (transform ? ' ' + transform : '')
+      arrow, 'transform', `translate${offset}(${this.em(-d)})${(transform ? ' ' + transform : '')}`
     );
   }
 

--- a/ts/output/chtml/Wrappers/menclose.ts
+++ b/ts/output/chtml/Wrappers/menclose.ts
@@ -353,9 +353,11 @@ CommonMencloseMixin<
    * @param {number} w        The length of the arrow
    * @param {number} a        The angle for the arrow
    * @param {boolean} double  True if this is a double-headed arrow
-   * @return {N}               The newly created arrow
+   * @param {string} offset   'X' for vertical arrow, 'Y' for horizontal
+   * @param {number} dist     Distance to translate in the offset direction
+   * @return {N}              The newly created arrow
    */
-  public arrow(w: number, a: number, double: boolean = false): N {
+  public arrow(w: number, a: number, double: boolean, offset: string = '', dist: number = 0): N {
     const W = this.getBBox().w;
     const style = {width: this.em(w)} as OptionList;
     if (W !== w) {
@@ -373,6 +375,7 @@ CommonMencloseMixin<
       this.adaptor.setAttribute(arrow, 'double', 'true');
     }
     this.adjustArrow(arrow, double);
+    this.moveArrow(arrow, offset, dist);
     return arrow;
   }
 
@@ -420,6 +423,20 @@ CommonMencloseMixin<
     if (double) {
       this.adaptor.setStyle(line, 'left', this.em(t * (x - 1)));
     }
+  }
+
+  /**
+   * @param {N} arrow        The arrow whose position is to be adjusted
+   * @param {string} offset  The direction to move the arrow
+   * @param {number} d       The distance to translate in that direction
+   */
+  protected moveArrow(arrow: N, offset: string, d: number) {
+    if (!d) return;
+    const transform = this.adaptor.getStyle(arrow, 'transform');
+    this.adaptor.setStyle(
+      arrow, 'transform',
+      `translate${offset}(${this.em(-d)})` + (transform ? ' ' + transform : '')
+    );
   }
 
   /********************************************************/

--- a/ts/output/common/Notation.ts
+++ b/ts/output/common/Notation.ts
@@ -41,13 +41,18 @@ export const SOLID = THICKNESS + 'em solid';  // a solid border
 export type Menclose = CommonMenclose<any, any, any>;
 
 /**
+ * Top, right, bottom, left padding data
+ */
+export type PaddingData = [number, number, number, number];
+
+/**
  * The functions used for notation definitions
  *
  * @templare N  The DOM node class
  */
 export type Renderer<W extends AnyWrapper, N> = (node: W, child: N) => void;
-export type BBoxExtender<W extends AnyWrapper> = (node: W) => number[];
-export type BBoxBorder<W extends AnyWrapper> = (node: W) => number[];
+export type BBoxExtender<W extends AnyWrapper> = (node: W) => PaddingData;
+export type BBoxBorder<W extends AnyWrapper> = (node: W) => PaddingData;
 export type Initializer<W extends AnyWrapper> = (node: W) => void;
 
 /**
@@ -112,7 +117,7 @@ export const arrowHead = (node: Menclose) => {
 /**
  * Adjust short bbox for tall arrow heads
  */
-export const arrowBBoxHD = (node: Menclose, TRBL: number[]) => {
+export const arrowBBoxHD = (node: Menclose, TRBL: PaddingData) => {
   if (node.childNodes[0]) {
     const {h, d} = node.childNodes[0].getBBox();
     TRBL[0] = TRBL[2] = Math.max(0, node.thickness * node.arrowhead.y - (h + d) / 2);
@@ -123,7 +128,7 @@ export const arrowBBoxHD = (node: Menclose, TRBL: number[]) => {
 /**
  * Adjust thin bbox for wide arrow heads
  */
-export const arrowBBoxW = (node: Menclose, TRBL: number[]) => {
+export const arrowBBoxW = (node: Menclose, TRBL: PaddingData) => {
   if (node.childNodes[0]) {
     const {w} = node.childNodes[0].getBBox();
     TRBL[1] = TRBL[3] = Math.max(0, node.thickness * node.arrowhead.y - w / 2);
@@ -193,7 +198,7 @@ export const CommonBorder = function<W extends Menclose, N>(render: Renderer<W, 
       // Indicate the extra space on the given side
       //
       bbox: (node) => {
-        const bbox = [0, 0, 0, 0];
+        const bbox = [0, 0, 0, 0] as PaddingData;
         bbox[i] = node.thickness + node.padding;
         return bbox;
       },
@@ -201,7 +206,7 @@ export const CommonBorder = function<W extends Menclose, N>(render: Renderer<W, 
       // Indicate the border on the given side
       //
       border: (node) => {
-        const bbox = [0, 0, 0, 0];
+        const bbox = [0, 0, 0, 0] as PaddingData;
         bbox[i] = node.thickness;
         return bbox;
       }
@@ -235,7 +240,7 @@ export const CommonBorder2 = function<W extends Menclose, N>(render: Renderer<W,
       //
       bbox: (node) => {
         const t = node.thickness + node.padding;
-        const bbox = [0, 0, 0, 0];
+        const bbox = [0, 0, 0, 0] as PaddingData;
         bbox[i1] = bbox[i2] = t;
         return bbox;
       },
@@ -243,7 +248,7 @@ export const CommonBorder2 = function<W extends Menclose, N>(render: Renderer<W,
       // Indicate the border on the two sides
       //
       border: (node) => {
-        const bbox = [0, 0, 0, 0];
+        const bbox = [0, 0, 0, 0] as PaddingData;
         bbox[i1] = bbox[i2] = node.thickness;
         return bbox;
       },
@@ -301,8 +306,8 @@ export const CommonDiagonalArrow = function<W extends Menclose, N>(render: Rende
       //   the arrow from them and the other arrow data
       //
       renderer: (node, _child) => {
-        const {a, W} = node.arrowData();
-        const arrow = node.arrow(W, c * (a - pi), double);
+        const [a, W] = node.arrowAW();
+       const arrow = node.arrow(W, c * (a - pi), double);
         render(node, arrow);
       },
       //
@@ -342,8 +347,9 @@ export const CommonArrow = function<W extends Menclose, N>(render: Renderer<W, N
       //
       renderer: (node, _child) => {
         const {w, h, d} = node.getBBox();
-        const W = (isVertical ? h + d : w);
-        const arrow = node.arrow(W, angle, double);
+        const [W, offset] = (isVertical ? [h + d, 'X'] : [w, 'Y']);
+        const dd = node.getOffset(offset);
+        const arrow = node.arrow(W, angle, double, offset, dd);
         render(node, arrow);
       },
       //

--- a/ts/output/svg/Notation.ts
+++ b/ts/output/svg/Notation.ts
@@ -69,7 +69,7 @@ export const computeLineData = {
  * @param {Menclose} node   The node whose line is to be drawn
  * @param {LineName} kind   The type of line to draw for the node
  * @param {string} offset   The offset direction, if any
- * @return {LineData}   The coordinates of the two nedpoints
+ * @return {LineData}       The coordinates of the two endpoints
  */
 export const lineData = function(node: Menclose, kind: LineName, offset: string = ''): LineData {
   const {h, d, w} = node.getBBox();

--- a/ts/output/svg/Notation.ts
+++ b/ts/output/svg/Notation.ts
@@ -45,6 +45,11 @@ export type DEFPAIR<N, T, D> = Notation.DefPair<SVGmenclose<N, T, D>, N>;
 export type LineName = Notation.Side | ('vertical' | 'horizontal' | 'up' | 'down');
 
 /**
+ * [x1,y1, x2,y2] endpoints for a line
+ */
+export type LineData = [number, number, number, number];
+
+/**
  * Functions for computing the line data for each type of line
  */
 export const computeLineData = {
@@ -52,24 +57,47 @@ export const computeLineData = {
   right: (h, d, w, t) => [w - t, -d, w - t, h],
   bottom: (_h, d, w, t) => [0, t - d, w, t - d],
   left: (h, d, _w, t) => [t, -d, t, h],
-  vertical: (h, d, w, t) => [w / 2 - t, h, w / 2 - t, -d],
-  horizontal: (h, d, w, t) => [0, (h - d) / 2 - t, w, (h - d) / 2 - t],
+  vertical: (h, d, w, _t) => [w / 2, h, w / 2, -d],
+  horizontal: (h, d, w, _t) => [0, (h - d) / 2, w, (h - d) / 2],
   up: (h, d, w, t) => [t, t - d, w - t, h - t],
   down: (h, d, w, t) => [t, h - t, w - t, t - d]
-} as {[kind: string]: (h: number, d: number, w: number, t: number) => [number, number, number, number]};
+} as {[kind: string]: (h: number, d: number, w: number, t: number) => LineData};
 
 /**
  * The data for a given line as two endpoints: [x1, y1, x2, y1]
  *
  * @param {Menclose} node   The node whose line is to be drawn
  * @param {LineName} kind   The type of line to draw for the node
- * @return {[number, number, number, number]}   The coordinates of the two nedpoints
+ * @param {string} offset   The offset direction, if any
+ * @return {LineData}   The coordinates of the two nedpoints
  */
-
-export const lineData = function(node: Menclose, kind: LineName): [number, number, number, number] {
+export const lineData = function(node: Menclose, kind: LineName, offset: string = ''): LineData {
   const {h, d, w} = node.getBBox();
   const t = node.thickness / 2;
-  return computeLineData[kind](h, d, w, t);
+  return lineOffset(computeLineData[kind](h, d, w, t), node, offset);
+};
+
+/**
+ * Recenter the line data for vertical and horizontal lines
+ *
+ * @param {LineData} data   The line endpoints to adjust
+ * @param {Menclose} node   The menclose node
+ * @param {string} offset   The direction to offset
+ */
+export const lineOffset = function(data: LineData, node: Menclose, offset: string): LineData {
+  if (offset) {
+    const d = node.getOffset(offset);
+    if (d) {
+      if (offset === 'X') {
+        data[0] -= d;
+        data[2] -= d;
+      } else {
+        data[1] -= d;
+        data[3] -= d;
+      }
+    }
+  }
+  return data;
 };
 
 
@@ -79,9 +107,10 @@ export const lineData = function(node: Menclose, kind: LineName): [number, numbe
  * @param {LineName} line  The name of the line to create
  * @return {RENDERER}      The renderer function for the given line
  */
-export const RenderLine = function<N, T, D>(line: LineName): RENDERER<N, T, D> {
+export const RenderLine = function<N, T, D>(line: LineName, offset: string = ''): RENDERER<N, T, D> {
   return ((node, _child) => {
-    node.adaptor.append(node.element, node.line(lineData(node, line)));
+    const L = node.line(lineData(node, line, offset));
+    node.adaptor.append(node.element, L);
   });
 };
 

--- a/ts/output/svg/Wrappers/menclose.ts
+++ b/ts/output/svg/Wrappers/menclose.ts
@@ -66,12 +66,12 @@ export class SVGmenclose<N, T, D> extends CommonMencloseMixin<
     Notation.DiagonalStrike('down'),
 
     ['horizontalstrike', {
-      renderer: Notation.RenderLine('horizontal'),
+      renderer: Notation.RenderLine('horizontal', 'Y'),
       bbox: (node) => [0, node.padding, 0, node.padding]
     }],
 
     ['verticalstrike', {
-      renderer: Notation.RenderLine('vertical'),
+      renderer: Notation.RenderLine('vertical', 'X'),
       bbox: (node) => [node.padding, 0, node.padding, 0]
     }],
 
@@ -228,14 +228,16 @@ export class SVGmenclose<N, T, D> extends CommonMencloseMixin<
   /********************************************************/
 
   /**
-   * Create an arrow using HTML elements
+   * Create an arrow using SVG elements
    *
    * @param {number} W        The length of the arrow
    * @param {number} a        The angle for the arrow
    * @param {boolean} double  True if this is a double-headed arrow
-   * @return {N}               The newly created arrow
+   * @param {string} offset   'X' for vertical arrow, 'Y' for horizontal
+   * @param {number} dist     Distance to translate in the offset direction
+   * @return {N}              The newly created arrow
    */
-  public arrow(W: number, a: number, double: boolean = false): N {
+  public arrow(W: number, a: number, double: boolean, offset: string = '', dist: number = 0): N {
     const {w, h, d} = this.getBBox();
     const dw = (W - w) / 2;
     const m = (h - d) / 2;
@@ -260,10 +262,16 @@ export class SVGmenclose<N, T, D> extends CommonMencloseMixin<
          'L', w + dw - x, m - t2,                   // lower side of shaft
          'l', -dx, t2 - y, 'Z'                      // lower head
        ));
+    const transform = [];
+    if (dist) {
+      transform.push(offset === 'X' ? `translate(${this.fixed(-dist)} 0)` : `translate(0 ${this.fixed(dist)})`);
+    }
     if (a) {
       const A = this.jax.fixed(-a * 180 / Math.PI);
-      this.adaptor.setAttribute(arrow, 'transform',
-                                'rotate(' + [A, this.fixed(w / 2), this.fixed(m)].join(' ') + ')');
+      transform.push(`rotate(${A} ${this.fixed(w / 2)} ${this.fixed(m)})`);
+    }
+    if (transform.length) {
+      this.adaptor.setAttribute(arrow, 'transform', transform.join(' '));
     }
     return arrow as N;
   }


### PR DESCRIPTION
This PR improves the placement of horizontal and vertical strikes and arrows, and makes sure diagonal arrows fit the actual box used.  This addresses the issues in mathjax/MathJax#2571, but we don't fully follow the spec, since we do allow notations to affect each other (e.g., top by itself and top with right will be different width.

The PR also adds a couple of new types for some arrays that are used.

Resolves issue mathjax/MathJax#2571 (for now).