### PR TITLE
Refactor some FontData properties, and allow specifying a FontData class rather than instance

### DIFF
--- a/components/src/output/chtml/fonts/tex/tex.js
+++ b/components/src/output/chtml/fonts/tex/tex.js
@@ -2,13 +2,10 @@ import './lib/tex.js';
 
 import {combineDefaults} from '../../../../../../js/components/global.js';
 import {Package} from '../../../../../../js/components/package.js';
-import {selectOptionsFromKeys} from '../../../../../../js/util/Options.js';
 import {TeXFont} from '../../../../../../js/output/chtml/fonts/tex.js';
 
-if (MathJax.startup) {
+MathJax.startup &&
   combineDefaults(MathJax.config, 'chtml', {
-    fontURL: Package.resolvePath('output/chtml/fonts/woff-v2', false)
+    fontURL: Package.resolvePath('output/chtml/fonts/woff-v2', false),
+    font: TeXFont
   });
-  const options = selectOptionsFromKeys(MathJax.config.chtml || {}, TeXFont.OPTIONS);
-  combineDefaults(MathJax.config, 'chtml', {font: new TeXFont(options)});
-}

--- a/components/src/output/svg/fonts/tex/tex.js
+++ b/components/src/output/svg/fonts/tex/tex.js
@@ -2,9 +2,5 @@ import './lib/tex.js';
 
 import {TeXFont} from '../../../../../../js/output/svg/fonts/tex.js';
 import {combineDefaults} from '../../../../../../js/components/global.js';
-import {selectOptionsFromKeys} from '../../../../../../js/util/Options.js';
 
-if (MathJax.startup) {
-  const options = selectOptionsFromKeys(MathJax.config.svg || {}, TeXFont.OPTIONS);
-  combineDefaults(MathJax.config, 'svg', {font: new TeXFont(options)});
-}
+MathJax.startup && combineDefaults(MathJax.config, 'svg', {font: TeXFont});

--- a/ts/output/chtml/fonts/tex.ts
+++ b/ts/output/chtml/fonts/tex.ts
@@ -368,4 +368,11 @@ CommonTeXFontMixin<ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData, Chtml
     },
   };
 
