### PR TITLE
Fix combining of mo elements so that properties don't become attributes

### DIFF
--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -110,7 +110,9 @@ namespace FilterUtil {
           // This treatment means we might loose some inheritance structure, but
           // no properties.
           _copyExplicit(['stretchy', 'rspace'], mo, m2);
-          NodeUtil.setProperties(mo, m2.getAllProperties());
+          for (const name of m2.getPropertyNames()) {
+            mo.setProperty(name, m2.getProperty(name));
+          }
           children.splice(next, 1);
           remove.push(m2);
           m2.parent = null;


### PR DESCRIPTION
This PR resolves an issue raised by Peter in #703 where a property of one of the nodes becomes an attribute.  It turns out this is due to the `setProperties()` call, which actually sets attributes by default (and properties under certain circumstances).  The function is unfortunately named, and perhaps should be adjusted.  The fix is just to copy the properties by hand.