### PR TITLE
Work around WebKit bug with CHTML characters.  (mathjax/MathJax#2435)

### DIFF
--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -58,6 +58,19 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
     'mjx-utext': {
       display: 'inline-block',
       padding: '.75em 0 .2em 0'
+    },
+    //
+    //  WebKit-specific CSS to handle bug with clipped characters.
+    //  (test found at https://browserstrangeness.bitbucket.io/css_hacks.html#safari)
+    //
+    '@supports (-webkit-marquee-repetition:infinite) and (object-fit:fill)': {
+      //
+      //  We don't really support nested CSS, so fake it byt putting the CSS
+      //    directly in the string, and commenting out the colon that is
+      //    inserted after the selector (that would normally be a CSS property name)
+      //    See issue #2435.
+      //
+      'mjx-c::before/*': '*/ {will-change: opacity}'
     }
   };
 

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -63,14 +63,8 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
     //  WebKit-specific CSS to handle bug with clipped characters.
     //  (test found at https://browserstrangeness.bitbucket.io/css_hacks.html#safari)
     //
-    '@supports (-webkit-marquee-repetition:infinite) and (object-fit:fill)': {
-      //
-      //  We don't really support nested CSS, so fake it byt putting the CSS
-      //    directly in the string, and commenting out the colon that is
-      //    inserted after the selector (that would normally be a CSS property name)
-      //    See issue #2435.
-      //
-      'mjx-c::before/*': '*/ {will-change: opacity}'
+    '_::-webkit-full-page-media, _:future, :root mjx-container': {
+      'will-change': 'opacity'
     }
   };
 


### PR DESCRIPTION
This PR applies a CSS fix to the clipped character bug in Safari with CHTML.  This is a long-standing bug, and it s great to have a fix for it.  This was suggested by @mt4c in mathjax/MathJax#2435.