### PR TITLE
Refactor node-based DOM adaptors to use a mixing for common code

### DIFF
--- a/ts/adaptors/NodeMixin.ts
+++ b/ts/adaptors/NodeMixin.ts
@@ -1,0 +1,160 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements a mixin for node-based adaptors that overrides
+ *                the methods that obtain DOM node sizes, when those aren't
+ *                available from the DOM itself.
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {DOMAdaptor} from '../core/DOMAdaptor.js';
+import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
+
+/**
+ * A constructor for a given class
+ *
+ * @template T   The class to construct
+ */
+export type Constructor<T> = (new(...args: any[]) => T);
+
+/**
+ * The type of an Adaptor class
+ */
+export type AdaptorConstructor<N, T, D> = Constructor<DOMAdaptor<N, T, D>>;
+
+/**
+ * The options to the NodeMixin
+ */
+export const NodeMixinOptions: OptionList = {
+  badCSS: true,     // getComputedStyles() is not implemented in the DOM
+  badSizes: true,   // element sizes (e.g., ClientWidth, etc.) are not implemented in the DOM
+};
+
+/**
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
+  Base: A,
+  options: typeof NodeMixinOptions = {}
+): A {
+
+  options = userOptions(defaultOptions({}, NodeMixinOptions), options);
+
+  return class NodeAdaptor extends Base {
+
+    /**
+     * The default options
+     */
+    public static OPTIONS: OptionList = {
+      ...(options.badCSS ? {
+        fontSize: 16,          // We can't compute the font size, so always use this
+        fontFamily: 'Times',   // We can't compute the font family, so always use this
+      } : {}),
+      ...(options.badSizes ? {
+        cjkCharWidth: 1,       // Width (in em units) of full width characters
+        unknownCharWidth: .6,  // Width (in em units) of unknown (non-full-width) characters
+        unknownCharHeight: .8, // Height (in em units) of unknown characters
+      } : {})
+    };
+
+    /**
+     * Pattern to identify CJK (i.e., full-width) characters
+     */
+    public static cjkPattern = new RegExp([
+      '[',
+      '\u1100-\u115F', // Hangul Jamo
+      '\u2329\u232A',  // LEFT-POINTING ANGLE BRACKET, RIGHT-POINTING ANGLE BRACKET
+      '\u2E80-\u303E', // CJK Radicals Supplement ... CJK Symbols and Punctuation
+      '\u3040-\u3247', // Hiragana ... Enclosed CJK Letters and Months
+      '\u3250-\u4DBF', // Enclosed CJK Letters and Months ... CJK Unified Ideographs Extension A
+      '\u4E00-\uA4C6', // CJK Unified Ideographs ... Yi Radicals
+      '\uA960-\uA97C', // Hangul Jamo Extended-A
+      '\uAC00-\uD7A3', // Hangul Syllables
+      '\uF900-\uFAFF', // CJK Compatibility Ideographs
+      '\uFE10-\uFE19', // Vertical Forms
+      '\uFE30-\uFE6B', // CJK Compatibility Forms ... Small Form Variants
+      '\uFF01-\uFF60\uFFE0-\uFFE6', // Halfwidth and Fullwidth Forms
+      '\u{1B000}-\u{1B001}', // Kana Supplement
+      '\u{1F200}-\u{1F251}', // Enclosed Ideographic Supplement
+      '\u{20000}-\u{3FFFD}', // CJK Unified Ideographs Extension B ... Tertiary Ideographic Plane
+      ']'
+    ].join(''), 'gu');
+
+    /**
+     * The options for the instance
+     */
+    public options: OptionList;
+
+    /**
+     * @param {any} window          The window to work with
+     * @param {OptionList} options  The options for the adaptor
+     * @constructor
+     */
+    constructor(...args: any[]) {
+      super(args[0]);
+      let CLASS = this.constructor as typeof NodeAdaptor;
+      this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), args[1]);
+    }
+
+    /**
+     * For DOMs that don't handle CSS well, use the font size from the options
+     *
+     * @override
+     */
+    public fontSize(node: N) {
+      return (options.badCSS ? this.options.fontSize : super.fontSize(node));
+    }
+
+    /**
+     * For DOMs that don't handle CSS well, use the font family from the options
+     *
+     * @override
+     */
+    public fontFamily(node: N) {
+      return (options.badCSS ? this.options.fontFamily : super.fontFamily(node));
+    }
+
+    /**
+     * @override
+     */
+    public nodeSize(node: N, em: number = 1, local: boolean = null) {
+      if (!options.badSizes) {
+        return super.nodeSize(node, em, local);
+      }
+      const text = this.textContent(node);
+      const non = Array.from(text.replace(NodeAdaptor.cjkPattern, '')).length;  // # of non-CJK chars
+      const CJK = Array.from(text).length - non;                                // # of cjk chars
+      return [
+        CJK * this.options.cjkCharWidth + non * this.options.unknownCharWidth,
+        this.options.unknownCharHeight
+      ] as [number, number];
+    }
+
+    /**
+     * @override
+     */
+    public nodeBBox(node: N) {
+      return (options.badSizes ? {left: 0, right: 0, top: 0, bottom: 0} : super.nodeBBox(node));
+    }
+
+  };
+
+}

