### PR TITLE
Re-implement \sideset using mmultiscripts.  (mathjax/MathJax#1217)

### DIFF
--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -203,6 +203,8 @@ export class SerializedMmlVisitor extends MmlVisitor {
     node.getProperty('variantForm') && this.setDataAttribute(data, 'alternate', '1');
     node.getProperty('pseudoscript') && this.setDataAttribute(data, 'pseudoscript', 'true');
     node.getProperty('autoOP') === false && this.setDataAttribute(data, 'auto-op', 'false');
+    const scriptalign = node.getProperty('scriptalign') as string;
+    scriptalign && this.setDataAttribute(data, 'script-align', scriptalign);
     const texclass = node.getProperty('texClass') as number;
     if (texclass !== undefined) {
       let setclass = true;

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -156,18 +156,27 @@ export class MathMLCompile<N, T, D> {
         continue;
       }
       if (name.substr(0, 9) === 'data-mjx-') {
-        if (name === 'data-mjx-alternate') {
+        switch (name.substr(9)) {
+        case 'alternate':
           mml.setProperty('variantForm', true);
-        } else if (name === 'data-mjx-variant') {
+          break;
+        case 'variant':
           mml.attributes.set('mathvariant', value);
           ignoreVariant = true;
-        } else if (name === 'data-mjx-smallmatrix') {
+          break;
+        case 'smallmatrix':
           mml.setProperty('scriptlevel', 1);
           mml.setProperty('useHeight', false);
-        } else if (name === 'data-mjx-accent') {
+          break;
+        case 'accent':
           mml.setProperty('mathaccent', value === 'true');
-        } else if (name === 'data-mjx-auto-op') {
+          break;
+        case 'auto-op':
           mml.setProperty('autoOP', value === 'true');
+          break;
+        case 'script-align':
+          mml.setProperty('scriptalign', value);
+          break;
         }
       } else if (name !== 'class') {
         let val = value.toLowerCase();

--- a/ts/input/tex/ams/AmsMappings.ts
+++ b/ts/input/tex/ams/AmsMappings.ts
@@ -54,8 +54,7 @@ new sm.CommandMap('AMSmath-macros', {
   dddot:      ['Accent', '20DB'],
   ddddot:     ['Accent', '20DC'],
 
-  sideset:    ['Macro', '\\mathop{\\mathop{\\rlap{\\phantom{#3}}}\\nolimits#1' +
-               '\\!\\mathop{#3}\\nolimits#2}', 3],
+  sideset:     'SideSet',
 
   boxed:      ['Macro', '\\fbox{$\\displaystyle{#1}$}', 1],
 

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -330,7 +330,7 @@ function splitSideSet(mml: MmlNode): [MmlNode, MmlNode] {
 }
 
 /**
- * Utility for checking if a \setset argument has scripts with an empty base.
+ * Utility for checking if a \sideset argument has scripts with an empty base.
  * @param {MmlNode} mml The node to check.
  * @return {boolean} True if the base is not and empty mi element.
  */

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -257,7 +257,7 @@ AmsMethods.SideSet = function (parser: TexParser, name: string) {
     if (preRest) {
       //
       //  Replace the empty base of the prescripts with a phantom element of the
-      //    original base, with width 0 (so of the correct height and depth).
+      //    original base, with width 0 (but still of the correct height and depth).
       //    so the scripts will be at the right heights.
       //
       preScripts.replaceChild(

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -262,7 +262,7 @@ AmsMethods.SideSet = function (parser: TexParser, name: string) {
       //
       preScripts.replaceChild(
         parser.create('node', 'mphantom', [
-          parser.create('node', 'mpadded', [base.copy()], {width: 0})
+          parser.create('node', 'mpadded', [ParseUtil.copyNode(base, parser)], {width: 0})
         ]),
         NodeUtil.getChildAt(preScripts, 0)
       );

--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -27,6 +27,7 @@ import {CommonMmultiscriptsMixin} from '../../common/Wrappers/mmultiscripts.js';
 import {MmlMmultiscripts} from '../../../core/MmlTree/MmlNodes/mmultiscripts.js';
 import {BBox} from '../../../util/BBox.js';
 import {StyleList} from '../../../util/StyleList.js';
+import {split} from '../../../util/string.js';
 
 /*****************************************************************/
 /**
@@ -59,6 +60,15 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
     },
     'mjx-prescripts > mjx-row > mjx-cell': {
       'text-align': 'right'
+    },
+    '[script-align="left"] > mjx-row > mjx-cell': {
+      'text-align': 'left'
+    },
+    '[script-align="center"] > mjx-row > mjx-cell': {
+      'text-align': 'center'
+    },
+    '[script-align="right"] > mjx-row > mjx-cell': {
+      'text-align': 'right'
     }
   };
 
@@ -71,6 +81,11 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
     const chtml = this.standardCHTMLnode(parent);
     const data = this.scriptData;
     //
+    //  Get the alignment for the scripts
+    //
+    const scriptalign = this.node.getProperty('scriptalign') || 'right left';
+    const [preAlign, postAlign] = split(scriptalign + ' ' + scriptalign);
+    //
     //  Combine the bounding boxes of the pre- and post-scripts,
     //  and get the resulting baseline offsets
     //
@@ -81,11 +96,13 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
     //  Place the pre-scripts, then the base, then the post-scripts
     //
     if (data.numPrescripts) {
-      this.addScripts(u, -v, true, data.psub, data.psup, this.firstPrescript, data.numPrescripts);
+      const scripts = this.addScripts(u, -v, true, data.psub, data.psup, this.firstPrescript, data.numPrescripts);
+      preAlign !== 'right' && this.adaptor.setAttribute(scripts, 'script-align', preAlign);
     }
     this.childNodes[0].toCHTML(chtml);
     if (data.numScripts) {
-      this.addScripts(u, -v, false, data.sub, data.sup, 1, data.numScripts);
+      const scripts = this.addScripts(u, -v, false, data.sub, data.sup, 1, data.numScripts);
+      postAlign !== 'left' && this.adaptor.setAttribute(scripts, 'script-align', postAlign);
     }
   }
 
@@ -99,8 +116,9 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
    * @param {BBox} sup       The superscript bounding box
    * @param {number} i       The starting index for the scripts
    * @param {number} n       The number of sub/super-scripts
+   * @return {N}             The script table for these scripts
    */
-  protected addScripts(u: number, v: number, isPre: boolean, sub: BBox, sup: BBox, i: number, n: number) {
+  protected addScripts(u: number, v: number, isPre: boolean, sub: BBox, sup: BBox, i: number, n: number): N {
     const adaptor = this.adaptor;
     const q = (u - sup.d) + (v - sub.h);             // separation of scripts
     const U = (u < 0 && v === 0 ? sub.h + u : u);    // vertical offset of table
@@ -110,12 +128,12 @@ CommonMmultiscriptsMixin<CHTMLWrapper<any, any, any>, Constructor<CHTMLmsubsup<a
     const sepRow = this.html('mjx-row', rowdef);
     const subRow = this.html('mjx-row');
     const name = 'mjx-' + (isPre ? 'pre' : '') + 'scripts';
-    adaptor.append(this.chtml, this.html(name, tabledef, [supRow, sepRow, subRow]));
     let m = i + 2 * n;
     while (i < m) {
       this.childNodes[i++].toCHTML(adaptor.append(subRow, this.html('mjx-cell')) as N);
       this.childNodes[i++].toCHTML(adaptor.append(supRow, this.html('mjx-cell')) as N);
     }
+    return adaptor.append(this.chtml, this.html(name, tabledef, [supRow, sepRow, subRow]));
   }
 
 }

--- a/ts/output/svg/Wrappers/mmultiscripts.ts
+++ b/ts/output/svg/Wrappers/mmultiscripts.ts
@@ -25,6 +25,25 @@ import {SVGWrapper, Constructor} from '../Wrapper.js';
 import {SVGmsubsup} from './msubsup.js';
 import {CommonMmultiscriptsMixin} from '../../common/Wrappers/mmultiscripts.js';
 import {MmlMmultiscripts} from '../../../core/MmlTree/MmlNodes/mmultiscripts.js';
+import {split} from '../../../util/string.js';
+
+/*****************************************************************/
+
+/**
+ * A function taking two widths and returning an offset of the first in the second
+ */
+export type AlignFunction = (w: number, W: number) => number;
+
+/**
+ * Get the function for aligning scripts horizontally (left, center, right(
+ */
+export function AlignX(align: string) {
+  return ({
+    left: (_w, _W) => 0,
+    center: (w, W) => (W - w) / 2,
+    right: (w, W) => W - w
+  } as {[name: string]: AlignFunction})[align] || ((_w, _W) => 0) as AlignFunction;
+}
 
 /*****************************************************************/
 /**
@@ -50,6 +69,11 @@ CommonMmultiscriptsMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, 
     const svg = this.standardSVGnode(parent);
     const data = this.scriptData;
     //
+    //  Get the alignment for the scripts
+    //
+    const scriptalign = this.node.getProperty('scriptalign') || 'right left';
+    const [preAlign, postAlign] = split(scriptalign + ' ' + scriptalign);
+    //
     //  Combine the bounding boxes of the pre- and post-scripts,
     //  and get the resulting baseline offsets
     //
@@ -61,14 +85,14 @@ CommonMmultiscriptsMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, 
     //
     let x = 0;  // scriptspace
     if (data.numPrescripts) {
-      x = this.addScripts(.05, u, v, true, this.firstPrescript, data.numPrescripts);
+      x = this.addScripts(.05, u, v, this.firstPrescript, data.numPrescripts, preAlign);
     }
     const base = this.baseChild;
     base.toSVG(svg);
     base.place(x, 0);
     x += base.getBBox().w;
     if (data.numScripts) {
-      this.addScripts(x, u, v, false, 1, data.numScripts);
+      this.addScripts(x, u, v, 1, data.numScripts, postAlign);
     }
   }
 
@@ -78,13 +102,14 @@ CommonMmultiscriptsMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, 
    * @param {number} x       The x offset of the scripts
    * @param {number} u       The baseline offset for the superscripts
    * @param {number} v       The baseline offset for the subscripts
-   * @param {boolean} isPre  True for prescripts, false for scripts
    * @param {number} i       The starting index for the scripts
    * @param {number} n       The number of sub/super-scripts
+   * @param {string} align   The alignment for the scripts
    * @return {number}        The right-hand offset of the scripts
    */
-  protected addScripts(x: number, u: number, v: number, isPre: boolean, i: number, n: number): number {
+  protected addScripts(x: number, u: number, v: number, i: number, n: number, align: string): number {
     const adaptor = this.adaptor;
+    const alignX = AlignX(align);
     const supRow = adaptor.append(this.element, this.svg('g'));
     const subRow = adaptor.append(this.element, this.svg('g'));
     this.place(x, u, supRow);
@@ -98,8 +123,8 @@ CommonMmultiscriptsMixin<SVGWrapper<any, any, any>, Constructor<SVGmsubsup<any, 
       const w = Math.max(subbox.w * subr, supbox.w * supr);
       sub.toSVG(subRow);
       sup.toSVG(supRow);
-      sub.place(dx + (isPre ? w - subbox.w * subr : 0), 0);
-      sup.place(dx + (isPre ? w - supbox.w * supr : 0), 0);
+      sub.place(dx + alignX(subbox.w * subr, w), 0);
+      sup.place(dx + alignX(supbox.w * supr, w), 0);
       dx += w;
     }
     return x + dx;

--- a/ts/output/svg/Wrappers/mmultiscripts.ts
+++ b/ts/output/svg/Wrappers/mmultiscripts.ts
@@ -35,7 +35,7 @@ import {split} from '../../../util/string.js';
 export type AlignFunction = (w: number, W: number) => number;
 
 /**
- * Get the function for aligning scripts horizontally (left, center, right(
+ * Get the function for aligning scripts horizontally (left, center, right)
  */
 export function AlignX(align: string) {
   return ({


### PR DESCRIPTION
This re-implements the `\sideset` macro to use `mmultiscripts` rather than as a replacement macro that has a phantom duplicate of the base with super- and subscripts.  In order to produce the same output as LaTeX, a new property was added to allow `mmultiscripts` to control the alignment of the pre- and post-scripts; `\sideset` has the pre-script left-aligned, but `mmultiscripts` has them right-aligned, so this property is needed to allow left-alignment to be specified.  That required changes to the CHTML and SVG output to support the new property, and to the MathML serializer to output the property to MathML, and the MathML input jax to read the property on input.  For the latter, since the number of such properties is getting larger, the old if-then-else-if construction was replaced by a switch.

Resolves (closed) issue mathjax/Mathjax#1217 and #177.