### PR TITLE
Fix regression in tagging caused by #630

### DIFF
--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -404,7 +404,7 @@ export class AbstractTags implements Tags {
   public clearTag() {
     this.label = '';
     this.tag(null, true);
-    this.currentTag = new TagInfo('', undefined, undefined);
+    this.currentTag.tagId = '';
   }
 
 
@@ -456,6 +456,7 @@ export class AbstractTags implements Tags {
     this.history = [];
     this.stack = [];
     this.clearTag();
+    this.currentTag = new TagInfo('', undefined, undefined);
     this.labels = {};
     this.ids = {};
     this.counter = this.allCounter;


### PR DESCRIPTION
PR #630 was too aggressive about clearing the tag environment so that environments that allow multiple tags no longer worked.  This puts back the original `clearTag()` code, but resets the tag at the beginning of the equation so that it still solves the issue from mathjax/MathJax#2643.