### PR TITLE
Lazy extension update

### DIFF
--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -121,7 +121,7 @@ export interface DOMAdaptor<N, T, D> {
   getElements(nodes: (string | N | N[])[], document: D): N[];
 
   /**
-   * Determine if a container node contains a given node is somewhere in its DOM tree
+   * Determine if a container node contains a given node somewhere in its DOM tree
    *
    * @param {N} container  The container to search
    * @param {N|T} node     The node to look for

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -437,15 +437,6 @@ export interface MathDocument<N, T, D> {
   state(state: number, restore?: boolean): MathDocument<N, T, D>;
 
   /**
-   * Rerender the MathItems on the page
-   *
-   * @param {number=} start    The state to start rerendering at
-   * @param {number=} end      The state to end rerendering at
-   * @return {MathDocument}    The math document instance
-   */
-  rerender(start?: number, end?: number): MathDocument<N, T, D>;
-
-  /**
    * Clear the processed values so that the document can be reprocessed
    *
    * @param {ResetList} options   The things to be reset

--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -27,6 +27,7 @@ import {HTMLMathItem} from '../../handlers/html/HTMLMathItem.js';
 import {HTMLDocument} from '../../handlers/html/HTMLDocument.js';
 import {HTMLHandler} from '../../handlers/html/HTMLHandler.js';
 import {handleRetriesFor} from '../../util/Retries.js';
+import {OptionList} from '../../util/Options.js';
 
 /**
  * Add the needed function to the window object.
@@ -309,6 +310,14 @@ B extends MathDocumentConstructor<HTMLDocument<N, T, D>>>(
   return class BaseClass extends BaseDocument {
 
     /**
+     * @override
+     */
+    public static OPTIONS: OptionList = {
+      ...BaseDocument.OPTIONS,
+      lazyMargin: '200px'
+    };
+
+    /**
      * The Intersection Observer used to track the appearance of the expression markers
      */
     public lazyObserver: IntersectionObserver;
@@ -352,7 +361,7 @@ B extends MathDocumentConstructor<HTMLDocument<N, T, D>>>(
       super(...args);
       this.options.MathItem =
         LazyMathItemMixin<N, T, D, Constructor<HTMLMathItem<N, T, D>>>(this.options.MathItem);
-      this.lazyObserver = new IntersectionObserver(this.lazyObserve.bind(this));
+      this.lazyObserver = new IntersectionObserver(this.lazyObserve.bind(this), {rootMargin: this.options.lazyMargin});
       this.lazyList = new LazyList<N, T, D>();
       const callback = this.lazyHandleSet.bind(this);
       this.lazyProcessSet = (window && window.requestIdleCallback ?


### PR DESCRIPTION
This PR updates the lazy-typesetting extension to add several new features.

*  The ability to typeset all untypeset math on the page before printing it (so that it will print properly, even when parts of the page haven't been viewed).  (mathjax/MathJax#2711)
*  A new option to control the margin to use for the observer trigger (so that expressions slightly outside the viewport will be typeset in anticipation of scrolling.
*  The ability to mark some containers to force the math they contain to always be typeset, regardless of whether they are in the viewport.  This allows math that is used in JSXgraph, for example, to be placed properly.  (mathjax/MathJax#2720)

There are also a typo in a comment that is fixed, and a redundant definition of `rerender()` in the MathDocument interface declaration was removed.

The three bullet points are each done in a separate commit, so it might be easier to look at them separately, rather than mixed together, as in this PR.  The third is the most complicated, as there was considerably infrastructure needed to manage that.  The new `lazyAlwaysTypeset` option is either an array of container nodes whose contents should always be typeset (non-lazily), or a single string or array of strings that represent CSS selectors for the containers to use.  E.g., 

``` js
    lazyAlwaysTypeset: '.always-typeset'
```

would make all containers with `class="always-typeset"` to have their math typeset regardless of whether they appear in the viewport or not.