### PR TITLE
Fix problems with verification and repair of malformed mtables.

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -193,8 +193,9 @@ export interface MmlNode extends Node {
    * @param {string} message         The error message to use
    * @param {PropertyList} options   The options telling how much to verify
    * @param {boolean} short          True means use just the kind if not using full errors
+   * @return {MmlNode}               The construted merror
    */
-  mError(message: string, options: PropertyList, short?: boolean): void;
+  mError(message: string, options: PropertyList, short?: boolean): MmlNode;
 
   /**
    * Check integrity of MathML structure
@@ -797,12 +798,14 @@ export abstract class AbstractMmlNode extends AbstractNode implements MmlNode {
    * @param {string} message         The error message to use
    * @param {PropertyList} options   The options telling how much to verify
    * @param {boolean} short          True means use just the kind if not using full errors
+   * @return {MmlNode}               The constructed merror
    */
-  public mError(message: string, options: PropertyList, short: boolean = false) {
+  public mError(message: string, options: PropertyList, short: boolean = false): MmlNode {
     if (this.parent && this.parent.isKind('merror')) {
       return null;
     }
     let merror = this.factory.create('merror');
+    merror.attributes.set('data-mjx-message', message);
     if (options['fullErrors'] || short) {
       let mtext = this.factory.create('mtext');
       let text = this.factory.create('text') as TextNode;
@@ -1189,7 +1192,9 @@ export abstract class AbstractMmlEmptyNode extends AbstractEmptyNode implements 
   /**
    *  @override
    */
-  public mError(_message: string, _options: PropertyList, _short: boolean = false) {}
+  public mError(_message: string, _options: PropertyList, _short: boolean = false) {
+    return null as MmlNode;
+  }
 
 }
 

--- a/ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/ts/core/MmlTree/MmlNodes/mtable.ts
@@ -147,7 +147,7 @@ export class MmlMtable extends AbstractMmlNode {
         const isMtd = child.isKind('mtd');
         //
         //  If there is already an mtr for previous children, just remove the child
-        //    otherwise repalce the child with a new mtr
+        //    otherwise replace the child with a new mtr
         //
         if (mtr) {
           this.removeChild(child);

--- a/ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/ts/core/MmlTree/MmlNodes/mtable.ts
@@ -161,7 +161,7 @@ export class MmlMtable extends AbstractMmlNode {
           child.parent = this;              // ... and make it think it is a child of the table again
           isMtd && mtr.appendChild(factory.create('mtd'));  // child will be replaced, so make sure there is an mtd
           const merror = child.mError('Children of ' + this.kind + ' must be mtr or mlabeledtr', options, isMtd);
-          mtr.childNodes[0].appendChild(merror);     // append the error to the mtd in the mtr
+          mtr.childNodes[mtr.childNodes.length - 1].appendChild(merror);   // append the error to the mtd in the mtr
         }
       }
     }

--- a/ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/ts/core/MmlTree/MmlNodes/mtr.ts
@@ -94,11 +94,12 @@ export class MmlMtr extends AbstractMmlNode {
       this.mError(this.kind + ' can only be a child of an mtable', options, true);
       return;
     }
-    if (!options['fixMtables']) {
-      for (const child of this.childNodes) {
-        if (!child.isKind('mtd')) {
-          let mtr = this.replaceChild(this.factory.create('mtr'), child) as MmlNode;
-          mtr.mError('Children of ' + this.kind + ' must be mtd', options, true);
+    for (const child of this.childNodes) {
+      if (!child.isKind('mtd')) {
+        let mtd = this.replaceChild(this.factory.create('mtd'), child) as MmlNode;
+        mtd.appendChild(child);
+        if (!options['fixMtables']) {
+          child.mError('Children of ' + this.kind + ' must be mtd', options);
         }
       }
     }

--- a/ts/core/Tree/Node.ts
+++ b/ts/core/Tree/Node.ts
@@ -97,6 +97,12 @@ export interface Node {
   replaceChild(newChild: Node, oldChild: Node): Node;
 
   /**
+   * @param {Node} child   Child node to be removed
+   * @return {Node}        The old child node that was removed
+   */
+  removeChild(child: Node): Node;
+
+  /**
    * @param {Node} child  A child node whose index in childNodes is desired
    * @return {number}     The index of the child in childNodes, or null if not found
    */
@@ -255,8 +261,21 @@ export abstract class AbstractNode implements Node {
     if (i !== null) {
       this.childNodes[i] = newChild;
       newChild.parent = this;
+      oldChild.parent = null;
     }
     return newChild;
+  }
+
+  /**
+   * @override
+   */
+  public removeChild(child: Node) {
+    const i = this.childIndex(child);
+    if (i !== null) {
+      this.childNodes.splice(i, 1);
+      child.parent = null;
+    }
+    return child;
   }
 
 


### PR DESCRIPTION
This PR produces better results for repairing and reporting issues with malformed mtables.  There are verification options available that are supposed to control the error messages produced for bad MathML, and one controls whether tables should be repaired silently or produce `merror` elements to report the problem.  The `fixMtables` option did not work well, as it did not produce proper messages in some cases, and didn't always produce a repaired table.

The fixes here include:

*  Correct interface for return value of error (it was listed as `void` but returned an `error` node).
*  Make sure that errors for missing `mtr` or `mtd` elements are in a valid `mtable`, and produce the right output (a colored `mtd` when used outside an `mtr`, or a colored `mtr` when used outside a table, and a colored entry when missing the `mtd`.
*  Missing `mtr` and `mtd` elements are inserted to make a valid table regardless of the verification options (those only control the error reporting).