### PR TITLE
Add support for restricting packages to particular named parsers (B)

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -105,7 +105,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @return {Configuration} The configuration object.
    */
   protected static configure(packages: (string | [string, number])[]): ParserConfiguration {
-    let configuration = new ParserConfiguration(packages);
+    let configuration = new ParserConfiguration(packages, TexParser.registeredName);
     configuration.init();
     return configuration;
   }

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -32,6 +32,7 @@ import TexError from './TexError.js';
 import {MmlNode, AbstractMmlNode} from '../../core/MmlTree/MmlNode.js';
 import {ParseInput, ParseResult} from './Types.js';
 import ParseOptions from './ParseOptions.js';
+import {ParserConfiguration} from './Configuration.js';
 import {StackItem, EnvList} from './StackItem.js';
 import {Symbol} from './Symbol.js';
 import {OptionList} from '../../util/Options.js';
@@ -41,6 +42,11 @@ import {OptionList} from '../../util/Options.js';
  * The main Tex Parser class.
  */
 export default class TexParser {
+
+  /**
+   * The name this parser is registered under
+   */
+  public static registeredName: string = '';
 
   /**
    * Counter for recursive macros.
@@ -65,6 +71,15 @@ export default class TexParser {
    * @type {string}
    */
   public currentCS: string = '';
+
+
+  /**
+   * Register this parser under the given name
+   */
+  public static register(name: string) {
+    this.registeredName = name;
+    ParserConfiguration.registerParser(name, this);
+  }
 
   /**
    * @constructor
@@ -510,5 +525,6 @@ export default class TexParser {
     return this.configuration.nodeFactory.create(kind, ...rest);
   }
 
-
 }
+
+TexParser.register('tex');

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -72,7 +72,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
       //
       //  Register the extension with the jax's configuration
       //
-      (jax as any).configuration.add(handler, jax, options);
+      (jax as any).configuration.add(extension, jax, options);
       //
       // If there are preprocessors, restart so that they run
       // (we don't have access to the document or MathItem needed to call

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -37,7 +37,8 @@ import './TextMacrosMappings.js';
 /**
  *  The base text macro configuration (used in the TextParser)
  */
-export const textBase = Configuration.create('text-base', {
+export const TextBaseConfiguration = Configuration.create('text-base', {
+  parser: 'text',
   handler: {
     character: ['command', 'text-special'],
     macro: ['text-macros']
@@ -103,7 +104,8 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
     //  Create the configuration and parseOptions objects for the
     //    internal TextParser and add the textBase configuration.
     //
-    const textConf = new ParserConfiguration(jax.parseOptions.options.textmacros.packages);
+    const textConf = new ParserConfiguration(jax.parseOptions.options.textmacros.packages,
+                                             TextParser.registeredName);
     textConf.init();
     const parseOptions = new ParseOptions(textConf, []);
     parseOptions.options = jax.parseOptions.options;      // share the TeX options

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -204,3 +204,5 @@ export class TextParser extends TexParser {
   }
 
 }
+
+TextParser.register('text');


### PR DESCRIPTION
This PR adds a registry of parsers so that each new parser class registers itself under a given name.  The packages use that name to indicate which parser they are targeted at.  When the `ParserConfiguation` is created, it is given the name of the parser that it targets, and uses the registry to decide if the packages are appropriate.

Pros:  You don't have to list all the superclasses anywhere, as any subclass of parser A can load package targeted at parser A.

Cons:  You have less control over the packages in the sense that you can't exclude superclasses like you can in #661.  You also have to explicitly register the parser classes as you create them.

This is a second proposal for handling the situation.