### PR TITLE
Add \data to html extension

### DIFF
--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -154,7 +154,7 @@ export const AutoloadConfiguration = Configuration.create(
         color: ['color', 'definecolor', 'textcolor', 'colorbox', 'fcolorbox'],
         enclose: ['enclose'],
         extpfeil: ['xtwoheadrightarrow', 'xtwoheadleftarrow', 'xmapsto', 'xlongequal', 'xtofrom', 'Newextarrow'],
-        html: ['href', 'class', 'style', 'cssId'],
+        html: ['data', 'href', 'class', 'style', 'cssId'],
         mhchem: ['ce', 'pu'],
         newcommand: ['newcommand', 'renewcommand', 'newenvironment', 'renewenvironment', 'def', 'let'],
         unicode: ['unicode'],

--- a/ts/input/tex/html/HtmlConfiguration.ts
+++ b/ts/input/tex/html/HtmlConfiguration.ts
@@ -28,6 +28,7 @@ import HtmlMethods from './HtmlMethods.js';
 
 
 new CommandMap('html_macros', {
+  data:    'Data',
   href:    'Href',
   'class': 'Class',
   style:   'Style',

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -28,6 +28,7 @@ import {ParseMethod} from '../Types.js';
 import NodeUtil from '../NodeUtil.js';
 import ParseUtil from "../ParseUtil.js";
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import TexError from '../TexError.js';
 
 
 // Namespace
@@ -45,7 +46,7 @@ let HtmlMethods: Record<string, ParseMethod> = {};
   for (const key in data) {
     // remove illegal attribute names
     if (!isLegalAttributeName(key)) {
-      continue;
+      throw new TexError('InvalidHTMLAttr', 'Invalid HTML attribute: %1', `data-${key}`);
     }
     NodeUtil.setAttribute(arg, `data-${key}`, data[key]);
   }

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -53,12 +53,15 @@ let HtmlMethods: Record<string, ParseMethod> = {};
   parser.Push(arg);
 };
 
+/** Regexp for matching non-characters as specified by {@link https://infra.spec.whatwg.org/#noncharacter}. */
+const nonCharacterRegexp = /[\u{FDD0}-\u{FDEF}\u{FFFE}\u{FFFF}\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
+
 /**
  * Whether the string is a valid HTML attribute name according to {@link https://html.spec.whatwg.org/multipage/syntax.html#attributes-2}.
  * @param {string} name String to validate.
  */
 function isLegalAttributeName(name: string): boolean {
-  return Boolean(name.match(/^([^\x00-\x1f\x7f-\x9f "'>\/=]+)$/));
+  return !(name.match(/[\x00-\x1f\x7f-\x9f "'>\/=]/) || name.match(nonCharacterRegexp));
 }
 
 /**

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -26,12 +26,39 @@
 import TexParser from '../TexParser.js';
 import {ParseMethod} from '../Types.js';
 import NodeUtil from '../NodeUtil.js';
+import ParseUtil from "../ParseUtil.js";
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 
 
 // Namespace
 let HtmlMethods: Record<string, ParseMethod> = {};
 
+/**
+ * Implements \data{dataset}{content}
+ * @param {TexParser} parser The calling parser.
+ * @param {string} name The macro name.
+ */
+ HtmlMethods.Data = (parser: TexParser, name: string) => {
+  const dataset = parser.GetArgument(name);
+  const arg = GetArgumentMML(parser, name);
+  const data = ParseUtil.keyvalOptions(dataset);
+  for (const key in data) {
+    // remove illegal attribute names
+    if (!isLegalAttributeName(key)) {
+      continue;
+    }
+    NodeUtil.setAttribute(arg, `data-${key}`, data[key]);
+  }
+  parser.Push(arg);
+};
+
+/**
+ * Whether the string is a valid HTML attribute name according to {@link https://html.spec.whatwg.org/multipage/syntax.html#attributes-2}.
+ * @param {string} name String to validate.
+ */
+function isLegalAttributeName(name: string): boolean {
+  return Boolean(name.match(/^([^\x00-\x1f\x7f-\x9f "'>\/=]+)$/));
+}
 
 /**
  * Implements \href{url}{math}

--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -142,6 +142,7 @@ new CommandMap('text-macros', {
   href:         'CheckAutoload',
   style:        'CheckAutoload',
   class:        'CheckAutoload',
+  data:         'CheckAutoload',
   cssId:        'CheckAutoload',
   unicode:      'CheckAutoload',
 


### PR DESCRIPTION
This PR is a continuation of #791 (which incorrectly committed to the master branch). It adds the `\data` command to the HTML extension to allow adding `data-*` attributes to MathJax content. Documentation is in https://github.com/mathjax/MathJax-docs/pull/299 (`MathJax-docs` doesn't seem to have a `develop` branch).