### PR TITLE
Remove movablelimits property if the accent base has it set

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -587,7 +587,7 @@ BaseMethods.Accent = function(parser: TexParser, name: string, accent: string, s
   NodeUtil.setAttribute(mml, 'stretchy', stretchy ? true : false);
   // @test Vector Op, Vector
   const mo = (NodeUtil.isEmbellished(c) ? NodeUtil.getCoreMO(c) : c);
-  if (NodeUtil.isType(mo, 'mo')) {
+  if (NodeUtil.isType(mo, 'mo') || NodeUtil.getProperty(mo, 'movablelimits')) {
     // @test Vector Op
     NodeUtil.setProperties(mo, {'movablelimits': false});
   }


### PR DESCRIPTION
If the base of an accent comes from `\operatorname`, for example, it will have the `movablelimits` property set to `true`, and so will convert to `msup` in in-line mode, causing incorrect rendering.  This PR makes sure `movable limits` is removed from an accent base to prevent that.