+  /**
+   * @override
+   */
+  protected getDelimiterData(n: number) {
+    return this.getChar('-smallop', n) || this.getChar('-size4', n);
+  }
+
 }

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -221,14 +221,17 @@ export abstract class CommonOutputJax<
   constructor(options: OptionList = null,
               defaultFactory: typeof CommonWrapperFactory = null,
               defaultFont: FC = null) {
-    const [jaxOptions, fontOptions] = separateOptions(options, defaultFont.OPTIONS);
+    const [fontClass, font] = (options.font instanceof FontData ?
+                               [options.font.constructor as typeof FontData, options.font] :
+                               [options.font || defaultFont, null]);
+    const [jaxOptions, fontOptions] = separateOptions(options, fontClass.OPTIONS);
     super(jaxOptions);
     this.factory = this.options.wrapperFactory ||
       new defaultFactory<N, T, D, CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
                          WW, WF, WC, CC, VV, DD, FD, FC>();
     this.factory.jax = this;
     this.cssStyles = this.options.cssStyles || new CssStyles();
-    this.font = this.options.font || new defaultFont(fontOptions);
+    this.font = font || new fontClass(fontOptions);
     this.unknownCache = new Map();
     const linebreaks = (this.options.linebreaks.LinebreakVisitor || LinebreakVisitor) as typeof Linebreaks;
     this.linebreaks = new linebreaks(this.factory);

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -409,7 +409,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   /**
    *  The default remappings
    */
-  protected static defaultAccentMap: RemapMap = {
+  public static defaultAccentMap: RemapMap = {
+    0x005E: '\u02C6',  // hat
+    0x007E: '\u02DC',  // tilde
     0x0300: '\u02CB',  // grave accent
     0x0301: '\u02CA',  // acute accent
     0x0302: '\u02C6',  // curcumflex

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -51,7 +51,7 @@ export type CharData<C extends CharOptions> =
   [number, number, number, C];
 
 /**
- * An object making character positions to character data
+ * An object mapping character positions to character data
  *
  * @template C  The CharOptions type
  */
@@ -60,7 +60,7 @@ export type CharMap<C extends CharOptions> = {
 };
 
 /**
- * An object making variants to character maps
+ * An object mapping variants to character maps
  *
  * @template C  The CharOptions type
  */
@@ -88,7 +88,7 @@ export interface VariantData<C extends CharOptions> {
 }
 
 /**
- * An object making variants names to variant data
+ * An object mapping variants names to variant data
  *
  * @template C  The CharOptions type
  * @template V  The VariantData type
@@ -257,6 +257,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    *  The standard variants to define
    */
   public static defaultVariants = [
+    //
+    //  The MathML variants
+    //
     ['normal'],
     ['bold', 'normal'],
     ['italic', 'normal'],
@@ -270,7 +273,19 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     ['bold-sans-serif', 'bold', 'sans-serif'],
     ['sans-serif-italic', 'italic', 'sans-serif'],
     ['sans-serif-bold-italic', 'bold-italic', 'bold-sans-serif'],
-    ['monospace', 'normal']
+    ['monospace', 'normal'],
+
+    //
+    //  Internal variants needed for TeX input and all output jax
+    //
+    ['-smallop', 'normal'],
+    ['-largeop', 'normal'],
+    ['-tex-calligraphic', 'italic'],
+    ['-tex-bold-calligraphic', 'bold-italic'],
+    ['-tex-oldstyle', 'normal'],
+    ['-tex-bold-oldstyle', 'bold'],
+    ['-tex-mathit', 'italic'],
+    ['-tex-variant', 'normal']
   ];
 
   /**
@@ -291,7 +306,16 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     'bold-sans-serif': ['sans-serif', false, true],
     'sans-serif-italic': ['sans-serif', true, false],
     'sans-serif-bold-italic': ['sans-serif', true, true],
-    monospace: ['monospace', false, false]
+    monospace: ['monospace', false, false],
+
+    '-smallop': ['unknown', false, false],
+    '-largeop': ['unknown', false, false],
+    '-tex-calligraphic': ['cursive', true, false],
+    '-tex-bold-calligraphic': ['cursive', true, true],
+    '-tex-oldstyle': ['unknown', false, false],
+    '-tex-bold-oldstyle': ['unknown', false, true],
+    '-tex-mathit': ['unknown', true, false],
+    '-tex-variant': ['unknown', false, false]
   };
 
   /**

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -420,25 +420,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     0x0308: '\u00A8',  // diaresis
     0x030A: '\u02DA',  // ring above
     0x030C: '\u02C7',  // caron
-    0x2192: '\u20D7',
-    0x2032: '\'',
-    0x2033: '\'\'',
-    0x2034: '\'\'\'',
-    0x2035: '`',
-    0x2036: '``',
-    0x2037: '```',
-    0x2057: '\'\'\'\'',
-    0x20D0: '\u21BC', // combining left harpoon
-    0x20D1: '\u21C0', // combining right harpoon
-    0x20D6: '\u2190', // combining left arrow
-    0x20E1: '\u2194', // combining left-right arrow
-    0x20F0: '*',      // combining asterisk
-    0x20DB: '...',    // combining three dots above
-    0x20DC: '....',   // combining four dots above
-    0x20EC: '\u21C1', // combining low left harpoon
-    0x20ED: '\u21BD', // combining low right harpoon
-    0x20EE: '\u2190', // combining low left arrows
-    0x20EF: '\u2192'  // combining low right arrows
+    0x2192: '\u20D7'
   };
 
   /**
@@ -855,6 +837,7 @@ export interface FontDataClass<C extends CharOptions, V extends VariantData<C>, 
   defaultCssFonts: CssFontMap;
   defaultVariants: string[][];
   defaultParams: FontParameters;
+  defaultAccentMap: RemapMap;
   /* tslint:disable-next-line:jsdoc-require */
   charOptions(font: CharMap<C>, n: number): C;
   new(...args: any[]): FontData<C, V, D>;

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -364,8 +364,9 @@ export function CommonMoMixin<
               }
               this.variant = this.font.getSizeVariant(c, i);
               this.size = i;
-              if (delim.schar && delim.schar[i]) {
-                this.stretch = {...this.stretch, c: delim.schar[i]};
+              const schar = (delim.schar ? delim.schar[Math.min(i, delim.schar.length - 1)] : 0);
+              if (schar) {
+                this.stretch = {...this.stretch, c: schar};
               }
               return;
             }

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -362,12 +362,7 @@ export function CommonMoMixin<
               if (mathaccent && i) {
                 i--;
               }
-              this.variant = this.font.getSizeVariant(c, i);
-              this.size = i;
-              const schar = (delim.schar ? delim.schar[Math.min(i, delim.schar.length - 1)] : 0);
-              if (schar) {
-                this.stretch = {...this.stretch, c: schar};
-              }
+              this.setDelimSize(c, i);
               return;
             }
             i++;
@@ -382,10 +377,21 @@ export function CommonMoMixin<
           this.invalidateBBox();
           this.getStretchBBox(WH, this.checkExtendedHeight(D, delim), delim);
         } else {
-          this.variant = this.font.getSizeVariant(c, i - 1);
-          this.size = i - 1;
+          this.setDelimSize(c, i - 1);
         }
       }
