### PR TITLE
Trim delimiter for \big and friends, and put \math* in a TeXAtom (mathjax/MathJax#2688, mathjax/MathJax#2689)

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -373,7 +373,7 @@ export default class TexParser {
         c += this.GetCS();
       } else if (c === '{' && braceOK) {
         this.i--;
-        c = this.GetArgument(name);
+        c = this.GetArgument(name).trim();
       }
       if (this.contains('delimiter', c)) {
         return this.convertDelimiter(c);

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -283,10 +283,7 @@ BaseMethods.MathFont = function(parser: TexParser, name: string, variant: string
     font: variant,
     multiLetterIdentifiers: true
   }, parser.configuration).mml();
-  if (mml.isKind('inferredMrow')) {
-    mml = parser.create('node', 'mrow', mml.childNodes);
-  }
-  parser.Push(mml);
+  parser.Push(parser.create('node', 'TeXAtom', [mml]));
 };
 
 /**


### PR DESCRIPTION
This PR fixes some issues reported by Peter.

1. `\bigg{\uparrow }` indicates an error (the trailing space was not being removed).
2. `\mathbf{x^x}^x` produces an error (the `\mathbf{...}` should be in a TeXAtom of type ORD.

Resolves issue mathjax/MathJax#2688 and mathjax/MathJax#2689.