### PR TITLE
A11y refocus on mouse collapse

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -116,7 +116,12 @@ export abstract class AbstractKeyExplorer<T> extends AbstractExplorer<T> impleme
   public Update(force: boolean = false) {
     if (!this.active && !force) return;
     this.highlighter.unhighlight();
-    this.highlighter.highlight(this.walker.getFocus(true).getNodes());
+    let nodes = this.walker.getFocus(true).getNodes();
+    if (!nodes.length) {
+      this.walker.refocus();
+      nodes = this.walker.getFocus().getNodes();
+    }
+    this.highlighter.highlight(nodes);
   }
 
   /**

--- a/ts/a11y/sre_browser.d.ts
+++ b/ts/a11y/sre_browser.d.ts
@@ -30,6 +30,7 @@ declare namespace sre {
     deactivate(): void;
     speech(): string;
     move(key: number): boolean;
+    refocus(): void;
     getFocus(update?: boolean): Focus;
     update(options: {[key: string]: string}): void;
   }


### PR DESCRIPTION
This solves the issue when a key walker looses focus due to mouse interference. E.g., if a subtree is collapsed at the root while the key explorer is focused on one of the nodes in the subtree.