### PR TITLE
Fix relative width in mpadded, and correct indentation

### DIFF
--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -116,7 +116,7 @@ AmsCdMethods.arrow = function(parser: TexParser, name: string) {
         a = '\\kern ' + top.getProperty('minw');
       } // minsize needs work
       if (a || b) {
-        let pad: EnvList = {width: '.67em', lspace: '.33em'};
+        let pad: EnvList = {width: '+.67em', lspace: '.33em'};
         mml = parser.create('node', 'munderover', [mml]) as MmlMunderover;
         if (a) {
           let nodeA = new TexParser(a, parser.stack.env, parser.configuration).mml();
@@ -128,28 +128,28 @@ AmsCdMethods.arrow = function(parser: TexParser, name: string) {
           let nodeB = new TexParser(b, parser.stack.env, parser.configuration).mml();
           NodeUtil.setChild(mml, mml.under, parser.create('node', 'mpadded', [nodeB], pad));
         }
-          if (parser.configuration.options.amscd.hideHorizontalLabels) {
-            mml = parser.create('node', 'mpadded', mml, {depth: 0, height: '.67em'});
-          }
+        if (parser.configuration.options.amscd.hideHorizontalLabels) {
+          mml = parser.create('node', 'mpadded', mml, {depth: 0, height: '.67em'});
         }
-      } else {
+      }
+    } else {
       //
       //  Lay out vertical arrows with mrow if there are labels
       //
-        let arrowNode = parser.create('token', 'mo', vdef, arrow);
-        mml = arrowNode;
-        if (a || b) {
-          mml = parser.create('node', 'mrow');
-          if (a) {
-            NodeUtil.appendChildren(
-              mml, [new TexParser('\\scriptstyle\\llap{' + a + '}', parser.stack.env, parser.configuration).mml()]);
-          }
-          arrowNode.texClass = TEXCLASS.ORD;
-          NodeUtil.appendChildren(mml, [arrowNode]);
-          if (b) {
-            NodeUtil.appendChildren(mml, [new TexParser('\\scriptstyle\\rlap{' + b + '}',
-                                                       parser.stack.env, parser.configuration).mml()]);
-          }
+      let arrowNode = parser.create('token', 'mo', vdef, arrow);
+      mml = arrowNode;
+      if (a || b) {
+        mml = parser.create('node', 'mrow');
+        if (a) {
+          NodeUtil.appendChildren(
+            mml, [new TexParser('\\scriptstyle\\llap{' + a + '}', parser.stack.env, parser.configuration).mml()]);
+        }
+        arrowNode.texClass = TEXCLASS.ORD;
+        NodeUtil.appendChildren(mml, [arrowNode]);
+        if (b) {
+          NodeUtil.appendChildren(mml, [new TexParser('\\scriptstyle\\rlap{' + b + '}',
+                                                      parser.stack.env, parser.configuration).mml()]);
+        }
       }
     }
   }


### PR DESCRIPTION
This PR corrects the width of an `mpadded` element used in the `amscd` extension so that it is an addition to the width rather than the width itself.  This was lost reign the v2 to v3 translation, apparently.  It also fixes some indentation problems in the code.