### PR TITLE
Remove munderover elements that have been cleaned.  (mathjax/MathJax#2691)

### DIFF
--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -243,7 +243,7 @@ namespace FilterUtil {
   let _moveLimits = function (options: ParseOptions, underover: string, subsup: string) {
     const remove: MmlNode[] = [];
     for (const mml of options.getList(underover)) {
-      if (mml.attributes.get('displaystyle') || mml.getProperty('removed')) {
+      if (mml.attributes.get('displaystyle')) {
         continue;
       }
       const base = mml.childNodes[(mml as any).base] as MmlNode;

--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -86,6 +86,7 @@ namespace FilterUtil {
    * @param {ParseOptions} data The parse options.
    */
   export let combineRelations = function(arg: {data: ParseOptions}) {
+    const remove: MmlNode[] = [];
     for (let mo of arg.data.getList('mo')) {
       if (mo.getProperty('relationsCombined') || !mo.parent ||
           (mo.parent && !NodeUtil.isType(mo.parent, 'mrow')) ||
@@ -111,6 +112,7 @@ namespace FilterUtil {
           _copyExplicit(['stretchy', 'rspace'], mo, m2);
           NodeUtil.setProperties(mo, m2.getAllProperties());
           children.splice(next, 1);
+          remove.push(m2);
           m2.parent = null;
           m2.setProperty('relationsCombined', true);
         } else {
@@ -127,7 +129,8 @@ namespace FilterUtil {
         }
       }
       mo.attributes.setInherited('form', (mo as MmlMo).getForms()[0]);
-      }
+    }
+    arg.data.removeFromList('mo', remove);
   };
 
 
@@ -191,6 +194,7 @@ namespace FilterUtil {
    * @param {string} up String representing the upper part.
    */
   let _cleanSubSup = function(options: ParseOptions, low: string, up: string) {
+    const remove: MmlNode[] = [];
     for (let mml of options.getList('m' + low + up) as any[]) {
       const children = mml.childNodes;
       if (children[mml[low]] && children[mml[up]]) {
@@ -206,7 +210,9 @@ namespace FilterUtil {
       } else {
         options.root = newNode;
       }
+      remove.push(mml);
     }
+    options.removeFromList('m' + low + up, remove);
   };
 
 
@@ -235,8 +241,9 @@ namespace FilterUtil {
    * @param {ParseOptions} data The parse options.
    */
   let _moveLimits = function (options: ParseOptions, underover: string, subsup: string) {
+    const remove: MmlNode[] = [];
     for (const mml of options.getList(underover)) {
-      if (mml.attributes.get('displaystyle')) {
+      if (mml.attributes.get('displaystyle') || mml.getProperty('removed')) {
         continue;
       }
       const base = mml.childNodes[(mml as any).base] as MmlNode;
@@ -249,8 +256,10 @@ namespace FilterUtil {
         } else {
           options.root = node;
         }
+        remove.push(mml);
       }
     }
+    options.removeFromList(underover, remove);
   };
 
   /**

--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -200,6 +200,24 @@ export default class ParseOptions {
 
 
   /**
+   * Remove a list of nodes from a saved list (e.g., when a filter removes the
+   * node from the DOM, like for munderover => munder).
+   *
+   * @param {string} property The property from which to remove nodes.
+   * @param {MmlNode[]} nodes The nodes to remove.
+   */
+  public removeFromList(property: string, nodes: MmlNode[]) {
+    const list = this.nodeLists[property] || [];
+    for (const node of nodes) {
+      const i = list.indexOf(node);
+      if (i >= 0) {
+        list.splice(i, 1);
+      }
+    }
+  }
+
+
+  /**
    * Tests if the node is in the tree spanned by the current root node.
    * @param {MmlNode} node The node to test.
    */


### PR DESCRIPTION
The `ParseOptions.nodeLists` object contains lists of elements generated during TeX input processing, and these are used by the post filters in order to do things like fix up `munderover` elements and combine `mo` relations.  Sometimes this means an element is removed and another put in its place.  When this happens, the element isn't currently being removed from its list, so later filters may try top process the removed element again.  This happens with the `cleanSubSup` and `moveLimits` filters.  If an `munderover` has been cleaned, it is still processed by `moveLimits`, sometimes leading to an error when the `munderover` has an empty child.

This PR adds a `removeFromList()` method to `ParseOptions` class that allows elements to be removed from its list.  Because the `for-of` loop will miss an element if you modify the array from within the loop, we keep a list of nodes to remove and remove them all at the end.

Resolves isse mathjax/MathJax#2691.