### PR TITLE
Prevent border-spacing and border-collapse from being inherited from an outer table

### DIFF
--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -56,7 +56,9 @@ CommonMtableMixin<CHTMLmtd<any, any, any>, CHTMLmtr<any, any, any>, CHTMLConstru
       'vertical-align': '.25em',
       'text-align': 'center',
       'position': 'relative',
-      'box-sizing': 'border-box'
+      'box-sizing': 'border-box',
+      'border-spacing': 0,            // prevent this from being inherited from an outer table
+      'border-collapse': 'collapse'   // similarly here
     },
     'mjx-mstyle[size="s"] mjx-mtable': {
       'vertical-align': '.354em'


### PR DESCRIPTION
This PR fixes a problem reported in WeBWorK (which is moving to v3).  The math was inside a larger table that had `border-spacing: 10px; border-collapse: separate`, and the arrays generated by MathJax within that outer table inherited those properties, making the spacing wrong for the math.   So I've added some CSS to the `mjx-mtable` element to reset these values.