### PR TITLE
Triggering links from the explorer.

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -292,6 +292,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
     }
     if (this.active) {
       this.Move(code);
+      if (this.triggerLink(code)) return;
       this.stopEvent(event);
       return;
     }
@@ -301,6 +302,24 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
     }
   }
 
+  /**
+   * Programmatically triggers a link if the focused node contains one.
+   */
+  protected triggerLink(code: number) {
+    if (code !== 13) {
+      return false;
+    }
+    let node = this.walker.getFocus().getNodes()?.[0];
+    let focus = node?.
+      getAttribute('data-semantic-postfix')?.
+      match(/(^| )link($| )/);
+    if (focus) {
+      // Works for CHTML only.
+      node.parentElement.click();
+      return true;
+    }
+    return false;
+  }
 
   /**
    * @override

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -304,6 +304,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
 
   /**
    * Programmatically triggers a link if the focused node contains one.
+   * @param {number} code The keycode of the last key pressed.
    */
   protected triggerLink(code: number) {
     if (code !== 13) {
@@ -314,8 +315,7 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
       getAttribute('data-semantic-postfix')?.
       match(/(^| )link($| )/);
     if (focus) {
-      // Works for CHTML only.
-      node.parentElement.click();
+      node.parentNode.dispatchEvent(new MouseEvent('click'));
       return true;
     }
     return false;

--- a/ts/a11y/sre_browser.d.ts
+++ b/ts/a11y/sre_browser.d.ts
@@ -21,7 +21,7 @@ declare namespace sre {
   }
 
   interface Focus {
-    getNodes(): Node[];
+    getNodes(): Element[];
   }
 
   interface Walker {


### PR DESCRIPTION
Hitting return on the node that announces itself to be a link will trigger the link.
Unfortunately, this only works for CHTML, not in SVG.

I've tried by setting focus on the anchor element and continue propagating the event. 
Unfortunately, that only works sporadically. 

Also dispatching a new event like below did not do the trick.
``` javascript
      let event = new KeyboardEvent('keydown', {code: '13', bubbles: true});
      node.parentElement.dispatchEvent(event);
```