### PR TITLE
Only process MJX-TeXAtom classes on mrow elements.  (mathjax/MathJax#2822)

### DIFF
--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -118,7 +118,7 @@ export class MathMLCompile<N, T, D> {
     }
     let type = texClass && kind === 'mrow' ? 'TeXAtom' : kind;
     for (const name of this.filterClassList(adaptor.allClasses(node))) {
-      if (name.match(/^MJX-TeXAtom-/)) {
+      if (name.match(/^MJX-TeXAtom-/) && kind === 'mrow') {
         texClass = name.substr(12);
         type = 'TeXAtom';
       } else if (name === 'MJX-fixedlimits') {


### PR DESCRIPTION
This PR makes sure that MathML input only tries to process the `MJX-TeXAtom-*` class names (from v2 output) when they appear on `mrow` elements.

Resolves issue mathjax/MathJax#2822