### PR TITLE
Make sure explicit attributes added by \mmlToken are not removed. (mathjax/MathJax#2806)

### DIFF
--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -71,8 +71,10 @@ namespace FilterUtil {
       if (!attribs) {
         return;
       }
+      const keep = new Set((attribs.get('mjx-keep-attrs') || '').split(/ /));
+      delete (attribs.getAllAttributes())['mjx-keep-attrs'];
       for (const key of attribs.getExplicitNames()) {
-        if (attribs.attributes[key] === mml.attributes.getInherited(key)) {
+        if (!keep.has(key) && attribs.attributes[key] === mml.attributes.getInherited(key)) {
           delete attribs.attributes[key];
         }
       }

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -706,6 +706,7 @@ BaseMethods.MmlToken = function(parser: TexParser, name: string) {
   let attr = parser.GetBrackets(name, '').replace(/^\s+/, '');
   const text = parser.GetArgument(name);
   const def: EnvList = {};
+  const keep: string[] = [];
   let node: MmlNode;
   try {
     node = parser.create('node', kind);
@@ -738,8 +739,12 @@ BaseMethods.MmlToken = function(parser: TexParser, name: string) {
         value = false;
       }
       def[match[1]] = value;
+      keep.push(match[1]);
     }
     attr = attr.substr(match[0].length);
+  }
+  if (keep.length) {
+    def['mjx-keep-attrs'] = keep.join(' ');
   }
   const textNode = parser.create('text', text);
   node.appendChild(textNode);


### PR DESCRIPTION
This PR modifies `\mmlToken` to make sure the attributes specified by it are not removed but the `cleanAttributes` filter, even if their values are the default values.  This was causing the spacing for `\bmod` to be lost (and so it failed to have the proper space in super and subscripts).

Resolves mathjax/MathJax#2806.