### PR TITLE
Add support for mglyph use of fontfamily/index.  (mathjax/MathJax#2298)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mglyph.ts
+++ b/ts/core/MmlTree/MmlNodes/mglyph.ts
@@ -38,6 +38,7 @@ export class MmlMglyph extends AbstractMmlTokenNode {
     ...AbstractMmlTokenNode.defaults,
     alt: '',
     src: '',
+    index: '',
     width: 'auto',
     height: 'auto',
     valign: '0em'
@@ -53,6 +54,18 @@ export class MmlMglyph extends AbstractMmlTokenNode {
    */
   public get kind() {
     return 'mglyph';
+  }
+
+  /**
+   * @override
+   */
+  public verifyAttributes(options: PropertyList) {
+    const {src, fontfamily, index} = this.attributes.getList('src', 'fontfamily', 'index');
+    if (src === '' && (fontfamily === '' || index === '')) {
+      this.mError('mglyph must have either src or fontfamily and index attributes', options, true);
+    } else {
+      super.verifyAttributes(options);
+    }
   }
 
 }

--- a/ts/output/chtml/Wrappers/mglyph.ts
+++ b/ts/output/chtml/Wrappers/mglyph.ts
@@ -24,6 +24,7 @@
 import {CHTMLWrapper, CHTMLConstructor} from '../Wrapper.js';
 import {CommonMglyphMixin} from '../../common/Wrappers/mglyph.js';
 import {MmlMglyph} from '../../../core/MmlTree/MmlNodes/mglyph.js';
+import {CHTMLTextNode} from './TextNode.js';
 import {StyleList, StyleData} from '../../../util/StyleList.js';
 
 /*****************************************************************/
@@ -59,6 +60,10 @@ CommonMglyphMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
    */
   public toCHTML(parent: N) {
     const chtml = this.standardCHTMLnode(parent);
+    if (this.charWrapper) {
+      (this.charWrapper as CHTMLTextNode<N, T, D>).toCHTML(chtml);
+      return;
+    }
     const {src, alt} = this.node.attributes.getList('src', 'alt');
     const styles: StyleData = {
       width: this.em(this.width),

--- a/ts/output/common/Wrappers/mglyph.ts
+++ b/ts/output/common/Wrappers/mglyph.ts
@@ -23,7 +23,7 @@
 
 import {AnyWrapper, WrapperConstructor, Constructor} from '../Wrapper.js';
 import {CommonTextNode} from './TextNode.js';
-import {TextNode} from '../../../core/MmlTree/MmlNodes/TextNode.js';
+import {TextNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../../../util/BBox.js';
 
 /*****************************************************************/
@@ -32,10 +32,16 @@ import {BBox} from '../../../util/BBox.js';
  */
 export interface CommonMglyph extends AnyWrapper {
   /**
-   * The image's width, height, and valign values converted to em's
+   * The image's width converted to em's
    */
   width: number;
+  /**
+   * The image's height converted to em's
+   */
   height: number;
+  /*
+   * The image's valign values converted to em's
+   */
   valign: number;
 
   /**
@@ -45,6 +51,10 @@ export interface CommonMglyph extends AnyWrapper {
 
   /**
    * Obtain the width, height, and valign.
+   * Note:  Currently, the width and height must be specified explicitly, or they default to 1em
+   *   Since loading the image may be asynchronous, it would require a restart.
+   *   A future extension could implement this either by subclassing this object, or
+   *   perhaps as a post-filter on the MathML input jax that adds the needed dimensions
    */
   getParameters(): void;
 }
@@ -65,20 +75,20 @@ export function CommonMglyphMixin<T extends WrapperConstructor>(Base: T): Mglyph
   return class extends Base {
 
     /**
-     * The image's width converted to em's
+     * @override
      */
     public width: number;
     /**
-     * The image's height converted to em's
+     * @override
      */
     public height: number;
     /**
-     * The image's valign values converted to em's
+     * @override
      */
     public valign: number;
 
     /**
-     * TextNode used for deprecated fontfamily/index use case
+     * @override
      */
     public charWrapper: CommonTextNode;
 
@@ -92,11 +102,7 @@ export function CommonMglyphMixin<T extends WrapperConstructor>(Base: T): Mglyph
     }
 
     /**
-     * Obtain the width, height, and valign.
-     * Note:  Currently, the width and height must be specified explicitly, or they default to 1em
-     *   Since loading the image may be asynchronous, it would require a restart.
-     *   A future extension could implement this either by subclassing this object, or
-     *   perhaps as a post-filter on the MathML input jax that adds the needed dimensions
+     * @override
      */
     public getParameters() {
       const {width, height, valign, src, index} =

--- a/ts/output/svg/Wrappers/mglyph.ts
+++ b/ts/output/svg/Wrappers/mglyph.ts
@@ -24,6 +24,7 @@
 import {SVGWrapper, SVGConstructor} from '../Wrapper.js';
 import {CommonMglyphMixin} from '../../common/Wrappers/mglyph.js';
 import {MmlMglyph} from '../../../core/MmlTree/MmlNodes/mglyph.js';
+import {SVGTextNode} from './TextNode.js';
 import {OptionList} from '../../../util/Options.js';
 
 /*****************************************************************/
@@ -48,6 +49,10 @@ CommonMglyphMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
    */
   public toSVG(parent: N) {
     const svg = this.standardSVGnode(parent);
+    if (this.charWrapper) {
+      (this.charWrapper as SVGTextNode<N, T, D>).toSVG(svg);
+      return;
+    }
     const {src, alt} = this.node.attributes.getList('src', 'alt');
     const h = this.fixed(this.height);
     const w = this.fixed(this.width);


### PR DESCRIPTION
This PR adds support for using the `fontfamily` and `index` attributes on `mglyph`, to bring it more in line with v2.  This does not do the check that the requested character is actually in the specified font, however, which was done in the HTML-CSS output jax of v2, so the `alt` attribute will not be used in this case.

The common glyph output wrapper now creates a TextNode for the character indicated by `index`, and uses that to produce the SVG or CHTML output (and to compute its bounding box).

It now reports an error if the `mglyph` doesn't have a `src` attribute and is also missing either the `fontfamily` or `index` attributes.

Resolves issue mathjax/MathJax#2298.