### PR TITLE
Fix typo in \DeclarePairedDelimiter*, and substitute arguments in pre and post sections. (mathjax/MathJax#2816, mathjax/MathJax#2758)

### DIFF
--- a/ts/input/tex/mathtools/MathtoolsMappings.ts
+++ b/ts/input/tex/mathtools/MathtoolsMappings.ts
@@ -94,9 +94,16 @@ new CommandMap('mathtools-macros', {
   MTFlushSpaceAbove: 'FlushSpaceAbove',
   MTFlushSpaceBelow: 'FlushSpaceBelow',
 
-  DeclarePairedDelimiters:    'DeclarePairedDelimiters',
-  DeclarePairedDelimitersX:   'DeclarePairedDelimitersX',
-  DeclarePairedDelimitersXPP: 'DeclarePairedDelimitersXPP',
+  DeclarePairedDelimiter:     'DeclarePairedDelimiter',
+  DeclarePairedDelimiterX:    'DeclarePairedDelimiterX',
+  DeclarePairedDelimiterXPP:  'DeclarePairedDelimiterXPP',
+
+  //
+  //  Typos from initial release -- kept for backward compatibility for now
+  //
+  DeclarePairedDelimiters:    'DeclarePairedDelimiter',
+  DeclarePairedDelimitersX:   'DeclarePairedDelimiterX',
+  DeclarePairedDelimitersXPP: 'DeclarePairedDelimiterXPP',
 
   centercolon: ['CenterColon', true, true],
   ordinarycolon: ['CenterColon', false],

--- a/ts/input/tex/mathtools/MathtoolsMethods.ts
+++ b/ts/input/tex/mathtools/MathtoolsMethods.ts
@@ -480,7 +480,9 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
       for (let i = args.length; i < n; i++) {
         args.push(parser.GetArgument(name));
       }
+      pre  = ParseUtil.substituteArgs(parser, args, pre);
       body = ParseUtil.substituteArgs(parser, args, body);
+      post = ParseUtil.substituteArgs(parser, args, post);
     }
     body = body.replace(/\\delimsize/g, delim);
     parser.string = [pre, left, open, body, right, close, post, parser.string.substr(parser.i)]
@@ -490,12 +492,12 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
   },
 
   /**
-   * Implements \DeclarePairedDelimiters.
+   * Implements \DeclarePairedDelimiter.
    *
    * @param {TexParser} parser   The calling parser.
    * @param {string} name        The macro name.
    */
-  DeclarePairedDelimiters(parser: TexParser, name: string) {
+  DeclarePairedDelimiter(parser: TexParser, name: string) {
     const cs = NewcommandUtil.GetCsNameArgument(parser, name);
     const open = parser.GetArgument(name);
     const close = parser.GetArgument(name);
@@ -503,12 +505,12 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
   },
 
   /**
-   * Implements \DeclarePairedDelimitersX.
+   * Implements \DeclarePairedDelimiterX.
    *
    * @param {TexParser} parser   The calling parser.
    * @param {string} name        The macro name.
    */
-  DeclarePairedDelimitersX(parser: TexParser, name: string) {
+  DeclarePairedDelimiterX(parser: TexParser, name: string) {
     const cs = NewcommandUtil.GetCsNameArgument(parser, name);
     const n = NewcommandUtil.GetArgCount(parser, name);
     const open = parser.GetArgument(name);
@@ -518,12 +520,12 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
   },
 
   /**
-   * Implements \DeclarePairedDelimitersXPP.
+   * Implements \DeclarePairedDelimiterXPP.
    *
    * @param {TexParser} parser   The calling parser.
    * @param {string} name        The macro name.
    */
-  DeclarePairedDelimitersXPP(parser: TexParser, name: string) {
+  DeclarePairedDelimiterXPP(parser: TexParser, name: string) {
     const cs = NewcommandUtil.GetCsNameArgument(parser, name);
     const n = NewcommandUtil.GetArgCount(parser, name);
     const pre = parser.GetArgument(name);


### PR DESCRIPTION
This PR fixes the names of the `\DecalrePairedDelimiter` macros (no `s`), but retains the old spellings for compatibility, at least for now.  It also does argument substitution on the pre and post material, as it does for the body.

Resolves issues mathjax/MathJax#2816 and mathjax/MathJax#2758.