### PR TITLE
Fix several issues with CHTML adaptive CSS.

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -230,8 +230,9 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
    * @param {CHTMLDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
   protected addDelimiterStyles(styles: StyleList, n: number, data: CHTMLDelimiterData) {
-    const c = this.charSelector(n);
+    let c = this.charSelector(n);
     if (data.c && data.c !== n) {
+      c = this.charSelector(data.c);
       styles['.mjx-stretched mjx-c' + c + '::before'] = {
         content: this.charContent(data.c)
       };

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -80,7 +80,7 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
                       this.jax.unknownText(String.fromCodePoint(n), variant) :
                       this.html('mjx-c', {class: this.char(n) + font}));
         adaptor.append(parent, node);
-        this.font.charUsage.add([variant, n]);
+        !data.unknown && this.font.charUsage.add([variant, n]);
       }
     }
   }

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -158,6 +158,7 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
   protected stretchHTML(chtml: N) {
     const c = this.getText().codePointAt(0);
     this.font.delimUsage.add(c);
+    this.childNodes[0].markUsed();
     const delim = this.stretch;
     const stretch = delim.stretch;
     const content: N[] = [];


### PR DESCRIPTION
This PR fixes several issues with how the CHTML output handles character usage information and the adaptive CSS for the ones used.

* The recent changes to how the usage data is recorded caused an error if a character that isn't in the MathJax fonts was used.  This PR prevents known characters from being recorded, and so prevents the later error when trying to set up the CSS for those characters (for which we don't have data).

    You can test this by typesetting `\unicode{x3333}`.  Without this PR, MathJax will produce an error and crash.  With the PR, it should generate the usual output.

* For stretchy characters that are aliased to other characters (e.g., U+2015 is aliased to U+2013 when stretched), the CSS wasn't properly tied to the correct character, and so the stretchy character didn't appear.  For example, `\overline{A}` ewoks not show the overlain.

* The CSS for the TextNode object wasn't being included if a stretchy character was used, but no unstretched characters were included.  For example `\left(\Rule{1em}{5em}{4em}\right)`.  This CSS is required to get the extenders to work properly, so this PR forces the TextNode wrapper to be marked as used when a stretchy character is produced by an `mo`.