### PR TITLE
Remove heuristic for U+2061 forcing previous item to be texClass=OP

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -289,18 +289,6 @@ export class MmlMo extends AbstractMmlTokenNode {
         this.texClass = TEXCLASS.CLOSE;
       }
     }
-    if (this.getText() === '\u2061') {
-      //
-      //  Force previous node to be TEXCLASS.OP and skip this node
-      //
-      if (prev && prev.getProperty('texClass') === undefined &&
-          prev.attributes.get('mathvariant') !== 'italic') {
-        prev.texClass = TEXCLASS.OP;
-        prev.setProperty('fnOP', true);
-      }
-      this.texClass = this.prevClass = TEXCLASS.NONE;
-      return prev;
-    }
     return this.adjustTeXclass(prev);
   }
   /**


### PR DESCRIPTION
This PR removes a heuristic that was supposed to turn multi-letter function names into operators with `texClass` of `OP` rather than `ORD` when followed by U+2061, but it turns out to be too aggressive, and ends up causing spacing problems, especially after enrichment (which adds the U+2061).  There are other heuristics that produce the same result, so this one really isn't needed, and should be removed.

For example:  `\Big| \mathcal{P}_a(x) \Big|` will have too much space between the first `|` and the `P` when enriched (to have the U+2061).