### PR TITLE
Refactor usage of all packages to reduce redundant code

### DIFF
--- a/components/src/dependencies.js
+++ b/components/src/dependencies.js
@@ -62,39 +62,11 @@ export const paths = {
   sre: '[mathjax]/sre/' + (typeof window === 'undefined' ? 'sre-node' : 'sre_browser')
 };
 
-const allPackages = [
-  '[tex]/action',
-  '[tex]/ams',
-  '[tex]/amscd',
-  '[tex]/bbox',
-  '[tex]/boldsymbol',
-  '[tex]/braket',
-  '[tex]/bussproofs',
-  '[tex]/cancel',
-  '[tex]/centernot',
-  '[tex]/color',
-  '[tex]/colortbl',
-  '[tex]/configmacros',
-  '[tex]/enclose',
-  '[tex]/extpfeil',
-  '[tex]/html',
-  '[tex]/mathtools',
-  '[tex]/mhchem',
-  '[tex]/newcommand',
-  '[tex]/noerrors',
-  '[tex]/noundefined',
-  '[tex]/physics',
-  '[tex]/require',
-  '[tex]/setoptions',
-  '[tex]/tagformat',
-  '[tex]/texhtml',
-  '[tex]/textcomp',
-  '[tex]/textmacros',
-  '[tex]/unicode',
-  '[tex]/verb',
-  '[tex]/cases',
-  '[tex]/empheq'
-];
+const allPackages = Array.from(Object.keys(dependencies))
+      .filter(name => name.substr(0,5) === '[tex]' &&
+              name !== '[tex]/autoload' &&
+              name !== '[tex]/colorv2' &&
+              name !== '[tex]/all-packages');
 
 export const provides = {
   'startup': ['loader'],

--- a/components/src/input/tex-full/tex-full.js
+++ b/components/src/input/tex-full/tex-full.js
@@ -1,14 +1,12 @@
 import './lib/tex-full.js';
-
+import '../tex/extensions/all-packages/all-packages.js';
 import {registerTeX} from '../tex/register.js';
-import {Loader} from '../../../../js/components/loader.js';
-import {AllPackages} from '../../../../js/input/tex/AllPackages.js';
-import '../../../../js/input/tex/require/RequireConfiguration.js';
 
-Loader.preLoad(
-  'input/tex-base',
-  '[tex]/all-packages',
-  '[tex]/require'
-);
+if (MathJax.loader) {
+  MathJax.loader.preLoad(
+    'input/tex-base',
+    '[tex]/all-packages'
+  );
+}
 
-registerTeX(['require',...AllPackages]);
+registerTeX();

--- a/components/src/input/tex/extensions/all-packages/all-packages.js
+++ b/components/src/input/tex/extensions/all-packages/all-packages.js
@@ -3,18 +3,10 @@ import './lib/all-packages.js';
 import {AllPackages} from '../../../../../../js/input/tex/AllPackages.js';
 import '../../../../../../js/input/tex/autoload/AutoloadConfiguration.js';
 import '../../../../../../js/input/tex/require/RequireConfiguration.js';
-import {insert} from '../../../../../../js/util/Options.js';
+import {registerTeX} from '../../register.js';
 
 if (MathJax.loader) {
   MathJax.loader.preLoad('[tex]/autoload', '[tex]/require');
 }
-if (MathJax.startup) {
-  if (!MathJax.config.tex) {
-    MathJax.config.tex = {};
-  }
-  let packages = MathJax.config.tex.packages;
-  MathJax.config.tex.packages = ['autoload', 'require', ...AllPackages];
-  if (packages) {
-    insert(MathJax.config.tex, {packages});
-  }
-}
+
+registerTeX(['require', ...AllPackages], false);

--- a/components/src/input/tex/register.js
+++ b/components/src/input/tex/register.js
@@ -1,10 +1,11 @@
-import {TeX} from '../../../../js/input/tex.js';
 import {insert} from '../../../../js/util/Options.js';
 
-export function registerTeX(packageList) {
+export function registerTeX(packageList = [], tex = true) {
   if (MathJax.startup) {
-    MathJax.startup.registerConstructor('tex', TeX);
-    MathJax.startup.useInput('tex');
+    if (tex) {
+      MathJax.startup.registerConstructor('tex', MathJax._.input.tex_ts.TeX);
+      MathJax.startup.useInput('tex');
+    }
     if (!MathJax.config.tex) {
       MathJax.config.tex = {};
     }


### PR DESCRIPTION
This PR refactors some of the component files to reduce redundancy, and to make it clearer which packages are not included in AllPackages.

Here, we make `registerTeX()` more flexible so that it can be used in `all-packages`, and have `tex-full` load `all-packages` since it already does all the work.