### PR TITLE
Fix problem where some menu settings weren't sticky  (mathjax/MathJax#2786)

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -371,6 +371,7 @@ export class Menu {
     this.initSettings();
     this.mergeUserSettings();
     this.initMenu();
+    this.applySettings();
   }
 
   /**
@@ -671,6 +672,18 @@ export class Menu {
   /*======================================================================*/
 
   /**
+   * Do what is needed to apply the initial user settings
+   */
+  protected applySettings() {
+    this.setTabOrder(this.settings.inTabOrder);
+    this.document.options.enableAssistiveMml = this.settings.assistiveMml;
+    this.document.outputJax.options.scale = parseFloat(this.settings.scale);
+    if (this.settings.renderer !== this.defaultSettings.renderer) {
+      this.setRenderer(this.settings.renderer);
+    }
+  }
+
+  /**
    * @param {string} scale   The new scaling value
    */
   protected setScale(scale: string) {
@@ -765,7 +778,7 @@ export class Menu {
       if (percent.match(/^\s*\d+(\.\d*)?\s*%?\s*$/)) {
         const scale = parseFloat(percent) / 100;
         if (scale) {
-          this.setScale(String(scale));
+          this.menu.pool.lookup('scale').setValue(String(scale));
         } else {
           alert('The scale should not be zero');
         }


### PR DESCRIPTION
This PR adds some initialization to the menu code that makes sure that the initial settings of the menu take effect on a page reload.  This was not the case for the in-tab-order, assistive MML, renderer, and scale settings (argh!).

Resolves issue mathjax/MathJax#2786, and similar problems with the other settings.

@zorkow, activating the explorer seems to override the in-tab-order setting.  Is that intentional?