### PR TITLE
Fix problem with msubsup when subscript is blank (#2765)

### DIFF
--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -94,7 +94,7 @@ CommonMsubsupMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLscriptbase<any,
       'padding-right': '.05em',  // scriptspace
       'padding-left': '.033em'   // extra_ic
     },
-    'mjx-script > *': {
+    'mjx-script > mjx-spacer': {
       display: 'block'
     }
   };


### PR DESCRIPTION
This PR fixes an issue in CommonHTML output where `msubsup` output when the subscript is empty shows the superscript in the subscript position in some instances (see the initial issue mathjax/MathJax#2765).  This was caused by CSS that was overriding the `display` property for the super- and subscript elements, when it really only needed to be for the spacer.  The order in which the CSS for the msubsup and the scripts are output also affected the results.  The fix is to limit the CSS to just the spacer.

Resolves issue mathjax/MathJax#2765.