### PR TITLE
Locale cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "esm": "^3.2.25",
         "mhchemparser": "^4.1.0",
         "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.4"
+        "speech-rule-engine": "^4.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.14.5",
@@ -2158,11 +2158,11 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/commondir": {
@@ -4014,11 +4014,11 @@
       }
     },
     "node_modules/speech-rule-engine": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.4.tgz",
-      "integrity": "sha512-WX1tV2+3NkGCTpKdXGupZKzmfigg4pXFxBqHyQwq59NqoezJQhbZnH8PU/ZSSIsbB4WlhHl3ssW1ZKbgq5Okng==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.5.tgz",
+      "integrity": "sha512-1ZfPUkwErbAxJ+96RjOs57AGVTgHwQDBk2nTXL7q5T9KxGkDDrO1Am6QXhpxZev8AoO8aglbRQxxh8OSj6gM3A==",
       "dependencies": {
-        "commander": "8.3.0",
+        "commander": "9.2.0",
         "wicked-good-xpath": "1.3.0",
         "xmldom-sre": "0.1.31"
       },
@@ -6554,9 +6554,9 @@
       "dev": true
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -7945,11 +7945,11 @@
       }
     },
     "speech-rule-engine": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.4.tgz",
-      "integrity": "sha512-WX1tV2+3NkGCTpKdXGupZKzmfigg4pXFxBqHyQwq59NqoezJQhbZnH8PU/ZSSIsbB4WlhHl3ssW1ZKbgq5Okng==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.5.tgz",
+      "integrity": "sha512-1ZfPUkwErbAxJ+96RjOs57AGVTgHwQDBk2nTXL7q5T9KxGkDDrO1Am6QXhpxZev8AoO8aglbRQxxh8OSj6gM3A==",
       "requires": {
-        "commander": "8.3.0",
+        "commander": "9.2.0",
         "wicked-good-xpath": "1.3.0",
         "xmldom-sre": "0.1.31"
       }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "esm": "^3.2.25",
     "mhchemparser": "^4.1.0",
     "mj-context-menu": "^0.6.1",
-    "speech-rule-engine": "^4.0.4"
+    "speech-rule-engine": "^4.0.5"
   }
 }

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -630,24 +630,6 @@ let csMenu = function(menu: MJContextMenu, sub: Submenu) {
 MJContextMenu.DynamicSubmenus.set('Clearspeak', csMenu);
 
 /**
- * Locale mapping to language names.
- * @type {{[locale: string]: string}}
- */
-const iso: {[locale: string]: string} = {
-  'ca': 'Catalan',
-  'da': 'Danish',
-  'de': 'German',
-  'en': 'English',
-  'es': 'Spanish',
-  'fr': 'French',
-  'hi': 'Hindi',
-  'it': 'Italian',
-  'nb': 'Bokmål',
-  'nn': 'Nynorsk',
-  'sv': 'Swedish'
-};
-
-/**
  * Creates dynamic locale menu.
  * @param {MJContextMenu} menu The context menu.
  * @param {Submenu} sub The submenu to attach.
@@ -655,10 +637,10 @@ const iso: {[locale: string]: string} = {
 let language = function(menu: MJContextMenu, sub: Submenu) {
   let radios: {type: string, id: string,
                content: string, variable: string}[] = [];
-  for (let lang of Sre.locales) {
+  for (let lang of Sre.locales.keys()) {
     if (lang === 'nemeth') continue;
     radios.push({type: 'radio', id: lang,
-                 content: iso[lang] || lang, variable: 'locale'});
+                 content: Sre.locales.get(lang) || lang, variable: 'locale'});
   }
   radios.sort((x, y) => x.content.localeCompare(y.content, 'en'));
   return menu.factory.get('subMenu')(menu.factory, {

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -398,6 +398,12 @@ let allExplorers: {[options: string]: ExplorerInit} = {
     explorer.speechGenerator.setOptions({
       locale: doc.options.sre.locale, domain: doc.options.sre.domain,
       style: doc.options.sre.style, modality: 'speech'});
+    // This weeds out the case of providing a non-existent locale option.
+    let locale = explorer.speechGenerator.getOptions().locale;
+    if (locale !== Sre.engineSetup().locale) {
+      doc.options.sre.locale = Sre.engineSetup().locale;
+      explorer.speechGenerator.setOptions({locale: doc.options.sre.locale});
+    }
     explorer.showRegion = 'subtitles';
     return explorer;
   },


### PR DESCRIPTION
These are the final adaptations to SRE's new locale handling. In particular,

* We ignore bad locale options provided by local settings. While non-existent locales are handled by SRE falling back to an existing default (e.g., English), currently each explorer retains the incorrect locale. Now the first explorer will correct the options to contain the default locale. 
* This also ensures that there will always be a valid locale selected in the `Accessibility > Speech > Language` menu.
* SRE now has its own mapping for locales from iso to language name. We make use of this now in MJ.

Note, that this currently works only with the next patch release of SRE. I'll do that tonight, and will push one more commit with the correct version number in `package.json`.

