### PR TITLE
Update svg output to properly handle token elements with multiple child nodes. (mathjax/MathJax#2836)

### DIFF
--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -69,6 +69,7 @@ CommonTextNodeMixin<CHTMLConstructor<any, any, any>>(CHTMLWrapper) {
     const adaptor = this.adaptor;
     const variant = this.parent.variant;
     const text = (this.node as TextNode).getText();
+    if (text.length === 0) return;
     if (variant === '-explicitFont') {
       adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w));
     } else {

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -58,16 +58,19 @@ CommonTextNodeMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
   public toSVG(parent: N) {
     const text = (this.node as TextNode).getText();
     const variant = this.parent.variant;
+    if (text.length === 0) return;
     if (variant === '-explicitFont') {
-      this.adaptor.append(parent, this.jax.unknownText(text, variant));
+      this.element = this.adaptor.append(parent, this.jax.unknownText(text, variant));
     } else {
       const chars = this.remappedText(text, variant);
+      if (this.parent.childNodes.length > 1) {
+        parent = this.element = this.adaptor.append(parent, this.svg('g', {'data-mml-node': 'text'}));
+      }
       let x = 0;
       for (const n of chars) {
         x += this.placeChar(n, x, 0, parent, variant);
       }
     }
-    this.element = this.adaptor.lastChild(parent);
   }
 
 }

--- a/ts/output/svg/Wrappers/mtext.ts
+++ b/ts/output/svg/Wrappers/mtext.ts
@@ -38,7 +38,7 @@ export class SVGmtext<N, T, D> extends
 CommonMtextMixin<SVGConstructor<any, any, any>>(SVGWrapper) {
 
   /**
-   * The mtet wrapper
+   * The mtext wrapper
    */
   public static kind = MmlMtext.prototype.kind;
 


### PR DESCRIPTION
This PR resolves an issue where SVG output of token nodes with more than one child would get the horizontal position of the children incorrect.  This was due to the incorrect handling of the `element` property.  The fix is to wrap the children in a `<g>` tag when there is more than one, and position that, rather than assuming the last child is the only child, as was previously done.

There is also a comment typo fix, and a set in the CHTML output to avoid empty nodes when there are no children in a token node with an explicit font.

Resolves issue mathjax/MathJax#2836.