### PR TITLE
Place super- and subscripts properly around \vcenter elements.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -227,7 +227,9 @@ export class MmlMo extends AbstractMmlTokenNode {
     if (parent.isEmbellished) {
       return (parent.coreMO() as MmlMo).getText();
     }
-    while ((((parent.isKind('mrow') || parent.isKind('TeXAtom') || parent.isKind('mstyle') ||
+    while ((((parent.isKind('mrow') ||
+              (parent.isKind('TeXAtom') && parent.texClass !== TEXCLASS.VCENTER) ||
+              parent.isKind('mstyle') ||
               parent.isKind('mphantom')) && parent.childNodes.length === 1) ||
             parent.isKind('munderover')) && parent.childNodes[0]) {
       parent = parent.childNodes[0] as MmlNode;

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -27,6 +27,7 @@
 import {AnyWrapper, WrapperConstructor, Constructor, AnyWrapperClass} from '../Wrapper.js';
 import {CommonMo} from './mo.js';
 import {CommonMunderover} from './munderover.js';
+import {TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
 import {MmlMsubsup} from '../../../core/MmlTree/MmlNodes/msubsup.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 import {BBox} from '../../../util/BBox.js';
@@ -368,7 +369,8 @@ export function CommonScriptbaseMixin<
       let core = this.getSemanticBase() || this.childNodes[0];
       while (core &&
              ((core.childNodes.length === 1 &&
-               (core.node.isKind('mrow') || core.node.isKind('TeXAtom') ||
+               (core.node.isKind('mrow') ||
+                (core.node.isKind('TeXAtom') && core.node.texClass !== TEXCLASS.VCENTER) ||
                 core.node.isKind('mstyle') || core.node.isKind('mpadded') ||
                 core.node.isKind('mphantom') || core.node.isKind('semantics'))) ||
               (core.node.isKind('munderover') && core.isMathAccent)))  {


### PR DESCRIPTION
This PR fixes a problem where super- and subscript were placed in the position for the UN-centered content, rather than the centered content.