### PR TITLE
Add versions to component files and check them when loaded

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -30,7 +30,7 @@ const path = require('path');
 /**
  * The amount of space for each level of indentation
  */
-const INDENT = '    ';
+const INDENT = '  ';
 
 /**
  * The pattern to use when looking for explort commands to process
@@ -51,6 +51,14 @@ const mjGlobal = path.join('..', mjPath, 'components', 'global.js');
  */
 const config = JSON.parse(fs.readFileSync(process.argv[2] || 'build.json'));
 
+function getType() {
+  const component = config.component || 'part';
+  if (component.match(/\/(svg|chtml|common)\/fonts\//)) return RegExp.$1 + '-font';
+  if (component.match(/\/(mathml|tex)\/.+\//)) return RegExp.$1 + '-extension';
+  if (component.match(/^(.+)\//)) return RegExp.$1;
+  return component;
+}
+
 /**
  * Extract the configuration values
  */
@@ -61,10 +69,10 @@ const EXCLUDE = new Map((config.exclude || []).map(name => [name, true]));  // f
 const EXCLUDESUBDIRS = config.excludeSubdirs === 'true';                    // exclude subdirectories or not
 const JS = config.js || config.mathjax || mjPath;                           // path to the compiled .js files
 const LIB = config.lib || './lib';                                          // path to the lib directory to create
+const TS = config.ts || JS.replace(/js$/, 'ts');                            // path to the .ts files
 const GLOBAL = config.global || mjGlobal;                                   // path to the global.js file
 const VERSION = config.version || mjGlobal.replace(/global/, 'version');    // path to the version.js file
-const TS = config.ts || JS.replace(/js$/, 'ts');                            // path to the .ts files
-
+const TYPE = config.type || getType();                                      // the module type
 
 /**
  * The list of files that need to be added to the lib directory
@@ -235,10 +243,16 @@ function processGlobal() {
     packages.push(processPackage(lines, INDENT, dir));
   }
   const name = (ID.match(/[^a-zA-Z0-9_]/) ? `"${ID}"` : ID);
-  lines.push('', `combineWithMathJax({_: {`);
-  lines.push(INDENT + `_versions: {${name}: VERSION},`);
-  lines.push(INDENT + packages.join(',\n' + INDENT));
-  lines.push('}});');
+  lines.push(
+    '',
+    'if (MathJax.loader) {',
+      INDENT + `MathJax.loader.checkVersion('${ID}', VERSION, '${TYPE}');`,
+    '}',
+    '',
+    `combineWithMathJax({_: {`,
+      INDENT + packages.join(',\n' + INDENT),
+    '}});'
+  );
   fs.writeFileSync(path.join(LIB, COMPONENT + '.js'), lines.join('\n') + '\n');
 }
 

--- a/components/bin/build
+++ b/components/bin/build
@@ -55,13 +55,16 @@ const config = JSON.parse(fs.readFileSync(process.argv[2] || 'build.json'));
  * Extract the configuration values
  */
 const COMPONENT = path.basename(config.component || 'part');                // name of the component
+const ID = config.id || config.component || 'part';                         // the ID of the component
 const TARGETS = config.targets || [];                                       // the files to include in the component
 const EXCLUDE = new Map((config.exclude || []).map(name => [name, true]));  // files to exclude from the component
 const EXCLUDESUBDIRS = config.excludeSubdirs === 'true';                    // exclude subdirectories or not
 const JS = config.js || config.mathjax || mjPath;                           // path to the compiled .js files
 const LIB = config.lib || './lib';                                          // path to the lib directory to create
 const GLOBAL = config.global || mjGlobal;                                   // path to the global.js file
+const VERSION = config.version || mjGlobal.replace(/global/, 'version');    // path to the version.js file
 const TS = config.ts || JS.replace(/js$/, 'ts');                            // path to the .ts files
+
 
 /**
  * The list of files that need to be added to the lib directory
@@ -222,6 +225,7 @@ function processGlobal() {
   console.info('  ' + COMPONENT + '.ts');
   const lines = [
     `import {combineWithMathJax} from '${GLOBAL}';`,
+    `import {VERSION} from '${VERSION}';`,
     '',
   ];
   const packages = [];
@@ -230,7 +234,9 @@ function processGlobal() {
     const dir = path.dirname(PACKAGE[0]).split(path.sep)[0];
     packages.push(processPackage(lines, INDENT, dir));
   }
+  const name = (ID.match(/[^a-zA-Z0-9_]/) ? `"${ID}"` : ID);
   lines.push('', `combineWithMathJax({_: {`);
+  lines.push(INDENT + `_versions: {${name}: VERSION},`);
   lines.push(INDENT + packages.join(',\n' + INDENT));
   lines.push('}});');
   fs.writeFileSync(path.join(LIB, COMPONENT + '.js'), lines.join('\n') + '\n');

--- a/components/src/input/mml/build.json
+++ b/components/src/input/mml/build.json
@@ -1,5 +1,5 @@
 {
-  "component": "inpu/mml",
+  "component": "input/mml",
   "targets": [
     "input/mathml.ts",
     "input/mathml"

--- a/components/src/input/mml/extensions/mml3/build.json
+++ b/components/src/input/mml/extensions/mml3/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[mml]/mml3",
   "component": "input/mml/extensions/mml3",
   "targets": ["input/mathml/mml3"]
 }

--- a/components/src/input/tex/extensions/action/build.json
+++ b/components/src/input/tex/extensions/action/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/action",
   "component": "input/tex/extensions/action",
   "targets": ["input/tex/action"]
 }

--- a/components/src/input/tex/extensions/all-packages/build.json
+++ b/components/src/input/tex/extensions/all-packages/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/all-packages",
   "component": "input/tex/extensions/all-packages",
   "targets": [
     "input/tex/AllPackages.ts",

--- a/components/src/input/tex/extensions/ams/build.json
+++ b/components/src/input/tex/extensions/ams/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/ams",
   "component": "input/tex/extensions/ams",
   "targets": ["input/tex/ams"]
 }

--- a/components/src/input/tex/extensions/amscd/build.json
+++ b/components/src/input/tex/extensions/amscd/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/amscd",
   "component": "input/tex/extensions/amscd",
   "targets": ["input/tex/amscd"]
 }

--- a/components/src/input/tex/extensions/autoload/build.json
+++ b/components/src/input/tex/extensions/autoload/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/autoload",
   "component": "input/tex/extensions/autoload",
   "targets": ["input/tex/autoload"]
 }

--- a/components/src/input/tex/extensions/bbox/build.json
+++ b/components/src/input/tex/extensions/bbox/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/bbox",
   "component": "input/tex/extensions/bbox",
   "targets": ["input/tex/bbox"]
 }

--- a/components/src/input/tex/extensions/boldsymbol/build.json
+++ b/components/src/input/tex/extensions/boldsymbol/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/boldsymbol",
   "component": "input/tex/extensions/boldsymbol",
   "targets": ["input/tex/boldsymbol"]
 }

--- a/components/src/input/tex/extensions/braket/build.json
+++ b/components/src/input/tex/extensions/braket/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/braket",
   "component": "input/tex/extensions/braket",
   "targets": ["input/tex/braket"]
 }

--- a/components/src/input/tex/extensions/bussproofs/build.json
+++ b/components/src/input/tex/extensions/bussproofs/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/bussproofs",
   "component": "input/tex/extensions/bussproofs",
   "targets": ["input/tex/bussproofs"]
 }

--- a/components/src/input/tex/extensions/cancel/build.json
+++ b/components/src/input/tex/extensions/cancel/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/cancel",
   "component": "input/tex/extensions/cancel",
   "targets": ["input/tex/cancel"]
 }

--- a/components/src/input/tex/extensions/cases/build.json
+++ b/components/src/input/tex/extensions/cases/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/cases",
   "component": "input/tex/extensions/cases",
   "targets": ["input/tex/cases"]
 }

--- a/components/src/input/tex/extensions/centernot/build.json
+++ b/components/src/input/tex/extensions/centernot/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/centernot",
   "component": "input/tex/extensions/centernot",
   "targets": ["input/tex/centernot"]
 }

--- a/components/src/input/tex/extensions/color/build.json
+++ b/components/src/input/tex/extensions/color/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/color",
   "component": "input/tex/extensions/color",
   "targets": ["input/tex/color"]
 }

--- a/components/src/input/tex/extensions/colortbl/build.json
+++ b/components/src/input/tex/extensions/colortbl/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/colortbl",
   "component": "input/tex/extensions/colortbl",
   "targets": ["input/tex/colortbl"]
 }

--- a/components/src/input/tex/extensions/colorv2/build.json
+++ b/components/src/input/tex/extensions/colorv2/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/colorv2",
   "component": "input/tex/extensions/colorv2",
   "targets": ["input/tex/colorv2"]
 }

--- a/components/src/input/tex/extensions/configmacros/build.json
+++ b/components/src/input/tex/extensions/configmacros/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/configmacros",
   "component": "input/tex/extensions/configmacros",
   "targets": ["input/tex/configmacros"]
 }

--- a/components/src/input/tex/extensions/empheq/build.json
+++ b/components/src/input/tex/extensions/empheq/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/empheq",
   "component": "input/tex/extensions/empheq",
   "targets": ["input/tex/empheq"]
 }

--- a/components/src/input/tex/extensions/enclose/build.json
+++ b/components/src/input/tex/extensions/enclose/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/enclose",
   "component": "input/tex/extensions/enclose",
   "targets": ["input/tex/enclose"]
 }

--- a/components/src/input/tex/extensions/extpfeil/build.json
+++ b/components/src/input/tex/extensions/extpfeil/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/extpfeil",
   "component": "input/tex/extensions/extpfeil",
   "targets": ["input/tex/extpfeil"]
 }

--- a/components/src/input/tex/extensions/gensymb/build.json
+++ b/components/src/input/tex/extensions/gensymb/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/gensymb",
   "component": "input/tex/extensions/gensymb",
   "targets": ["input/tex/gensymb"]
 }

--- a/components/src/input/tex/extensions/html/build.json
+++ b/components/src/input/tex/extensions/html/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/html",
   "component": "input/tex/extensions/html",
   "targets": ["input/tex/html"]
 }

--- a/components/src/input/tex/extensions/mathtools/build.json
+++ b/components/src/input/tex/extensions/mathtools/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/mathtools",
   "component": "input/tex/extensions/mathtools",
   "targets": ["input/tex/mathtools"]
 }

--- a/components/src/input/tex/extensions/mhchem/build.json
+++ b/components/src/input/tex/extensions/mhchem/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/mhchem",
   "component": "input/tex/extensions/mhchem",
   "targets": ["input/tex/mhchem"],
   "exclude": ["input/tex/mhchem/mhchem_parser.d.ts"]

--- a/components/src/input/tex/extensions/newcommand/build.json
+++ b/components/src/input/tex/extensions/newcommand/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/newcommand",
   "component": "input/tex/extensions/newcommand",
   "targets": ["input/tex/newcommand"]
 }

--- a/components/src/input/tex/extensions/noerrors/build.json
+++ b/components/src/input/tex/extensions/noerrors/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/noerrors",
   "component": "input/tex/extensions/noerrors",
   "targets": ["input/tex/noerrors"]
 }

--- a/components/src/input/tex/extensions/noundefined/build.json
+++ b/components/src/input/tex/extensions/noundefined/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/noundefined",
   "component": "input/tex/extensions/noundefined",
   "targets": ["input/tex/noundefined"]
 }

--- a/components/src/input/tex/extensions/physics/build.json
+++ b/components/src/input/tex/extensions/physics/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/physics",
   "component": "input/tex/extensions/physics",
   "targets": ["input/tex/physics"]
 }

--- a/components/src/input/tex/extensions/require/build.json
+++ b/components/src/input/tex/extensions/require/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/require",
   "component": "input/tex/extensions/require",
   "targets": ["input/tex/require"]
 }

--- a/components/src/input/tex/extensions/setoptions/build.json
+++ b/components/src/input/tex/extensions/setoptions/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/setoptions",
   "component": "input/tex/extensions/setoptions",
   "targets": ["input/tex/setoptions"]
 }

--- a/components/src/input/tex/extensions/tagformat/build.json
+++ b/components/src/input/tex/extensions/tagformat/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/tagformat",
   "component": "input/tex/extensions/tagformat",
   "targets": ["input/tex/tagformat"]
 }

--- a/components/src/input/tex/extensions/textcomp/build.json
+++ b/components/src/input/tex/extensions/textcomp/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/textcomp",
   "component": "input/tex/extensions/textcomp",
   "targets": ["input/tex/textcomp"]
 }

--- a/components/src/input/tex/extensions/textmacros/build.json
+++ b/components/src/input/tex/extensions/textmacros/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/textmacros",
   "component": "input/tex/extensions/textmacros",
   "targets": ["input/tex/textmacros"]
 }

--- a/components/src/input/tex/extensions/unicode/build.json
+++ b/components/src/input/tex/extensions/unicode/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/unicode",
   "component": "input/tex/extensions/unicode",
   "targets": ["input/tex/unicode"]
 }

--- a/components/src/input/tex/extensions/upgreek/build.json
+++ b/components/src/input/tex/extensions/upgreek/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/upgreek",
   "component": "input/tex/extensions/upgreek",
   "targets": ["input/tex/upgreek"]
 }

--- a/components/src/input/tex/extensions/verb/build.json
+++ b/components/src/input/tex/extensions/verb/build.json
@@ -1,4 +1,5 @@
 {
+  "id": "[tex]/verb",
   "component": "input/tex/extensions/verb",
   "targets": ["input/tex/verb"]
 }

--- a/components/webpack.common.js
+++ b/components/webpack.common.js
@@ -46,11 +46,15 @@ function quoteRE(string) {
 const PLUGINS = function (js, dir) {
   const mjdir = path.resolve(__dirname, '..', 'js');
   const jsdir = path.resolve(dir, js);
+  const package = path.resolve(__dirname, '..', 'package.json');
 
   //
   //  Record the js directory for the pack command
   //
-  return [new webpack.DefinePlugin({__JSDIR__: jsdir})];
+  return [new webpack.DefinePlugin({
+    __JSDIR__: jsdir,
+    PACKAGE_VERSION: `'${require(package).version}'`
+  })];
 };
 
 /**

--- a/ts/components/global.ts
+++ b/ts/components/global.ts
@@ -22,6 +22,8 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import {VERSION} from './version.js';
+
 /**
  * The MathJax variable as a configuration object
  */
@@ -127,7 +129,7 @@ if (typeof global.MathJax === 'undefined') {
  */
 if (!(global.MathJax as MathJaxObject).version) {
   global.MathJax = {
-    version: '3.2.0',
+    version: VERSION,
     _: {},
     config: global.MathJax
   };

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -177,7 +177,7 @@ export namespace Loader {
       extension.checkNoLoad();
       promises.push(extension.promise.then(() => {
         if (!CONFIG.versionWarnings) return;
-        if (!versions.has(Package.resolvePath(name))) {
+        if (extension.isLoaded && !versions.has(Package.resolvePath(name))) {
           console.warn(`No version information available for component ${name}`);
         }
       }) as Promise<null>);

--- a/ts/components/version.ts
+++ b/ts/components/version.ts
@@ -1,0 +1,25 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2018-2021 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  The version of MathJax (iused to tell what version a component
+ *                was compiled against).
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+export const VERSION = '3.2.0';

--- a/ts/components/version.ts
+++ b/ts/components/version.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview  The version of MathJax (iused to tell what version a component
+ * @fileoverview  The version of MathJax (used to tell what version a component
  *                was compiled against).
  *
  * @author dpvc@mathjax.org (Davide Cervone)

--- a/ts/components/version.ts
+++ b/ts/components/version.ts
@@ -22,4 +22,23 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-export const VERSION = '3.2.0';
+declare const PACKAGE_VERSION: string;  // provided by webpack via DefinePlugin
+
+export const VERSION = (
+  typeof PACKAGE_VERSION === 'undefined' ?
+    //
+    //  This will not be included in the webpack version, so only runs in node
+    //
+    (function () {
+      //
+      //  Look up the version from the package.json file
+      //
+      /* tslint:disable-next-line:no-eval */
+      const load = eval('require');
+      /* tslint:disable-next-line:no-eval */
+      const dirname = eval('__dirname');
+      const path = load('path');
+      return load(path.resolve(dirname, '..', '..', 'package.json')).version;
+    })() :
+  PACKAGE_VERSION
+);

--- a/ts/mathjax.ts
+++ b/ts/mathjax.ts
@@ -21,6 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import {VERSION} from './components/version.js';
 import {HandlerList} from './core/HandlerList.js';
 import {handleRetriesFor, retryAfter} from './util/Retries.js';
 import {OptionList} from './util/Options.js';
@@ -34,7 +35,7 @@ export const mathjax = {
   /**
    *  The MathJax version number
    */
-  version: '3.2.0',
+  version: VERSION,
 
   /**
    *  The list of registers document handlers

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -74,6 +74,11 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
   };
 
   /**
+   * @override
+   */
+  public static JAX = 'CHTML';
+
+  /**
    * The default class names to use for each variant
    */
   protected static defaultVariantClasses: StringMap = {};

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -244,6 +244,16 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   };
 
   /**
+   * The name of the output jax this font data is for (used by extensions)
+   */
+  public static JAX: string = 'common';
+
+  /**
+   * The name of the font that is being defined (used by extensions)
+   */
+  public static NAME: string = '';
+
+  /**
    *  The standard variants to define
    */
   public static defaultVariants = [

--- a/ts/output/common/fonts/tex.ts
+++ b/ts/output/common/fonts/tex.ts
@@ -41,6 +41,11 @@ export function CommonTeXFontMixin<
   return class extends Base {
 
     /**
+     * @override
+     */
+    public static NAME = 'TeX';
+
+    /**
      *  Add the extra variants for the TeX fonts
      */
     protected static defaultVariants = [

--- a/ts/output/svg/FontData.ts
+++ b/ts/output/svg/FontData.ts
@@ -64,6 +64,19 @@ export class SVGFontData extends FontData<SVGCharOptions, SVGVariantData, SVGDel
   /**
    * @override
    */
+  public static OPTIONS = {
+    ...FontData.OPTIONS,
+    dynamicPrefix: './output/svg/fonts'
+  };
+
+  /**
+   * @override
+   */
+  public static JAX = 'SVG';
+
+  /**
+   * @override
+   */
   public static charOptions(font: SVGCharMap, n: number) {
     return super.charOptions(font, n) as SVGCharOptions;
   }


### PR DESCRIPTION
This PR adds support for version checking so that components know the version that was used to build them, and the component loader can check the component version to make sure it is the same as the one loading it.  If there is a mismatch, a (non-fatal) warning is issued.  (In the future, this could be extended to make better choices about whether the version mismatch should be fatal or not.)  The warnings can be suppressed via the `versionWarnings: false` option to the `loader` configuration.  

The idea is that, now that we are going to have separate repositories for fonts and TeX extensions, and people are going to be making their own extensions, we need a means of checking whether the extensions can work with the vision of MathJax that is loading them.  This is a first step in that direction, which at least indicates when a version mismatch occurs.

Note that most of the files in this PR are only changed to include an ID to use with the versions, so can be gone over quickly.