--- a/ts/adaptors/jsdomAdaptor.ts
+++ b/ts/adaptors/jsdomAdaptor.ts
@@ -22,107 +22,18 @@
  */
 
 import {HTMLAdaptor} from './HTMLAdaptor.js';
-import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
+import {NodeMixin, Constructor} from './NodeMixin.js';
+import {OptionList} from '../util/Options.js';
 
-export class JsdomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
+/**
+ * The constructor for an HTMLAdaptor
+ */
+export type HTMLAdaptorConstructor = Constructor<HTMLAdaptor<HTMLElement, Text, Document>>;
 
-  /**
-   * The default options
-   */
-  public static OPTIONS: OptionList = {
-    fontSize: 16,          // We can't compute the font size, so always use this
-    fontFamily: 'Times',   // We can't compute the font family, so always use this
-    cjkCharWidth: 1,       // Width (in em units) of full width characters
-    unknownCharWidth: .6,  // Width (in em units) of unknown (non-full-width) characters
-    unknownCharHeight: .8, // Height (in em units) of unknown characters
-  };
-
-  /**
-   * Pattern to identify CJK (i.e., full-width) characters
-   */
-  public static cjkPattern = new RegExp([
-    '[',
-    '\u1100-\u115F', // Hangul Jamo
-    '\u2329\u232A',  // LEFT-POINTING ANGLE BRACKET, RIGHT-POINTING ANGLE BRACKET
-    '\u2E80-\u303E', // CJK Radicals Supplement ... CJK Symbols and Punctuation
-    '\u3040-\u3247', // Hiragana ... Enclosed CJK Letters and Months
-    '\u3250-\u4DBF', // Enclosed CJK Letters and Months ... CJK Unified Ideographs Extension A
-    '\u4E00-\uA4C6', // CJK Unified Ideographs ... Yi Radicals
-    '\uA960-\uA97C', // Hangul Jamo Extended-A
-    '\uAC00-\uD7A3', // Hangul Syllables
-    '\uF900-\uFAFF', // CJK Compatibility Ideographs
-    '\uFE10-\uFE19', // Vertical Forms
-    '\uFE30-\uFE6B', // CJK Compatibility Forms ... Small Form Variants
-    '\uFF01-\uFF60\uFFE0-\uFFE6', // Halfwidth and Fullwidth Forms
-    '\u{1B000}-\u{1B001}', // Kana Supplement
-    '\u{1F200}-\u{1F251}', // Enclosed Ideographic Supplement
-    '\u{20000}-\u{3FFFD}', // CJK Unified Ideographs Extension B ... Tertiary Ideographic Plane
-    ']'
-  ].join(''), 'gu');
-
-  /**
-   * The options for the instance
-   */
-  public options: OptionList;
-
-  /**
-   * @param {Window} window   The window to work with
-   * @param {OptionList} options  The options for the jsdom adaptor
-   * @constructor
-   */
-  constructor(window: Window, options: OptionList = null) {
-    super(window);
-    let CLASS = this.constructor as typeof JsdomAdaptor;
-    this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
-  }
-
-  /**
-   * JSDOM's getComputedStyle() implementation is badly broken, and only
-   *   return the styles explicitly set on the given node, not the
-   *   inherited values frmo the cascading style sheets (so it is pretty
-   *   useless).  This is somethig we can't really work around, so use
-   *   the default value given in the options instead.  Sigh
-   *
-   * @override
-   */
-  public fontSize(_node: HTMLElement) {
-    return this.options.fontSize;
-  }
-
-  /**
-   * JSDOM's getComputedStyle() implementation is badly broken, and only
-   *   return the styles explicitly set on the given node, not the
-   *   inherited values frmo the cascading style sheets (so it is pretty
-   *   useless).  This is somethig we can't really work around, so use
-   *   the default value given in the options instead.  Sigh
-   *
-   * @override
-   */
-  public fontFamily(_node: HTMLElement) {
-    return this.options.fontFamily;
-  }
-
-  /**
-   * @override
-   */
-  public nodeSize(node: HTMLElement, _em: number = 1, _local: boolean = null) {
-    const text = this.textContent(node);
-    const non = Array.from(text.replace(JsdomAdaptor.cjkPattern, '')).length; // # of non-CJK chars
-    const CJK = Array.from(text).length - non;                                // # of cjk chars
-    return [
-      CJK * this.options.cjkCharWidth + non * this.options.unknownCharWidth,
-      this.options.unknownCharHeight
-    ] as [number, number];
-  }
-
-  /**
-   * @override
-   */
-  public nodeBBox(_node: HTMLElement) {
-    return {left: 0, right: 0, top: 0, bottom: 0};
-  }
-
-}
+/**
+ * The JsdomAdaptor class
+ */
+export class JsdomAdaptor extends NodeMixin<HTMLElement, Text, Document, HTMLAdaptorConstructor>(HTMLAdaptor) {}
 
 /**
  * Function for creating an HTML adaptor using jsdom
@@ -130,6 +41,6 @@ export class JsdomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
  * @param {any} JSDOM      The jsdom object to use for this adaptor
  * @return {HTMLAdaptor}   The newly created adaptor
  */
