### PR TITLE
Provide support for dynamically loading font data

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -56,6 +56,7 @@ export interface MathJaxConfig extends MJConfig {
     pageReady?: () => void;  // Function to perform when page is ready
     invalidOption?: 'fatal' | 'warn'; // Do invalid options produce a warning, or throw an error?
     optionError?: (message: string, key: string) => void,  // Function to report invalid options
+    loadAllFontFiles: false; // true means force all dynamic font files to load initially
     [name: string]: any;     // Other configuration blocks
   };
 }
@@ -67,7 +68,7 @@ export type MATHDOCUMENT = MathDocument<any, any, any>;
 export type HANDLER = Handler<any, any, any>;
 export type DOMADAPTOR = DOMAdaptor<any, any, any>;
 export type INPUTJAX = InputJax<any, any, any>;
-export type OUTPUTJAX = OutputJax<any, any, any>;
+export type OUTPUTJAX = OutputJax<any, any, any> & {font: any};
 export type COMMONJAX = CommonOutputJax<any, any, any, any, any, any, any, any, any, any, any>;
 export type TEX = TeX<any, any, any>;
 
@@ -297,7 +298,8 @@ export namespace Startup {
    * Setting Mathjax.startup.pageReady in the configuration will override this.
    */
   export function defaultPageReady() {
-    return (CONFIG.typeset && MathJax.typesetPromise ?
+    return (CONFIG.loadAllFontFiles && output.font ? output.font.loadDynamicFiles() : Promise.resolve())
+      .then(CONFIG.typeset && MathJax.typesetPromise ?
             MathJax.typesetPromise(CONFIG.elements) as Promise<void> :
             Promise.resolve());
   }

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -68,7 +68,7 @@ export type MATHDOCUMENT = MathDocument<any, any, any>;
 export type HANDLER = Handler<any, any, any>;
 export type DOMADAPTOR = DOMAdaptor<any, any, any>;
 export type INPUTJAX = InputJax<any, any, any>;
-export type OUTPUTJAX = OutputJax<any, any, any> & {font: any};
+export type OUTPUTJAX = OutputJax<any, any, any>;
 export type COMMONJAX = CommonOutputJax<any, any, any, any, any, any, any, any, any, any, any>;
 export type TEX = TeX<any, any, any>;
 
@@ -298,7 +298,8 @@ export namespace Startup {
    * Setting Mathjax.startup.pageReady in the configuration will override this.
    */
   export function defaultPageReady() {
-    return (CONFIG.loadAllFontFiles && output.font ? output.font.loadDynamicFiles() : Promise.resolve())
+    return (CONFIG.loadAllFontFiles && (output as COMMONJAX).font ?
+            (output as COMMONJAX).font.loadDynamicFiles() : Promise.resolve())
       .then(CONFIG.typeset && MathJax.typesetPromise ?
             MathJax.typesetPromise(CONFIG.elements) as Promise<void> :
             Promise.resolve());

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -209,7 +209,7 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    */
   public updateStyles(styles: StyleList): StyleList {
     for (const N of this.delimUsage.update()) {
-      this.addDelimiterStyles(styles, N, this.delimiters[N] as ChtmlDelimiterData);
+      this.addDelimiterStyles(styles, N, this.getDelimiter(N));
     }
     for (const [name, N] of this.charUsage.update()) {
       const variant = this.variant[name];

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -21,7 +21,8 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {CharMap, CharOptions, CharData, VariantData, DelimiterData, FontData, DIRECTION} from '../common/FontData.js';
+import {CharMap, CharOptions, CharDataArray, VariantData,
+        DelimiterData, FontData, DIRECTION} from '../common/FontData.js';
 import {Usage} from './Usage.js';
 import {StringMap} from './Wrapper.js';
 import {StyleList, StyleData} from '../../util/StyleList.js';
@@ -43,7 +44,7 @@ export interface ChtmlCharOptions extends CharOptions {
  * Shorthands for CHTML char maps and char data
  */
 export type ChtmlCharMap = CharMap<ChtmlCharOptions>;
-export type ChtmlCharData = CharData<ChtmlCharOptions>;
+export type ChtmlCharData = CharDataArray<ChtmlCharOptions>;
 
 /**
  * The extra data needed for a Variant in CHTML output
@@ -65,11 +66,13 @@ export interface ChtmlDelimiterData extends DelimiterData {
  * The CHTML FontData class
  */
 export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData> {
+
   /**
    * Default options
    */
   public static OPTIONS = {
     ...FontData.OPTIONS,
+    dynamicPrefix: './output/chtml/fonts',
     fontURL: 'js/output/chtml/fonts/tex-woff-v2'
   };
 
@@ -160,7 +163,9 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     super.defineChars(name, chars);
     const letter = this.variant[name].letter;
     for (const n of Object.keys(chars)) {
-      const options = ChtmlFontData.charOptions(chars, parseInt(n));
+      const i = parseInt(n);
+      if (!Array.isArray(chars[i])) continue;
+      const options = ChtmlFontData.charOptions(chars, i);
       if (options.f === undefined) {
         options.f = letter;
       }
@@ -235,7 +240,7 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
         const char = variant.chars[N] as ChtmlCharData;
         if ((char[3] || {}).smp) continue;
         if (char.length < 4) {
-          (char)[3] = {};
+          char[3] = {};
         }
         this.addCharStyles(styles, vletter, N, char);
       }

--- a/ts/output/chtml/fonts/tex.ts
+++ b/ts/output/chtml/fonts/tex.ts
@@ -57,8 +57,18 @@ import {delimiters} from '../../common/fonts/tex/delimiters.js';
 /**
  *  The TeXFont class
  */
-export class TeXFont extends
-CommonTeXFontMixin<ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData, ChtmlFontDataClass>(ChtmlFontData) {
+const Base = CommonTeXFontMixin
+  <ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData, ChtmlFontDataClass>(ChtmlFontData);
+
+export class TeXFont extends Base {
+
+  /**
+   * @override
+   */
+  public static OPTIONS = {
+    ...Base.OPTIONS,
+    dynamicPrefix: Base.OPTIONS.dynamicPrefix + '/tex/dynamic'
+  };
 
   /**
    * Fonts to prefix any explicit ones

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -889,7 +889,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     if (dynamic.failed) return;
     if (!dynamic.promise) {
       const file = (dynamic.file.match(/^(?:[\/\[]|[a-z]+:\/\/)/) ? dynamic.file :
-                    this.options.dynamicPrefix + '/' + dynamic.file);
+                    this.options.dynamicPrefix + '/' + dynamic.file.replace(/\.js$/, ''));
       dynamic.promise = asyncLoad(file).catch(err => {
         dynamic.failed = true;
         console.warn(err);

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -37,7 +37,7 @@ import {CommonMrow} from './Wrappers/mrow.js';
 import {BBox} from '../../util/BBox.js';
 import {LineBBox} from './LineBBox.js';
 import {FontData, FontDataClass, DelimiterData,
-        VariantData, CharData, CharOptions, DIRECTION, NOSTRETCH} from './FontData.js';
+        VariantData, CharOptions, CharDataArray, DIRECTION, NOSTRETCH} from './FontData.js';
 
 /*****************************************************************/
 
@@ -1152,7 +1152,7 @@ export class CommonWrapper<
       //    the Math Alphabet mapping for this character.
       //  Otherwise use the original code point, n.
       //
-      chars = chars.map((n) => ((map[n] || [])[3] || {}).smp || n);
+      chars = chars.map((n) => (map[n] as CharDataArray<CC>)?.[3]?.smp || n);
     }
     return chars;
   }
@@ -1206,7 +1206,7 @@ export class CommonWrapper<
    * @param {number} n         The number of the character to look up
    * @return {CharData}        The full CharData object, with CharOptions guaranteed to be defined
    */
-  protected getVariantChar(variant: string, n: number): CharData<CC> {
+  protected getVariantChar(variant: string, n: number): CharDataArray<CC> {
     const char = this.font.getChar(variant, n) || [0, 0, 0, {unknown: true} as CC];
     if (char.length === 3) {
       (char as any)[3] = {};

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -97,6 +97,7 @@ export function CommonTeXFontMixin<
       0x20EE: '\u2190', // combining low left arrows
       0x20EF: '\u2192'  // combining low right arrows
     };
+
   };
 
 }

--- a/ts/output/svg/FontData.ts
+++ b/ts/output/svg/FontData.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {CharMap, CharOptions, CharData, VariantData, DelimiterData, FontData} from '../common/FontData.js';
+import {CharMap, CharOptions, CharDataArray, VariantData, DelimiterData, FontData} from '../common/FontData.js';
 export * from '../common/FontData.js';
 
 export type CharStringMap = {[name: number]: string};
@@ -38,7 +38,7 @@ export interface SvgCharOptions extends CharOptions {
  * Shorthands for SVG char maps and char data
  */
 export type SvgCharMap = CharMap<SvgCharOptions>;
-export type SvgCharData = CharData<SvgCharOptions>;
+export type SvgCharData = CharDataArray<SvgCharOptions>;
 
 /**
  * The extra data needed for a Variant in SVG output

--- a/ts/output/svg/fonts/tex.ts
+++ b/ts/output/svg/fonts/tex.ts
@@ -57,8 +57,19 @@ import {delimiters} from '../../common/fonts/tex/delimiters.js';
 /**
  *  The TeXFont class
  */
-export class TeXFont extends
-CommonTeXFontMixin<SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontDataClass>(SvgFontData) {
+
+
+const Base = CommonTeXFontMixin<SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontDataClass>(SvgFontData);
+
+export class TeXFont extends Base {
+
+  /**
+   * @override
+   */
+  public static OPTIONS = {
+    ...Base.OPTIONS,
+    dynamicPrefix: Base.OPTIONS.dynamicPrefix + '/tex/dynamic'
+  };
 
   /**
    *  The stretchy delimiter data


### PR DESCRIPTION
This PR adds the ability to specify font extensions that will be loaded dynamically when less-used characters are needed. You can specify any number of extensions, and these can contain characters from any number of variants, or additional delimiters.  The specification for a dynamic extension includes the file to load for the extension, along with the ranges of characters that it provides in each variant that it modifies.  When an output jax needs one of these characters or delimiters, the extension is loaded and set up, and the expression is reprocessed.

