### PR TITLE
New methods to add to a font via an extension

### DIFF
--- a/components/src/node-main/node-main.js
+++ b/components/src/node-main/node-main.js
@@ -22,6 +22,7 @@ const path = eval("require('path')");  // use actual node version, not webpack's
  */
 require('../startup/init.js');
 const {Loader, CONFIG} = require('../../../js/components/loader.js');
+const {Package} = require('../../../js/components/package.js');
 const {combineDefaults, combineConfig} = require('../../../js/components/global.js');
 
 /*
@@ -55,7 +56,8 @@ if (path.basename(dir) === 'node-main') {
   const ROOT = path.resolve(dir, '../../../js');
   const REQUIRE = MathJax.config.loader.require;
   MathJax._.mathjax.mathjax.asyncLoad = function (name) {
-    return REQUIRE(name.charAt(0) === '.' ? path.resolve(ROOT, name) : name);
+    return REQUIRE(name.charAt(0) === '.' ? path.resolve(ROOT, name) :
+                   name.charAt(0) === '[' ? Package.resolvePath(name) : name);
   };
 }
 

--- a/ts/output/common/Direction.ts
+++ b/ts/output/common/Direction.ts
@@ -1,0 +1,26 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2021 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  The direction enum for delimiters
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+export const enum DIRECTION {None, Vertical, Horizontal}
+export const V = DIRECTION.Vertical;
+export const H = DIRECTION.Horizontal;

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -28,7 +28,7 @@ import {asyncLoad} from '../../util/AsyncLoad.js';
 import {retryAfter} from '../../util/Retries.js';
 import {mathjax} from '../../mathjax.js';
 import {DIRECTION} from './Direction.js';
-export {DIRECTION, V, H} from './Direction.js';
+export {DIRECTION} from './Direction.js';
 
 /****************************************************************************/
 

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -719,7 +719,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @template D  The DelimiterData type
    */
   public static dynamicSetup<C extends CharOptions, D extends DelimiterData>(
-    extension: string, file: string, variants: CharMapMap<C>, delimiters: DelimiterMap<D> = []
+    extension: string, file: string, variants: CharMapMap<C>, delimiters: DelimiterMap<D> = {}
   ) {
     const data = (extension ? this.dynamicExtensions.get(extension) : null);
     const files = (extension ? data.files : this.dynamicFiles);

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -712,7 +712,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
       ['stretchVariants', 'defaultStretchVariants']
     ] as [keyof FontExtensionData, keyof typeof FontData][]) {
       if (data[src]) {
-        this[dst] = mergeOptions(this[dst], data[src]);
+        this[dst] = mergeOptions(this[dst] as OptionList, data[src]);
       }
     }
     if (data.dynamicFiles) {

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -27,6 +27,8 @@ import {StyleList} from '../../util/StyleList.js';
 import {asyncLoad} from '../../util/AsyncLoad.js';
 import {retryAfter} from '../../util/Retries.js';
 import {mathjax} from '../../mathjax.js';
+import {DIRECTION} from './Direction.js';
+export {DIRECTION, V, H} from './Direction.js';
 
 /****************************************************************************/
 
@@ -120,15 +122,6 @@ export type CssFontData = [string, boolean, boolean];
 export type CssFontMap = {
   [name: string]: CssFontData;
 };
-
-/****************************************************************************/
-
-/**
- * Stretchy delimiter data
- */
-export const enum DIRECTION {None, Vertical, Horizontal}
-export const V = DIRECTION.Vertical;
-export const H = DIRECTION.Horizontal;
 
 /****************************************************************************/
 
@@ -233,6 +226,13 @@ export type FontParameters = {
   extra_ic: number
 };
 
+/**
+ * A list of FontParameters
+ */
+export type FontParameterList = {
+  [key in keyof FontParameters]?: number;
+};
+
 /****************************************************************************/
 
 /**
@@ -260,6 +260,7 @@ export type DynamicFileDef = [string, DynamicVariants, DynamicRanges?];
  * Data stored about a dynamic font
  */
 export type DynamicFile = {
+  extension: string;              // name of the extension for this file (or blank)
   file: string;                   // file containing the character data
   variants: DynamicVariants;      // characters in each variant in the file
   delimiters: DynamicRanges;      // delimiters in the file
@@ -274,6 +275,22 @@ export type DynamicFile = {
 export type DynamicFileList = {[name: string]: DynamicFile};
 
 /**
+ * Data for dynamic files for a font or font extension
+ */
+export type DynamicFont = {
+  name: string;
+  prefix: string;
+  files: DynamicFileList;
+  sizeN: number;
+  stretchN: number;
+};
+
+/**
+ * The list of dynamic fonts and extensions
+ */
+export type DynamicFontMap = Map<string, DynamicFont>;
+
+/**
  * Map of characters that load a dynamic file
  */
 export type DynamicCharMap = {[name: number]: DynamicFile};
@@ -282,20 +299,24 @@ export type DynamicCharMap = {[name: number]: DynamicFile};
 
 /**
  * Data for a Font extension
+ *
+ * @template C  The CharOptions type
+ * @template D  The DelimiterData type
  */
-export type FontExtensionData = {
+export type FontExtensionData<C extends CharOptions, D extends DelimiterData> = {
+  name: string;
   options?: OptionList;
-  variants?: string[][];
+  variants?: string[][] | {'[+]'?: string[][], '[-]'?: string[][]};
   cssFonts?: CssFontMap;
   accentMap?: RemapMap;
   moMap?: RemapMap;
   mnMap?: RemapMap;
-  parameters?: FontParameters;
-  delimiters?: DelimiterMap<any>;
-  chars?: CharMapMap<any>;
-  sizeVariants?: string[];
-  stretchVariants?: string[];
-  dynamicFiles?: DynamicFileDef[];
+  parameters?: FontParameterList;
+  delimiters?: DelimiterMap<D>;
+  chars?: CharMapMap<C>;
+  sizeVariants?: string[] | {'[+]'?: string[], '[-]'?: string[]};
+  stretchVariants?: string[] | {'[+]'?: string[], '[-]'?: string[]};
+  ranges?: DynamicFileDef[];
 };
 
 /**
@@ -564,12 +585,12 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   /**
    * The default delimiter data
    */
-  protected static defaultDelimiters: DelimiterMap<any> = {};
+  protected static defaultDelimiters: DelimiterMap<DelimiterData> = {};
 
   /**
    * The default character data
    */
-  protected static defaultChars: CharMapMap<any> = {};
+  protected static defaultChars: CharMapMap<CharOptions> = {};
 
   /**
    * The default variants for the fixed size stretchy delimiters
@@ -585,6 +606,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * The dynamic file data
    */
   protected static dynamicFiles: DynamicFileList = {};
+
+  /**
+   * The font extension dynamic data
+   */
+  protected static dynamicExtensions: DynamicFontMap = new Map();
 
   /**
    * The font options
@@ -642,6 +668,13 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   protected _styles: StyleList;
 
   /**
+   * @return {typeof FontData}   The constructor for this object
+   */
+  public get CLASS(): typeof FontData {
+    return this.constructor as typeof FontData;
+  }
+
+  /**
    * @param {CharMap} font   The font to check
    * @param {number} n       The character to get options for
    * @return {CharOptions}   The options for the character
@@ -661,15 +694,16 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * Define the dynamic file information.
    *
    * @param {DynamicFileDef[]} dynamicFiles   The definitions to make
+   * @param {string} extension                The name of the extension for this file (or empty)
    * @return {DynamicFileList}                The object of dynamic file data
    */
-  public static defineDynamicFiles(dynamicFiles: DynamicFileDef[]): DynamicFileList {
+  public static defineDynamicFiles(dynamicFiles: DynamicFileDef[], extension: string = ''): DynamicFileList {
     const list: DynamicFileList = {};
-    dynamicFiles.map(([file, variants, delimiters]) => {
+    (dynamicFiles || []).map(([file, variants, delimiters]) => {
       list[file] = {
-        file, variants, delimiters: delimiters || [],
+        extension, file, variants, delimiters: delimiters || [],
         promise: null, failed: false, setup: ((_font) => { list[file].failed = true; })
-      } as DynamicFile;
+      };
     });
     return list;
   }
@@ -677,6 +711,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   /**
    * Create the setup function for a given dynamically loaded file
    *
+   * @param {string} extension      The name of the font extension for this file
    * @param {string} file           The file being loaded
    * @param {CharMapMap} variants   The character data to be added
    *
@@ -684,20 +719,61 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @template D  The DelimiterData type
    */
   public static dynamicSetup<C extends CharOptions, D extends DelimiterData>(
-    file: string, variants: CharMapMap<C>, delimiters: DelimiterMap<D> = []
+    extension: string, file: string, variants: CharMapMap<C>, delimiters: DelimiterMap<D> = []
   ) {
-    this.dynamicFiles[file].setup = (font) => {
+    const data = (extension ? this.dynamicExtensions.get(extension) : null);
+    const files = (extension ? data.files : this.dynamicFiles);
+    files[file].setup = (font) => {
       Object.keys(variants).forEach(name => font.defineChars(name, variants[name]));
       font.defineDelimiters(delimiters);
+      extension && this.adjustDelimiters(font.delimiters, Object.keys(delimiters), data.sizeN, data.stretchN);
     };
+  }
+
+  /**
+   * @param {DelimiterMap<DelimiteData>} delimiters   The delimiter list to modify
+   * @param {string[]} keys                           The ids of the delimiters to check
+   * @param {number} sizeN                            The original number of size variants
+   * @param {number} stretcN                          The original number ot stretch variants
+   */
+  public static adjustDelimiters(delimiters: DelimiterMap<DelimiterData>, keys: string[],
+                                 sizeN: number, stretchN: number) {
+    keys.forEach(id => {
+      const delim = delimiters[parseInt(id)];
+      if ('dir' in delim) {
+        if (delim.variants) {
+          delim.variants = this.adjustArrayIndices(delim.variants, sizeN);
+        }
+        if (delim.stretchv) {
+          delim.stretchv = this.adjustArrayIndices(delim.stretchv, stretchN);
+        }
+      }
+    });
+  }
+
+  /**
+   * @param {number[]} list   The list of nunbers to adjust
+   * @param {number} N        The pivot number
+   */
+  protected static adjustArrayIndices(list: number[], N: number) {
+    return list.map(n => (n < 0 ? N - 1 - n : n));
   }
 
   /**
    * Add extension data into the defaults for this font
    *
    * @param {FontExtensionData} data    The extension data to add
+   * @param {string} prefix             The [prefix] to add to all component names
    */
-  public static addExtension(data: FontExtensionData) {
+  public static addExtension(data: FontExtensionData<CharOptions, DelimiterData>, prefix: string = '') {
+    const extension = {
+      name: data.name,
+      prefix: prefix,
+      files: this.defineDynamicFiles(data.ranges, data.name),
+      sizeN: this.defaultSizeVariants.length,
+      stretchN: this.defaultStretchVariants.length
+    };
+    this.dynamicExtensions.set(data.name, extension);
     for (const [src, dst] of [
       ['options', 'OPTIONS'],
       ['variants', 'defaultVariants'],
@@ -706,17 +782,17 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
       ['moMap', 'defaultMoMap'],
       ['mnMap', 'defaultMnMap'],
       ['parameters', 'defaultParams'],
-      ['delimiters', 'defaultDelimiters'],
       ['chars', 'defaultChars'],
       ['sizeVariants', 'defaultSizeVariants'],
       ['stretchVariants', 'defaultStretchVariants']
-    ] as [keyof FontExtensionData, keyof typeof FontData][]) {
+    ] as [keyof FontExtensionData<CharOptions, DelimiterData>, keyof typeof FontData][]) {
       if (data[src]) {
-        this[dst] = mergeOptions(this[dst] as OptionList, data[src]);
+        this[dst] = mergeOptions(this[dst] as OptionList, data[src] as OptionList);
       }
     }
-    if (data.dynamicFiles) {
-      Object.assign(this.dynamicFiles, this.defineDynamicFiles(data.dynamicFiles));
+    if (data.delimiters) {
+      Object.assign(this.defaultDelimiters, data.delimiters);
+      this.adjustDelimiters(this.defaultDelimiters, Object.keys(data.delimiters), extension.sizeN, extension.stretchN);
     }
   }
 
@@ -728,7 +804,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @constructor
    */
   constructor(options: OptionList = null) {
-    let CLASS = (this.constructor as typeof FontData);
+    let CLASS = this.CLASS;
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     this.params = {...CLASS.defaultParams};
     this.sizeVariants = [...CLASS.defaultSizeVariants];
@@ -736,22 +812,31 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     this.defineCssFonts(CLASS.defaultCssFonts);
     this.cssFamilyPrefix = CLASS.defaultCssFamilyPrefix;
     this.createVariants(CLASS.defaultVariants);
-    this.defineDelimiters(CLASS.defaultDelimiters);
-    for (const name of Object.keys(CLASS.defaultChars)) {
-      this.defineChars(name, CLASS.defaultChars[name]);
-    }
+    this.defineDelimiters(CLASS.defaultDelimiters as DelimiterMap<D>);
+    Object.keys(CLASS.defaultChars).forEach(name => this.defineChars(name, CLASS.defaultChars[name] as CharMap<C>));
     this.defineRemap('accent', CLASS.defaultAccentMap);
     this.defineRemap('mo', CLASS.defaultMoMap);
     this.defineRemap('mn', CLASS.defaultMnMap);
     this.defineDynamicCharacters(CLASS.dynamicFiles);
+    CLASS.dynamicExtensions.forEach(data => this.defineDynamicCharacters(data.files));
   }
 
   /**
    * Add an extension to an existing font instance (options will get their defaults).
    *
    * @param {FontExtensionData} data    The data for the font extension to merge into this font.
+   * @param {string} prefix             The [prefix] to add to all component names
    */
-  public addExtension(data: FontExtensionData) {
+  public addExtension(data: FontExtensionData<C, D>, prefix: string = '') {
+    const dynamicFont = {
+      name: data.name,
+      prefix: prefix,
+      files: this.CLASS.defineDynamicFiles(data.ranges, prefix),
+      sizeN: this.sizeVariants.length,
+      stretchN: this.stretchVariants.length
+    };
+    this.CLASS.dynamicExtensions.set(data.name, dynamicFont);
+
     data.options && defaultOptions(this.options, data.options);
     data.parameters && defaultOptions(this.params, data.parameters);
     if (data.sizeVariants) {
@@ -762,18 +847,19 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     }
     data.cssFonts && this.defineCssFonts(mergeOptions([], data.cssFonts));
     data.variants && this.createVariants(mergeOptions([], data.variants));
-    data.delimiters && this.defineDelimiters(mergeOptions([], data.delimiters));
+    if (data.delimiters) {
+      this.defineDelimiters(mergeOptions([], data.delimiters));
+      this.CLASS.adjustDelimiters(this.delimiters, Object.keys(data.delimiters),
+                                  dynamicFont.sizeN, dynamicFont.stretchN);
+    }
     for (const name of Object.keys(data.chars || {})) {
       this.defineChars(name, data.chars[name]);
     }
     data.accentMap && this.defineRemap('accent', data.accentMap);
     data.moMap && this.defineRemap('mo', data.moMap);
     data.mnMap && this.defineRemap('mn', data.mnMap);
-    if (data.dynamicFiles) {
-      const CLASS = this.constructor as typeof FontData;
-      const dynamicFiles = CLASS.defineDynamicFiles(data.dynamicFiles);
-      Object.assign(CLASS.dynamicFiles, dynamicFiles);
-      this.defineDynamicCharacters(dynamicFiles);
+    if (data.ranges) {
+      this.defineDynamicCharacters(dynamicFont.files);
     }
   }
 
@@ -841,7 +927,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * the Math Alphanumeric block for a given variant.
    */
   protected remapSmpChars(chars: CharMap<C>, name: string) {
-    const CLASS = (this.constructor as typeof FontData);
+    const CLASS = this.CLASS;
     if (CLASS.VariantSmp[name]) {
       const SmpRemap = CLASS.SmpRemap;
       const SmpGreek = [null, null, CLASS.SmpRemapGreekU, CLASS.SmpRemapGreekL];
@@ -896,7 +982,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @param {CharMap} chars  The characters to define
    */
   public defineChars(name: string, chars: CharMap<C>) {
-    let variant = this.variant[name];
+    const variant = this.variant[name];
     Object.assign(variant.chars, chars);
     for (const link of variant.linked) {
       Object.assign(link, chars);
@@ -976,6 +1062,17 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   }
 
   /**
+   * @param {DynamicFile} dynamic    The data for the dynamic file
+   * @return {string}                The prefixed name for the file
+   */
+  protected dynamicFileName(dynamic: DynamicFile): string {
+    const prefix = (!dynamic.extension ? this.options.dynamicPrefix :
+                    this.CLASS.dynamicExtensions.get(dynamic.extension).prefix);
+    return (dynamic.file.match(/^(?:[\/\[]|[a-z]+:\/\/|[a-z]:)/i) ? dynamic.file :
+      prefix + '/' + dynamic.file.replace(/\.js$/, ''));
+  }
+
+  /**
    * Load the data for the character from the proper file,
    *   and do any associated setup that needs access to the FontData instance.
    *
@@ -983,11 +1080,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @return {Promise<void>}        The promise that is resolved when the file is loaded
    */
   public async loadDynamicFile(dynamic: DynamicFile): Promise<void> {
-    if (dynamic.failed) return Promise.resolve();
+    if (dynamic.failed) return Promise.reject(new Error(`dynamic file '${dynamic.file}' failed to load`));
     if (!dynamic.promise) {
-      const file = (dynamic.file.match(/^(?:[\/\[]|[a-z]+:\/\/)/) ? dynamic.file :
-                    this.options.dynamicPrefix + '/' + dynamic.file.replace(/\.js$/, ''));
-      dynamic.promise = asyncLoad(file).catch(err => {
+      dynamic.promise = asyncLoad(this.dynamicFileName(dynamic)).catch(err => {
         dynamic.failed = true;
         console.warn(err);
       });
@@ -1001,8 +1096,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @return {Promise<void[]>}   A promise that is resolved after all the dynamic files are loaded.
    */
   public loadDynamicFiles(): Promise<void[]> {
-    const dynamicFiles = (this.constructor as typeof FontData).dynamicFiles;
+    const dynamicFiles = this.CLASS.dynamicFiles;
     const promises = Object.keys(dynamicFiles).map(name => this.loadDynamicFile(dynamicFiles[name]));
+    for (const data of this.CLASS.dynamicExtensions.values()) {
+      promises.push(...Object.keys(data.files).map(name => this.loadDynamicFile(data.files[name])));
+    }
     return Promise.all(promises);
   }
 
@@ -1014,21 +1112,26 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     if (!mathjax.asyncLoad) {
       throw Error('MathJax(loadDynamicFilesSync): mathjax.asyncLoad must be specified and synchronous');
     }
-    const dynamicFiles = (this.constructor as typeof FontData).dynamicFiles;
-    for (const name of Object.keys(dynamicFiles)) {
-      const dynamic = dynamicFiles[name];
-      if (!dynamic.promise) {
-        const file = (dynamic.file.match(/^(?:[\/\[]|[a-z]+:\/\/)/) ? dynamic.file :
-                      this.options.dynamicPrefix + '/' + dynamic.file.replace(/\.js$/, ''));
-        dynamic.promise = Promise.resolve();
-        try {
-          mathjax.asyncLoad(file);
-        } catch (err) {
-          dynamic.failed = true;
-          console.warn(err);
-        }
-        dynamic.setup(this);
+    const dynamicFiles = this.CLASS.dynamicFiles;
+    Object.keys(dynamicFiles).forEach(name => this.loadDynamicFileSync(dynamicFiles[name]));
+    for (const data of this.CLASS.dynamicExtensions.values()) {
+      Object.keys(data.files).forEach(name => this.loadDynamicFileSync(data.files[name]));
+    }
+  }
+
+  /**
+   * @param {DynamicFile} dynamic    The dynamic file to load
+   */
+  public loadDynamicFileSync(dynamic: DynamicFile) {
+    if (!dynamic.promise) {
+      dynamic.promise = Promise.resolve();
+      try {
+        mathjax.asyncLoad(this.dynamicFileName(dynamic));
+      } catch (err) {
+        dynamic.failed = true;
+        console.warn(err);
       }
+      dynamic.setup(this);
     }
   }
 
@@ -1039,6 +1142,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public getDelimiter(n: number): DelimiterData {
     const delim = this.delimiters[n];
     if (delim && !('dir' in delim)) {
+      this.delimiters[n] = null;
       retryAfter(this.loadDynamicFile(delim));
       return null;
     }
@@ -1084,6 +1188,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public getChar(name: string, n: number): CharDataArray<C> {
     const char = this.variant[name].chars[n];
     if (char && !Array.isArray(char)) {
+      const variant = this.variant[name];
+      delete variant.chars[n];
+      variant.linked.forEach(link => delete link[n]);
       retryAfter(this.loadDynamicFile(char));
       return null;
     }
@@ -1142,13 +1249,13 @@ export interface FontDataClass<C extends CharOptions, V extends VariantData<C>, 
   /* tslint:disable-next-line:jsdoc-require */
   charOptions(font: CharMap<C>, n: number): C;
   /* tslint:disable-next-line:jsdoc-require */
-  defineDynamicFiles(dynamicFiles: DynamicFileDef[]): DynamicFileList;
+  defineDynamicFiles(dynamicFiles: DynamicFileDef[], prefix?: string): DynamicFileList;
   /* tslint:disable-next-line:jsdoc-require */
   dynamicSetup<C extends CharOptions, D extends DelimiterData>(
-    file: string, variants: CharMapMap<C>, delimiters?: DelimiterMap<D>
+    font: string, file: string, variants: CharMapMap<C>, delimiters?: DelimiterMap<D>
   ): void;
   /* tslint:disable-next-line:jsdoc-require */
-  addExtension(data: FontExtensionData): void;
+  addExtension(data: FontExtensionData<C, D>, prefix?: string): void;
   new(...args: any[]): FontData<C, V, D>;
 }
 

--- a/ts/output/common/fonts/tex/delimiters.ts
+++ b/ts/output/common/fonts/tex/delimiters.ts
@@ -15,7 +15,8 @@
  *  limitations under the License.
  */
 
-import {DelimiterMap, DelimiterData, V, H} from '../../FontData.js';
+import {DelimiterMap, DelimiterData} from '../../FontData.js';
+import {V, H} from '../../Direction.js';
 
 export const HDW1 = [.75, .25, .875];
 export const HDW2 = [.85, .349, .667];


### PR DESCRIPTION
This PR adds methods to support creating an extension that modifies an existing font.  For example, an extension could override the characters used for the letters and numbers while leaving all the other characters in place, or could add coverage for special symbols that are missing from the font originally.

There are two new `addExtension()` methods:  a static one on the `FontData` class that modifies the class defaults before it is instantiated, and one on the `FontData` instance that modifies the data for a given font instance.  This allows a font to be extended before it is used, or to be extended dynamically once it is in place.

The font tools (currently under construction) will create the needed data and extension files that call the new `addExtension()` methods.