### PR TITLE
Only return a DOCTYPE if there is one

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -247,7 +247,7 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public doctype(doc: D) {
-    return `<!DOCTYPE ${doc.doctype.name}>`;
+    return (doc.doctype ? `<!DOCTYPE ${doc.doctype.name}>` : '');
   }
 
   /**

--- a/ts/adaptors/lite/Document.ts
+++ b/ts/adaptors/lite/Document.ts
@@ -61,6 +61,6 @@ export class LiteDocument {
       this.head = new LiteElement('head'),
       this.body = new LiteElement('body')
     ]);
-    this.type = '<!DOCTYPE html>';
+    this.type = '';
   }
 }


### PR DESCRIPTION
This PR fixes a problem where `adaptor.doctype()` could fail if the original document doesn't have a `<!DOCTYPE>` comment (in HTML and jsdom adaptors).  It also prevents the LiteDOM from returning a doctype if the original didn't have one.