### PR TITLE
Add \data to html extension

### DIFF
--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -154,7 +154,7 @@ export const AutoloadConfiguration = Configuration.create(
         color: ['color', 'definecolor', 'textcolor', 'colorbox', 'fcolorbox'],
         enclose: ['enclose'],
         extpfeil: ['xtwoheadrightarrow', 'xtwoheadleftarrow', 'xmapsto', 'xlongequal', 'xtofrom', 'Newextarrow'],
-        html: ['href', 'class', 'style', 'cssId'],
+        html: ['data', 'href', 'class', 'style', 'cssId'],
         mhchem: ['ce', 'pu'],
         newcommand: ['newcommand', 'renewcommand', 'newenvironment', 'renewenvironment', 'def', 'let'],
         unicode: ['unicode'],

--- a/ts/input/tex/html/HtmlConfiguration.ts
+++ b/ts/input/tex/html/HtmlConfiguration.ts
@@ -28,6 +28,7 @@ import HtmlMethods from './HtmlMethods.js';
 
 
 new CommandMap('html_macros', {
+  data:    'Data',
   href:    'Href',
   'class': 'Class',
   style:   'Style',

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -26,6 +26,7 @@
 import TexParser from '../TexParser.js';
 import {ParseMethod} from '../Types.js';
 import NodeUtil from '../NodeUtil.js';
+import ParseUtil from "../ParseUtil.js";
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 
 
@@ -40,19 +41,23 @@ let HtmlMethods: Record<string, ParseMethod> = {};
 HtmlMethods.Data = (parser: TexParser, name: string) => {
   const dataset = parser.GetArgument(name);
   const arg = GetArgumentMML(parser, name);
-  for (const [prop, val] of splitTokens(dataset)) {
-    NodeUtil.setAttribute(arg, `data-${prop}`, val);
+  const data = ParseUtil.keyvalOptions(dataset);
+  for (const key in data) {
+    // remove illegal attribute names
+    if (!isLegalAttributeName(key)) {
+      continue;
+    }
+    NodeUtil.setAttribute(arg, `data-${key}`, data[key]);
   }
   parser.Push(arg);
 };
 
 /**
- * Split a dataset string into tokens.
- * @param {string} str String to split.
+ * Whether the string is a valid HTML attribute name according to {@link https://html.spec.whatwg.org/multipage/syntax.html#attributes-2}.
+ * @param {string} name String to validate.
  */
-function splitTokens(str: string) {
-  const matches = Array.from(str.matchAll(/\b([A-Za-z0-9_-]+)=(['"])(.+?)\2/g));
-  return matches.map(([, name, , val]) => [name, val]);
+function isLegalAttributeName(name: string): boolean {
+  return !!name.match(/^([^\x00-\x1f\x7f-\x9f "'>\/=]+)$/);
 }
 
 /**

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -57,7 +57,7 @@ HtmlMethods.Data = (parser: TexParser, name: string) => {
  * @param {string} name String to validate.
  */
 function isLegalAttributeName(name: string): boolean {
-  return !!name.match(/^([^\x00-\x1f\x7f-\x9f "'>\/=]+)$/);
+  return Boolean(name.match(/^([^\x00-\x1f\x7f-\x9f "'>\/=]+)$/));
 }
 
 /**

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -32,6 +32,28 @@ import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 // Namespace
 let HtmlMethods: Record<string, ParseMethod> = {};
 
+/**
+ * Implements \data{dataset}{content}
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The macro name.
+ */
+HtmlMethods.Data = (parser: TexParser, name: string) => {
+  const dataset = parser.GetArgument(name);
+  const arg = GetArgumentMML(parser, name);
+  for (const [prop, val] of splitTokens(dataset)) {
+    NodeUtil.setAttribute(arg, `data-${prop}`, val);
+  }
+  parser.Push(arg);
+};
+
+/**
+ * Split a dataset string into tokens.
+ * @param str String to split.
+ */
+function splitTokens(str: string) {
+  const matches = Array.from(str.matchAll(/\b([A-Za-z0-9_-]+)=(['"])(.+?)\2/g));
+  return matches.map(([, name, , val]) => [name, val]);
+}
 
 /**
  * Implements \href{url}{math}
@@ -119,6 +141,5 @@ let GetArgumentMML = function(parser: TexParser, name: string): MmlNode {
   NodeUtil.copyAttributes(arg, mrow);
   return mrow;
 };
-
 
 export default HtmlMethods;

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -48,7 +48,7 @@ HtmlMethods.Data = (parser: TexParser, name: string) => {
 
 /**
  * Split a dataset string into tokens.
- * @param str String to split.
+ * @param {string} str String to split.
  */
 function splitTokens(str: string) {
   const matches = Array.from(str.matchAll(/\b([A-Za-z0-9_-]+)=(['"])(.+?)\2/g));
@@ -141,5 +141,6 @@ let GetArgumentMML = function(parser: TexParser, name: string): MmlNode {
   NodeUtil.copyAttributes(arg, mrow);
   return mrow;
 };
+
 
 export default HtmlMethods;

--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -140,6 +140,7 @@ new CommandMap('text-macros', {
   href:         'CheckAutoload',
   style:        'CheckAutoload',
   class:        'CheckAutoload',
+  data:         'CheckAutoload',
   cssId:        'CheckAutoload',
   unicode:      'CheckAutoload',
 


### PR DESCRIPTION
This PR adds the `\data` command to the HTML extension to allow adding `data-*` attributes to MathJax content.

I have opened a separate PR to document this command: https://github.com/mathjax/MathJax-docs/pull/299