### PR TITLE
Move mml3 filter to an mmlFilter so that forceReparse isn't needed. (mathjax/MathJax#2718)

### DIFF
--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -76,7 +76,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
   /**
    * A list of functions to call on the parsed MathML DOM before conversion to internal structure
    */
-  protected mmlFilters: FunctionList;
+  public mmlFilters: FunctionList;
 
   /**
    * @override

--- a/ts/input/mathml/mml3/mml3-node.ts
+++ b/ts/input/mathml/mml3/mml3-node.ts
@@ -22,13 +22,19 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import {MathDocument} from '../../../core/MathDocument.js';
+
 /**
  * Create the transform function that uses Saxon-js to perform the
  *   xslt transformation.
  *
- * @return {(mml: string) => string)}   The transformation function
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ *
+ * @return {(node: N, doc: MathDocument<N,T,D>) => N)}   The transformation function
  */
-export function createTransform(): (mml: string) => string {
+export function createTransform<N, T, D>(): (node: N, doc: MathDocument<N, T, D>) => N {
   /* tslint:disable-next-line:no-eval */
   const nodeRequire = eval('require');   // get the actual require from node.
   /* tslint:disable-next-line:no-eval */
@@ -43,24 +49,27 @@ export function createTransform(): (mml: string) => string {
   const fs = nodeRequire('fs');          // use the real version from node.
   const xsltFile = path.resolve(dirname, 'mml3.sef.json');  // load the preprocessed stylesheet.
   const xslt = JSON.parse(fs.readFileSync(xsltFile));       // and parse it.
-  return (mml: string) => {
+  return (node: N, doc: MathDocument<N, T, D>) => {
+    const adaptor = doc.adaptor;
+    let mml = adaptor.outerHTML(node);
     //
     //  Make sure the namespace is present
     //
     if (!mml.match(/ xmlns[=:]/)) {
-        mml = mml.replace(/<(?:(\w+)(:))?math/, '<$1$2math xmlns$2$1="http://www.w3.org/1998/Math/MathML"');
+      mml = mml.replace(/<(?:(\w+)(:))?math/, '<$1$2math xmlns$2$1="http://www.w3.org/1998/Math/MathML"');
     }
-    let result;
     //
     //  Try to run the transform, and if it fails, return the original MathML
+    //
+    let result;
     try {
-      result = Saxon.transform({
+      result = adaptor.firstChild(adaptor.body(adaptor.parse(Saxon.transform({
         stylesheetInternal: xslt,
         sourceText: mml,
         destination: 'serialized'
-      }).principalResult;
+      }).principalResult))) as N;
     } catch (err) {
-      result = mml;
+      result = node;
     }
     return result;
   };


### PR DESCRIPTION
This PR move the MML3 filter from being a `preFilter` to being an `mmlFilter`.  That way it will always run and you don' have to specify `forceReparse: true`.  It also means that (in the browser) you don't have to serialize the math and then re-parse it, as is currently done, since the browser's XSLT parser can work on any DOM fragment.  The node version must serialize and re-parse, however.

There is a new `enableMml3` configuration option that controls whether the filter is added or not (so that if the extension is packaged with a combined configuration, it can be disabled).

This also make the `mmlFilters` public, as it should have been originally.

Resolves issue mathjax/MathJax#2718.