### PR TITLE
Wrap sideset in an TeXAtom of class OP

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -324,17 +324,19 @@ AmsMethods.SideSet = function (parser: TexParser, name: string) {
     mml = postScripts;
   }
   //
-  //  Push the needed pieces onto the stack.
+  //  Put the needed pieces into a TeXAtom of class OP.
   //  Note that the postScripts are in the mml element,
   //    either as part of the mmultiscripts node, or the
   //    msubsup with the base inserted into it.
   //
+  const mrow = parser.create('node', 'TeXAtom', [], {texClass: TEXCLASS.OP, movesupsub: true, movablelimits: true});
   if (preRest) {
-    preScripts && parser.Push(preScripts);
-    parser.Push(preRest);
+    preScripts && mrow.appendChild(preScripts);
+    mrow.appendChild(preRest);
   }
-  parser.Push(mml);
-  postRest && parser.Push(postRest);
+  mrow.appendChild(mml);
+  postRest && mrow.appendChild(postRest);
+  parser.Push(mrow);
 };
 
 /**


### PR DESCRIPTION
This PR resolves the issue raised by Peter with `\sideset{}{^*}{\sum}_{a\mid A_y}` where the final underscore should place its argument under the sum rather than in subscript position.  This is done by placing everything into a TeXAtom of class OP so that the limits are placed above and below in displaystyle.

The positioning is not quite the same as in LaTeX, however.  You could get the proper placement using

```
\sideset{}{^*}{\sum}_{a\mid A_y\hphantom{*}}
```

but I am hesitant to add such phantoms automatically as they would have to be removed in textstyle, and would also require special processing of subscript and superscripts that follow the `\sideset`.  That could be done, but would require additional StackItems to handle it.  