### PR TITLE
Update node-main for webpack 5

### DIFF
--- a/components/src/node-main/webpack.config.js
+++ b/components/src/node-main/webpack.config.js
@@ -7,6 +7,11 @@ const package = PACKAGE(
   __dirname                           // our directory
 );
 
-package.output.libraryTarget = 'this';  // make node-main.js exports available to caller
+// make node-main.js exports available to caller
+package.output.library = {
+  name: 'init',
+  type: 'commonjs',
+  export: 'init'
+};
 
 module.exports = package;


### PR DESCRIPTION
This PR updates the `webpack.config.js` file for the node-main component (which is what you get when you `require('mathjax')`) to work with the latest version of webpack to which we updated in 3.1.4.  This fixes the error that occurs when you do `require('mathjax')` with the `mathjax` npm package.  (The `mathjax-full` package works fine because it uses the source version rather than the webpacked version).

Resolves issue mathjax/MathJax#2683.