### PR TITLE
Fix problem where errors during mhchem argument collection are not properly handled.  (mathjax/MathJax#2835)

### DIFF
--- a/ts/input/tex/mhchem/MhchemConfiguration.ts
+++ b/ts/input/tex/mhchem/MhchemConfiguration.ts
@@ -43,14 +43,15 @@ MhchemMethods.xArrow = AmsMethods.xArrow;
  * @param{string} machine     The name of the fininte-state machine to use
  */
 MhchemMethods.Machine = function(parser: TexParser, name: string, machine: 'tex' | 'ce' | 'pu') {
+  let arg = parser.GetArgument(name);
+  let tex;
   try {
-    let arg = parser.GetArgument(name);
-    let tex = mhchemParser.toTex(arg, machine);
-    parser.string = tex + parser.string.substr(parser.i);
-    parser.i = 0;
+    tex = mhchemParser.toTex(arg, machine);
   } catch (err) {
-    throw new TexError(err[0], err[1], err.slice(2));
+    throw new TexError(err[0], err[1]);
   }
+  parser.string = tex + parser.string.substr(parser.i);
+  parser.i = 0;
 };
 
 new CommandMap(


### PR DESCRIPTION
This PR isolates the call to `mhchemParser` and in order to handle the different error format used by the TeX parser and the mhchem parser, as reported in mathjax/MathJax#2835.

Resolves issue mathjax/MathJax#2835.
