### PR TITLE
Update \operatorname to work more like in LaTeX.  (mathjax/MathJax#2830)

### DIFF
--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -40,10 +40,11 @@ namespace ParseMethods {
   export function variable(parser: TexParser, c: string) {
     // @test Identifier Font
     const def = ParseUtil.getFontDef(parser);
-    if (parser.stack.env.multiLetterIdentifiers && parser.stack.env.font !== '') {
-      c = parser.string.substr(parser.i - 1).match(/^[a-z]+/i)[0];
+    const env = parser.stack.env;
+    if (env.multiLetterIdentifiers && env.font !== '') {
+      c = parser.string.substr(parser.i - 1).match(env.multiLetterIdentifiers as RegExp)[0];
       parser.i += c.length - 1;
-      if (def.mathvariant === TexConstant.Variant.NORMAL) {
+      if (def.mathvariant === TexConstant.Variant.NORMAL && env.noAutoOP && c.length > 1) {
         def.autoOP = false;
       }
     }

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -28,7 +28,7 @@ import TexError from './TexError.js';
 import StackItemFactory from './StackItemFactory.js';
 
 // Union types for abbreviation.
-export type EnvProp = string | number | boolean;
+export type EnvProp = string | number | boolean | RegExp;
 
 export type EnvList = {[key: string]: EnvProp};
 

--- a/ts/input/tex/ams/AmsConfiguration.ts
+++ b/ts/input/tex/ams/AmsConfiguration.ts
@@ -51,6 +51,7 @@ let init = function(config: ParserConfiguration) {
 export const AmsConfiguration = Configuration.create(
   'ams', {
     handler: {
+      character: ['AMSmath-operatorLetter'],
       delimiter: ['AMSsymbols-delimiter', 'AMSmath-delimiter'],
       macro: ['AMSsymbols-mathchar0mi', 'AMSsymbols-mathchar0mo',
               'AMSsymbols-delimiter', 'AMSsymbols-macros',

--- a/ts/input/tex/ams/AmsMappings.ts
+++ b/ts/input/tex/ams/AmsMappings.ts
@@ -39,6 +39,10 @@ new sm.CharacterMap('AMSmath-mathchar0mo', ParseMethods.mathchar0mo, {
   iiiint:     ['\u2A0C', {texClass: TEXCLASS.OP}]
 });
 
+/**
+ * Extra characters that are letters in \operatorname
+ */
+new sm.RegExpMap('AMSmath-operatorLetter', AmsMethods.operatorLetter, /[-*]/i);
 
 /**
  * Macros from the AMS Math package.
@@ -74,7 +78,6 @@ new sm.CommandMap('AMSmath-macros', {
 
   DeclareMathOperator: 'HandleDeclareOp',
   operatorname:        'HandleOperatorName',
-  SkipLimits:          'SkipLimits',
 
   genfrac:     'Genfrac',
   frac:       ['Genfrac', '', '', '', ''],

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -282,7 +282,7 @@ BaseMethods.MathFont = function(parser: TexParser, name: string, variant: string
   let mml = new TexParser(text, {
     ...parser.stack.env,
     font: variant,
-    multiLetterIdentifiers: /^[a-z]+/i,
+    multiLetterIdentifiers: /^[a-zA-Z]+/,
     noAutoOP: true
   }, parser.configuration).mml();
   parser.Push(parser.create('node', 'TeXAtom', [mml]));

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -282,7 +282,8 @@ BaseMethods.MathFont = function(parser: TexParser, name: string, variant: string
   let mml = new TexParser(text, {
     ...parser.stack.env,
     font: variant,
-    multiLetterIdentifiers: true
+    multiLetterIdentifiers: /^[a-z]+/i,
+    noAutoOP: true
   }, parser.configuration).mml();
   parser.Push(parser.create('node', 'TeXAtom', [mml]));
 };


### PR DESCRIPTION
This PR improves the implementation of `\operatorname` (and `\DeclareMathOperator`) to work more like in true LaTeX.  In the past, the macro replaced `-` and `*` by `\text{-}` and `\text{*}` in order to handle what LaTeX dues using `\catcode`.  Here, we take advantage of features added to `ParseMethods.variable` to get `\mathrm{}` to produce multi-character `mi` elements to get `\operatorname` to do the same.  The `multiLetterIdentifiers` environment value has been replaced by a regular expression for the characters to use (and `EnvProp` is extended to allow that).  Then we make a new map that matches `-` and `*` and checks whether we are in an `\operatorname`, and if so, parses the characters like variables, otherwise parses them as usual.

The `\operatorname` macro is rewritten to parse the arguments itself, rather than using a replacement macro internally, so that we can set the `multiLetterIdentifiers` regular expression and the `operatorLetters` environment property.  This also means we can handle the following `\limits` directly rather than needing the extra `\SkipLimits` macro to do that.

Finally, `\DeclareMathOperator` is set up to define the macro in terms of `\operatorname` rather than `\mathop`.

Resolves issue mathjax/MathJax#2830
