### PR TITLE
Make CHTML use actual characters rather than CSS content specifications

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -262,7 +262,7 @@ CommonOutputJax<
   /**
    * @override
    */
-  public unknownText(text: string, variant: string, width: number = null) {
+  public unknownText(text: string, variant: string, width: number = null, rscale: number = 1) {
     const styles: StyleList = {};
     const scale = 100 / this.math.metrics.scale;
     if (scale !== 100) {
@@ -282,7 +282,7 @@ CommonOutputJax<
     //
     if (width !== null) {
       const metrics = this.math.metrics;
-      styles.width = Math.round(width * metrics.em * metrics.scale) + 'px';
+      styles.width = Math.round(width * metrics.em * metrics.scale * rscale) + 'px';
     }
     //
     return this.html('mjx-utext', {variant: variant, style: styles}, [this.text(text)]);

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -263,15 +263,12 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    * @param {ChtmlDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
   protected addDelimiterStyles(styles: StyleList, n: number, data: ChtmlDelimiterData) {
-    let c = this.charSelector(n);
-    if (data.c && data.c !== n) {
-      c = this.charSelector(data.c);
-    }
     if (!data.stretch) return;
+    const c = (data.c && data.c !== n ? this.charSelector(data.c) : this.charSelector(n));
     if (data.dir === DIRECTION.Vertical) {
-      this.addDelimiterVStyles(styles, c, data);
+      this.addDelimiterVStyles(styles, n, c, data);
     } else {
-      this.addDelimiterHStyles(styles, c, data);
+      this.addDelimiterHStyles(styles, n, c, data);
     }
   }
 
@@ -279,10 +276,11 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
 
   /**
    * @param {StyleList} styles         The style object to add styles to
+   * @param {number} n                 The delimiter unicode number
    * @param {string} c                 The delimiter character string
    * @param {ChtmlDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
-  protected addDelimiterVStyles(styles: StyleList, c: string, data: ChtmlDelimiterData) {
+  protected addDelimiterVStyles(styles: StyleList, _n: number, c: string, data: ChtmlDelimiterData) {
     const HDW = data.HDW as ChtmlCharData;
     const [beg, ext, end, mid] = data.stretch;
     const Hb = this.addDelimiterVPart(styles, c, 'beg', beg, HDW);
@@ -338,17 +336,19 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
 
   /**
    * @param {StyleList} styles         The style object to add styles to
+   * @param {number} n                 The delimiter unicode number
    * @param {string} c                 The delimiter character string
    * @param {ChtmlDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
-  protected addDelimiterHStyles(styles: StyleList, c: string, data: ChtmlDelimiterData) {
+  protected addDelimiterHStyles(styles: StyleList, n: number, c: string, data: ChtmlDelimiterData) {
     const [beg, ext, end, mid] = data.stretch;
+    const [begV, extV, endV, midV] = this.getStretchVariants(n);
     const HDW = data.HDW as ChtmlCharData;
-    this.addDelimiterHPart(styles, c, 'beg', beg, HDW);
-    this.addDelimiterHPart(styles, c, 'ext', ext, HDW);
-    this.addDelimiterHPart(styles, c, 'end', end, HDW);
+    this.addDelimiterHPart(styles, c, 'beg', beg, begV, HDW);
+    this.addDelimiterHPart(styles, c, 'ext', ext, extV, HDW);
+    this.addDelimiterHPart(styles, c, 'end', end, endV, HDW);
     if (mid) {
-      this.addDelimiterHPart(styles, c, 'mid', mid, HDW);
+      this.addDelimiterHPart(styles, c, 'mid', mid, midV, HDW);
       styles['mjx-stretchy-h' + c + ' > mjx-ext'] = {width: '50%'};
     }
   }
@@ -358,11 +358,13 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    * @param {string} c          The vertical character whose part is being added
    * @param {string} part       The name of the part (beg, ext, end, mid) that is being added
    * @param {number} n          The unicode character to use for the part
+   * @param {string} v          The variant for the character
    * @param {ChtmlCharData} HDW The height-depth-width data for the stretchy character
    */
-  protected addDelimiterHPart(styles: StyleList, c: string, part: string, n: number, HDW: ChtmlCharData) {
+  protected addDelimiterHPart(styles: StyleList, c: string, part: string, n: number, v: string, HDW: ChtmlCharData) {
     if (!n) return;
-    const css: StyleData = {padding: this.padding(HDW, 0, -HDW[2])};
+    const w = this.getChar(v, n)[2];
+    const css: StyleData = {padding: this.padding(HDW as ChtmlCharData, 0, w - HDW[2])};
     styles['mjx-stretchy-h' + c + ' mjx-' + part + ' mjx-c'] = css;
   }
 

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -453,7 +453,8 @@ export function AddCSS(font: ChtmlCharMap, options: CharOptionsMap): ChtmlCharMa
     const n = parseInt(c);
     const data = options[n];
     if (data.c) {
-      data.c = data.c.replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
+      data.c = data.c.replace(/\\[0-9A-F]+/ig,
+                              (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
     }
     Object.assign(FontData.charOptions(font, n), data);
   }

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -115,7 +115,8 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
       const text = (this.node as TextNode).getText();
       if (text.length === 0) return;
       if (variant === '-explicitFont') {
-        adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w));
+      const rscale = this.parent.getBBox().rscale;
+        adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, rscale));
       } else {
         let utext = '';
         const chars = this.remappedText(text, variant);

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -24,7 +24,7 @@
 import {CHTML} from '../../chtml.js';
 import {ChtmlWrapper, ChtmlWrapperClass} from '../Wrapper.js';
 import {ChtmlWrapperFactory} from '../WrapperFactory.js';
-import {ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData,
+import {ChtmlCharOptions, ChtmlCharData, ChtmlVariantData, ChtmlDelimiterData,
         ChtmlFontData, ChtmlFontDataClass} from '../FontData.js';
 import {CommonTextNode, CommonTextNodeClass, CommonTextNodeMixin} from '../../common/Wrappers/TextNode.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
@@ -95,7 +95,8 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
      */
     public static styles: StyleList = {
       'mjx-c': {
-        display: 'inline-block'
+        display: 'inline-block',
+        width: 0
       },
       'mjx-utext': {
         display: 'inline-block',
@@ -117,11 +118,11 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
       } else {
         const chars = this.remappedText(text, variant);
         for (const n of chars) {
-          const data = this.getVariantChar(variant, n)[3];
+          const data = (this.getVariantChar(variant, n) as ChtmlCharData)[3];
           const font = (data.f ? ' TEX-' + data.f : '');
           const node = (data.unknown ?
                         this.jax.unknownText(String.fromCodePoint(n), variant) :
-                        this.html('mjx-c', {class: this.char(n) + font}));
+                        this.html('mjx-c', {class: this.char(n) + font}, [this.text(data.c || String.fromCodePoint(n))]));
           adaptor.append(parents[0], node);
           !data.unknown && this.font.charUsage.add([variant, n]);
         }

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -115,8 +115,8 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
       const text = (this.node as TextNode).getText();
       if (text.length === 0) return;
       if (variant === '-explicitFont') {
-      const rscale = this.parent.getBBox().rscale;
-        adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, rscale));
+        const {scale} = this.parent.getBBox();
+        adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, scale));
       } else {
         let utext = '';
         const chars = this.remappedText(text, variant);

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -105,7 +105,8 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       'mjx-stretchy-h > mjx-ext': {
         '/* IE */ overflow': 'hidden',
         '/* others */ overflow': 'clip visible',
-        width: '100%'
+        width: '100%',
+        'text-align': 'center'
       },
       'mjx-stretchy-h > mjx-ext > mjx-c': {
         transform: 'scalex(500)',
@@ -195,7 +196,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
     /**
      * Create the HTML for a multi-character stretchy delimiter
      *
-     * @param {N[]} chtml  The parent elements in which to put the delimiter
+     * @param {N} chtml  The parent element in which to put the delimiter
      */
     protected stretchHTML(chtml: N[]) {
       const c = this.getText().codePointAt(0);
@@ -203,20 +204,18 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       this.childNodes[0].markUsed();
       const delim = this.stretch;
       const stretch = delim.stretch;
+      const stretchv = this.font.getStretchVariants(c);
       const content: N[] = [];
       //
       //  Set up the beginning, extension, and end pieces
       //
-      this.createPart('mjx-beg', stretch[0], content);
-      this.createPart('mjx-ext', stretch[1], content);
+      this.createPart('mjx-beg', stretch[0], stretchv[0], content);
+      this.createPart('mjx-ext', stretch[1], stretchv[1], content);
       if (stretch.length === 4) {
-        //
-        //  Set up the beginning, extension, and end pieces
-        //
-        this.createPart('mjx-mid', stretch[3], content);
-        this.createPart('mjx-ext', stretch[1], content);
+        this.createPart('mjx-mid', stretch[3], stretchv[3], content);
+        this.createPart('mjx-ext', stretch[1], stretchv[1], content);
       }
-      this.createPart('mjx-end', stretch[2], content);
+      this.createPart('mjx-end', stretch[2], stretchv[2], content);
       //
       //  Set the styles needed
       //
@@ -249,17 +248,14 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
      *
      * @param {string} part    The part to create
      * @param {number} n       The unicode character to use
+     * @param {string} v       The variant for the character
      * @param {N[]} content    The DOM assembly
      */
-    protected createPart(part: string, n: number, content: N[]) {
+    protected createPart(part: string, n: number, v: string, content: N[]) {
       if (n) {
-        content.push(
-          this.html(part, {}, [
-            this.html('mjx-c', {}, [
-              this.text(String.fromCodePoint(n))
-            ])
-          ])
-        );
+        let c = (this.font.getChar(v, n)[3].c as string || String.fromCodePoint(n))
+          .replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
+        content.push(this.html(part, {}, [this.html('mjx-c', {}, [this.text(c)])]));
       }
     }
 

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -102,19 +102,13 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
         display: 'inline-block',
         transform: 'scalex(1.0000001)'      // improves blink positioning
       },
-      'mjx-stretchy-h > * > mjx-c::before': {
-        display: 'inline-block',
-        width: 'initial'
-      },
       'mjx-stretchy-h > mjx-ext': {
         '/* IE */ overflow': 'hidden',
         '/* others */ overflow': 'clip visible',
         width: '100%'
       },
-      'mjx-stretchy-h > mjx-ext > mjx-c::before': {
-        transform: 'scalex(500)'
-      },
       'mjx-stretchy-h > mjx-ext > mjx-c': {
+        transform: 'scalex(500)',
         width: 0
       },
       'mjx-stretchy-h > mjx-beg > mjx-c': {
@@ -139,7 +133,6 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       'mjx-stretchy-v > * > mjx-c': {
         transform: 'scaley(1.0000001)',       // improves Firefox and blink positioning
         'transform-origin': 'left center',
-        overflow: 'hidden'
       },
       'mjx-stretchy-v > mjx-ext': {
         display: 'block',
@@ -149,17 +142,15 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
         '/* IE */ overflow': 'hidden',
         '/* others */ overflow': 'visible clip',
       },
-      'mjx-stretchy-v > mjx-ext > mjx-c::before': {
-        width: 'initial',
-        'box-sizing': 'border-box'
-      },
       'mjx-stretchy-v > mjx-ext > mjx-c': {
+        width: 'auto',
+        'box-sizing': 'border-box',
         transform: 'scaleY(500) translateY(.075em)',
         overflow: 'visible'
       },
       'mjx-mark': {
         display: 'inline-block',
-        height: '0px'
+        height: 0
       }
     };
 
@@ -216,22 +207,16 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       //
       //  Set up the beginning, extension, and end pieces
       //
-      if (stretch[0]) {
-        content.push(this.html('mjx-beg', {}, [this.html('mjx-c')]));
-      }
-      content.push(this.html('mjx-ext', {}, [this.html('mjx-c')]));
+      this.createPart('mjx-beg', stretch[0], content);
+      this.createPart('mjx-ext', stretch[1], content);
       if (stretch.length === 4) {
         //
-        //  Braces have a middle and second extensible piece
+        //  Set up the beginning, extension, and end pieces
         //
-        content.push(
-          this.html('mjx-mid', {}, [this.html('mjx-c')]),
-          this.html('mjx-ext', {}, [this.html('mjx-c')])
-        );
+        this.createPart('mjx-mid', stretch[3], content);
+        this.createPart('mjx-ext', stretch[1], content);
       }
-      if (stretch[2]) {
-        content.push(this.html('mjx-end', {}, [this.html('mjx-c')]));
-      }
+      this.createPart('mjx-end', stretch[2], content);
       //
       //  Set the styles needed
       //
@@ -257,6 +242,25 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       const adaptor = this.adaptor;
       chtml[0] && adaptor.append(chtml[0], html);
       chtml[1] && adaptor.append(chtml[1], chtml[0] ? adaptor.clone(html) : html);
+    }
+
+    /**
+     * Create an element of a multi-character assembly
+     *
+     * @param {string} part    The part to create
+     * @param {number} n       The unicode character to use
+     * @param {N[]} content    The DOM assembly
+     */
+    protected createPart(part: string, n: number, content: N[]) {
+      if (n) {
+        content.push(
+          this.html(part, {}, [
+            this.html('mjx-c', {}, [
+              this.text(String.fromCodePoint(n))
+            ])
+          ])
+        );
+      }
     }
 
   };

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -767,6 +767,14 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   }
 
   /**
+   * @param {number} n   The delimiter character number whose variants are needed
+   * @return {string[]}  The variants for the parts of the delimiter
+   */
+  public getStretchVariants(n: number): string[] {
+    return [0, 1, 2, 3].map(i => this.getStretchVariant(n, i));
+  }
+
+  /**
    * @param {string} name  The variant whose character data is being querried
    * @param {number} n     The unicode number for the character to be found
    * @return {CharData}    The data for the given character (or undefined)


### PR DESCRIPTION
This PR updates the CHTML output jax to use actual character data rather than CSS `content` rules to insert the characters used for display.  This allows the content of CHTML output to be selected and copied, as in v2 (note, however, that because the height/depth of the MathJax TeX fonts are near zero, the selection will not show very well -- this will be fixed as part of the update to the TeX fonts).  

This also changes the CHTML `TextNode` implementation to combine unknown characters into a single `utext` element rather than having a separate one for each character.  This allows combining characters to combine (e.g., multiple-character emoji or flags) when they are entered directly as text, even without `\text{}`).