### PR TITLE
Add \noscript command

### DIFF
--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -774,6 +774,45 @@ export class NotItem extends BaseItem {
   }
 }
 
+export class NonscriptItem extends BaseItem {
+
+  /**
+   * @override
+   */
+  public get kind() {
+    return 'nonscript';
+  }
+
+  /**
+   * @override
+   */
+  public checkItem(item: StackItem): CheckType {
+    if (item.isKind('mml') && item.Size() === 1) {
+      let mml = item.First;
+      //
+      //  Space macros like \, wrap with an mstyle to set scriptlevel=0 (so size is independent of level)
+      //
+      if (mml.isKind('mstyle') && mml.notParent) {
+        mml = NodeUtil.getChildren(NodeUtil.getChildren(mml)[0])[0];
+      }
+      if (mml.isKind('mspace')) {
+        //
+        //  If the space is in an mstyle, wrap it in an mrow so we can test is scriptlevel.
+        //  The mrow will be removed in the post-filter.
+        //
+        if (mml !== item.First) {
+          mml = this.create('node', 'mrow', [item.Pop()]);
+          item.Push(mml);
+        }
+        //
+        //  Save the item for alter post-processing
+        //
+        this.factory.configuration.addNode('nonscript', item.First);
+      }
+    }
+    return [[item], true];
+  }
+}
 
 /**
  * Item indicating a dots command has been encountered.

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -774,6 +774,9 @@ export class NotItem extends BaseItem {
   }
 }
 
+/**
+ * A StackItem that removes an mspace that follows it (for \nonscript).
+ */
 export class NonscriptItem extends BaseItem {
 
   /**
@@ -787,25 +790,30 @@ export class NonscriptItem extends BaseItem {
    * @override
    */
   public checkItem(item: StackItem): CheckType {
+    //
+    //  Check if the next item is an mspace (or an mspace in an mstyle) and remove it.
+    //
     if (item.isKind('mml') && item.Size() === 1) {
       let mml = item.First;
       //
-      //  Space macros like \, wrap with an mstyle to set scriptlevel=0 (so size is independent of level)
+      //  Space macros like \, are wrapped with an mstyle to set scriptlevel="0"
+      //    (so size is independent of level), we look at the contents of the mstyle for the mspace.
       //
       if (mml.isKind('mstyle') && mml.notParent) {
         mml = NodeUtil.getChildren(NodeUtil.getChildren(mml)[0])[0];
       }
       if (mml.isKind('mspace')) {
         //
-        //  If the space is in an mstyle, wrap it in an mrow so we can test is scriptlevel.
-        //  The mrow will be removed in the post-filter.
+        //  If the space is in an mstyle, wrap it in an mrow so we can test its scriptlevel
+        //    in the post-filter (the mrow will be removed in the filter).  We can't test
+        //    the mstyle's scriptlevel, since it is ecxplicitly setting it to 0.
         //
         if (mml !== item.First) {
-          mml = this.create('node', 'mrow', [item.Pop()]);
-          item.Push(mml);
+          const mrow = this.create('node', 'mrow', [item.Pop()]);
+          item.Push(mrow);
         }
         //
-        //  Save the item for alter post-processing
+        //  Save the mspace for later post-processing.
         //
         this.factory.configuration.addNode('nonscript', item.First);
       }

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -572,6 +572,7 @@ new sm.CommandMap('macros', {
   rule:               'rule',
   Rule:              ['Rule'],
   Space:             ['Rule', 'blank'],
+  nonscript:          'Nonscript',
 
   big:               ['MakeBig', TEXCLASS.ORD, 0.85],
   Big:               ['MakeBig', TEXCLASS.ORD, 1.15],

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -904,6 +904,16 @@ BaseMethods.Hskip = function(parser: TexParser, name: string) {
 
 
 /**
+ * Handle removal of spaces in script modes
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The macro name.
+ */
+BaseMethods.Nonscript = function(parser: TexParser, _name: string) {
+  parser.Push(parser.itemFactory.create('nonscript'));
+};
+
+
+/**
  * Handle Rule and Space command
  * @param {TexParser} parser The calling parser.
  * @param {string} name The macro name.


### PR DESCRIPTION
This PR implements the `\nonscript` command, which removes the following spacing command (like `\hskip`, `\kern`, `\hspace`, etc.).  This is used int macro definitions to handle not use spacing in scripts, when given explicitly.

This is handled by using a new StackItem for the `\nonscript` that checks what is pushed after it, and if an `mspace` (or an `mspace` inside an `mstyle`, as produced by `\,` and similar macros), then we add the space into a list to be post-filtered (once the `scriptlevel` is known).   The case of am `mstyle` containing an `mspace` is handled by wrapping it in an `mrow` so that we can test the `scriptlevel` (since the `mstyle` will have `scriptlevel="0"` set).  The `mrow` is removed in the post-filter if the space is being retained (otherwise the `mrow` together with its contents are removed).