### PR TITLE
Update component files for changes to sre component

### DIFF
--- a/components/src/a11y/complexity/build.json
+++ b/components/src/a11y/complexity/build.json
@@ -3,7 +3,6 @@
   "targets": [
     "a11y/complexity.ts",
     "a11y/complexity",
-    "a11y/semantic-enrich.ts",
-    "a11y/sre.ts"
+    "a11y/semantic-enrich.ts"
   ]
 }

--- a/components/src/a11y/explorer/build.json
+++ b/components/src/a11y/explorer/build.json
@@ -1,4 +1,4 @@
 {
   "component": "a11y/explorer",
-  "targets": ["a11y/explorer.ts", "a11y/sre.ts", "a11y/explorer"]
+  "targets": ["a11y/explorer.ts", "a11y/explorer"]
 }

--- a/components/src/a11y/explorer/webpack.config.js
+++ b/components/src/a11y/explorer/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = PACKAGE(
   [                                   // packages to link to
     'components/src/ui/menu/lib',
     'components/src/a11y/semantic-enrich/lib',
+    'components/src/a11y/sre/lib',
     'components/src/input/mml/lib',
     'components/src/core/lib'
   ],

--- a/components/src/a11y/semantic-enrich/build.json
+++ b/components/src/a11y/semantic-enrich/build.json
@@ -1,5 +1,5 @@
 {
   "component": "a11y/semantic-enrich",
-  "targets": ["a11y/semantic-enrich.ts", "a11y/sre.ts"]
+  "targets": ["a11y/semantic-enrich.ts"]
 }
 

--- a/components/src/a11y/semantic-enrich/webpack.config.js
+++ b/components/src/a11y/semantic-enrich/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = PACKAGE(
   [                                   // packages to link to
     'components/src/input/mml/lib',
     'components/src/core/lib',
-    'node_modules/speech-rule-engine/js'
+    'components/src/a11y/sre/lib'
   ],
   __dirname                           // our directory
 );

--- a/components/src/a11y/sre/webpack.config.js
+++ b/components/src/a11y/sre/webpack.config.js
@@ -5,8 +5,7 @@ module.exports = PACKAGE(
   '../../../../js',                   // location of the MathJax js library
   [                                   // packages to link to
     'components/src/input/mml/lib',
-    'components/src/core/lib',
-    'node_modules/speech-rule-engine/js'
+    'components/src/core/lib'
   ],
   __dirname                           // our directory
 );


### PR DESCRIPTION
The PR should resolve the problem you were having with loading the are components in the lab.

The main issue is that SRE was being included in both the semantic-enrich and explorer modules, and that caused duplication of the modules that seems to have triggered the export problem.  The reason this was happening is that the `build.json` files included `a11y/sre.ts` as targets, which is no longer necessary since the `a11y/sre` module is self-contained (it may be that it wasn't necessary before, but including the old `a11y/sre.ts` wasn't a problem since it was just a small file with no need for shared code).  So I've removed the `a11y/sre.ts` from all the targets.

The other issue was that the webpack files needs to refer to `components/a11y/sre/lib` not `node_modules/speech-rule-engine/js`.  This array is a list of `lib` files (that were created by the `components/bin/build` command) for the comments whose code this new component is to share rather than include in itself.  These are not the `js` libraries themselves.  These provide the shared-code entry points, and webpack is directed to link against the `lib` versions of the files (which use the `MathJax._` versions of the objects) when they are imported rather than include the full library code.  That is how the dynamically loaded components can share code with previously loaded components in the browser while still working in node directly (without the remapping that webpack does).