### PR TITLE
Make sure math-in-text forms an ORD atom with textmacros. (mathjax/MathJax#2828)

### DIFF
--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -141,6 +141,9 @@ export class TextParser extends TexParser {
    */
   public PushMath(mml: MmlNode) {
     const env = this.stack.env;
+    if (!mml.isKind('TeXAtom')) {
+      mml = this.create('node', 'TeXAtom', [mml]);  // make sure the math is an ORD
+    }
     for (const name of ['mathsize', 'mathcolor']) {
       if (env[name] && !mml.attributes.getExplicit(name)) {
         if (!mml.isToken && !mml.isKind('mstyle')) {


### PR DESCRIPTION
This PR forces the math that is typeset within text to be of TeX class ORD when the texmacros extension is in use (making it consistent with when textmacros is *not* in use).

Resolves issue mathjax/MathJax#2828.