### PR TITLE
Add support for HTML within TeX

### DIFF
--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -47,6 +47,7 @@ export const dependencies = {
   '[tex]/require': ['input/tex-base'],
   '[tex]/setoptions': ['input/tex-base'],
   '[tex]/tagformat': ['input/tex-base'],
+  '[tex]/texhtml': ['input/tex-base'],
   '[tex]/textcomp': ['input/tex-base', '[tex]/textmacros'],
   '[tex]/textmacros': ['input/tex-base'],
   '[tex]/unicode': ['input/tex-base'],

--- a/components/src/input/tex/extensions/texhtml/build.json
+++ b/components/src/input/tex/extensions/texhtml/build.json
@@ -1,0 +1,4 @@
+{
+  "component": "input/tex/extensions/texhtml",
+  "targets": ["input/tex/texhtml"]
+}

--- a/components/src/input/tex/extensions/texhtml/texhtml.js
+++ b/components/src/input/tex/extensions/texhtml/texhtml.js
@@ -1,0 +1,2 @@
+import './lib/texhtml.js';
+//import './config.js';

--- a/components/src/input/tex/extensions/texhtml/texhtml.js
+++ b/components/src/input/tex/extensions/texhtml/texhtml.js
@@ -1,2 +1,1 @@
 import './lib/texhtml.js';
-//import './config.js';

--- a/components/src/input/tex/extensions/texhtml/webpack.config.js
+++ b/components/src/input/tex/extensions/texhtml/webpack.config.js
@@ -1,0 +1,11 @@
+const PACKAGE = require('../../../../../webpack.common.js');
+
+module.exports = PACKAGE(
+  'input/tex/extensions/texhtml',     // the package to build
+  '../../../../../../js',             // location of the MathJax js library
+  [                                   // packages to link to
+    'components/src/input/tex-base/lib',
+    'components/src/core/lib'
+  ],
+  __dirname                           // our directory
+);

--- a/components/src/source.js
+++ b/components/src/source.js
@@ -50,6 +50,7 @@ export const source = {
   '[tex]/setoptions': `${src}/input/tex/extensions/setoptions/setoptions.js`,
   '[tex]/tagformat': `${src}/input/tex/extensions/tagformat/tagformat.js`,
   '[tex]/textmacros': `${src}/input/tex/extensions/textmacros/textmacros.js`,
+  '[tex]/texhtml': `${src}/input/tex/extensions/texhtml/texhtml.js`,
   '[tex]/unicode': `${src}/input/tex/extensions/unicode/unicode.js`,
   '[tex]/verb': `${src}/input/tex/extensions/verb/verb.js`,
   '[tex]/cases': `${src}/input/tex/extensions/cases/cases.js`,

--- a/ts/core/MmlTree/MmlNodes/HtmlNode.ts
+++ b/ts/core/MmlTree/MmlNodes/HtmlNode.ts
@@ -63,6 +63,14 @@ export class HtmlNode<N> extends AbstractMmlEmptyNode {
    * @return {HTMLNode}            The HTML node (for chaining of method calls)
    */
   public setHTML(html: N, adaptor: DOMAdaptor<any, any, any> = null): HtmlNode<N> {
+    //
+    // Test if the HTML element has attributes and wrap in a <span> if not
+    //
+    try {
+      adaptor.getAttribute(html, 'data-mjx-hdw');
+    } catch (error) {
+      html = adaptor.node('span', {}, [html]);
+    }
     this.html = html;
     this.adaptor = adaptor;
     return this;

--- a/ts/core/Tree/Visitor.ts
+++ b/ts/core/Tree/Visitor.ts
@@ -49,9 +49,8 @@ export type VisitorFunction<N extends VisitorNode<N>> =
  * The Visitor interface
  *
  * @template N   The node type being traversed
- * @template C   The node class for N (the constructor rather than instance of the class)
  */
-export interface Visitor<N extends Node<N, C>, C extends NodeClass<N, C>> {
+export interface Visitor<N extends VisitorNode<N>> {
 
   /**
    * Visit the tree rooted at the given node (passing along any needed parameters)

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {userOptions, defaultOptions, OptionList, makeArray} from '../../util/Options.js';
+import {userOptions, defaultOptions, OptionList, makeArray, expandable} from '../../util/Options.js';
 import {DOMAdaptor} from '../../core/DOMAdaptor.js';
 
 /**
@@ -52,7 +52,7 @@ export class HTMLDomStrings<N, T, D> {
                                         // The names of the tags whose contents will not be
                                         // scanned for math delimiters
 
-    includeHtmlTags: {br: '\n', wbr: '', '#comment': ''},
+    includeHtmlTags: expandable({br: '\n', wbr: '', '#comment': ''}),
                                         //  tags to be included in the text (and what
                                         //  text to replace them with)
 
@@ -70,7 +70,7 @@ export class HTMLDomStrings<N, T, D> {
   /**
    * The options for this instance
    */
-  protected options: OptionList;
+  public options: OptionList;
 
   /**
    * The array of strings found in the DOM
@@ -201,7 +201,11 @@ export class HTMLDomStrings<N, T, D> {
   protected handleTag(node: N, ignore: boolean): N | T {
     if (!ignore) {
       let text = this.options['includeHtmlTags'][this.adaptor.kind(node)];
-      this.extendString(node, text);
+      if (Array.isArray(text)) {
+        this.extendString(node, text[0] + this.adaptor.outerHTML(node) + text[1]);
+      } else {
+        this.extendString(node, text);
+      }
     }
     return this.adaptor.next(node);
   }

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -201,8 +201,8 @@ export class HTMLDomStrings<N, T, D> {
   protected handleTag(node: N, ignore: boolean): N | T {
     if (!ignore) {
       let text = this.options['includeHtmlTags'][this.adaptor.kind(node)];
-      if (Array.isArray(text)) {
-        this.extendString(node, text[0] + this.adaptor.outerHTML(node) + text[1]);
+      if (text instanceof Function) {
+        this.extendString(node, text(node, this.adaptor));
       } else {
         this.extendString(node, text);
       }

--- a/ts/input/tex/AllPackages.ts
+++ b/ts/input/tex/AllPackages.ts
@@ -49,6 +49,7 @@ import './noundefined/NoUndefinedConfiguration.js';
 import './physics/PhysicsConfiguration.js';
 import './setoptions/SetOptionsConfiguration.js';
 import './tagformat/TagFormatConfiguration.js';
+import './texhtml/TexHtmlConfiguration.js';
 import './textcomp/TextcompConfiguration.js';
 import './textmacros/TextMacrosConfiguration.js';
 import './upgreek/UpgreekConfiguration.js';
@@ -87,6 +88,7 @@ if (typeof MathJax !== 'undefined' && MathJax.loader) {
     '[tex]/verb',
     '[tex]/configmacros',
     '[tex]/tagformat',
+    '[tex]/texhtml',
     '[tex]/textcomp',
     '[tex]/textmacros',
     '[tex]/setoptions',
@@ -122,6 +124,7 @@ export const AllPackages: string[] = [
   'verb',
   'configmacros',
   'tagformat',
+  'texhtml',
   'textcomp',
   'textmacros'
 ];

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -182,7 +182,8 @@ export const options = {
       autoload: false,
       configmacros: false,
       tagformat: false,
-      setoptions: false
+      setoptions: false,
+      texhtml: false
     }),
     //
     //  The default allow value if the extension isn't in the list above

--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -1,0 +1,89 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/**
+ * @fileoverview Configuration file for the texhtml package.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+import {Configuration} from '../Configuration.js';
+import TexParser from '../TexParser.js';
+import {CommandMap} from '../SymbolMap.js';
+import {ParseMethod} from '../Types.js';
+import ParseOptions from '../ParseOptions.js';
+import TexError from '../TexError.js';
+import {HTMLDocument} from '../../../handlers/html/HTMLDocument.js';
+import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
+import {HTMLDomStrings} from '../../../handlers/HTML/HTMLDomStrings.js';
+
+export const TexHtmlMethods: Record<string, ParseMethod> = {
+  /**
+   * Handle the \texHTML macro
+   *
+   * @param {TexParser} parser  The active TeX parser
+   * @param {string} name       The name of the macro
+   */
+  TexHtml(parser: TexParser, name: string) {
+    if (!parser.options.allowTexHTML) {
+      throw new TexError('NoTexHtml', '%1 is not allowed in the current configuration', name);
+    }
+    //
+    //  get and parse the HTML fragment.
+    //
+    const html = parser.GetArgument(name)
+      .trim()
+      .replace(/^<tex-html>(.*)<\/tex-html>/, '$1')   // remove redundant <tex-html> node
+      .replace(/^\\texHTML\{(.*)\}$/, '$1');          // remove \texHTML introduced by <tex-html> by FindTeX
+    const adaptor = parser.configuration.packageData.get('texhtml').adaptor;
+    const nodes = adaptor.childNodes(adaptor.body(adaptor.parse(html)));
+    if (nodes.length === 0) return;
+    //
+    // Create an mtext element containing the HtmlNode internal node and push it.
+    //
+    const DOM = (nodes.length === 1 ? nodes[0] : adaptor.node('div', {}, nodes));
+    const node = (parser.create('node', 'html') as HtmlNode<any>).setHTML(DOM, adaptor);
+    parser.Push(parser.create('node', 'mtext', [node]));
+  }
+};
+
+new CommandMap('texhtml', {texHTML: 'TexHtml'}, TexHtmlMethods);
+
+export const TexHtmlConfiguration = Configuration.create(
+  'texhtml', {
+    handler: {macro: ['texhtml']},
+    options: {
+      allowTexHTML: false    // Must turn this on explicitly, since it allows unfiltered HTML insertion.
+    },
+    config: () => {
+      if (HTMLDomStrings) {
+        const include = HTMLDomStrings.OPTIONS.includeHtmlTags;
+        if (!include['tex-html']) {
+          include['tex-html'] = ['\\texHTML{', '}'];
+        }
+      }
+    },
+    preprocessors: [(data: {document: HTMLDocument<any, any, any>, data: ParseOptions}) => {
+      data.data.packageData.set('texhtml', {adaptor: data.document.adaptor});  // save the DOMadaptor
+    }],
+    postprocessors: [(data: {data: ParseOptions}) => {
+      data.data.packageData.set('texhtml', {adaptor: null});                   // clear the DOMadaptor
+    }]
+  }
+);
+

--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -31,6 +31,7 @@ import TexError from '../TexError.js';
 import {HTMLDocument} from '../../../handlers/html/HTMLDocument.js';
 import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
 import {HTMLDomStrings} from '../../../handlers/HTML/HTMLDomStrings.js';
+import {DOMAdaptor} from '../../../core/DOMAdaptor.js';
 
 export const TexHtmlMethods: Record<string, ParseMethod> = {
   /**
@@ -74,7 +75,10 @@ export const TexHtmlConfiguration = Configuration.create(
       if (HTMLDomStrings) {
         const include = HTMLDomStrings.OPTIONS.includeHtmlTags;
         if (!include['tex-html']) {
-          include['tex-html'] = ['\\texHTML{', '}'];
+          include['tex-html'] = (node: any, adaptor: DOMAdaptor<any, any, any>) =>
+            '\\texHTML{' +
+            adaptor.innerHTML(node).replace(/\}/g, '&#x7D;').replace(/\{/g, '&#x7B;') +
+            '}';
         }
       }
     },

--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -30,7 +30,7 @@ import ParseOptions from '../ParseOptions.js';
 import TexError from '../TexError.js';
 import {HTMLDocument} from '../../../handlers/html/HTMLDocument.js';
 import {HtmlNode} from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
-import {HTMLDomStrings} from '../../../handlers/HTML/HTMLDomStrings.js';
+import {HTMLDomStrings} from '../../../handlers/html/HTMLDomStrings.js';
 import {DOMAdaptor} from '../../../core/DOMAdaptor.js';
 
 


### PR DESCRIPTION
This PR adds a `texhtml` extension for the TeX input jax that allows HTML within TeX input.  This is done by enclosing the HTML in a special tag, `<tex-html>...</tex-html>` that is processed specially by the TeX input jax:  it inserts `\texHTML{...}` around a serialized version of the HTML so that it can be part of a TeX string.  The `\texHTML` macro then turns the HTML into the internal `mtext` node containing an `HtmlNode` that handles the HTML in the internal MathML representation.  So for example:

```
$$3 + <tex-html><input type="text" id="answer" size="10"></tex-html> = 10$$
```

When used in an HTML page, the HTML will already be in the page as actual DOM nodes, but when used with `MathJax.tex2chtml()` or `MathJax.tex2svg`, the DOM elements will not be parsed as HTML, so you should use the `\texHTML` macro directly, as in

``` js
MathJax.tex2svg('3 + \texHTML{<input type="text" id="answer" size="10">} = 10', {display: true});
```

If you used `'3 + <tex-html><input type="text" id="answer" size="10"></tex-html> = 10'` as the string, then the tags would be interpreted as less-than signs followed by their names as variables, and so on.

If you want an expression that will work in both a conversion string and in the document DOM itself, you can use `\texHTML{<tex-html>...</tex-html>}` around the HTML.  In the DOM, the `<tex-html>...</tex-html>` will insert another `\texHTML{...}`, but the `\texHTML` macro will remove that redundant macro, if there is one in its argument string.  Similarly, when used in a string setting, `\texHTML` will remove the outer `<tex-html>` node, if there is one.

So this can be used in both the browser and in node applications, and the same TeX expression can be made to work in both.  As with the HTML-in-token-nodes, you can use `data-mjx-hdw` attributes to specify the size of the HTML in node (or in the browser, when the `htmlHDW` document option is set to `'use'` or `'force'`).

In its usual use case in the browser, the HTML will come from the DOM already, and so MathJax doesn't include HTML sanitization.  Because of this, however, the `texHTML` extension does represent a security risk on sites that allow user content, if they don't sanitize the user input themselves.  For this reason, there is an `allowTexHTML` option for the TeX input jax that must be enabled in order for the `\texHTML` macro to be used.  That way, even if someone used `\require{texhtml}`, they won't be able to use it unless the web page has specifically authorized its use.  (This should also be able to be controlled by the Safe extension, but not every web site is using it that should be, and since this is such a large risk, it seemed best to make the default be disabled, even if the website loads the extension explicitly.)

To make `<tex-html>` work, the `HTMLDomStrings` object was enhanced so that its `includeHtmlTags` option is more general.  It is a little hard to hook that into the TeX extension, since the extension doesn't have access to the output jax (where the dom-string parser is stored) or to the user options before the document is created (where the `includeHtmlTags` option could be set).  So this extension patches the `HTMLDomStrings` class's `OPTIONS` value directly.  That's a bit of a hack, but there doesn't seem to be a better way.

