### PR TITLE
Provide switch for warn/error for invalid options

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -35,7 +35,7 @@ import {OutputJax} from '../core/OutputJax.js';
 import {CommonOutputJax} from '../output/common/OutputJax.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {PrioritizedList} from '../util/PrioritizedList.js';
-import {OptionList} from '../util/Options.js';
+import {OptionList, OPTIONS} from '../util/Options.js';
 
 import {TeX} from '../input/tex.js';
 
@@ -54,6 +54,8 @@ export interface MathJaxConfig extends MJConfig {
     typeset?: boolean;       // Perform initial typeset?
     ready?: () => void;      // Function to perform when components are ready
     pageReady?: () => void;  // Function to perform when page is ready
+    invalidOption?: 'fatal' | 'warn'; // Do invalid options produce a warning, or throw an error?
+    optionError?: (message: string, key: string) => void,  // Function to report invalid options
     [name: string]: any;     // Other configuration blocks
   };
 }
@@ -534,8 +536,8 @@ export const MathJax = MJGlobal as MathJaxObject;
 
 /*
  * If the startup module hasn't been added to the MathJax variable,
- *   Add the startup configuration and data objects, and create
- *   the initial typeset and conversion calls.
+ *   Add the startup configuration and data objects, and
+ *   set the method for handling invalid options, if provided.
  */
 if (typeof MathJax._.startup === 'undefined') {
 
@@ -554,6 +556,13 @@ if (typeof MathJax._.startup === 'undefined') {
     startup: Startup,
     options: {}
   });
+
+  if (MathJax.config.startup.invalidOption) {
+    OPTIONS.invalidOption = MathJax.config.startup.invalidOption;
+  }
+  if (MathJax.config.startup.optionError) {
+    OPTIONS.optionError = MathJax.config.startup.optionError;
+  }
 
 }
 

--- a/ts/util/Options.ts
+++ b/ts/util/Options.ts
@@ -68,6 +68,27 @@ export const APPEND = '[+]';
  */
 export const REMOVE = '[-]';
 
+
+/**
+ *  Provides options for the option utlities.
+ */
+export const OPTIONS = {
+  invalidOption: 'warn' as ('fatal' | 'warn'),
+  /**
+   * Function to report messages for invalid options
+   *
+   * @param {string} message   The message for the invalid parameter.
+   * @param {string} key       The invalid key itself.
+   */
+  optionError: (message: string, _key: string) => {
+    if (OPTIONS.invalidOption === 'fatal') {
+      throw new Error(message);
+    }
+    console.warn('MathJax: ' + message);
+  }
+};
+
+
 /**
  * A Class to use for options that should not produce warnings if an undefined key is used
  */
@@ -163,7 +184,8 @@ export function insert(dst: OptionList, src: OptionList, warn: boolean = true): 
       if (typeof key === 'symbol') {
         key = (key as symbol).toString();
       }
-      throw new Error('Invalid option "' + key + '" (no default value).');
+      OPTIONS.optionError(`Invalid option "${key}" (no default value).`, key);
+      continue;
     }
     //
     // Shorthands for the source and destination values


### PR DESCRIPTION
This PR changes invalid-option messages from fatal to warning (so MathJax will still run when a bad option is specified).  New configuration options are added to the `startup` block to control whether the message is a warning or a fatal one, and to provide a function that is called when there is an invalid option (so that you can trap these easier, and handle them in whatever way is desired). 