### PR TITLE
Prevent CHTML adaptice CSS from adding character CSS multiple times

### DIFF
--- a/ts/output/chtml/Usage.ts
+++ b/ts/output/chtml/Usage.ts
@@ -23,14 +23,13 @@
 
 /**
  * Class used for tracking usage of font characters or wrappers
- *  (should extend Set<T>, but that doesn't work for compiling to ES2015).
  */
 export class Usage<T> {
 
   /**
    * The used items.
    */
-  protected used: Set<T> = new Set<T>();
+  protected used: Set<string> = new Set<string>();
 
   /**
    * The items marked as used since last update.
@@ -41,10 +40,11 @@ export class Usage<T> {
    * @param {T} item   The item that has been used
    */
   public add(item: T) {
-    if (!this.used.has(item)) {
+    const name = JSON.stringify(item);
+    if (!this.used.has(name)) {
       this.needsUpdate.push(item);
     }
-    this.used.add(item);
+    this.used.add(name);
   }
 
   /**
@@ -52,7 +52,7 @@ export class Usage<T> {
    * @return {boolean}   True if the item has been used
    */
   public has(item: T): boolean {
-    return this.used.has(item);
+    return this.used.has(JSON.stringify(item));
   }
 
   /**


### PR DESCRIPTION
The CHTML adaptive CSS currently adds CSS rules for characters multiple times if they are used in multiple typeset calls.  I.e., typesetting `$$x$$`, then adding another `$$x$$` to the page and typesetting again will cause two copies of the CSS for the italic "x" to be added to the CHTML stylesheet.

This is due to the fact that the usage tracking for the characters uses a `Set()` object with arrays that represent the variant and the character in that variant, but since two arrays are different even if they contain the same content, the fact that `["italic", 0x1D465]` was already in the set was not being taken into account.

This PR fixes the problem by using a string rather than the array as the element in the set.  The original array is JSON stringified so that two copies of the arrays will be considered the same (while not disrupting the use as `Usage<number>` and `Usage<string>` since numbers and strings stringify as themselves).