### PR TITLE
Handle document created by parsing in XHTML.  (mathjax/MathJax#2788)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -227,21 +227,21 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public head(doc: D) {
-    return doc.head;
+    return doc.head || (doc as any as N);
   }
 
   /**
    * @override
    */
   public body(doc: D) {
-    return doc.body;
+    return doc.body || (doc as any as N);
   }
 
   /**
    * @override
    */
   public root(doc: D) {
-    return doc.documentElement;
+    return doc.documentElement || (doc as any as N);
   }
 
   /**


### PR DESCRIPTION
MathJax uses HTML parsing by default for parsing MathML strings (so that when we support HTML-in-MathML, it should work).  But in an XHTML document, the parsing structure is not the same as in HTML, so this PR alters the HTML adaptor to work with that structure as well.