### PR TITLE
Add ability to serialize annotation-xml content.

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -111,11 +111,20 @@ export interface MinText<N, T> {
 /**
  * The minimum fields needed for a DOMParser
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template D  The Document class
  */
 export interface MinDOMParser<D> {
   parseFromString(text: string, format?: string): D;
+}
+
+/*****************************************************************/
+/**
+ * The minimum fields needed for a DOMParser
+ *
+ * @template N  The HTMLElement node class
+ */
+export interface MinXMLSerializer<N> {
+  serializeToString(node: N): string;
 }
 
 /*****************************************************************/
@@ -129,6 +138,9 @@ export interface MinWindow<N, D> {
   document: D;
   DOMParser: {
     new(): MinDOMParser<D>
+  };
+  XMLSerializer: {
+    new(): MinXMLSerializer<N>;
   };
   NodeList: any;
   HTMLCollection: any;
@@ -394,6 +406,11 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    */
   public outerHTML(node: N) {
     return node.outerHTML;
+  }
+
+  public serializeXML(node: N) {
+    const serializer = new this.window.XMLSerializer();
+    return serializer.serializeToString(node) as string;
   }
 
   /**

--- a/ts/adaptors/browserAdaptor.ts
+++ b/ts/adaptors/browserAdaptor.ts
@@ -30,6 +30,7 @@ declare global {
   interface Window {
     Document: typeof Document;
     DOMParser: typeof DOMParser;
+    XMLSerializer: typeof XMLSerializer;
     HTMLElement: typeof HTMLElement;
     HTMLCollection: typeof HTMLCollection;
     NodeList: typeof NodeList;

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -355,9 +355,10 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     const attributes = adaptor.allAttributes(node).map(
       (x: AttributeData) => x.name + '="' + (CDATA[x.name] ? x.value : this.protectAttribute(x.value)) + '"'
     ).join(' ');
+    const content = this.serializeInner(adaptor, node, xml);
     const html =
       '<' + tag + (attributes ? ' ' + attributes : '')
-      + (SELF_CLOSING[tag] ? (xml ? ' />' : '>') : '>' + adaptor.innerHTML(node) + '</' + tag + '>');
+          + (content && !SELF_CLOSING[tag] ? `>${content}</${tag}>` : xml ? '/>' : '>');
     return html;
   }
 
@@ -366,7 +367,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
    * @param {LiteElement} node     The node whose innerHTML is needed
    * @return {string}              The serialized element (like innerHTML)
    */
-  public serializeInner(adaptor: LiteAdaptor, node: LiteElement): string {
+  public serializeInner(adaptor: LiteAdaptor, node: LiteElement, xml: boolean = false): string {
     const PCDATA = (this.constructor as typeof LiteParser).PCDATA;
     if (PCDATA.hasOwnProperty(node.kind)) {
       return adaptor.childNodes(node).map(x => adaptor.value(x)).join('');
@@ -375,7 +376,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
       const kind = adaptor.kind(x);
       return (kind === '#text' ? this.protectHTML(adaptor.value(x)) :
               kind === '#comment' ? (x as LiteComment).value :
-              this.serialize(adaptor, x as LiteElement));
+              this.serialize(adaptor, x as LiteElement, xml));
     }).join('');
   }
 

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -345,9 +345,10 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   /**
    * @param {LiteAdaptor} adaptor  The adaptor for managing nodes
    * @param {LiteElement} node     The node to serialize
+   * @param {boolean} xml          True when producing XML, false for HTML
    * @return {string}              The serialized element (like outerHTML)
    */
-  public serialize(adaptor: LiteAdaptor, node: LiteElement): string {
+  public serialize(adaptor: LiteAdaptor, node: LiteElement, xml: boolean = false): string {
     const SELF_CLOSING = (this.constructor as typeof LiteParser).SELF_CLOSING;
     const CDATA = (this.constructor as typeof LiteParser).CDATA_ATTR;
     const tag = adaptor.kind(node);
@@ -355,8 +356,8 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
       (x: AttributeData) => x.name + '="' + (CDATA[x.name] ? x.value : this.protectAttribute(x.value)) + '"'
     ).join(' ');
     const html =
-      '<' + tag + (attributes ? ' ' + attributes : '') + '>'
-      + (SELF_CLOSING[tag] ? '' : adaptor.innerHTML(node) + '</' + tag + '>');
+      '<' + tag + (attributes ? ' ' + attributes : '')
+      + (SELF_CLOSING[tag] ? (xml ? ' />' : '>') : adaptor.innerHTML(node) + '</' + tag + '>');
     return html;
   }
 

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -357,7 +357,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     ).join(' ');
     const html =
       '<' + tag + (attributes ? ' ' + attributes : '')
-      + (SELF_CLOSING[tag] ? (xml ? ' />' : '>') : adaptor.innerHTML(node) + '</' + tag + '>');
+      + (SELF_CLOSING[tag] ? (xml ? ' />' : '>') : '>' + adaptor.innerHTML(node) + '</' + tag + '>');
     return html;
   }
 

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -466,6 +466,13 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   /**
    * @override
    */
+  public serializeXML(node: LiteElement) {
+    return this.parser.serialize(this, node, true);
+  }
+
+  /**
+   * @override
+   */
   public setAttribute(node: LiteElement, name: string, value: string | number, ns: string = null) {
     if (typeof value !== 'string') {
       value = String(value);

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -241,6 +241,12 @@ export interface DOMAdaptor<N, T, D> {
   outerHTML(node: N): string;
 
   /**
+   * @param {N} node   The HTML node whose serialized string is to be obtained
+   * @return {string}  The serialized node and its content
+   */
+  serializeXML(node: N): string;
+
+  /**
    * @param {N} node               The HTML node whose attribute is to be set
    * @param {string|number} name   The name of the attribute to set
    * @param {string} value         The new value of the attribute
@@ -557,6 +563,11 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * @override
    */
   public abstract outerHTML(node: N): string;
+
+  /**
+   * @override
+   */
+  public abstract serializeXML(node: N): string;
 
   /**
    * @override

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -1231,7 +1231,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
    * @return {string}  The serialized XML content
    */
   public getSerializedXML(): string {
-    return this.adaptor.outerHTML(this.xml);
+    return this.adaptor.serializeXML(this.xml);
   }
 
   /**


### PR DESCRIPTION
This PR adds a `serializeXML()` method for the DOMadaptor, and implements it in the HTML and Lite adaptors.  This is then used by the `XMLNode` class to get its serialized version for output in serialized MathML.  This allows `<annotation-xml>` element that contain HTML content with self-closing tags like `<input>` that don't usually produce valid XML to produce a serialized version that can be parsed by SRE as well as by MathJax.  This allows `<annotation-xml>` to be used with the assistive tools.