### PR TITLE
svg mglyph: set valid alttext

### DIFF
--- a/ts/output/svg/Wrappers/mglyph.ts
+++ b/ts/output/svg/Wrappers/mglyph.ts
@@ -56,7 +56,7 @@ CommonMglyphMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
       width: w, height: h,
       transform: 'translate(0 ' + y + ') matrix(1 0 0 -1 0 0)',
       preserveAspectRatio: 'none',
-      alt: alt, title: alt,
+      "aria-label": alt,
       href: src
     };
     const img = this.svg('image', properties);


### PR DESCRIPTION
Replaces invalid alt and title with aria-label attribute.

Re-resolves mathjax/MathJax#2065 (which was fixed the same way in 2.x)