### PR TITLE
Use 'overflow: clip visible' for stretchy characters to avoid unwanted clipping. (mathjax/MathJax#2701)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -69,7 +69,7 @@ export interface MinHTMLElement<N, T> {
   className: string;
   classList: DOMTokenList;
   style: OptionList;
-  sheet?: {insertRule: (rule: string) => void};
+  sheet?: {insertRule: (rule: string, index?: number) => void};
 
   childNodes: (N | T)[] | NodeList;
   firstChild: N | T | Node;
@@ -518,7 +518,11 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    */
   public insertRules(node: N, rules: string[]) {
     for (const rule of rules.reverse()) {
-      node.sheet.insertRule(rule);
+      try {
+        node.sheet.insertRule(rule, 0);
+      } catch (e) {
+        console.warn(`MathJax: can't insert css rule '${rule}': ${e.message}`);
+      }
     }
   }
 

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -517,13 +517,12 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public insertRules(node: N, rules: string[]) {
-    let rule;
-    try {
-      for (rule of rules.reverse()) {
+    for (const rule of rules.reverse()) {
+      try {
         node.sheet.insertRule(rule, 0);
+      } catch (e) {
+        console.warn(`MathJax: can't insert css rule '${rule}': ${e.message}`);
       }
-    } catch (e) {
-      console.warn(`MathJax: can't insert css rule '${rule}': ${e.message}`);
     }
   }
 

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -517,12 +517,13 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public insertRules(node: N, rules: string[]) {
-    for (const rule of rules.reverse()) {
-      try {
+    let rule;
+    try {
+      for (rule of rules.reverse()) {
         node.sheet.insertRule(rule, 0);
-      } catch (e) {
-        console.warn(`MathJax: can't insert css rule '${rule}': ${e.message}`);
       }
+    } catch (e) {
+      console.warn(`MathJax: can't insert css rule '${rule}': ${e.message}`);
     }
   }
 

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -65,7 +65,8 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       width: 'initial'
     },
     'mjx-stretchy-h > mjx-ext': {
-      overflow: 'hidden',
+      '/* IE */ overflow': 'hidden',
+      '/* others */ overflow': 'clip visible',
       width: '100%'
     },
     'mjx-stretchy-h > mjx-ext > mjx-c::before': {
@@ -103,7 +104,8 @@ CommonMoMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       height: '100%',
       'box-sizing': 'border-box',
       border: '0px solid transparent',
-      overflow: 'hidden'
+      '/* IE */ overflow': 'hidden',
+      '/* others */ overflow': 'visible clip',
     },
     'mjx-stretchy-v > mjx-ext > mjx-c::before': {
       width: 'initial',


### PR DESCRIPTION
This PR changes the overflow property used for the extenders in stretchy characters so that they clip only in the direction of the stretching.  This avoid accidentally clipping thin horizontal and vertical lines, for example.

It also adds the index to the `insertRule()` call in the HTMLadaptor so that it works in IE (which seems to require it), and wraps the call in `try/catch` so that rules that are only valid in modern browsers won't cause problems in IE (or other older browsers).

Resolves issue mathjax/MathJax#2701.