### PR TITLE
Update webpack files for empheq and cases (mathjax/MathJax#2762)

### DIFF
--- a/components/src/input/tex/extensions/cases/webpack.config.js
+++ b/components/src/input/tex/extensions/cases/webpack.config.js
@@ -1,14 +1,14 @@
 const PACKAGE = require('../../../../../webpack.common.js');
 
 module.exports = PACKAGE(
-  'cases',             // the package to build
-  '../../../../../js', // location of the compiled js files
-  [                    // packages to link to (relative to Mathjax components)
+  'input/tex/extensions/cases',             // the package to build
+  '../../../../../../js',                   // location of the compiled js files
+  [                                         // packages to link to (relative to Mathjax components)
     'components/src/input/tex-base/lib',
     'components/src/input/tex/extensions/ams/lib',
     'components/src/input/tex/extensions/empheq/lib',
     'components/src/core/lib'
   ],
-  __dirname            // our directory
+  __dirname                                 // our directory
 );
 

--- a/components/src/input/tex/extensions/empheq/webpack.config.js
+++ b/components/src/input/tex/extensions/empheq/webpack.config.js
@@ -1,12 +1,12 @@
 const PACKAGE = require('../../../../../webpack.common.js');
 
 module.exports = PACKAGE(
-  'empheq',            // the package to build
-  '../../../../../js', // location of the compiled js files
-  [                    // packages to link to
+  'input/tex/extensions/empheq',          // the package to build
+  '../../../../../../js',                 // location of the compiled js files
+  [                                       // packages to link to
     'components/src/input/tex-base/lib',
     'components/src/core/lib'
   ],
-  __dirname            // our directory
+  __dirname                               // our directory
 );
 


### PR DESCRIPTION
This PR corrects the location for the `empheq` and `cases` extensions, which were being put into the wrong place.

Resolves issue mathjax/MathJax#2762.