### PR TITLE
Updates to latest version of SRE.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "esm": "^3.2.25",
         "mhchemparser": "^4.1.0",
         "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^3.2.0"
+        "speech-rule-engine": "^3.3.3"
       },
       "devDependencies": {
         "@babel/core": "^7.13.16",
@@ -3627,9 +3627,9 @@
       }
     },
     "node_modules/speech-rule-engine": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.2.0.tgz",
-      "integrity": "sha512-Vg1pNhl3cdVPk5XWn8su+bUNs+jaY1UmvKLeLui+iJ5/a0Kr7cOfO2gGuYOMd/3+0wLvzEqmou8rtz5REBd9xQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.3.3.tgz",
+      "integrity": "sha512-0exWw+0XauLjat+f/aFeo5T8SiDsO1JtwpY3qgJE4cWt+yL/Stl0WP4VNDWdh7lzGkubUD9lWP4J1ASnORXfyQ==",
       "dependencies": {
         "commander": ">=7.0.0",
         "wicked-good-xpath": "^1.3.0",
@@ -7449,9 +7449,9 @@
       }
     },
     "speech-rule-engine": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.2.0.tgz",
-      "integrity": "sha512-Vg1pNhl3cdVPk5XWn8su+bUNs+jaY1UmvKLeLui+iJ5/a0Kr7cOfO2gGuYOMd/3+0wLvzEqmou8rtz5REBd9xQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.3.3.tgz",
+      "integrity": "sha512-0exWw+0XauLjat+f/aFeo5T8SiDsO1JtwpY3qgJE4cWt+yL/Stl0WP4VNDWdh7lzGkubUD9lWP4J1ASnORXfyQ==",
       "requires": {
         "commander": ">=7.0.0",
         "wicked-good-xpath": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "esm": "^3.2.25",
     "mhchemparser": "^4.1.0",
     "mj-context-menu": "^0.6.1",
-    "speech-rule-engine": "^3.2.0"
+    "speech-rule-engine": "^3.3.3"
   }
 }

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -628,6 +628,7 @@ const iso: {[locale: string]: string} = {
   'en': 'English',
   'es': 'Spanish',
   'fr': 'French',
+  'hi': 'Hindi',
   'it': 'Italian'
 };
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -252,10 +252,12 @@ export class SpeechExplorer extends AbstractKeyExplorer<string> {
    */
   public Update(force: boolean = false) {
     super.Update(force);
+    let options = this.speechGenerator.getOptions();
+    SRE.setupEngine({modality: options.modality,
+                     locale: options.locale});
     this.region.Update(this.walker.speech());
     // This is a necessary in case speech options have changed via keypress
     // during walking.
-    let options = this.speechGenerator.getOptions();
     if (options.modality === 'speech') {
       this.document.options.sre.domain = options.domain;
       this.document.options.sre.style = options.style;


### PR DESCRIPTION
Upgrades SRE by
* Including `v3.3.3` (see issue [528](https://github.com/zorkow/speech-rule-engine/issues/528) for version jump!) in `package.json` and `package-lock.json` files.
* Integrates Hindi into the context menu.
* Fixes a minor issue in the explorer, where Braille could bleed into the speech after a locale change.