### PR TITLE
Fix mathaccent regression reported by Peter

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -496,7 +496,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    * @param {string} mo   The test of the mo element
    */
   protected checkMathAccent(mo: string) {
-    if (this.getProperty('mathaccent') !== undefined || !this.Parent.isKind('munderover')) return;
+    if (this.getProperty('mathaccent') !== undefined || !this.Parent || !this.Parent.isKind('munderover')) return;
     const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
     if (mo.match(MATHACCENT)) {
       this.setProperty('mathaccent', true);

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -496,7 +496,9 @@ export class MmlMo extends AbstractMmlTokenNode {
    * @param {string} mo   The test of the mo element
    */
   protected checkMathAccent(mo: string) {
-    if (this.getProperty('mathaccent') !== undefined || !this.Parent || !this.Parent.isKind('munderover')) return;
+    const parent = this.Parent;
+    if (this.getProperty('mathaccent') !== undefined || !parent ||
+        !parent.isKind('munderover') || parent.childNodes[0] === this) return;
     const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
     if (mo.match(MATHACCENT)) {
       this.setProperty('mathaccent', true);

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -497,8 +497,9 @@ export class MmlMo extends AbstractMmlTokenNode {
    */
   protected checkMathAccent(mo: string) {
     const parent = this.Parent;
-    if (this.getProperty('mathaccent') !== undefined || !parent ||
-        !parent.isKind('munderover') || parent.childNodes[0] === this) return;
+    if (this.getProperty('mathaccent') !== undefined || !parent || !parent.isKind('munderover')) return;
+    const base = parent.childNodes[0] as MmlNode;
+    if (base.isEmbellished && base.coreMO() === this) return;
     const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
     if (mo.match(MATHACCENT)) {
       this.setProperty('mathaccent', true);


### PR DESCRIPTION
This PR makes sure the parent element is not null before querying it.

This also fixes a second problem, where the base of an `mover` could be marked as a math accent.