### PR TITLE
Implement HTML in MathML token nodes.  (mathjax/MathJax#1128)

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -181,6 +181,11 @@ export interface MinHTMLAdaptor<N, T, D> extends DOMAdaptor<N, T, D> {
 export class HTMLAdaptor<N extends MinHTMLElement<N, T>, T extends MinText<N, T>, D extends MinDocument<N, T>> extends
 AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
   /**
+   * The HTML adaptor can measure DOM node sizes
+   */
+  public canMeasureNodes: boolean = true;
+
+  /**
    * The window object for this adaptor
    */
   public window: MinWindow<N, D>;

--- a/ts/adaptors/NodeMixin.ts
+++ b/ts/adaptors/NodeMixin.ts
@@ -99,6 +99,11 @@ export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
     ].join(''), 'gu');
 
     /**
+     * The node adaptors can't measure DOM node sizes
+     */
+    public canMeasureNodes: boolean = false;
+
+    /**
      * The options for the instance
      */
     public options: OptionList;

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -39,6 +39,7 @@ import {OptionList} from '../util/Options.js';
  * Implements a lightweight DOMAdaptor on liteweight HTML elements
  */
 export class LiteBase extends AbstractDOMAdaptor<LiteElement, LiteText, LiteDocument> {
+
   /**
    * The document in which the HTML nodes will be created
    */

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -57,6 +57,11 @@ export interface DOMAdaptor<N, T, D> {
   document: D;
 
   /**
+   * True when the adaptor can measure DOM node sizes
+   */
+  canMeasureNodes: boolean;
+
+  /**
    * @param {string} text    The serialized document to be parsed
    * @param {string} format  The format (e.g., 'text/html' or 'text/xhtml')
    * @return {D}             The parsed document
@@ -379,6 +384,11 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * The document in which the HTML nodes will be created
    */
   public document: D;
+
+  /**
+   * True when the adaptor can measure DOM node sizes
+   */
+  public canMeasureNodes: boolean = true;
 
   /**
    * @param {D} document  The document in which the nodes will be created

--- a/ts/core/MmlTree/MML.ts
+++ b/ts/core/MmlTree/MML.ts
@@ -61,6 +61,8 @@ import {MmlSemantics, MmlAnnotation, MmlAnnotationXML} from './MmlNodes/semantic
 
 import {TeXAtom} from './MmlNodes/TeXAtom.js';
 import {MathChoice} from './MmlNodes/mathchoice.js';
+import {HtmlNode} from './MmlNodes/HtmlNode.js';
+
 
 /************************************************************************/
 /**
@@ -121,5 +123,6 @@ export let MML: {[kind: string]: MmlNodeClass} = {
   [MathChoice.prototype.kind]: MathChoice,
 
   [TextNode.prototype.kind]: TextNode,
-  [XMLNode.prototype.kind]: XMLNode
+  [XMLNode.prototype.kind]: XMLNode,
+  [HtmlNode.prototype.kind]: HtmlNode,
 };

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -859,6 +859,8 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
     for (const child of this.childNodes) {
       if (child instanceof TextNode) {
         text += child.getText();
+      } else if ('textContent' in child) {
+        text += (child as any).textContent();
       }
     }
     return text;

--- a/ts/core/MmlTree/MmlNodes/HtmlNode.ts
+++ b/ts/core/MmlTree/MmlNodes/HtmlNode.ts
@@ -1,0 +1,110 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implement html-in-mathml internal node type
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {AbstractMmlEmptyNode}  from '../../../core/MmlTree/MmlNode.js';
+import {DOMAdaptor} from '../../../core/DOMadaptor.js';
+import {PropertyList} from '../../../core/Tree/Node.js';
+
+
+/******************************************************************/
+/**
+ * The HtmlNode calss for storing HTML within token elements
+ *
+ * @template N   The HTMLElement class
+ */
+export class HtmlNode<N> extends AbstractMmlEmptyNode {
+  /**
+   * The HTML content for this node
+   */
+  protected html: N = null;
+
+  /**
+   * DOM adaptor for the content
+   */
+  protected adaptor: DOMAdaptor<any, any, any> = null;
+
+  /**
+   * @override
+   */
+  public get kind() {
+    return 'html';
+  }
+
+  /**
+   * @return {Object}  Return the node's HTML content
+   */
+  public getHTML(): Object {
+    return this.html;
+  }
+
+  /**
+   * @param {object} html          The HTML content to be saved
+   * @param {DOMAdaptor} adaptor   DOM adaptor for the content
+   * @return {HTMLNode}            The HTML node (for chaining of method calls)
+   */
+  public setHTML(html: N, adaptor: DOMAdaptor<any, any, any> = null): HtmlNode<N> {
+    this.html = html;
+    this.adaptor = adaptor;
+    return this;
+  }
+
+  /**
+   * @return {string}  The serialized HTML content
+   */
+  public getSerializedHTML(): string {
+    return this.adaptor.outerHTML(this.html);
+  }
+
+  /**
+   * @return {string}   The text of the HTML content
+   */
+  public textContent(): string {
+    return this.adaptor.textContent(this.html);
+  }
+
+  /**
+   * @override
+   */
+  public copy(): HtmlNode<N> {
+    return (this.factory.create(this.kind) as HtmlNode<N>).setHTML(this.adaptor.clone(this.html));
+  }
+
+  /**
+   * Just indicate that this is HTML data
+   */
+  public toString() {
+    const kind = this.adaptor.kind(this.html);
+    return `HTML=<${kind}>...</${kind}>` ;
+  }
+
+  /**
+   * @override
+   */
+  public verifyTree(options: PropertyList) {
+    if (this.parent && !this.parent.isToken) {
+      this.mError('HTML can only be a child of a token element', options, true);
+      return;
+    }
+  }
+
+}

--- a/ts/core/MmlTree/MmlNodes/HtmlNode.ts
+++ b/ts/core/MmlTree/MmlNodes/HtmlNode.ts
@@ -21,9 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {AbstractMmlEmptyNode}  from '../../../core/MmlTree/MmlNode.js';
-import {DOMAdaptor} from '../../../core/DOMadaptor.js';
-import {PropertyList} from '../../../core/Tree/Node.js';
+import {AbstractMmlEmptyNode}  from '../MmlNode.js';
+import {DOMAdaptor} from '../../DOMAdaptor.js';
+import {PropertyList} from '../../Tree/Node.js';
 
 
 /******************************************************************/

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -95,8 +95,8 @@ export class SerializedMmlVisitor extends MmlVisitor {
    * @param {string} space   The amount of indenting for this node
    * @return {string}        The serialization of the HTML
    */
-  public visitHtmlNode(node: HtmlNode<any>, space: string): string {
-    return space + node.getSerializedHTML();
+  public visitHtmlNode(node: HtmlNode<any>, _space: string): string {
+    return node.getSerializedHTML();
   }
 
   /**

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -25,6 +25,7 @@
 import {MmlVisitor} from './MmlVisitor.js';
 import {MmlNode, TextNode, XMLNode, TEXCLASS, TEXCLASSNAMES} from './MmlNode.js';
 import {MmlMi} from './MmlNodes/mi.js';
+import {HtmlNode} from './MmlNodes/HTMLNode.js';
 
 
 export const DATAMJX = 'data-mjx-';
@@ -87,6 +88,15 @@ export class SerializedMmlVisitor extends MmlVisitor {
    */
   public visitXMLNode(node: XMLNode, space: string): string {
     return space + node.getSerializedXML();
+  }
+
+  /**
+   * @param {HtmlNode} node  The HTML node to visit
+   * @param {string} space   The amount of indenting for this node
+   * @return {string}        The serialization of the HTML
+   */
+  public visitHtmlNode(node: HtmlNode<any>, space: string): string {
+    return space + node.getSerializedHTML();
   }
 
   /**

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -25,7 +25,7 @@
 import {MmlVisitor} from './MmlVisitor.js';
 import {MmlNode, TextNode, XMLNode, TEXCLASS, TEXCLASSNAMES} from './MmlNode.js';
 import {MmlMi} from './MmlNodes/mi.js';
-import {HtmlNode} from './MmlNodes/HTMLNode.js';
+import {HtmlNode} from './MmlNodes/HtmlNode.js';
 
 
 export const DATAMJX = 'data-mjx-';

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -24,6 +24,7 @@
 import {MmlFactory} from '../../core/MmlTree/MmlFactory.js';
 import {MmlNode, TextNode, XMLNode, AbstractMmlNode, AbstractMmlTokenNode, TEXCLASS}
 from '../../core/MmlTree/MmlNode.js';
+import {HtmlNode} from '../../core/MmlTree/MmlNodes/HTMLNode.js';
 import {userOptions, defaultOptions, OptionList} from '../../util/Options.js';
 import * as Entities from '../../util/Entities.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
@@ -44,6 +45,7 @@ export class MathMLCompile<N, T, D> {
    */
   public static OPTIONS: OptionList = {
     MmlFactory: null,                   // The MmlFactory to use (defaults to a new MmlFactory)
+    allowHtmlInTokenNodes: false,       // True if HTML is allowed in token nodes
     fixMisplacedChildren: true,         // True if we want to use heuristics to try to fix
                                         //   problems with the tree based on HTML not handling
                                         //   self-closing tags properly
@@ -61,11 +63,11 @@ export class MathMLCompile<N, T, D> {
   /**
    *  The instance of the MmlFactory object and
    */
-  protected factory: MmlFactory;
+  public factory: MmlFactory;
   /**
    *  The options (the defaults with the user options merged in)
    */
-  protected options: OptionList;
+  public options: OptionList;
 
   /**
    *  Merge the user options into the defaults, and save them
@@ -125,7 +127,22 @@ export class MathMLCompile<N, T, D> {
         limits = true;
       }
     }
-    this.factory.getNodeClass(type) || this.error('Unknown node type "' + type + '"');
+    if (!this.factory.getNodeClass(type)) {
+      return this.unknownNode(type, node);
+    }
+    return this.createMml(type, node, texClass, limits);
+  }
+
+  /**
+   * Create an actual MmlNode tree from a given DOM node.
+   *
+   * @param {string} type      The type of MmlNode to create
+   * @param {N} node           The original DOM node that is being transcribed
+   * @param {string} texClass  The texClass specified on the node, if any
+   * @param {boolean} limits   True if fixed limits are to be used
+   * @return {MmlNode}         The final MmlNode tree
+   */
+  protected createMml(type: string, node: N, texClass: string, limits: boolean): MmlNode {
     let mml = this.factory.create(type);
     if (type === 'TeXAtom' && texClass === 'OP' && !limits) {
       mml.setProperty('movesupsub', true);
@@ -139,6 +156,21 @@ export class MathMLCompile<N, T, D> {
     this.checkClass(mml, node);
     this.addChildren(mml, node);
     return mml;
+  }
+
+  /**
+   * Handle unknown node by either creating an HTML node, or throwing an error.
+   *
+   * @param {string} type   The type of node being requested
+   * @param {N} node        The HTML node used to create it.
+   * @return {MmlNode}      The HtmlNode holding the node (or null)
+   */
+  protected unknownNode(type: string, node: N): MmlNode {
+    if (this.factory.getNodeClass('html') && this.options.allowHtmlInTokenNodes) {
+      return (this.factory.create('html') as HtmlNode<N>).setHTML(node, this.adaptor);
+    }
+    this.error('Unknown node type "' + type + '"');
+    return null;
   }
 
   /**
@@ -230,7 +262,7 @@ export class MathMLCompile<N, T, D> {
         mml.appendChild((this.factory.create('XML') as XMLNode).setXML(child, adaptor));
       } else {
         let childMml = mml.appendChild(this.makeNode(child));
-        if (childMml.arity === 0 && adaptor.childNodes(child).length) {
+        if (childMml.arity === 0 && adaptor.childNodes(child).length && !childMml.isKind('html')) {
           if (this.options['fixMisplacedChildren']) {
             this.addChildren(mml, child);
           } else {
@@ -240,6 +272,7 @@ export class MathMLCompile<N, T, D> {
         }
       }
     }
+    mml.isToken && this.trimSpace(mml);
   }
 
   /**
@@ -253,7 +286,7 @@ export class MathMLCompile<N, T, D> {
     if ((mml.isToken || mml.getProperty('isChars')) && mml.arity) {
       if (mml.isToken) {
         text = Entities.translate(text);
-        text = this.trimSpace(text);
+        text = this.normalizeSpace(text);
       }
       mml.appendChild((this.factory.create('text') as TextNode).setText(text));
     } else if (text.match(/\S/)) {
@@ -317,16 +350,24 @@ export class MathMLCompile<N, T, D> {
   }
 
   /**
-   * @param {string} text  The text to have leading/trailing spaced removed
+   * @param {string} text  The text to have spacing normalized
    * @return {string}      The trimmed text
    */
-  protected trimSpace(text: string): string {
+  protected normalizeSpace(text: string): string {
     return text.replace(/[\t\n\r]/g, ' ')    // whitespace to spaces
-               .replace(/^ +/, '')           // initial whitespace
-               .replace(/ +$/, '')           // trailing whitespace
                .replace(/  +/g, ' ');        // internal multiple whitespace
   }
 
+  /**
+   * @param {MmlNode} text  The token node whose leacing/trailing spaces should be removed
+   */
+  protected trimSpace(mml: MmlNode) {
+    let child = mml.childNodes[0] as TextNode;
+    if (!child) return;
+    child.isKind('text') && child.setText(child.getText().replace(/^ +/, ''));
+    child = mml.childNodes[mml.childNodes.length - 1] as TextNode;
+    child.isKind('text') && child.setText(child.getText().replace(/ +$/, ''));
+  }
   /**
    * @param {string} message  The error message to produce
    */

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -24,7 +24,7 @@
 import {MmlFactory} from '../../core/MmlTree/MmlFactory.js';
 import {MmlNode, TextNode, XMLNode, AbstractMmlNode, AbstractMmlTokenNode, TEXCLASS}
 from '../../core/MmlTree/MmlNode.js';
-import {HtmlNode} from '../../core/MmlTree/MmlNodes/HTMLNode.js';
+import {HtmlNode} from '../../core/MmlTree/MmlNodes/HtmlNode.js';
 import {userOptions, defaultOptions, OptionList} from '../../util/Options.js';
 import * as Entities from '../../util/Entities.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';

--- a/ts/output/chtml/Wrappers.ts
+++ b/ts/output/chtml/Wrappers.ts
@@ -47,6 +47,7 @@ import {ChtmlMglyph} from './Wrappers/mglyph.js';
 import {ChtmlSemantics, ChtmlAnnotation, ChtmlAnnotationXML, ChtmlXmlNode} from './Wrappers/semantics.js';
 import {ChtmlTeXAtom} from './Wrappers/TeXAtom.js';
 import {ChtmlTextNode} from './Wrappers/TextNode.js';
+import {ChtmlHtmlNode} from './Wrappers/HtmlNode.js';
 
 export const ChtmlWrappers: {[kind: string]: ChtmlWrapperClass<any, any, any>} = {
   [ChtmlMath.kind]: ChtmlMath,
@@ -83,5 +84,6 @@ export const ChtmlWrappers: {[kind: string]: ChtmlWrapperClass<any, any, any>} =
   [ChtmlXmlNode.kind]: ChtmlXmlNode,
   [ChtmlTeXAtom.kind]: ChtmlTeXAtom,
   [ChtmlTextNode.kind]: ChtmlTextNode,
+  [ChtmlHtmlNode.kind]: CHTMLHtmlNode,
   [ChtmlWrapper.kind]: ChtmlWrapper
 };

--- a/ts/output/chtml/Wrappers.ts
+++ b/ts/output/chtml/Wrappers.ts
@@ -84,6 +84,6 @@ export const ChtmlWrappers: {[kind: string]: ChtmlWrapperClass<any, any, any>} =
   [ChtmlXmlNode.kind]: ChtmlXmlNode,
   [ChtmlTeXAtom.kind]: ChtmlTeXAtom,
   [ChtmlTextNode.kind]: ChtmlTextNode,
-  [ChtmlHtmlNode.kind]: CHTMLHtmlNode,
+  [ChtmlHtmlNode.kind]: ChtmlHtmlNode,
   [ChtmlWrapper.kind]: ChtmlWrapper
 };

--- a/ts/output/chtml/Wrappers/HtmlNode.ts
+++ b/ts/output/chtml/Wrappers/HtmlNode.ts
@@ -46,7 +46,14 @@ export class ChtmlHtmlNode<N, _T, _D> extends CommonHtmlNodeMixin<any, ChtmlCons
    */
   public static styles: StyleList = {
     'mjx-html': {
-      'line-height': 'normal'
+      'line-height': 'normal',
+      'text-align': 'initial'
+    },
+    'mjx-html-holder': {
+      display: 'block',
+      position: 'absolute',
+      width: '100%',
+      height: '100%'
     }
   };
 

--- a/ts/output/chtml/Wrappers/HtmlNode.ts
+++ b/ts/output/chtml/Wrappers/HtmlNode.ts
@@ -21,48 +21,94 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {ChtmlWrapper, ChtmlConstructor} from '../Wrapper.js';
-import {CommonHtmlNodeMixin} from '../../common/Wrappers/HtmlNode.js';
+import {CHTML} from '../../chtml.js';
+import {ChtmlWrapper, ChtmlWrapperClass} from '../Wrapper.js';
+import {ChtmlWrapperFactory} from '../WrapperFactory.js';
+import {ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData,
+        ChtmlFontData, ChtmlFontDataClass} from '../FontData.js';
+import {CommonHtmlNode, CommonHtmlNodeClass, CommonHtmlNodeMixin} from '../../common/Wrappers/HtmlNode.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
 import {StyleList as StyleList} from '../../../util/StyleList.js';
 
 /*****************************************************************/
 /**
- * The ChtmlhtmlNode wrapper for the HtmlNode object
+ * The ChtmlHtmlNode interface for the CHTML HtmlNode wrapper
  *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class ChtmlHtmlNode<N, _T, _D> extends CommonHtmlNodeMixin<any, ChtmlConstructor<any, any, any>>(ChtmlWrapper) {
+export interface ChtmlHtmlNodeNTD<N, T, D> extends ChtmlWrapper<N, T, D>, CommonHtmlNode<
+  N, T, D,
+  CHTML<N, T, D>, ChtmlWrapper<N, T, D>, ChtmlWrapperFactory<N, T, D>, ChtmlWrapperClass<N, T, D>,
+  ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData, ChtmlFontData, ChtmlFontDataClass
+> {}
 
-  /**
-   * The html wrapper
-   */
-  public static kind = HtmlNode.prototype.kind;
+/**
+ * The ChtmlHtmlNodeClass interface for the CHTML HtmlNode wrapper
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export interface ChtmlHtmlNodeClass<N, T, D> extends ChtmlWrapperClass<N, T, D>, CommonHtmlNodeClass<
+  N, T, D,
+  CHTML<N, T, D>, ChtmlWrapper<N, T, D>, ChtmlWrapperFactory<N, T, D>, ChtmlWrapperClass<N, T, D>,
+  ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData, ChtmlFontData, ChtmlFontDataClass
+> {
+  new(factory: ChtmlWrapperFactory<N, T, D>, node: MmlNode, parent?: ChtmlWrapper<N, T, D>): ChtmlHtmlNodeNTD<N, T, D>;
+}
 
-  /**
-   * @override
-   */
-  public static styles: StyleList = {
-    'mjx-html': {
-      'line-height': 'normal',
-      'text-align': 'initial'
-    },
-    'mjx-html-holder': {
-      display: 'block',
-      position: 'absolute',
-      width: '100%',
-      height: '100%'
+
+/*****************************************************************/
+
+/**
+ * The ChtmlHtmlNode wrapper class for the MmlHtmlNode class
+ */
+export const ChtmlHtmlNode = (function <N, T, D>(): ChtmlHtmlNodeClass<N, T, D> {
+
+  const Base = CommonHtmlNodeMixin<
+      N, T, D,
+      CHTML<N, T, D>, ChtmlWrapper<N, T, D>, ChtmlWrapperFactory<N, T, D>, ChtmlWrapperClass<N, T, D>,
+      ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData, ChtmlFontData, ChtmlFontDataClass,
+      ChtmlHtmlNodeClass<N, T, D>
+    >(ChtmlWrapper);
+
+  // Avoid message about base constructors not having the same type
+  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
+  // @ts-ignore
+  return class ChtmlHtmlNode extends Base implements ChtmlHtmlNodeNTD<N, T, D> {
+
+    /**
+     * @override
+     */
+    public static kind = HtmlNode.prototype.kind;
+
+    /**
+     * @override
+     */
+    public static styles: StyleList = {
+      'mjx-html': {
+        'line-height': 'normal',
+        'text-align': 'initial'
+      },
+      'mjx-html-holder': {
+        display: 'block',
+        position: 'absolute',
+        width: '100%',
+        height: '100%'
+      }
+    };
+
+    /**
+     * @override
+     */
+    public toCHTML(parent: N) {
+      this.markUsed();
+      this.dom = this.adaptor.append(parent, this.getHTML()) as N;
     }
+
   };
 
-  /**
-   * @override
-   */
-  public toCHTML(parent: N) {
-    this.markUsed();
-    this.dom = this.adaptor.append(parent, this.getHTML());
-  }
-
-}
+})<any, any, any>();

--- a/ts/output/chtml/Wrappers/HtmlNode.ts
+++ b/ts/output/chtml/Wrappers/HtmlNode.ts
@@ -1,0 +1,61 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the ChtmlHtmlNode wrapper for the HtmlNode object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {ChtmlWrapper, ChtmlConstructor} from '../Wrapper.js';
+import {CommonHtmlNodeMixin} from '../../common/Wrappers/HtmlNode.js';
+import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
+import {StyleList as StyleList} from '../../../util/StyleList.js';
+
+/*****************************************************************/
+/**
+ * The ChtmlhtmlNode wrapper for the HtmlNode object
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export class ChtmlHtmlNode<N, _T, _D> extends CommonHtmlNodeMixin<any, ChtmlConstructor<any, any, any>>(ChtmlWrapper) {
+
+  /**
+   * The html wrapper
+   */
+  public static kind = HtmlNode.prototype.kind;
+
+  /**
+   * @override
+   */
+  public static styles: StyleList = {
+    'mjx-html': {
+      'line-height': 'normal'
+    }
+  };
+
+  /**
+   * @override
+   */
+  public toCHTML(parent: N) {
+    this.markUsed();
+    this.dom = this.adaptor.append(parent, this.getHTML());
+  }
+
+}

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -25,6 +25,7 @@ import {AbstractOutputJax} from '../core/OutputJax.js';
 import {MathDocument} from '../core/MathDocument.js';
 import {MathItem, Metrics, STATE} from '../core/MathItem.js';
 import {MmlNode} from '../core/MmlTree/MmlNode.js';
+import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {FontData, FontDataClass, CharOptions, VariantData, DelimiterData, CssFontData} from './common/FontData.js';
 import {OptionList, separateOptions} from '../util/Options.js';
 import {CommonWrapper, CommonWrapperClass} from './common/Wrapper.js';
@@ -107,6 +108,7 @@ export abstract class CommonOutputJax<
     exFactor: .5,                  // default size of ex in em units
     displayAlign: 'center',        // default for indentalign when set to 'auto'
     displayIndent: '0',            // default for indentshift when set to 'auto'
+    htmlHDW: 'auto',               // 'use', 'force', or 'ignore' data-mjx-hdw attributes
     wrapperFactory: null,          // The wrapper factory to use
     font: null,                    // The FontData object to use
     cssStyles: null                // The CssStyles object to use
@@ -203,6 +205,20 @@ export abstract class CommonOutputJax<
     this.font = this.options.font || new defaultFont(fontOptions);
     this.unknownCache = new Map();
   }
+
+  /**
+   * @override
+   */
+  public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
+    super.setAdaptor(adaptor);
+    //
+    //  Set the htmlHDW option based on the adaptor's ability to measure nodes
+    //
+    if (this.options.htmlHDW === 'auto') {
+      this.options.htmlHDW = (adaptor.canMeasureNodes ? 'ignore' : 'force');
+    }
+  }
+
 
   /*****************************************************************/
 

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -947,7 +947,7 @@ export class CommonWrapper<
    * @param {(N|T)[]} content  The child nodes for the created HTML node
    * @return {N}               The generated HTML tree
    */
-  public html(type: string, def: OptionList = {}, content: any[] = []): any {
+  public html(type: string, def: OptionList = {}, content: (N | T)[] = []): N {
     return this.jax.html(type, def, content);
   }
 

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -30,6 +30,7 @@ import {unicodeChars} from '../../util/string.js';
 import * as LENGTHS from '../../util/lengths.js';
 import {Styles} from '../../util/Styles.js';
 import {StyleList} from '../../util/StyleList.js';
+import {OptionList} from '../../util/Options.js';
 import {CommonOutputJax} from '../common.js';
 import {CommonWrapperFactory} from './WrapperFactory.js';
 import {CommonMo} from './Wrappers/mo.js';
@@ -293,7 +294,7 @@ export class CommonWrapper<
   /**
    * Styles that must be handled directly by the wrappers (mostly having to do with fonts)
    */
-  protected removedStyles: StringMap = null;
+  public removedStyles: StringMap = null;
 
   /**
    * The explicit styles set by the node
@@ -933,6 +934,21 @@ export class CommonWrapper<
       (char as any)[3] = {};
     }
     return char as [number, number, number, CC];
+  }
+
+  /*******************************************************************/
+  /*
+   * Easy access to some utility routines
+   */
+
+  /**
+   * @param {string} type      The tag name of the HTML node to be created
+   * @param {OptionList} def   The properties to set for the created node
+   * @param {(N|T)[]} content  The child nodes for the created HTML node
+   * @return {N}               The generated HTML tree
+   */
+  public html(type: string, def: OptionList = {}, content: any[] = []): any {
+    return this.jax.html(type, def, content);
   }
 
 }

--- a/ts/output/common/Wrappers/HtmlNode.ts
+++ b/ts/output/common/Wrappers/HtmlNode.ts
@@ -1,0 +1,102 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the CommonHtmlNode wrapper mixin for the HtmlNode object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {AnyWrapper, WrapperConstructor, Constructor} from '../Wrapper.js';
+import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
+import {BBox} from '../../../util/BBox.js';
+import {StyleList} from '../../../util/Styles.js';
+import {ExtendedMetrics} from '../../common/OutputJax.js';
+
+/*****************************************************************/
+/**
+ * The CommonHtmlNode interface
+ */
+export interface CommonHtmlNode<N> extends AnyWrapper {
+
+  /**
+   * @return {N}   The HTML for the node
+   */
+  getHTML(): N;
+}
+
+/**
+ * Shorthand for the CommonHtmlNode constructor
+ */
+export type HtmlNodeConstructor<N> = Constructor<CommonHtmlNode<N>>;
+
+
+/*****************************************************************/
+/**
+ *  The CommonHtmlNode wrapper mixin for the HtmlNode object
+ *
+ * @template N  The HTMLElement class
+ * @template T  The Wrapper class constructor type
+ */
+export function CommonHtmlNodeMixin<N, T extends WrapperConstructor>(Base: T): HtmlNodeConstructor<N> & T {
+
+  return class extends Base {
+
+    /**
+     * @override
+     */
+    public computeBBox(bbox: BBox, _recompute: boolean = false) {
+      const {w, h, d} = this.jax.measureXMLnode(this.getHTML());
+      bbox.w = w;
+      bbox.h = h;
+      bbox.d = d;
+    }
+
+    /**
+     * @return {N}   The HTML for the node
+     */
+    public getHTML(): N {
+      const styles: StyleList = {};
+      const html = this.adaptor.clone((this.node as HtmlNode<N>).getHTML() as N);
+      const metrics = this.jax.math.metrics as ExtendedMetrics;
+      const scale = 100 / metrics.scale;
+      if (scale !== 100) {
+        styles['font-size'] = this.jax.fixed(scale, 1) + '%';
+      }
+      const parent = this.adaptor.parent(this.jax.math.start.node);
+      styles['font-family'] = this.parent.styles?.styles?.['font-family'] ||
+        metrics.family || this.adaptor.fontFamily(parent) || 'initial';
+      return this.html('mjx-html', {variant: this.parent.variant, style: styles}, [html]);
+    }
+
+    /**
+     * @override
+     */
+    protected getStyles() {}
+
+    /**
+     * @override
+     */
+    protected getScale() {}
+
+    /**
+     * @override
+     */
+    protected getVariant() {}
+
+  };
+}

--- a/ts/output/common/Wrappers/HtmlNode.ts
+++ b/ts/output/common/Wrappers/HtmlNode.ts
@@ -21,18 +21,45 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {AnyWrapper, WrapperConstructor, Constructor} from '../Wrapper.js';
+import {CommonWrapper, CommonWrapperClass, CommonWrapperConstructor} from '../Wrapper.js';
+import {CommonWrapperFactory} from '../WrapperFactory.js';
+import {CharOptions, VariantData, DelimiterData, FontData, FontDataClass} from '../FontData.js';
+import {CommonOutputJax} from '../../common.js';
 import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
 import {BBox} from '../../../util/BBox.js';
 import {StyleList} from '../../../util/Styles.js';
-import {ExtendedMetrics, UnknownBBox} from '../../common/OutputJax.js';
+import {ExtendedMetrics, UnknownBBox} from '../../common.js';
 import {split} from '../../../util/string.js';
 
 /*****************************************************************/
 /**
  * The CommonHtmlNode interface
+ *
+ * @template N   The DOM node type
+ * @template T   The DOM text node type
+ * @template D   The DOM document type
+ * @template JX  The OutputJax type
+ * @template WW  The Wrapper type
+ * @template WF  The WrapperFactory type
+ * @template WC  The WrapperClass type
+ * @template CC  The CharOptions type
+ * @template VV  The VariantData type
+ * @template DD  The DelimiterData type
+ * @template FD  The FontData type
+ * @template FC  The FontDataClass type
  */
-export interface CommonHtmlNode<N> extends AnyWrapper {
+export interface CommonHtmlNode<
+  N, T, D,
+  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  CC extends CharOptions,
+  VV extends VariantData<CC>,
+  DD extends DelimiterData,
+  FD extends FontData<CC, VV, DD>,
+  FC extends FontDataClass<CC, VV, DD>
+> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
 
   /**
    * @return {N}   The HTML for the node
@@ -62,21 +89,69 @@ export interface CommonHtmlNode<N> extends AnyWrapper {
 }
 
 /**
- * Shorthand for the CommonHtmlNode constructor
+ * The CommonHtmlNodeClass interface
+ *
+ * @template N   The DOM node type
+ * @template T   The DOM text node type
+ * @template D   The DOM document type
+ * @template JX  The OutputJax type
+ * @template WW  The Wrapper type
+ * @template WF  The WrapperFactory type
+ * @template WC  The WrapperClass type
+ * @template CC  The CharOptions type
+ * @template VV  The VariantData type
+ * @template DD  The DelimiterData type
+ * @template FD  The FontData type
+ * @template FC  The FontDataClass type
  */
-export type HtmlNodeConstructor<N> = Constructor<CommonHtmlNode<N>>;
-
+export interface CommonHtmlNodeClass<
+  N, T, D,
+  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  CC extends CharOptions,
+  VV extends VariantData<CC>,
+  DD extends DelimiterData,
+  FD extends FontData<CC, VV, DD>,
+  FC extends FontDataClass<CC, VV, DD>
+> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
 
 /*****************************************************************/
 /**
- *  The CommonHtmlNode wrapper mixin for the HtmlNode object
+ * The CommonHtmlNode wrapper mixin for the HtmlNode object
  *
- * @template N  The HTMLElement class
- * @template T  The Wrapper class constructor type
+ * @template N   The DOM node type
+ * @template T   The DOM text node type
+ * @template D   The DOM document type
+ * @template JX  The OutputJax type
+ * @template WW  The Wrapper type
+ * @template WF  The WrapperFactory type
+ * @template WC  The WrapperClass type
+ * @template CC  The CharOptions type
+ * @template VV  The VariantData type
+ * @template DD  The DelimiterData type
+ * @template FD  The FontData type
+ * @template FC  The FontDataClass type
+ *
+ * @template B   The Mixin interface to create
  */
-export function CommonHtmlNodeMixin<N, T extends WrapperConstructor>(Base: T): HtmlNodeConstructor<N> & T {
+export function CommonHtmlNodeMixin<
+  N, T, D,
+  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  CC extends CharOptions,
+  VV extends VariantData<CC>,
+  DD extends DelimiterData,
+  FD extends FontData<CC, VV, DD>,
+  FC extends FontDataClass<CC, VV, DD>,
+  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+>(Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>): B {
 
-  return class extends Base {
+  return class CommonHtmlNodeMixin extends Base
+  implements CommonHtmlNode<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
 
     /**
      * @override
@@ -102,7 +177,7 @@ export function CommonHtmlNodeMixin<N, T extends WrapperConstructor>(Base: T): H
         styles['font-size'] = jax.fixed(100 / metrics.scale, 1) + '%';
       }
       const parent = adaptor.parent(jax.math.start.node);
-      styles['font-family'] = this.parent.styles?.styles?.['font-family'] ||
+      styles['font-family'] = this.parent.styles?.get('font-family') ||
         metrics.family || adaptor.fontFamily(parent) || 'initial';
       return this.html('mjx-html', {variant: this.parent.variant, style: styles}, [html]);
     }
@@ -158,5 +233,6 @@ export function CommonHtmlNodeMixin<N, T extends WrapperConstructor>(Base: T): H
      */
     protected getVariant() {}
 
-  };
+  } as any as B;
+
 }

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -157,7 +157,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     if (styles) {
       this.adaptor.setAttribute(this.dom, 'style', styles);
     }
-    BBox.StyleAdjust.forEach(([name, , lr]) => {
+    BBox.StyleAdjust.forEach(([name, , lr]: [string, any, number | null]) => {
       if (lr !== 0) return;
       const x = this.styles.get(name);
       if (x) {

--- a/ts/output/svg/Wrappers.ts
+++ b/ts/output/svg/Wrappers.ts
@@ -51,6 +51,7 @@ import {SvgSemantics, SvgAnnotation, SvgAnnotationXML, SvgXmlNode} from './Wrapp
 import {SvgMglyph} from './Wrappers/mglyph.js';
 import {SvgTeXAtom} from './Wrappers/TeXAtom.js';
 import {SvgTextNode} from './Wrappers/TextNode.js';
+import {SvgHtmlNode} from './Wrappers/HtmlNode.js';
 
 export const SvgWrappers: {[kind: string]: SvgWrapperClass<any, any, any>} = {
   [SvgMath.kind]: SvgMath,
@@ -89,5 +90,6 @@ export const SvgWrappers: {[kind: string]: SvgWrapperClass<any, any, any>} = {
   [SvgMglyph.kind]: SvgMglyph,
   [SvgTeXAtom.kind]: SvgTeXAtom,
   [SvgTextNode.kind]: SvgTextNode,
+  [SvgHtmlNode.kind]: SvgHtmlNode,
   [SvgWrapper.kind]: SvgWrapper
 };

--- a/ts/output/svg/Wrappers/HtmlNode.ts
+++ b/ts/output/svg/Wrappers/HtmlNode.ts
@@ -46,8 +46,18 @@ export class SvgHtmlNode<N, _T, _D> extends CommonHtmlNodeMixin<any, SvgConstruc
    */
   public static styles: StyleList = {
     'foreignObject[data-mjx-html]': {
-      'line-height': 'normal',
       overflow: 'visible'
+    },
+    'mjx-html': {
+      display: 'inline-block',
+      'line-height': 'normal',
+      'text-align': 'initial',
+    },
+    'mjx-html-holder': {
+      display: 'block',
+      position: 'absolute',
+      width: '100%',
+      height: '100%'
     }
   };
 

--- a/ts/output/svg/Wrappers/HtmlNode.ts
+++ b/ts/output/svg/Wrappers/HtmlNode.ts
@@ -21,61 +21,106 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {SvgWrapper, SvgConstructor} from '../Wrapper.js';
-import {CommonHtmlNodeMixin} from '../../common/Wrappers/HtmlNode.js';
+import {SVG} from '../../svg.js';
+import {SvgWrapper, SvgWrapperClass} from '../Wrapper.js';
+import {SvgWrapperFactory} from '../WrapperFactory.js';
+import {SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass} from '../FontData.js';
+import {CommonHtmlNode, CommonHtmlNodeClass, CommonHtmlNodeMixin} from '../../common/Wrappers/HtmlNode.js';
+import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
 import {StyleList} from '../../../util/StyleList.js';
 
 /*****************************************************************/
 /**
- * The SvghtmlNode wrapper for the HtmlNode object
+ * The SvgHtmlNode interface for the SVG HtmlNode wrapper
  *
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
  */
-export class SvgHtmlNode<N, _T, _D> extends CommonHtmlNodeMixin<any, SvgConstructor<any, any, any>>(SvgWrapper) {
+export interface SvgHtmlNodeNTD<N, T, D> extends SvgWrapper<N, T, D>, CommonHtmlNode<
+  N, T, D,
+  SVG<N, T, D>, SvgWrapper<N, T, D>, SvgWrapperFactory<N, T, D>, SvgWrapperClass<N, T, D>,
+  SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass
+> {}
 
-  /**
-   * The html wrapper
-   */
-  public static kind = HtmlNode.prototype.kind;
+/**
+ * The SvgHtmlNodeClass interface for the SVG HtmlNode wrapper
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export interface SvgHtmlNodeClass<N, T, D> extends SvgWrapperClass<N, T, D>, CommonHtmlNodeClass<
+  N, T, D,
+  SVG<N, T, D>, SvgWrapper<N, T, D>, SvgWrapperFactory<N, T, D>, SvgWrapperClass<N, T, D>,
+  SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass
+> {
+  new(factory: SvgWrapperFactory<N, T, D>, node: MmlNode, parent?: SvgWrapper<N, T, D>): SvgHtmlNodeNTD<N, T, D>;
+}
 
-  /**
-   * @override
-   */
-  public static styles: StyleList = {
-    'foreignObject[data-mjx-html]': {
-      overflow: 'visible'
-    },
-    'mjx-html': {
-      display: 'inline-block',
-      'line-height': 'normal',
-      'text-align': 'initial',
-    },
-    'mjx-html-holder': {
-      display: 'block',
-      position: 'absolute',
-      width: '100%',
-      height: '100%'
+
+/*****************************************************************/
+
+/**
+ * The SvgHtmlNode wrapper class for the MmlHtmlNode class
+ */
+export const SvgHtmlNode = (function <N, T, D>(): SvgHtmlNodeClass<N, T, D> {
+
+  const Base = CommonHtmlNodeMixin<
+      N, T, D,
+      SVG<N, T, D>, SvgWrapper<N, T, D>, SvgWrapperFactory<N, T, D>, SvgWrapperClass<N, T, D>,
+      SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass,
+      SvgHtmlNodeClass<N, T, D>
+    >(SvgWrapper);
+
+  // Avoid message about base constructors not having the same type
+  //   (they should both be SvgWrapper<N, T, D>, but are thought of as different by typescript)
+  // @ts-ignore
+  return class SvgHtmlNode extends Base implements SvgHtmlNodeNTD<N, T, D> {
+
+    /**
+     * @override
+     */
+    public static kind = HtmlNode.prototype.kind;
+
+    /**
+     * @override
+     */
+    public static styles: StyleList = {
+      'foreignObject[data-mjx-html]': {
+        overflow: 'visible'
+      },
+      'mjx-html': {
+        display: 'inline-block',
+        'line-height': 'normal',
+        'text-align': 'initial',
+      },
+      'mjx-html-holder': {
+        display: 'block',
+        position: 'absolute',
+        width: '100%',
+        height: '100%'
+      }
+    };
+
+    /**
+     * @override
+     */
+    public toSVG(parent: N) {
+      const metrics = this.jax.math.metrics;
+      const em = metrics.em * metrics.scale;
+      const scale = this.fixed(1 / em);
+      const {w, h, d} = this.getBBox();
+      this.dom = this.adaptor.append(parent, this.svg('foreignObject', {
+        'data-mjx-html': true,
+        y: this.jax.fixed(-h * em) + 'px',
+        width: this.jax.fixed(w * em) + 'px',
+        height: this.jax.fixed((h + d) * em) + 'px',
+        transform: `scale(${scale}) matrix(1 0 0 -1 0 0)`
+      }, [this.getHTML()])) as N;
     }
+
   };
 
-  /**
-   * @override
-   */
-  public toSVG(parent: N) {
-    const metrics = this.jax.math.metrics;
-    const em = metrics.em * metrics.scale;
-    const scale = this.fixed(1 / em);
-    const {w, h, d} = this.getBBox();
-    this.dom = this.adaptor.append(parent, this.svg('foreignObject', {
-      'data-mjx-html': true,
-      y: this.jax.fixed(-h * em) + 'px',
-      width: this.jax.fixed(w * em) + 'px',
-      height: this.jax.fixed((h + d) * em) + 'px',
-      transform: `scale(${scale}) matrix(1 0 0 -1 0 0)`
-    }, [this.getHTML()]));
-  }
-
-}
+})<any, any, any>();

--- a/ts/output/svg/Wrappers/HtmlNode.ts
+++ b/ts/output/svg/Wrappers/HtmlNode.ts
@@ -1,0 +1,71 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements the SvgHtmlNode wrapper for the HtmlNode object
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {SvgWrapper, SvgConstructor} from '../Wrapper.js';
+import {CommonHtmlNodeMixin} from '../../common/Wrappers/HtmlNode.js';
+import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
+import {StyleList} from '../../../util/StyleList.js';
+
+/*****************************************************************/
+/**
+ * The SvghtmlNode wrapper for the HtmlNode object
+ *
+ * @template N  The HTMLElement node class
+ * @template T  The Text node class
+ * @template D  The Document class
+ */
+export class SvgHtmlNode<N, _T, _D> extends CommonHtmlNodeMixin<any, SvgConstructor<any, any, any>>(SvgWrapper) {
+
+  /**
+   * The html wrapper
+   */
+  public static kind = HtmlNode.prototype.kind;
+
+  /**
+   * @override
+   */
+  public static styles: StyleList = {
+    'foreignObject[data-mjx-html]': {
+      'line-height': 'normal',
+      overflow: 'visible'
+    }
+  };
+
+  /**
+   * @override
+   */
+  public toSVG(parent: N) {
+    const metrics = this.jax.math.metrics;
+    const em = metrics.em * metrics.scale;
+    const scale = this.fixed(1 / em);
+    const {w, h, d} = this.getBBox();
+    this.dom = this.adaptor.append(parent, this.svg('foreignObject', {
+      'data-mjx-html': true,
+      y: this.jax.fixed(-h * em) + 'px',
+      width: this.jax.fixed(w * em) + 'px',
+      height: this.jax.fixed((h + d) * em) + 'px',
+      transform: `scale(${scale}) matrix(1 0 0 -1 0 0)`
+    }, [this.getHTML()]));
+  }
+
+}

--- a/ts/output/svg/Wrappers/mfenced.ts
+++ b/ts/output/svg/Wrappers/mfenced.ts
@@ -25,7 +25,7 @@ import {SVG} from '../../svg.js';
 import {SvgWrapper, SvgWrapperClass} from '../Wrapper.js';
 import {SvgWrapperFactory} from '../WrapperFactory.js';
 import {SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass} from '../FontData.js';
-import {CommonMfenced, CommonMfencedClass, CommonMfencedMixin} from '../../common/Wrappers/Mfenced.js';
+import {CommonMfenced, CommonMfencedClass, CommonMfencedMixin} from '../../common/Wrappers/mfenced.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {MmlMfenced} from '../../../core/MmlTree/MmlNodes/mfenced.js';
 import {SvgInferredMrowNTD} from './mrow.js';


### PR DESCRIPTION
This PR implements the ability to include HTML within token elements in MathML (as allowed in HTML5).  It does so by implementing an HtmlNode class that holds the HTML tree.  This is inserted into the MathML token node child array whenever a non-MathML node is found.  Thus `<mtext>abc<input type="button" value="Push Me">def</mtext>` is allowed, and would produce an `mtext` element containing a button surrounded by some plain text.

Because the HTML is not currently sanitized (something that could be added to the `safe` extension), allowing HTML in token elements would be a security issue for sites that allow user-entered MathML.  For this reason, the MathML input jax has a new option `allowHtmlInTokenNodes` to control whether to allow it, and it is false by default.

The `makeNode()` method in `MathMLCompile.ts` has been broken into three parts, to make them shorter (it was getting a bit long) by the addition of a `createMml()` method that is used to create the internal MML node when everything has been verified, and an `unknownNode()` method for handling unknown nodes (either by making an `HtmlNode` or throwing an error).

Because token nodes can now contain multiple children (in the past we assumed there was only one text node), the normalization of the spaces in the text must be handled differently, so the `trimSpaces()` method has been broken into two pieces:  one standardized the whitespace to actual spaces (not tabs or newlines) and makes multiple spaces into single ones, and one that trims the initial and final space once all the text nodes are in place.  There are also some changes to the handling of the TextNode in the output wrappers.  In particular, the SVG output had to be modified to add extra `g` elements when there are multiple child nodes for a token node, so that the characters can be positioned properly by the `place()` method.  (In the past, since there was only one text element and its offset was 0 within the token node, it didn't matter, but now it does.)

Resolves issues mathjax/MathJax#1128 and mathjax/MathJax#487.