+    }
+
+    /**
+     * @param {number} c     The character neing set
+     * @param {number} i     The size for that character
+     */
+    protected setDelimSize(c: number, i: number) {
+      const delim = this.stretch;
+      this.variant = this.font.getSizeVariant(c, i);
+      this.size = i;
+      const schar = (delim.schar ? delim.schar[Math.min(i, delim.schar.length - 1)] || c : c);
+      this.stretch = {...delim, c: schar};
     }
 
     /**

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -383,7 +383,7 @@ export function CommonMoMixin<
     }
 
     /**
-     * @param {number} c     The character neing set
+     * @param {number} c     The character being set
      * @param {number} i     The size for that character
      */
     protected setDelimSize(c: number, i: number) {

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -50,16 +50,8 @@ export function CommonTeXFontMixin<
      */
     protected static defaultVariants = [
       ...Base.defaultVariants,
-      ['-smallop', 'normal'],
-      ['-largeop', 'normal'],
       ['-size3', 'normal'],
-      ['-size4', 'normal'],
-      ['-tex-calligraphic', 'italic'],
-      ['-tex-bold-calligraphic', 'bold-italic'],
-      ['-tex-oldstyle', 'normal'],
-      ['-tex-bold-oldstyle', 'bold'],
-      ['-tex-mathit', 'italic'],
-      ['-tex-variant', 'normal']
+      ['-size4', 'normal']
     ];
 
     /**
@@ -67,15 +59,8 @@ export function CommonTeXFontMixin<
      */
     protected static defaultCssFonts: CssFontMap = {
       ...Base.defaultCssFonts,
-      '-smallop': ['serif', false, false],
-      '-largeop': ['serif', false, false],
       '-size3': ['serif', false, false],
-      '-size4': ['serif', false, false],
-      '-tex-calligraphic': ['cursive', true, false],
-      '-tex-bold-calligraphic': ['cursive', true, true],
-      '-tex-oldstyle': ['serif', false, false],
-      '-tex-bold-oldstyle': ['serif', false, true],
-      '-tex-mathit': ['serif', true, false]
+      '-size4': ['serif', false, false]
     };
 
     /**
@@ -87,13 +72,6 @@ export function CommonTeXFontMixin<
      *  The default variants for the standard stretchy assmebly parts
      */
     protected static defaultStretchVariants = ['-size4'];
-
-    /**
-     * @override
-     */
-    protected getDelimiterData(n: number) {
-      return this.getChar('-smallop', n) || this.getChar('-size4', n);
-    }
 
   };
 

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {FontDataClass, CharOptions, VariantData, DelimiterData, CssFontMap} from '../FontData.js';
+import {FontDataClass, CharOptions, VariantData, DelimiterData, CssFontMap, RemapMap} from '../FontData.js';
 
 /*****************************************************************/
 /**
@@ -73,7 +73,30 @@ export function CommonTeXFontMixin<
      */
     protected static defaultStretchVariants = ['-size4'];
 
+    /**
+     *  The default remappings
+     */
+    protected static defaultAccentMap: RemapMap = {
+      ...Base.defaultAccentMap,
+      0x2032: '\'',
+      0x2033: '\'\'',
+      0x2034: '\'\'\'',
+      0x2035: '`',
+      0x2036: '``',
+      0x2037: '```',
+      0x2057: '\'\'\'\'',
+      0x20D0: '\u21BC', // combining left harpoon
+      0x20D1: '\u21C0', // combining right harpoon
+      0x20D6: '\u2190', // combining left arrow
+      0x20E1: '\u2194', // combining left-right arrow
+      0x20F0: '*',      // combining asterisk
+      0x20DB: '...',    // combining three dots above
+      0x20DC: '....',   // combining four dots above
+      0x20EC: '\u21C1', // combining low left harpoon
+      0x20ED: '\u21BD', // combining low right harpoon
+      0x20EE: '\u2190', // combining low left arrows
+      0x20EF: '\u2192'  // combining low right arrows
+    };
   };
 
 }
-


### PR DESCRIPTION
This PR reorganizes some properties from the `FontData` object and its subclasses so that TeX-specific information is in the TeX font subclass, and the common data is in `FontData`.  This includes:

* Moving `getDelimiterData()` to the CHTML TeX font subclass.
* Moving the `-tex-*` variants that are used by the TeX input jax into the common `FontData` so that they don't have to be repeated in every subclass.
* Moving the MathJax-TeX-font specific remappings into the TeX font subclass (they aren't the same for STIX and other fonts).

In addition, the `font` option for the output jax is extended to allow the specification of a FontData class rather than just an instance.  That simplifies the components that set up the fonts for CHTML and SVG, which used to have to create a font instance but now can just pass the font class.

Finally, the `schar` property in the delimiter data can now repeat its final value automatically (reducing the length of the array when a value is repeated multiple times, as is the case in a number of delimiters).