### PR TITLE
Have physics package match nested parentheses, fix spacing issues (mathjax/MathJax#2760, mathjax/MathJax#2831)

### DIFF
--- a/ts/input/tex/physics/PhysicsConfiguration.ts
+++ b/ts/input/tex/physics/PhysicsConfiguration.ts
@@ -33,7 +33,8 @@ export const PhysicsConfiguration = Configuration.create(
       macro: [
         'Physics-automatic-bracing-macros',
         'Physics-vector-macros',
-        'Physics-vector-chars',
+        'Physics-vector-mo',
+        'Physics-vector-mi',
         'Physics-derivative-macros',
         'Physics-expressions-macros',
         'Physics-quick-quad-macros',

--- a/ts/input/tex/physics/PhysicsItems.ts
+++ b/ts/input/tex/physics/PhysicsItems.ts
@@ -86,8 +86,8 @@ export class AutoOpen extends BaseItem {
       this.getProperty('big') as string
     );
     //
-    //  Remove fence markers so it is treated as a regular mrow when
-    //  setting the tex class, so it is not class INNER (#2760)
+    //  Remove fence markers that would cause it to be TeX class INNER,
+    //  so it is treated as a regular mrow when setting the tex class (#2760)
     //
     NodeUtil.removeProperties(mml, 'open', 'close', 'texClass');
     return mml;

--- a/ts/input/tex/physics/PhysicsItems.ts
+++ b/ts/input/tex/physics/PhysicsItems.ts
@@ -25,10 +25,24 @@
 
 import {CheckType, BaseItem, StackItem} from '../StackItem.js';
 import ParseUtil from '../ParseUtil.js';
+import NodeUtil from '../NodeUtil.js';
 import TexParser from '../TexParser.js';
-
+import {AbstractMmlTokenNode} from '../../../core/MmlTree/MmlNode.js';
 
 export class AutoOpen extends BaseItem {
+
+  /**
+   * @override
+   */
+  protected static errors = Object.assign(Object.create(BaseItem.errors), {
+    'stop': ['ExtraOrMissingDelims', 'Extra open or missing close delimiter']
+  });
+
+  /**
+   * The number of unpaired open delimiters that need to be matched before
+   *   a close delimiter will close this item. (#2831)
+   */
+  protected openCount: number = 0;
 
   /**
    * @override
@@ -64,20 +78,36 @@ export class AutoOpen extends BaseItem {
       this.Push(new TexParser(right, parser.stack.env,
                               parser.configuration).mml());
     }
-    let mml = super.toMml();
-    return ParseUtil.fenced(this.factory.configuration,
-                            this.getProperty('open') as string,
-                            mml,
-                            this.getProperty('close') as string,
-                            this.getProperty('big') as string);
+    let mml = ParseUtil.fenced(
+      this.factory.configuration,
+      this.getProperty('open') as string,
+      super.toMml(),
+      this.getProperty('close') as string,
+      this.getProperty('big') as string
+    );
+    //
+    //  Remove fence markers so it is treated as a regular mrow when
+    //  setting the tex class, so it is not class INNER (#2760)
+    //
+    NodeUtil.removeProperties(mml, 'open', 'close', 'texClass');
+    return mml;
   }
 
   /**
    * @override
    */
   public checkItem(item: StackItem): CheckType {
+    //
+    //  Check for nested open delimiters (#2831)
+    //
+    if (item.isKind('mml') && item.Size() === 1) {
+      const mml = item.toMml();
+      if (mml.isKind('mo') && (mml as AbstractMmlTokenNode).getText() === this.getProperty('open')) {
+        this.openCount++;
+      }
+    }
     let close = item.getProperty('autoclose');
-    if (close && close === this.getProperty('close')) {
+    if (close && close === this.getProperty('close') && !this.openCount--) {
       if (this.getProperty('ignore')) {
         this.Clear();
         return [[], true];

--- a/ts/input/tex/physics/PhysicsMappings.ts
+++ b/ts/input/tex/physics/PhysicsMappings.ts
@@ -58,14 +58,17 @@ new CommandMap('Physics-automatic-bracing-macros', {
 /**
  * Macros for physics package (section 2.2).
  */
-new CharacterMap('Physics-vector-chars', ParseMethods.mathchar0mi, {
+new CharacterMap('Physics-vector-mo', ParseMethods.mathchar0mo, {
   dotproduct:    ['\u22C5', {mathvariant: TexConstant.Variant.BOLD}],
   vdot:          ['\u22C5', {mathvariant: TexConstant.Variant.BOLD}],
   crossproduct:  '\u00D7',
   cross:         '\u00D7',
   cp:            '\u00D7',
   // This is auxiliary!
-  gradientnabla: ['\u2207', {mathvariant: TexConstant.Variant.BOLD}],
+  gradientnabla: ['\u2207', {mathvariant: TexConstant.Variant.BOLD}]
+});
+
+new CharacterMap('Physics-vector-mi', ParseMethods.mathchar0mi, {
   real:          ['\u211C', {mathvariant: TexConstant.Variant.NORMAL}],
   imaginary:     ['\u2111', {mathvariant: TexConstant.Variant.NORMAL}]
 });


### PR DESCRIPTION
This PR causes nested delimiters to be handled properly (not closing the delimiters until the inner ones are also closed).  It also fixes the spacing issue around the delimiters (the physics package prevents the stretchy delimiters from getting TeX class INNER, so I've removed the properties that cause `setTeXclass()` to mark it as INNER so that it will be handled as a normal `mrow` with an OPEN at the front and a CLOSE at the end).  Also, some operators were being enclosed in `mi` rather than `mo`, producing the wrong spacing (e.g., in `\div` and `\curl`), so I've changed that as well to match the LaTeX output.  Finally, an expression that is missing its final delimiter would produce a math input error, so I've added the missing error message so that the missing close delimiter will be reported.

This resolves issues mathjax/MathJax#2760 and mathjax/MathJax#2831.