### PR TITLE
Expose SRE's toSpeech

### DIFF
--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -54,6 +54,8 @@ export namespace Sre {
 
   export const toEnriched = Api.toEnriched;
 
+  export const toSpeech = Api.toSpeech;
+
   export const clearspeakPreferences = ClearspeakPreferences;
 
   export const getHighlighter = HighlighterFactory.highlighter;


### PR DESCRIPTION
This PR exposes SRE's `toSpeech` API method in the `sre.ts` module. Although the method itself is not used elsewhere in `mathjax-src` it is used quite frequently in our demo files. 
Previously, this was not an issue, as we imported all of `sre_browser` via the global `SRE` variable, which made all API methods available there. However, now only API methods that are explicitly exported can be used, which only leaves `toEnriched`.

I would not regard this as a breaking change and therefore it would be helpful if we could include it in 4.2.1.