### PR TITLE
Fix problem with detecting whether ex-height can be computed, and work around jsdom problems

### DIFF
--- a/ts/adaptors/jsdomAdaptor.ts
+++ b/ts/adaptors/jsdomAdaptor.ts
@@ -30,6 +30,8 @@ export class JsdomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
    * The default options
    */
   public static OPTIONS: OptionList = {
+    fontSize: 16,          // We can't compute the font size, so always use this
+    fontFamily: 'Times',   // We can't compute the font family, so always use this
     cjkCharWidth: 1,       // Width (in em units) of full width characters
     unknownCharWidth: .6,  // Width (in em units) of unknown (non-full-width) characters
     unknownCharHeight: .8, // Height (in em units) of unknown characters
@@ -72,6 +74,32 @@ export class JsdomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
     super(window);
     let CLASS = this.constructor as typeof JsdomAdaptor;
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
+  }
+
+  /**
+   * JSDOM's getComputedStyle() implementation is badly broken, and only
+   *   return the styles explicitly set on the given node, not the
+   *   inherited values frmo the cascading style sheets (so it is pretty
+   *   useless).  This is somethig we can't really work around, so use
+   *   the default value given in the options instead.  Sigh
+   *
+   * @override
+   */
+  public fontSize(_node: HTMLElement) {
+    return this.options.fontSize;
+  }
+
+  /**
+   * JSDOM's getComputedStyle() implementation is badly broken, and only
+   *   return the styles explicitly set on the given node, not the
+   *   inherited values frmo the cascading style sheets (so it is pretty
+   *   useless).  This is somethig we can't really work around, so use
+   *   the default value given in the options instead.  Sigh
+   *
+   * @override
+   */
+  public fontFamily(_node: HTMLElement) {
+    return this.options.fontFamily;
   }
 
   /**

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -423,8 +423,9 @@ export abstract class CommonOutputJax<
     const adaptor = this.adaptor;
     const family = (getFamily ? adaptor.fontFamily(node) : '');
     const em = adaptor.fontSize(node);
-    const ex = (adaptor.nodeSize(adaptor.childNode(node, 1) as N)[1] / 60) || (em * this.options.exFactor);
-    const containerWidth = (adaptor.getStyle(node, 'display') === 'table' ?
+    const [w, h] = adaptor.nodeSize(adaptor.childNode(node, 1) as N);
+    const ex = (w ? h / 60 : em * this.options.exFactor);
+    const containerWidth = (!w ? 1000000 : adaptor.getStyle(node, 'display') === 'table' ?
                             adaptor.nodeSize(adaptor.lastChild(node) as N)[0] - 1 :
                             adaptor.nodeBBox(adaptor.lastChild(node) as N).left -
                             adaptor.nodeBBox(adaptor.firstChild(node) as N).left - 2);


### PR DESCRIPTION
This PR fixes a regression in 3.1.3 that causes liteDOM and jsdom adapters to get the ex-height badly wrong.  This was due to changes made to process CJK characters that also added some default height, which confused the test to see if the `exFactor` needed to be used.

There are also some problems with jsdom's implementation of `getComputesStyle()`, which doesn't actually inherit styles, it only lists the ones explicitly on the given element.  The CSSStyleDeclaration implementation is broken in a number of ways, and I've had to patch it before, but this issue would take some work.  This PR adds options to the jsdom to set the font size and family to use (just as we do with the LiteDOM), since `getComputedStyle()` can't be trusted.

Resolves issue mathjax/MathJax#2694.