### PR TITLE
Include CSS to reset border-collapse in CHTML output.  (mathjax/MathJax#2861)

### DIFF
--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -57,6 +57,7 @@ CommonMathMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
       'font-size': '100%',
       'font-size-adjust': 'none',
       'letter-spacing': 'normal',
+      'border-collapse': 'collapse',
       'word-wrap': 'normal',
       'word-spacing': 'normal',
       'white-space': 'nowrap',


### PR DESCRIPTION
This PR resolves the issue raised in mathjax/MathJax#2861 where attribute settings on a surrounding `<table>` can bleed into MathJax CHTML output.  It adds CSS to prevent that.