### PR TITLE
Clear the stylesheet when used in a new MathDocument.  (mathjax/MathJax#2678)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -143,6 +143,13 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   /**
    * @override
    */
+  public initialize() {
+    this.chtmlStyles = null;
+  }
+
+  /**
+   * @override
+   */
   public escaped(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
     this.setDocument(html);
     return this.html('span', {}, [this.text(math.math)]);

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -135,8 +135,9 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
    */
   public initialize() {
     if (this.options.fontCache === 'global') {
-      this.fontCache.clearCache();
+      this.clearFontCache();
     }
+    this.svgStyles = null;
   }
 
   /**


### PR DESCRIPTION
This PR makes sure the output jax clear its internal stylesheet pointer when it is used in a new document.

Resolves issue mathjax/MathJax#2678.