### PR TITLE
Update SVG output so that following a link scrolls to the top of the tag.  (mathjax/MathJax#2588)

### DIFF
--- a/ts/output/svg/Wrappers/mtable.ts
+++ b/ts/output/svg/Wrappers/mtable.ts
@@ -144,7 +144,7 @@ CommonMtableMixin<SVGmtd<any, any, any>, SVGmtr<any, any, any>, SVGConstructor<a
    */
   public handleColor() {
     super.handleColor();
-    const rect = this.adaptor.firstChild(this.element);
+    const rect = this.firstChild();
     if (rect) {
       this.adaptor.setAttribute(rect, 'width', this.fixed(this.getWidth()));
     }

--- a/ts/output/svg/Wrappers/mtd.ts
+++ b/ts/output/svg/Wrappers/mtd.ts
@@ -70,7 +70,7 @@ CommonMtdMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
    */
   public placeColor(x: number, y: number, W: number, H: number) {
     const adaptor = this.adaptor;
-    const child = adaptor.firstChild(this.element);
+    const child = this.firstChild();
     if (child && adaptor.kind(child) === 'rect' && adaptor.getAttribute(child, 'data-bgcolor')) {
       adaptor.setAttribute(child, 'x', this.fixed(x));
       adaptor.setAttribute(child, 'y', this.fixed(y));

--- a/ts/output/svg/Wrappers/mtr.ts
+++ b/ts/output/svg/Wrappers/mtr.ts
@@ -138,7 +138,7 @@ CommonMtrMixin<SVGmtd<any, any, any>, SVGConstructor<any, any, any>>(SVGWrapper)
    */
   protected placeColor() {
     const adaptor = this.adaptor;
-    const child = adaptor.firstChild(this.element);
+    const child = this.firstChild();
     if (child && adaptor.kind(child) === 'rect' && adaptor.getAttribute(child, 'data-bgcolor')) {
       const [TL, BL] = [this.tLine / 2, this.bLine / 2];
       const [TS, BS] = [this.tSpace, this.bSpace];


### PR DESCRIPTION
In Firefox, following a link in SVG output would scroll to the *bottom* of the linked content rather than the top.  In Safari, that would occur if the linked content was a `<text>` node, like from a `\tag` with `mtextInheritFont: true`.  This PR adjusts the output of elements with ID so that Firefox and Safari (and Chrome) all scroll to the top of the linked content.

That required shifting the element with the ID upward by its height, and then shifting its contents down by the sea amount (so that it is in the correct visual location, but the element's location for linking purposes is the top of the content.  A `<text>` element is also added so that Safari will scroll to the right location.

Since this required putting some unexpected elements as the children of the node with the `id` attribute, a new `firstChild()` method was added that skips over the unexpected nodes.  That also allows moving the `rect` that was used as the hotbox for an `href` to also be put inside the element with the `href` rather than just before it, as in the past.  (This corresponds to Peter's suggestion in mathjax/MathJax#2530.)  The `firstChild()` method skips the `href` element as well.

Resolves mathjax/MathJax#2588.