### PR TITLE
Trim MathML string before parsing it.  (mathjax/MathJax#2805)

### DIFF
--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -136,7 +136,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
   public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
     let mml = math.start.node;
     if (!mml || !math.end.node || this.options['forceReparse'] || this.adaptor.kind(mml) === '#text') {
-      let mathml = this.executeFilters(this.preFilters, math, document, math.math || '<math></math>');
+      let mathml = this.executeFilters(this.preFilters, math, document, (math.math || '<math></math>').trim());
       let doc = this.checkForErrors(this.adaptor.parse(mathml, 'text/' + this.options['parseAs']));
       let body = this.adaptor.body(doc);
       if (this.adaptor.childNodes(body).length !== 1) {


### PR DESCRIPTION
This PR trims whitespace from the ends of the serialized MathML sting before parsing it (so that we don't get unwanted text nodes on either side that cause MathJax to indicate multiple nodes were produced).

Resolves issue mathjax/MathJax#2805.