### PR TITLE
Add a11y enable options to menu handler so that they can be configured (mathjax/MathJax#2651)

### DIFF
--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -167,7 +167,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       //    initially, and so would cause "undefined option" error messages
       //    if a user tries to configure them.  So we include them here.
       //    They are overridden by the options from the extensions when
-      //    those are laoded (via ...BaseDocument.OPTIONS).
+      //    those are loaded (via ...BaseDocument.OPTIONS).
       //
       enableEnrichment: true,
       enableComplexity: true,

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -162,6 +162,17 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
      * @override
      */
     public static OPTIONS = {
+      //
+      //  These options are from the a11y extensions, which may not be loaded
+      //    initially, and so would cause "undefined option" error messages
+      //    if a user tries to configure them.  So we include them here.
+      //    They are overridden by the options from the extensions when
+      //    those are laoded (via ...BaseDocument.OPTIONS).
+      //
+      enableEnrichment: true,
+      enableComplexity: true,
+      enableExplorer: true,
+      enrichSpeech: 'none',
       ...BaseDocument.OPTIONS,
       MenuClass: Menu,
       menuOptions: Menu.OPTIONS,

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -173,6 +173,8 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       enableComplexity: true,
       enableExplorer: true,
       enrichSpeech: 'none',
+      enrichError: (_doc: MenuMathDocument, _math: MenuMathItem, err: Error) =>
+        console.warn('Enrichment Error:', err),
       ...BaseDocument.OPTIONS,
       MenuClass: Menu,
       menuOptions: Menu.OPTIONS,


### PR DESCRIPTION
This PR adds the a11y "enable" options to the menu handler so that a page author can include them in the MathJax configuration even if the extensions aren't loaded yet.  Without this, having `enableExporer`, for example, in the configuration would lead to an error about the option not being defined.  This defines them when the menu component is loaded, since it may load the a11y extensions later.

Resolves issue mathjax/MathJax#2651.