### PR TITLE
Add support for shifting combining-character accents into place

### DIFF
--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -33,6 +33,7 @@ import {StyleList} from '../../util/StyleList.js';
 export interface CharOptions {
   ic?: number;                  // italic correction value
   sk?: number;                  // skew value
+  dx?: number;                  // offset for combining characters
   unknown?: boolean;            // true if not found in the given variant
   smp?: number;                 // Math Alphanumeric codepoint this char is mapped to
 }

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -375,8 +375,9 @@ export class CommonWrapper<
    */
   protected copySkewIC(bbox: BBox) {
     const first = this.childNodes[0];
-    if (first && first.bbox.sk) {
-      bbox.sk = first.bbox.sk;
+    if (first) {
+      first.bbox.sk && (bbox.sk = first.bbox.sk);
+      first.bbox.dx && (bbox.dx = first.bbox.dx);
     }
     const last = this.childNodes[this.childNodes.length - 1];
     if (last && last.bbox.ic) {

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -375,12 +375,14 @@ export class CommonWrapper<
    */
   protected copySkewIC(bbox: BBox) {
     const first = this.childNodes[0];
-    if (first) {
-      first.bbox.sk && (bbox.sk = first.bbox.sk);
-      first.bbox.dx && (bbox.dx = first.bbox.dx);
+    if (first?.bbox.sk) {
+      bbox.sk = first.bbox.sk;
+    }
+    if (first?.bbox.dx) {
+      bbox.dx = first.bbox.dx;
     }
     const last = this.childNodes[this.childNodes.length - 1];
-    if (last && last.bbox.ic) {
+    if (last?.bbox.ic) {
       bbox.ic = last.bbox.ic;
       bbox.w += bbox.ic;
     }

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -93,6 +93,7 @@ export function CommonTextNodeMixin<T extends WrapperConstructor>(Base: T): Text
           if (d > bbox.d) bbox.d = d;
           bbox.ic = data.ic || 0;
           bbox.sk = data.sk || 0;
+          bbox.dx = data.dx || 0;
         }
         if (chars.length > 1) {
           bbox.sk = 0;

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -635,7 +635,7 @@ export function CommonScriptbaseMixin<
       const widths = boxes.map(box => box.w * box.rscale);
       widths[0] -= (this.baseRemoveIc && !this.baseCore.node.attributes.get('largeop') ? this.baseIc : 0);
       const w = Math.max(...widths);
-      const dw = [];
+      const dw = [] as number[];
       let m = 0;
       for (const i of widths.keys()) {
         dw[i] = (align === 'center' ? (w - widths[i]) / 2 :
@@ -649,6 +649,7 @@ export function CommonScriptbaseMixin<
           dw[i] += m;
         }
       }
+      [1, 2].map(i => dw[i] += (boxes[i] ? boxes[i].dx * boxes[0].scale : 0));
       return dw;
     }
 

--- a/ts/util/BBox.ts
+++ b/ts/util/BBox.ts
@@ -71,6 +71,7 @@ export class BBox {
   public pwidth: string; // percentage width (for tables)
   public ic: number;     // italic correction
   public sk: number;     // skew
+  public dx: number;     // offset for combining characters as accents
   /* tslint:enable */
 
   /**
@@ -96,7 +97,7 @@ export class BBox {
     this.w = def.w || 0;
     this.h = ('h' in def ? def.h : -BIGDIMEN);
     this.d = ('d' in def ? def.d : -BIGDIMEN);
-    this.L = this.R = this.ic = this.sk = 0;
+    this.L = this.R = this.ic = this.sk = this.dx = 0;
     this.scale = this.rscale = 1;
     this.pwidth = '';
   }


### PR DESCRIPTION
This PR adds code to allow combining characters to be properly places as accents (both above and below).  It introduces a new item of font data for an offset to apply, and then passes that through the BBox to the under-over methods that determines the positioning.  Since accents are centered and combining characters have zero width (the data doesn't identify the actual size or placement of the character), we add a shift that moves the center of a combining character to the horizontal origin.

This resolves an issue Peter pointed out with combining-character accents in the STIX2 fonts.