### PR TITLE
Fix error where a second use of \| delim causes the wrong size to be used.

### DIFF
--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -273,7 +273,7 @@ export function CommonMoMixin<T extends WrapperConstructor>(Base: T): MoConstruc
               this.variant = this.font.getSizeVariant(c, i);
               this.size = i;
               if (delim.schar && delim.schar[i]) {
-                this.stretch.c = delim.schar[i];
+                this.stretch = {...this.stretch, c: delim.schar[i]};
               }
               return;
             }


### PR DESCRIPTION
A change in 3.1.4 to make stretchy delimiters that end up using a different untied point produce the correct character had a side effect of making them unstretchable after the first use.  The `\Vert` double bar is one such, and so the second (and subsequent) uses of `\Vert` will not stretch.  E.g. `\left\Vert \frac 1 2 \right\Vert` will have the right-hand delimiter un-stretched.  This PR resolves the problem.

Resolves issue mathjax/MathJax#2697.