### PR TITLE
Revert "Clear the stylesheet when used in a new MathDocument.  (mathjax/MathJax#2678)"

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -143,13 +143,6 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   /**
    * @override
    */
-  public initialize() {
-    this.chtmlStyles = null;
-  }
-
-  /**
-   * @override
-   */
   public escaped(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
     this.setDocument(html);
     return this.html('span', {}, [this.text(math.math)]);

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -135,9 +135,8 @@ CommonOutputJax<N, T, D, SVGWrapper<N, T, D>, SVGWrapperFactory<N, T, D>, SVGFon
    */
   public initialize() {
     if (this.options.fontCache === 'global') {
-      this.clearFontCache();
+      this.fontCache.clearCache();
     }
-    this.svgStyles = null;
   }
 
   /**


### PR DESCRIPTION
Reverts mathjax/MathJax-src#693, which was incorrectly targeted to master.