### PR TITLE
Update the CHTML adaptive CSS process to insert new rules rather than replacing the stylesheet entirely.

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -69,6 +69,7 @@ export interface MinHTMLElement<N, T> {
   className: string;
   classList: DOMTokenList;
   style: OptionList;
+  sheet?: {insertRule: (rule: string) => void};
 
   childNodes: (N | T)[] | NodeList;
   firstChild: N | T | Node;
@@ -510,6 +511,15 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    */
   public allStyles(node: N) {
     return node.style.cssText;
+  }
+
+  /**
+   * @override
+   */
+  public insertRules(node: N, rules: string[]) {
+    for (const rule of rules.reverse()) {
+      node.sheet.insertRule(rule);
+    }
   }
 
   /**

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -585,6 +585,13 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   /**
    * @override
    */
+  public insertRules(node: LiteElement, rules: string[]) {
+    node.children = [this.text(rules.join('\n\n') + '\n\n' + this.textContent(node))];
+  }
+
+  /**
+   * @override
+   */
   public fontSize(_node: LiteElement) {
     return this.options.fontSize;
   }

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -332,6 +332,12 @@ export interface DOMAdaptor<N, T, D> {
   allStyles(node: N): string;
 
   /**
+   * @param {N} node           The stylesheet node where the rule will be added
+   * @param {string[]} rules   The rule to add at the beginning of the stylesheet
+   */
+  insertRules(node: N, rules: string[]): void;
+
+  /**
    * @param {N} node        The HTML node whose font size is to be determined
    * @return {number}       The font size (in pixels) of the node
    */
@@ -633,6 +639,11 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * @override
    */
   public abstract allStyles(node: N): string;
+
+  /**
+   * @override
+   */
+  public abstract insertRules(node: N, rules: string[]): void;
 
   /**
    * @override

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -24,7 +24,7 @@
 import {CommonOutputJax} from './common/OutputJax.js';
 import {CommonWrapper} from './common/Wrapper.js';
 import {StyleList} from '../util/Styles.js';
-import {StyleList as CssStyleList} from '../util/StyleList.js';
+import {StyleList as CssStyleList, CssStyles} from '../util/StyleList.js';
 import {OptionList} from '../util/Options.js';
 import {MathDocument} from '../core/MathDocument.js';
 import {MathItem} from '../core/MathItem.js';
@@ -32,6 +32,7 @@ import {MmlNode} from '../core/MmlTree/MmlNode.js';
 import {CHTMLWrapper} from './chtml/Wrapper.js';
 import {CHTMLWrapperFactory} from './chtml/WrapperFactory.js';
 import {CHTMLFontData} from './chtml/FontData.js';
+import {Usage} from './chtml/Usage.js';
 import {TeXFont} from './chtml/fonts/tex.js';
 import * as LENGTHS from '../util/lengths.js';
 import {unicodeChars} from '../util/string.js';
@@ -121,10 +122,14 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   public static STYLESHEETID = 'MJX-CHTML-styles';
 
   /**
-   *  Used to store the CHTMLWrapper factory,
-   *  the FontData object, and the CssStyles object.
+   *  Used to store the CHTMLWrapper factory.
    */
   public factory: CHTMLWrapperFactory<N, T, D>;
+
+  /**
+   * The usage information for the wrapper classes
+   */
+  public wrapperUsage: Usage<string>;
 
   /**
    * The CHTML stylesheet, once it is constructed
@@ -138,6 +143,7 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   constructor(options: OptionList = null) {
     super(options, CHTMLWrapperFactory as any, TeXFont);
     this.font.adaptiveCSS(this.options.adaptiveCSS);
+    this.wrapperUsage = new Usage<string>();
   }
 
   /**
@@ -152,29 +158,60 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
    * @override
    */
   public styleSheet(html: MathDocument<N, T, D>) {
-    if (this.chtmlStyles && !this.options.adaptiveCSS) {
+    if (this.chtmlStyles) {
+      if (this.options.adaptiveCSS) {
+        //
+        // Update the style sheet rules
+        //
+        const styles = new CssStyles();
+        this.addWrapperStyles(styles);
+        this.updateFontStyles(styles);
+        this.adaptor.insertRules(this.chtmlStyles, styles.getStyleRules());
+      }
       return this.chtmlStyles;  // stylesheet is already added to the document
     }
     const sheet = this.chtmlStyles = super.styleSheet(html);
     this.adaptor.setAttribute(sheet, 'id', CHTML.STYLESHEETID);
+    this.wrapperUsage.update();
     return sheet;
+  }
+
+  /**
+   * @param {CssStyles} styles   The styles to update with newly used character styles
+   */
+  protected updateFontStyles(styles: CssStyles) {
+    styles.addStyles(this.font.updateStyles());
   }
 
   /**
    * @override
    */
-  protected addClassStyles(CLASS: typeof CommonWrapper) {
-    if (!this.options.adaptiveCSS || (CLASS as typeof CHTMLWrapper).used) {
-      if ((CLASS as typeof CHTMLWrapper).autoStyle && CLASS.kind !== 'unknown') {
-        this.cssStyles.addStyles({
-          ['mjx-' + CLASS.kind]: {
-            display: 'inline-block',
-            'text-align': 'left'
-          }
-        });
+  protected addWrapperStyles(styles: CssStyles) {
+    if (this.options.adaptiveCSS) {
+      for (const kind of this.wrapperUsage.update()) {
+        const wrapper = this.factory.getNodeClass(kind) as any as typeof CommonWrapper;
+        wrapper && this.addClassStyles(wrapper, styles);
       }
-      super.addClassStyles(CLASS);
+    } else {
+      super.addWrapperStyles(styles);
     }
+  }
+
+  /**
+   * @override
+   */
+  protected addClassStyles(wrapper: typeof CommonWrapper, styles: CssStyles) {
+    const CLASS = wrapper as typeof CHTMLWrapper;
+    if (CLASS.autoStyle && CLASS.kind !== 'unknown') {
+      styles.addStyles({
+        ['mjx-' + CLASS.kind]: {
+          display: 'inline-block',
+          'text-align': 'left'
+        }
+      });
+    }
+    this.wrapperUsage.add(CLASS.kind);
+    super.addClassStyles(wrapper, styles);
   }
 
   /**
@@ -191,9 +228,8 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   public clearCache() {
     this.cssStyles.clear();
     this.font.clearCache();
-    for (const kind of this.factory.getKinds()) {
-      this.factory.getNodeClass(kind).used = false;
-    }
+    this.wrapperUsage.clear();
+    this.chtmlStyles = null;
   }
 
   /**

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -187,13 +187,13 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
    * @override
    */
   protected addWrapperStyles(styles: CssStyles) {
-    if (this.options.adaptiveCSS) {
-      for (const kind of this.wrapperUsage.update()) {
-        const wrapper = this.factory.getNodeClass(kind) as any as typeof CommonWrapper;
-        wrapper && this.addClassStyles(wrapper, styles);
-      }
-    } else {
+    if (!this.options.adaptiveCSS) {
       super.addWrapperStyles(styles);
+      return;
+    }
+    for (const kind of this.wrapperUsage.update()) {
+      const wrapper = this.factory.getNodeClass(kind) as any as typeof CommonWrapper;
+      wrapper && this.addClassStyles(wrapper, styles);
     }
   }
 

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -22,6 +22,7 @@
  */
 
 import {CharMap, CharOptions, CharData, VariantData, DelimiterData, FontData, DIRECTION} from '../common/FontData.js';
+import {Usage} from './Usage.js';
 import {StringMap} from './Wrapper.js';
 import {StyleList, StyleData} from '../../util/StyleList.js';
 import {em} from '../../util/lengths.js';
@@ -36,7 +37,6 @@ export * from '../common/FontData.js';
 export interface CHTMLCharOptions extends CharOptions {
   c?: string;                   // the content value (for css)
   f?: string;                   // the font postfix (for css)
-  used?: boolean;               // true when the character has been used on the page
 }
 
 /**
@@ -57,7 +57,6 @@ export interface CHTMLVariantData extends VariantData<CHTMLCharOptions> {
  * The extra data needed for a Delimiter in CHTML output
  */
 export interface CHTMLDelimiterData extends DelimiterData {
-  used?: boolean;               // true when this delimiter has been used on the page
 }
 
 /****************************************************************************/
@@ -104,6 +103,20 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
     }
   };
 
+  /***********************************************************************/
+
+  /**
+   * Data about the characters used (for adaptive CSS)
+   */
+  public charUsage: Usage<[string, number]> = new Usage<[string, number]>();
+
+  /**
+   * Data about the delimiters used (for adpative CSS)
+   */
+  public delimUsage: Usage<number> = new Usage<number>();
+
+  /***********************************************************************/
+
   /**
    * @override
    */
@@ -124,24 +137,9 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    * Clear the cache of which characters have been used
    */
   public clearCache() {
-    if (!this.options.adaptiveCSS) return;
-    //
-    // Clear delimiter usage
-    //
-    for (const n of Object.keys(this.delimiters)) {
-      this.delimiters[parseInt(n)].used = false;
-    }
-    //
-    // Clear the character usage
-    //
-    for (const name of Object.keys(this.variant)) {
-      const chars = this.variant[name].chars;
-      for (const n of Object.keys(chars)) {
-        const options = chars[parseInt(n)][3] as CHTMLCharOptions;
-        if (options) {
-          options.used = false;
-        }
-      }
+    if (this.options.adaptiveCSS) {
+      this.charUsage.clear();
+      this.delimUsage.clear();
     }
   }
 
@@ -179,22 +177,21 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
     //
     //  Include the default styles
     //
-    let styles: StyleList = {...CLASS.defaultStyles};
+    const styles: StyleList = {...CLASS.defaultStyles};
     //
     //  Add fonts with proper URL
     //
     this.addFontURLs(styles, CLASS.defaultFonts, this.options.fontURL);
     //
-    //  Create styles needed for the delimiters
+    //  Create styles needed for the delimiters and characters
     //
-    for (const n of Object.keys(this.delimiters)) {
-      const N = parseInt(n);
-      this.addDelimiterStyles(styles, N, this.delimiters[N]);
-    }
+    this.addDelimiterCharStyles(styles);
+    this.addVariantCharStyles(styles);
     //
-    //  Create styles needed for the characters in each variant
+    //   We have updated the rules, so clear the update data
     //
-    this.addVariantChars(styles);
+    this.delimUsage.update();
+    this.charUsage.update();
     //
     //  Return the final style sheet
     //
@@ -202,9 +199,37 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
   }
 
   /**
-   * @param {StyleList} styles  The style list to add characters to
+   * Get the styles for any newly used characters and delimiters
    */
-  protected addVariantChars(styles: StyleList) {
+  public updateStyles() {
+    const styles: StyleList = {};
+    for (const N of this.delimUsage.update()) {
+      this.addDelimiterStyles(styles, N, this.delimiters[N]);
+    }
+    for (const [name, N] of this.charUsage.update()) {
+      const variant = this.variant[name];
+      this.addCharStyles(styles, variant.letter, N, variant.chars[N]);
+    }
+    return styles;
+  }
+
+  /**
+   * @param {StyleList} styles  The style list to add delimiter styles to.
+   */
+  protected addDelimiterCharStyles(styles: StyleList) {
+    const allCSS = !this.options.adaptiveCSS;
+    for (const n of Object.keys(this.delimiters)) {
+      const N = parseInt(n);
+      if (allCSS || this.delimUsage.has(N)) {
+        this.addDelimiterStyles(styles, N, this.delimiters[N]);
+      }
+    }
+  }
+
+  /**
+   * @param {StyleList} styles  The style list to add character styles to.
+   */
+  protected addVariantCharStyles(styles: StyleList) {
     const allCSS = !this.options.adaptiveCSS;
     for (const name of Object.keys(this.variant)) {
       const variant = this.variant[name];
@@ -216,7 +241,7 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
         if (allCSS && char.length < 4) {
           (char as CHTMLCharData)[3] = {};
         }
-        if (char.length === 4 || allCSS) {
+        if (allCSS || this.charUsage.has([name, N])) {
           this.addCharStyles(styles, vletter, N, char);
         }
       }
@@ -244,7 +269,6 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    * @param {CHTMLDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
   protected addDelimiterStyles(styles: StyleList, n: number, data: CHTMLDelimiterData) {
-    if (this.options.adaptiveCSS && !data.used) return;
     const c = this.charSelector(n);
     if (data.c && data.c !== n) {
       styles['.mjx-stretched mjx-c' + c + '::before'] = {
@@ -363,7 +387,6 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    */
   protected addCharStyles(styles: StyleList, vletter: string, n: number, data: CHTMLCharData) {
     const options = data[3] as CHTMLCharOptions;
-    if (this.options.adaptiveCSS && !options.used) return;
     const letter = (options.f !== undefined ? options.f : vletter);
     const selector = 'mjx-c' + this.charSelector(n) + (letter ? '.TEX-' + letter : '');
     styles[selector + '::before'] = {

--- a/ts/output/chtml/Usage.ts
+++ b/ts/output/chtml/Usage.ts
@@ -1,0 +1,76 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2021 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Keeps track of usage of font characters and wrappers
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+/**
+ * Class used for traking usage of font characters or wrppers
+ *  (should extend Set<T>, but that doesn't work for compiling to ES2015).
+ */
+export class Usage<T> {
+
+  /**
+   * The used items.
+   */
+  protected used: Set<T> = new Set<T>();
+
+  /**
+   * The items marked as used since last update.
+   */
+  protected needsUpdate: T[] = [];
+
+  /**
+   * @param {T} item   The item that has been used
+   */
+  public add(item: T) {
+    if (!this.used.has(item)) {
+      this.needsUpdate.push(item);
+    }
+    this.used.add(item);
+  }
+
+  /**
+   * @param {T} item     The item to check for being used
+   * @return {boolean}   True if the item has been used
+   */
+  public has(item: T): boolean {
+    return this.used.has(item);
+  }
+
+  /**
+   * Clear the usage information
+   */
+  public clear() {
+    this.used.clear();
+    this.needsUpdate = [];
+  }
+
+  /**
+   * Get the items marked as used since the last update.
+   */
+  public update() {
+    const update = this.needsUpdate;
+    this.needsUpdate = [];
+    return update;
+  }
+
+}
+

--- a/ts/output/chtml/Usage.ts
+++ b/ts/output/chtml/Usage.ts
@@ -22,7 +22,7 @@
  */
 
 /**
- * Class used for traking usage of font characters or wrppers
+ * Class used for tracking usage of font characters or wrappers
  *  (should extend Set<T>, but that doesn't work for compiling to ES2015).
  */
 export class Usage<T> {

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -80,12 +80,6 @@ export interface CHTMLWrapperClass extends AnyWrapperClass {
    */
   autoStyle: boolean;
 
-  /**
-   * True when an instance of this class has been typeset
-   * (used to control whether the styles for this class need to be output)
-   */
-  used: boolean;
-
 }
 
 /*****************************************************************/
@@ -116,12 +110,6 @@ CommonWrapper<
    * that sets display:inline-block (as needed for the output for MmlNodes).
    */
   public static autoStyle = true;
-
-  /**
-   * True when an instance of this class has been typeset
-   * (used to control whether the styles for this class need to be output)
-   */
-  public static used: boolean = false;
 
   /**
    * @override
@@ -181,7 +169,7 @@ CommonWrapper<
    * Mark this class as having been typeset (so its styles will be output)
    */
   public markUsed() {
-    (this.constructor as CHTMLWrapperClass).used = true;
+    this.jax.wrapperUsage.add(this.kind);
   }
 
   /**

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -81,7 +81,7 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
                       this.jax.unknownText(String.fromCodePoint(n), variant) :
                       this.html('mjx-c', {class: this.char(n) + font}));
         adaptor.append(parent, node);
-        data.used = true;
+        this.font.charUsage.add([variant, n]);
       }
     }
   }

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -157,8 +157,8 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
    */
   protected stretchHTML(chtml: N) {
     const c = this.getText().codePointAt(0);
+    this.font.delimUsage.add(c);
     const delim = this.stretch;
-    delim.used = true;
     const stretch = delim.stretch;
     const content: N[] = [];
     //

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -100,16 +100,6 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
   };
 
   /**
-   * Make sure styles get output when called from munderover with movable limits
-   *
-   * @override
-   */
-  public markUsed() {
-    super.markUsed();
-    (CHTMLmsubsup as any).used = true;
-  }
-
-  /**
    * @override
    */
   public toCHTML(parent: N) {

--- a/ts/output/chtml/Wrappers/mtr.ts
+++ b/ts/output/chtml/Wrappers/mtr.ts
@@ -138,9 +138,16 @@ CommonMlabeledtrMixin<CHTMLmtd<any, any, any>, Constructor<CHTMLmtr<any, any, an
       const align = this.node.attributes.get('rowalign') as string;
       const attr = (align !== 'baseline' && align !== 'axis' ? {rowalign: align} : {});
       const row = this.html('mjx-mtr', attr, [child]);
-      (CHTMLmtr as any).used = true;
       this.adaptor.append((this.parent as CHTMLmtable<N, T, D>).labels, row);
     }
+  }
+
+  /**
+   * @override
+   */
+  public markUsed() {
+    super.markUsed();
+    this.jax.wrapperUsage.add(CHTMLmtr.kind);
   }
 
 }

--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -221,4 +221,14 @@ CommonMunderoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any,
     this.adjustUnderDepth(under, underbox);
   }
 
+  /**
+   * Make sure styles get output when called from munderover with movable limits
+   *
+   * @override
+   */
+  public markUsed() {
+    super.markUsed();
+    this.jax.wrapperUsage.add(CHTMLmsubsup.kind);
+  }
+
 }

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -467,14 +467,14 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @param {CssStyles} styles   The style obejct to add to
+   * @param {CssStyles} styles   The style object to add to
    */
   protected addFontStyles(styles: CssStyles) {
     styles.addStyles(this.font.styles);
   }
 
   /**
-   * @param {CssStyles} styles   The style obejct to add to
+   * @param {CssStyles} styles   The style object to add to
    */
   protected addWrapperStyles(styles: CssStyles) {
     for (const kind of this.factory.getKinds()) {

--- a/ts/output/common/OutputJax.ts
+++ b/ts/output/common/OutputJax.ts
@@ -455,15 +455,10 @@ export abstract class CommonOutputJax<
       }
     }
     //
-    // Gather the CSS from the classes
+    // Gather the CSS from the classes and font
     //
-    for (const kind of this.factory.getKinds()) {
-      this.addClassStyles(this.factory.getNodeClass(kind));
-    }
-    //
-    // Get the font styles
-    //
-    this.cssStyles.addStyles(this.font.styles);
+    this.addWrapperStyles(this.cssStyles);
+    this.addFontStyles(this.cssStyles);
     //
     // Create the stylesheet for the CSS
     //
@@ -472,10 +467,27 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @param {any} CLASS  The Wrapper class whose styles are to be added
+   * @param {CssStyles} styles   The style obejct to add to
    */
-  protected addClassStyles(CLASS: typeof CommonWrapper) {
-    this.cssStyles.addStyles(CLASS.styles);
+  protected addFontStyles(styles: CssStyles) {
+    styles.addStyles(this.font.styles);
+  }
+
+  /**
+   * @param {CssStyles} styles   The style obejct to add to
+   */
+  protected addWrapperStyles(styles: CssStyles) {
+    for (const kind of this.factory.getKinds()) {
+      this.addClassStyles(this.factory.getNodeClass(kind), styles);
+    }
+  }
+
+  /**
+   * @param {typeof CommonWrapper} CLASS  The Wrapper class whose styles are to be added
+   * @param {CssStyles} styles            The style object to add to.
+   */
+  protected addClassStyles(CLASS: typeof CommonWrapper, styles: CssStyles) {
+    styles.addStyles(CLASS.styles);
   }
 
   /*****************************************************************/

--- a/ts/util/StyleList.ts
+++ b/ts/util/StyleList.ts
@@ -94,13 +94,20 @@ export class CssStyles {
    * @return {string} The CSS string for the style list
    */
   public getStyleString(): string {
+    return this.getStyleRules().join('\n\n');
+  }
+
+  /**
+   * @return {string[]}  An array of rule strings for the style list
+   */
+  public getStyleRules(): string[] {
     const selectors = Object.keys(this.styles);
     const defs: string[] = new Array(selectors.length);
     let i = 0;
     for (const selector of selectors) {
       defs[i++] = selector + ' {\n' + this.getStyleDefString(this.styles[selector]) + '\n}';
     }
-    return defs.join('\n\n');
+    return defs;
   }
 
   /**


### PR DESCRIPTION
The lazy-typeset extension causes equations to be updated frequently, and for CHTML, that means updating the CHTML stylesheet.  It turns out that that can be expensive on large pages.  This PR improves the updating of the CSS by inserting individual rules into the stylesheet rather than replacing it outright.  That means the browser only has to update a few rules rather than think they *all* have changed.  This brings the performance of the lazy-typesetting for CHTML to nearly the same as for SVG.

This also updates the way that usage information for the CSS rules is stored.  It introduces a new Usage class for holding the data and uses that for keeping track of the wrappers and characters that need to be included in the stylesheet.  This moves that information out of the wrappers and character instances (saving storage space in those that aren't used).

You might want to look at `ts/output/chtml/Usage.ts` for the implementation of the Usage object before trying to understand the changes to the other files.