### PR TITLE
Allow SRE to use resolverPath during startup

### DIFF
--- a/components/src/a11y/sre/webpack.config.js
+++ b/components/src/a11y/sre/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = PACKAGE(
   '../../../../js',                   // location of the MathJax js library
   [                                   // packages to link to
     'components/src/input/mml/lib',
-    'components/src/core/lib'
+    'components/src/core/lib',
+    'components/src/startup/lib'
   ],
   __dirname                           // our directory
 );

--- a/components/src/mml-chtml/mml-chtml.js
+++ b/components/src/mml-chtml/mml-chtml.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/mml/mml.js';

--- a/components/src/mml-svg/mml-svg.js
+++ b/components/src/mml-svg/mml-svg.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/mml/mml.js';

--- a/components/src/node-main/node-main.js
+++ b/components/src/node-main/node-main.js
@@ -20,10 +20,9 @@ const path = eval("require('path')");  // use actual node version, not webpack's
 /*
  * Load the needed MathJax components
  */
-require('../startup/lib/startup.js');
+require('../startup/init.js');
 const {Loader, CONFIG} = require('../../../js/components/loader.js');
 const {combineDefaults, combineConfig} = require('../../../js/components/global.js');
-const {dependencies, paths, provides} = require('../dependencies.js');
 
 /*
  * Set up the initial configuration
@@ -32,9 +31,6 @@ combineDefaults(MathJax.config, 'loader', {
   require: eval('require'),      // use node's require() to load files
   failed: (err) => {throw err}   // pass on error message to init()'s catch function
 });
-combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
-combineDefaults(MathJax.config.loader, 'paths', paths);
-combineDefaults(MathJax.config.loader, 'provides', provides);
 
 /*
  * Preload core and liteDOM adaptor (needed for node)

--- a/components/src/startup/init.js
+++ b/components/src/startup/init.js
@@ -1,0 +1,9 @@
+import './lib/startup.js';
+
+import {combineDefaults} from '../../../js/components/global.js';
+import {dependencies, paths, provides, compatibility} from '../dependencies.js';
+
+combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
+combineDefaults(MathJax.config.loader, 'paths', paths);
+combineDefaults(MathJax.config.loader, 'provides', provides);
+combineDefaults(MathJax.config.loader, 'source', compatibility);

--- a/components/src/startup/startup.js
+++ b/components/src/startup/startup.js
@@ -1,13 +1,5 @@
-import './lib/startup.js';
-
+import './init.js';
 import {Loader, CONFIG} from '../../../js/components/loader.js';
-import {combineDefaults} from '../../../js/components/global.js';
-import {dependencies, paths, provides, compatibility} from '../dependencies.js';
-
-combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
-combineDefaults(MathJax.config.loader, 'paths', paths);
-combineDefaults(MathJax.config.loader, 'provides', provides);
-combineDefaults(MathJax.config.loader, 'source', compatibility);
 
 Loader.preLoad('loader');
 

--- a/components/src/tex-chtml-full/tex-chtml-full.js
+++ b/components/src/tex-chtml-full/tex-chtml-full.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/tex-full/tex-full.js';

--- a/components/src/tex-chtml/tex-chtml.js
+++ b/components/src/tex-chtml/tex-chtml.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/tex/tex.js';

--- a/components/src/tex-mml-chtml/tex-mml-chtml.js
+++ b/components/src/tex-mml-chtml/tex-mml-chtml.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/tex/tex.js';

--- a/components/src/tex-mml-svg/tex-mml-svg.js
+++ b/components/src/tex-mml-svg/tex-mml-svg.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/tex/tex.js';

--- a/components/src/tex-svg-full/tex-svg-full.js
+++ b/components/src/tex-svg-full/tex-svg-full.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/tex-full/tex-full.js';

--- a/components/src/tex-svg/tex-svg.js
+++ b/components/src/tex-svg/tex-svg.js
@@ -1,4 +1,4 @@
-import '../startup/lib/startup.js';
+import '../startup/init.js';
 import './preload.js';
 import '../core/core.js';
 import '../input/tex/tex.js';

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -38,14 +38,12 @@ declare namespace global {
 //
 // We could also use a custom method for loading locales that are webpacked into
 // the distribution.
-(() => {
-  if (typeof window !== 'undefined') {
-    window.SREfeature = {json: Package.resolvePath('[sre]', false) + '/mathmaps'};
-  } else {
-    // TODO: This is does not yet work correctly!
-    global.SREfeature = {json: MJGlobal.config.loader.paths.mathjax + '/sre/mathmaps'};
-  }
-})();
+if (typeof window !== 'undefined') {
+  window.SREfeature = {json: Package.resolvePath('[sre]', false) + '/mathmaps'};
+} else {
+  // TODO: This is does not yet work correctly!
+  global.SREfeature = {json: MJGlobal.config.loader.paths.mathjax + '/sre/mathmaps'};
+}
 
 export {engineReady as sreReady, setupEngine, engineSetup, toEnriched} from 'speech-rule-engine/js/common/system.js';
 export {Walker} from 'speech-rule-engine/js/walker/walker.js';


### PR DESCRIPTION
The addition of the paths, dependencies, etc, was being added in the `components/src/startup.js` file, which was loaded last by the combined components like `tex-chtml`.  This means that that data wasn't available to other components that are imported into the combined components (like SRE4).  This PR separates adding of paths, etc, into a startup init file, so that they can be added before other imports, making the default paths, etc, available to imported files, as they should be.  It also makes it easier to make combined configuration files by loading the init file rather than the lib/startup.js file, which wasn't very intuitive.

It also, fixed the sre webpack `libs` definition so that it shares the startup code.

Finally, I removed a closure function in `sre.js` that wasn't needed, since there are no local variables.