### PR TITLE
Fix setting of movablelimits to false for \overset and similar macros.  (mathjax/MathJax#2709)

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -374,11 +374,7 @@ namespace ParseUtil {
    */
   export function underOver(parser: TexParser, base: MmlNode, script: MmlNode, pos: string, stack: boolean): MmlNode {
     // @test Overline
-    const symbol = NodeUtil.getForm(base);
-    if ((symbol && symbol[3] && symbol[3]['movablelimits']) || NodeUtil.getProperty(base, 'movablelimits')) {
-      // @test Overline Sum
-      NodeUtil.setProperties(base, {'movablelimits': false});
-    }
+    ParseUtil.checkMovableLimits(base);
     if (NodeUtil.isType(base, 'munderover') && NodeUtil.isEmbellished(base)) {
       // @test Overline Limits
       NodeUtil.setProperties(NodeUtil.getCoreMO(base), {lspace: 0, rspace: 0});
@@ -395,6 +391,18 @@ namespace ParseUtil {
     }
     NodeUtil.setProperty(node, 'subsupOK', true);
     return node;
+  }
+
+  /**
+   * Set movablelimits to false if necessary.
+   * @param {MmlNode} base   The base node being tested.
+   */
+  export function checkMovableLimits(base: MmlNode) {
+    const symbol = (NodeUtil.isType(base, 'mo') ? NodeUtil.getForm(base) : null);
+    if (NodeUtil.getProperty(base, 'movablelimits') || (symbol && symbol[3] && symbol[3].movablelimits)) {
+      // @test Overline Sum
+      NodeUtil.setProperties(base, {movablelimits: false});
+    }
   }
 
   /**

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -625,9 +625,7 @@ BaseMethods.Overset = function(parser: TexParser, name: string) {
   // @test Overset
   const top = parser.ParseArg(name);
   const base = parser.ParseArg(name);
-  if (NodeUtil.getAttribute(base, 'movablelimits') || NodeUtil.getProperty(base, 'movablelimits')) {
-    NodeUtil.setProperties(base, {'movablelimits': false});
-  }
+  ParseUtil.checkMovableLimits(base);
   const node = parser.create('node', 'mover', [base, top]);
   parser.Push(node);
 };
@@ -642,10 +640,7 @@ BaseMethods.Underset = function(parser: TexParser, name: string) {
   // @test Underset
   const bot = parser.ParseArg(name);
   const base = parser.ParseArg(name);
-  if (NodeUtil.isType(base, 'mo') || NodeUtil.getProperty(base, 'movablelimits')) {
-    // @test Overline Sum
-    NodeUtil.setProperties(base, {'movablelimits': false});
-  }
+  ParseUtil.checkMovableLimits(base);
   const node = parser.create('node', 'munder', [base, bot]);
   parser.Push(node);
 };
@@ -660,9 +655,7 @@ BaseMethods.Overunderset = function(parser: TexParser, name: string) {
   const top = parser.ParseArg(name);
   const bot = parser.ParseArg(name);
   const base = parser.ParseArg(name);
-  if (NodeUtil.isType(base, 'mo') || NodeUtil.getProperty(base, 'movablelimits')) {
-    NodeUtil.setProperties(base, {'movablelimits': false});
-  }
+  ParseUtil.checkMovableLimits(base);
   const node = parser.create('node', 'munderover', [base, bot, top]);
   parser.Push(node);
 };


### PR DESCRIPTION
This PR adds a `ParseUtil` method for determining if a base needs to have `movablelimits` set to false, and then uses it in `\oerset`, `\underset`, `\overundetset`, and `ParseUtil.underOver()` (used by `\overbrace` and similar macros).  This makes sure all these situations work the same (currently there are three different criteria being used).

Resolves issue mathjax/MathJax#2709.