### PR TITLE
Fix placement of surd when root extends above the horizontal line (mathjax/MathJax#2764)

### DIFF
--- a/ts/output/svg/Wrappers/msqrt.ts
+++ b/ts/output/svg/Wrappers/msqrt.ts
@@ -56,7 +56,6 @@ export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<any, any,
     //
     //  Get the parameters for the spacing of the parts
     //
-    const rbox = this.getBBox();
     const sbox = surd.getBBox();
     const bbox = base.getBBox();
     const q = this.getPQ(sbox)[1];
@@ -72,12 +71,12 @@ export class SVGmsqrt<N, T, D> extends CommonMsqrtMixin<SVGConstructor<any, any,
     //
     this.addRoot(SVG, root, sbox, H);
     surd.toSVG(SVG);
-    surd.place(this.dx, rbox.h - sbox.h - t);
+    surd.place(this.dx, H - sbox.h);
     base.toSVG(BASE);
     base.place(this.dx + sbox.w, 0);
     this.adaptor.append(SVG, this.svg('rect', {
       width: this.fixed(bbox.w), height: this.fixed(t),
-      x: this.fixed(this.dx + sbox.w), y: this.fixed(rbox.h - 2 * t)
+      x: this.fixed(this.dx + sbox.w), y: this.fixed(H - t)
     }));
   }
 


### PR DESCRIPTION
This PR fixes a problem in SVG output for `mroot` when the height of the root extends above that of the surd itself, as in

```
\sqrt[\frac{1}{2}]{1}
```

In that case, the root symbol was too high.  This PR positions it correctly.

Resolves issue mathjax/MathJax#2764.