### PR TITLE
Make sure all character data is included when adaptiveCSS is false.  (mathjax/MathJax#2724)

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -185,7 +185,11 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
     //
     //  Add the styles for delimiters and characters
     //
-    this.updateStyles(styles);
+    if (this.options.adaptiveCSS) {
+      this.updateStyles(styles);
+    } else {
+      this.allStyles(styles);
+    }
     //
     //  Return the final style sheet
     //
@@ -207,6 +211,35 @@ export class CHTMLFontData extends FontData<CHTMLCharOptions, CHTMLVariantData, 
       this.addCharStyles(styles, variant.letter, N, variant.chars[N]);
     }
     return styles;
+  }
+
+  /**
+   * @param {StyleList} styles  The style list to add characters to
+   */
+  protected allStyles(styles: StyleList) {
+    //
+    //  Create styles needed for the delimiters
+    //
+    for (const n of Object.keys(this.delimiters)) {
+      const N = parseInt(n);
+      this.addDelimiterStyles(styles, N, this.delimiters[N]);
+    }
+    //
+    //  Add style for all character data
+    //
+    for (const name of Object.keys(this.variant)) {
+      const variant = this.variant[name];
+      const vletter = variant.letter;
+      for (const n of Object.keys(variant.chars)) {
+        const N = parseInt(n);
+        const char = variant.chars[N];
+        if ((char[3] || {}).smp) continue;
+        if (char.length < 4) {
+          (char as CHTMLCharData)[3] = {};
+        }
+        this.addCharStyles(styles, vletter, N, char);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes a problem introduced in v3.2.0 where setting `adaptiveCSS` to `false` would not produce the full CSS; it included all the wrapper CSS, but left out the unused character CSS.  This fixes that problem.

Resolves issue mathjax/MathJax#2724.