### PR TITLE
Add \textup and \textnormal to allowed textmacros. (mathjax/MathJax#2846)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -102,6 +102,8 @@ new CommandMap('text-macros', {
   Huge:         ['SetSize', 2.49],
 
   Bbb:          ['Macro', '{\\bbFont #1}', 1],
+  textnormal:   ['Macro', '{\\rm #1}', 1],
+  textup:       ['Macro', '{\\rm #1}', 1],
   textrm:       ['Macro', '{\\rm #1}', 1],
   textit:       ['Macro', '{\\it #1}', 1],
   textbf:       ['Macro', '{\\bf #1}', 1],


### PR DESCRIPTION
the `\textup` and `\textnormal` macros were left out of `textmacros` (since they were added after `textmacros` was created).  This PR added them in alongside the other `\textXYZ` macros.

Resolves issue mathjax/MathJax#2846.