### PR TITLE
Fix problem with not closing empty tags in HTML serialization (mathjax/MathJax#2674)

### DIFF
--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -1,3 +1,4 @@
+
 /*************************************************************
  *
  *  Copyright (c) 2018 The MathJax Consortium
@@ -358,7 +359,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     const content = this.serializeInner(adaptor, node, xml);
     const html =
       '<' + tag + (attributes ? ' ' + attributes : '')
-          + (content && !SELF_CLOSING[tag] ? `>${content}</${tag}>` : xml ? '/>' : '>');
+          + ((!xml || content) && !SELF_CLOSING[tag] ? `>${content}</${tag}>` : xml ? '/>' : '>');
     return html;
   }
 


### PR DESCRIPTION
This PR fixes a problem with HTML serialization (as opposed to XML serialization) where empty non-self-closing tags would not be properly closed.

Resolves issue mathjax/MathJax#2674.