-export function jsdomAdaptor(JSDOM: any, options: OptionList = null): HTMLAdaptor<HTMLElement, Text, Document> {
+export function jsdomAdaptor(JSDOM: any, options: OptionList = null): JsdomAdaptor {
   return new JsdomAdaptor(new JSDOM().window, options);
 }

--- a/ts/adaptors/linkedomAdaptor.ts
+++ b/ts/adaptors/linkedomAdaptor.ts
@@ -22,65 +22,26 @@
  */
 
 import {HTMLAdaptor} from './HTMLAdaptor.js';
-import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
+import {NodeMixin, Constructor} from './NodeMixin.js';
+import {OptionList} from '../util/Options.js';
 
-export class LinkedomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
+/**
+ * The constructor for an HTMLAdaptor
+ */
+export type HTMLAdaptorConstructor = Constructor<HTMLAdaptor<HTMLElement, Text, Document>>;
 
-  /**
-   * The default options
-   */
-  public static OPTIONS: OptionList = {
-    fontSize: 16,          // We can't compute the font size, so always use this
-    fontFamily: 'Times',   // We can't compute the font family, so always use this
-    cjkCharWidth: 1,       // Width (in em units) of full width characters
-    unknownCharWidth: .6,  // Width (in em units) of unknown (non-full-width) characters
-    unknownCharHeight: .8, // Height (in em units) of unknown characters
-  };
-
-  /**
-   * Pattern to identify CJK (i.e., full-width) characters
-   */
-  public static cjkPattern = new RegExp([
-    '[',
-    '\u1100-\u115F', // Hangul Jamo
-    '\u2329\u232A',  // LEFT-POINTING ANGLE BRACKET, RIGHT-POINTING ANGLE BRACKET
-    '\u2E80-\u303E', // CJK Radicals Supplement ... CJK Symbols and Punctuation
-    '\u3040-\u3247', // Hiragana ... Enclosed CJK Letters and Months
-    '\u3250-\u4DBF', // Enclosed CJK Letters and Months ... CJK Unified Ideographs Extension A
-    '\u4E00-\uA4C6', // CJK Unified Ideographs ... Yi Radicals
-    '\uA960-\uA97C', // Hangul Jamo Extended-A
-    '\uAC00-\uD7A3', // Hangul Syllables
-    '\uF900-\uFAFF', // CJK Compatibility Ideographs
-    '\uFE10-\uFE19', // Vertical Forms
-    '\uFE30-\uFE6B', // CJK Compatibility Forms ... Small Form Variants
-    '\uFF01-\uFF60\uFFE0-\uFFE6', // Halfwidth and Fullwidth Forms
-    '\u{1B000}-\u{1B001}', // Kana Supplement
-    '\u{1F200}-\u{1F251}', // Enclosed Ideographic Supplement
-    '\u{20000}-\u{3FFFD}', // CJK Unified Ideographs Extension B ... Tertiary Ideographic Plane
-    ']'
-  ].join(''), 'gu');
-
-  /**
-   * The options for the instance
-   */
-  public options: OptionList;
-
-  /**
-   * @param {Window} window   The window to work with
-   * @param {OptionList} options  The options for the linkedom adaptor
-   * @constructor
-   */
-  constructor(window: Window, options: OptionList = null) {
-    super(window);
-    window.constructor.prototype.HTMLCollection = class {};  // add fake class for missing HTMLCollecton
-    let CLASS = this.constructor as typeof LinkedomAdaptor;
-    this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
-  }
+/**
+ * The LinkedomAdaptor class
+ */
+export class LinkedomAdaptor extends NodeMixin<HTMLElement, Text, Document, HTMLAdaptorConstructor>(HTMLAdaptor) {
 
   /**
    * @override
    */
   public parse(text: string, format: string = 'text/html') {
+    //
+    //  Make sure the text string has nodes (in particular, it can't be empty)
+    //
     if (!text.match(/^(?:\s|\n)*</)) text = '<html>' + text + '</html>';
     return this.parser.parseFromString(text, format);
   }
@@ -95,54 +56,16 @@ export class LinkedomAdaptor extends HTMLAdaptor<HTMLElement, Text, Document> {
     return this.outerHTML(node);
   }
 
-  /**
-   * Linkedom doesn't implement getComputedStyle(), so just
-   * use the default value (unfortunately).
-   *
-   * @override
-   */
-  public fontSize(_node: HTMLElement) {
-    return this.options.fontSize;
-  }
-
-  /**
-   * Linkedom doesn't implement getComputedStyle(), so just
-   * use the default value (unfortunately).
-   *
-   * @override
-   */
-  public fontFamily(_node: HTMLElement) {
-    return this.options.fontFamily;
-  }
-
-  /**
-   * @override
-   */
-  public nodeSize(node: HTMLElement, _em: number = 1, _local: boolean = null) {
-    const text = this.textContent(node);
-    const non = Array.from(text.replace(LinkedomAdaptor.cjkPattern, '')).length; // # of non-CJK chars
-    const CJK = Array.from(text).length - non;                                   // # of cjk chars
-    return [
-      CJK * this.options.cjkCharWidth + non * this.options.unknownCharWidth,
-      this.options.unknownCharHeight
-    ] as [number, number];
-  }
-
-  /**
-   * @override
-   */
-  public nodeBBox(_node: HTMLElement) {
-    return {left: 0, right: 0, top: 0, bottom: 0};
-  }
-
 }
 
 /**
  * Function for creating an HTML adaptor using linkedom
  *
- * @param {any} parseHTML   The linkedom HTML parser to use for this adaptor
- * @return {HTMLAdaptor}    The newly created adaptor
+ * @param {any} parseHTML       The linkedom HTML parser to use for this adaptor
+ * @return {LinkeddomAdaptor}   The newly created adaptor
  */
-export function linkedomAdaptor(parseHTML: any, options: OptionList = null): HTMLAdaptor<HTMLElement, Text, Document> {
-  return new LinkedomAdaptor(parseHTML('<html></html>'), options);
+export function linkedomAdaptor(parseHTML: any, options: OptionList = null): LinkedomAdaptor {
+  const window = parseHTML('<html></html>');
+  window.constructor.prototype.HTMLCollection = class {};  // add fake class for missing HTMLCollecton
+  return new LinkedomAdaptor(window, options);
 }

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -22,6 +22,7 @@
  */
 
 import {AbstractDOMAdaptor} from '../core/DOMAdaptor.js';
+import {NodeMixin, Constructor} from './NodeMixin.js';
 import {LiteDocument} from './lite/Document.js';
 import {LiteElement, LiteNode} from './lite/Element.js';
 import {LiteText, LiteComment} from './lite/Text.js';
@@ -29,52 +30,15 @@ import {LiteList} from './lite/List.js';
 import {LiteWindow} from './lite/Window.js';
 import {LiteParser} from './lite/Parser.js';
 import {Styles} from '../util/Styles.js';
-import {userOptions, defaultOptions, OptionList} from '../util/Options.js';
+import {OptionList} from '../util/Options.js';
 
 /************************************************************/
+
+
 /**
  * Implements a lightweight DOMAdaptor on liteweight HTML elements
  */
-export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteDocument> {
-  /**
-   * The default options
-   */
-  public static OPTIONS: OptionList = {
-    fontSize: 16,          // We can't compute the font size, so always use this
-    fontFamily: 'Times',   // We can't compute the font family, so always use this
-    cjkCharWidth: 1,       // Width (in em units) of full width characters
-    unknownCharWidth: .6,  // Width (in em units) of unknown (non-full-width) characters
-    unknownCharHeight: .8, // Height (in em units) of unknown characters
-  };
-
-  /**
-   * Pattern to identify CJK (.i.e., full-width) characters
-   */
-  public static cjkPattern = new RegExp([
-    '[',
-    '\u1100-\u115F', // Hangul Jamo
-    '\u2329\u232A',  // LEFT-POINTING ANGLE BRACKET, RIGHT-POINTING ANGLE BRACKET
-    '\u2E80-\u303E', // CJK Radicals Supplement ... CJK Symbols and Punctuation
-    '\u3040-\u3247', // Hiragana ... Enclosed CJK Letters and Months
-    '\u3250-\u4DBF', // Enclosed CJK Letters and Months ... CJK Unified Ideographs Extension A
-    '\u4E00-\uA4C6', // CJK Unified Ideographs ... Yi Radicals
-    '\uA960-\uA97C', // Hangul Jamo Extended-A
-    '\uAC00-\uD7A3', // Hangul Syllables
-    '\uF900-\uFAFF', // CJK Compatibility Ideographs
-    '\uFE10-\uFE19', // Vertical Forms
-    '\uFE30-\uFE6B', // CJK Compatibility Forms ... Small Form Variants
-    '\uFF01-\uFF60\uFFE0-\uFFE6', // Halfwidth and Fullwidth Forms
-    '\u{1B000}-\u{1B001}', // Kana Supplement
-    '\u{1F200}-\u{1F251}', // Enclosed Ideographic Supplement
-    '\u{20000}-\u{3FFFD}', // CJK Unified Ideographs Extension B ... Tertiary Ideographic Plane
-    ']'
-  ].join(''), 'gu');
-
-  /**
-   * The options for the instance
-   */
-  public options: OptionList;
-
+export class LiteBase extends AbstractDOMAdaptor<LiteElement, LiteText, LiteDocument> {
   /**
    * The document in which the HTML nodes will be created
    */
@@ -94,10 +58,8 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
    * @param {OptionList} options  The options for the lite adaptor (e.g., fontSize)
    * @constructor
    */
-  constructor(options: OptionList = null) {
+  constructor() {
     super();
-    let CLASS = this.constructor as typeof LiteAdaptor;
-    this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     this.parser = new LiteParser();
     this.window = new LiteWindow();
   }
@@ -105,7 +67,7 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   /**
    * @override
    */
-  public parse(text: string, format?: string) {
+  public parse(text: string, format?: string): LiteDocument {
     return this.parser.parseFromString(text, format, this);
   }
 
@@ -452,21 +414,21 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   /**
    * @override
    */
-  public innerHTML(node: LiteElement) {
+  public innerHTML(node: LiteElement): string {
     return this.parser.serializeInner(this, node);
   }
 
   /**
    * @override
    */
-  public outerHTML(node: LiteElement) {
+  public outerHTML(node: LiteElement): string {
     return this.parser.serialize(this, node);
   }
 
   /**
    * @override
    */
-  public serializeXML(node: LiteElement) {
+  public serializeXML(node: LiteElement): string {
     return this.parser.serialize(this, node, true);
   }
 
@@ -589,31 +551,30 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
     node.children = [this.text(rules.join('\n\n') + '\n\n' + this.textContent(node))];
   }
 
+  /*******************************************************************/
+  /*
+   *  The next four methods get overridden by the NodeMixin below
+   */
+
   /**
    * @override
    */
   public fontSize(_node: LiteElement) {
-    return this.options.fontSize;
+    return 0;
   }
 
   /**
    * @override
    */
   public fontFamily(_node: LiteElement) {
-    return this.options.fontFamily;
+    return '';
   }
 
   /**
    * @override
    */
-  public nodeSize(node: LiteElement, _em: number = 1, _local: boolean = null) {
-    const text = this.textContent(node);
-    const non = Array.from(text.replace(LiteAdaptor.cjkPattern, '')).length; // # of non-CJK chars
-    const CJK = Array.from(text).length - non;                               // # of cjk chars
-    return [
-      CJK * this.options.cjkCharWidth + non * this.options.unknownCharWidth,
-      this.options.unknownCharHeight
-    ] as [number, number];
+  public nodeSize(_node: LiteElement, _em: number = 1, _local: boolean = null) {
+    return [0, 0] as [number, number];
   }
 
   /**
@@ -622,7 +583,13 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
   public nodeBBox(_node: LiteElement) {
     return {left: 0, right: 0, top: 0, bottom: 0};
   }
+
 }
+
+/**
+ * The LiteAdaptor class (add in the NodeMixin methods and options)
+ */
+export class LiteAdaptor extends NodeMixin<LiteElement, LiteText, LiteDocument, Constructor<LiteBase>>(LiteBase) {}
 
 /************************************************************/
 /**
@@ -632,5 +599,5 @@ export class LiteAdaptor extends AbstractDOMAdaptor<LiteElement, LiteText, LiteD
  * @return {LiteAdaptor}        The newly created adaptor
  */
 export function liteAdaptor(options: OptionList = null): LiteAdaptor {
-  return new LiteAdaptor(options);
+  return new LiteAdaptor(null, options);
 }


### PR DESCRIPTION
This PR introduces a `NodeMixin` function for adding common methods and properties to a base DOM adaptor.  These methods are the ones that implement features that aren't available in node DOMs, like `getComputedStyles()` and measuring of DOM elements.

The jsdom and linkedom adaptors are refactored to use this mix-in, as is the liteDOM, though that is a bit more complicated, as the mix-in can't be used with an abstract class, and so we need to make a base lite class to use with the mix-in to get the full adaptor.  This means that the last four methods in `LiteBase` will be overridden by the mix-in, but I don't see any way around that.