### PR TITLE
Take relative scaling into account for CHTML output of non-MathJax fonts (mathjax/MathJax#2818)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -261,7 +261,7 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
   /**
    * @override
    */
-  public unknownText(text: string, variant: string, width: number = null) {
+  public unknownText(text: string, variant: string, width: number = null, rscale: number = 1) {
     const styles: StyleList = {};
     const scale = 100 / this.math.metrics.scale;
     if (scale !== 100) {
@@ -281,7 +281,7 @@ CommonOutputJax<N, T, D, CHTMLWrapper<N, T, D>, CHTMLWrapperFactory<N, T, D>, CH
     //
     if (width !== null) {
       const metrics = this.math.metrics;
-      styles.width = Math.round(width * metrics.em * metrics.scale) + 'px';
+      styles.width = Math.round(width * metrics.em * metrics.scale * rscale) + 'px';
     }
     //
     return this.html('mjx-utext', {variant: variant, style: styles}, [this.text(text)]);

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -71,7 +71,8 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
     const variant = this.parent.variant;
     const text = (this.node as TextNode).getText();
     if (variant === '-explicitFont') {
-      adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w));
+      const rscale = this.parent.getBBox().rscale;
+      adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, rscale));
     } else {
       let utext = '';
       const chars = this.remappedText(text, variant);

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -71,8 +71,8 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
     const variant = this.parent.variant;
     const text = (this.node as TextNode).getText();
     if (variant === '-explicitFont') {
-      const rscale = this.parent.getBBox().rscale;
-      adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, rscale));
+      const scale = this.parent.getBBox().scale;
+      adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, scale));
     } else {
       let utext = '';
       const chars = this.remappedText(text, variant);


### PR DESCRIPTION
In order to work around a bug in Safari, when text is taken from an unknown font (e.g., when there is a character not in the MathJax fonts, or when `mtextInheritFont` is used, or when an `style` attribute sets the font explicitly), MathJax's CHTML output sets the width of the text explicitly, and uses `px` units to avoid potential px-to-em conversion issues.  But that means the width is not affected bu font-size changes, and that leads to the bounding-box for the text to be the wrong size when used in script or script-script styles.  For example, 

    \scriptstyle\sqrt{\style{font-family:Arial}{\text{Text in explicit font}}}

would get the wrong width for the line over the radicand.  This PR resolves that issue by including the relative scaling in its width computations.

Note that this PR is based off the `chtml-chars` branch, rather than `develop`, since the TextNode changes required here differ from what would be needed in `develop`, and I don't want to have `chtml-chars` to cause conflicts.

This resolves issue mathjax/MathJax#2818.