### PR TITLE
Add a minimum height for accented characters.  (mathjax/MathJax#2766)

### DIFF
--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -142,6 +142,7 @@ CommonMoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsup<any, any, an
     this.baseChild.toCHTML(base);
     const overbox = this.scriptChild.getBBox();
     const basebox = this.baseChild.getBBox();
+    this.adjustBaseHeight(base, basebox);
     const k = this.getOverKU(basebox, overbox)[0];
     const delta = (this.isLineAbove ? 0 : this.getDelta());
     this.adaptor.setStyle(over, 'paddingBottom', this.em(k));
@@ -209,6 +210,7 @@ CommonMunderoverMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<any,
     const overbox = this.overChild.getBBox();
     const basebox = this.baseChild.getBBox();
     const underbox = this.underChild.getBBox();
+    this.adjustBaseHeight(base, basebox);
     const ok = this.getOverKU(basebox, overbox)[0];
     const uk = this.getUnderKV(basebox, underbox)[0];
     const delta = this.getDelta();

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -101,4 +101,18 @@ CommonScriptbaseMixin<CHTMLWrapper<any, any, any>, CHTMLConstructor<any, any, an
     adaptor.append(adaptor.firstChild(under) as N, box);
   }
 
+  /**
+   * @param {N} base        The HTML element for the base
+   * @param {BBox} basebox  The bbox for the base
+   */
+  protected adjustBaseHeight(base: N, basebox: BBox) {
+    if (this.node.attributes.get('accent')) {
+      const minH = this.font.params.x_height * basebox.scale;
+      if (basebox.h < minH) {
+        this.adaptor.setStyle(base, 'paddingTop', this.em(minH - basebox.h));
+        basebox.h = minH;
+      }
+    }
+  }
+
 }

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -155,6 +155,9 @@ export function CommonMoverMixin<
       bbox.empty();
       const basebox = this.baseChild.getBBox();
       const overbox = this.scriptChild.getBBox();
+      if (this.node.attributes.get('accent')) {
+        basebox.h = Math.max(basebox.h, this.font.params.x_height * basebox.scale);
+      }
       const u = this.getOverKU(basebox, overbox)[1];
       const delta = (this.isLineAbove ? 0 : this.getDelta());
       const [bw, ow] = this.getDeltaW([basebox, overbox], [0, delta]);
@@ -262,6 +265,9 @@ export function CommonMunderoverMixin<
       const overbox = this.overChild.getBBox();
       const basebox = this.baseChild.getBBox();
       const underbox = this.underChild.getBBox();
+      if (this.node.attributes.get('accent')) {
+        basebox.h = Math.max(basebox.h, this.font.params.x_height * basebox.scale);
+      }
       const u = this.getOverKU(basebox, overbox)[1];
       const v = this.getUnderKV(basebox, underbox)[1];
       const delta = this.getDelta();


### PR DESCRIPTION
This makes the output for `mover` and `munderover` consistent with TeX when used for accents, and brings v3 in line with v2 output.

Resolves issue mathjax/MathJax#2766.