### PR TITLE
Fix several issues with tables (label alignment in CHTML, lines in SVG, centering). (mathjax/Mathjax#2601)

### DIFF
--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -530,7 +530,6 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
    *   and set the baseline for labels that are baseline aligned.
    */
   protected updateRowHeights() {
-    if (this.node.attributes.get('equalrows') as boolean) return;
     let {H, D, NH, ND} = this.getTableData();
     const space = this.getRowHalfSpacing();
     for (let i = 0; i < this.numRows; i++) {

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -357,7 +357,7 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
   }
 
   /**
-   * @param {CHTMLWrapper} row   The row whose hieght is to be set
+   * @param {CHTMLWrapper} row   The row whose height is to be set
    * @param {number} HD          The height to be set for the row
    */
   protected setRowHeight(row: CHTMLWrapper<N, T, D>, HD: number) {

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -648,13 +648,13 @@ export class CommonWrapper<
    * @param {number} D        The total depth
    * @param {number} h        The height to be aligned
    * @param {number} d        The depth to be aligned
-   * @param {string} align    How to align (top, bottom, middle, axis, baseline)
+   * @param {string} align    How to align (top, bottom, center, axis, baseline)
    * @return {number}         The y position of the aligned baseline
    */
   protected getAlignY(H: number, D: number, h: number, d: number, align: string): number {
     return (align === 'top' ? H - h :
             align === 'bottom' ? d - D :
-            align === 'middle' ? ((H - h) - (D - d)) / 2 :
+            align === 'center' ? ((H - h) - (D - d)) / 2 :
             0); // baseline and axis
   }
 

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -173,7 +173,7 @@ export interface CommonMtable<C extends AnyWrapper, R extends CommonMtr<C>> exte
    * @param {number} i     The row whose hight and depth should be adjusted
    * @param {number[]} H   The row heights
    * @param {number[]} D   The row depths
-   * @param {number} M     The maximum heoght of top/bottom aligned items
+   * @param {number} M     The maximum height of top/bottom aligned items
    */
   extendHD(i: number, H: number[], D: number[], M: number): void;
 

--- a/ts/output/svg/Wrappers/mtable.ts
+++ b/ts/output/svg/Wrappers/mtable.ts
@@ -53,18 +53,18 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
    * @override
    */
   public static styles: StyleList = {
-    'g[data-mml-node="mtable"] > line[data-line]': {
+    'g[data-mml-node="mtable"] > line[data-line], svg[data-table] > g > line[data-line]': {
       'stroke-width': '70px',
       fill: 'none'
     },
-    'g[data-mml-node="mtable"] > rect[data-frame]': {
+    'g[data-mml-node="mtable"] > rect[data-frame], svg[data-table] > g > rect[data-frame]': {
       'stroke-width': '70px',
       fill: 'none'
     },
-    'g[data-mml-node="mtable"] > .mjx-dashed': {
+    'g[data-mml-node="mtable"] > .mjx-dashed, svg[data-table] > g > .mjx-dashed': {
       'stroke-dasharray': '140'
     },
-    'g[data-mml-node="mtable"] > .mjx-dotted': {
+    'g[data-mml-node="mtable"] > .mjx-dotted, svg[data-table] > g > .mjx-dotted': {
       'stroke-linecap': 'round',
       'stroke-dasharray': '0,140'
     },


### PR DESCRIPTION
This PR fixes a number of issues with table output:

* Labels in CHTML could not align with their rows (mathjax/MathJax#2601).  This was due to accumulated round-off problems, which is resolved by explicitly setting the row heights regardless of whether they should already be correct or not.
* When rows have `rowalign` specified, the height and depth weren't properly computed (it was always computed as though alignment were `baseline`).
*  Cells with `rowalign` set to `top`, `bottom`, or `center` could cause the height and depth of the row to be too large (the sizes were always computed as through the alignment were `baseline`).
* The `center` alignment was incorrectly called `middle`, so didn't work properly in SVG.
* The positioning of a row label in CHTML wasn't always correct when `rowalign` was specified.
* In SVG, row lines on labeled rows where not visible (the CSS wasn't being properly applied to them).