### PR TITLE
Fix nested nth root

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -336,10 +336,11 @@ export default class TexParser {
     if (this.GetNext() !== '[') {
       return def;
     }
-    let j = ++this.i, parens = 0;
+    let j = ++this.i, parens = 0, squareParens = 1;
     while (this.i < this.string.length) {
       switch (this.string.charAt(this.i++)) {
       case '{':   parens++; break;
+      case '[':   squareParens++; break;
       case '\\':  this.i++; break;
       case '}':
         if (parens-- <= 0) {
@@ -349,7 +350,8 @@ export default class TexParser {
         }
         break;
       case ']':
-        if (parens === 0) {
+        squareParens--;
+        if (parens === 0 && squareParens === 0) {
           return this.string.slice(j, this.i - 1);
         }
         break;


### PR DESCRIPTION
### Issue Summary

When I convert a nth root which index is also nthroot, I get a corrupted SVG. See below what I mean.
![nth-root-summary](https://user-images.githubusercontent.com/72270591/168701826-65d77fe0-8058-4588-9078-25913b6f9aa6.png)

Sample TeX: `\\sqrt[\\sqrt[]{}]{}`, `\\sqrt[\\sqrt[3]{8}]{16}`

Actually, I use [tex-to-svg](https://github.com/CreatifCreateur/TeX-to-SVG) to convert TeX fo SVG. It references to MathJax and executes the following code.
```
    const tex = new TeX({ packages });
    const svg = new SVG({ fontCache: (FONT_CACHE ? 'local' : 'none') });
    const html = mathjax.document('', { InputJax: tex, OutputJax: svg });
    const node = html.convert(str, {
        display: !INLINE,
        em: options.em,
        ex: options.ex,
        containerWidth: options.width
    });
```

The error occurs in TexParser. It says "Could not find closing ']'". 

Call stack
```
./node_modules/mathjax-full/js/input/tex/TexParser.js.TexParser.GetBrackets (TexParser.js:259)
./node_modules/mathjax-full/js/input/tex/base/BaseMethods.js.BaseMethods.Sqrt (BaseMethods.js:273)
./node_modules/mathjax-full/js/input/tex/SymbolMap.js.CommandMap.parse (SymbolMap.js:221)
./node_modules/mathjax-full/js/input/tex/MapHandler.js.SubHandler.parse (MapHandler.js:78)
./node_modules/mathjax-full/js/input/tex/TexParser.js.TexParser.parse (TexParser.js:104)
controlSequence (ParseMethods.js:59)
./node_modules/mathjax-full/js/input/tex/SymbolMap.js.AbstractSymbolMap.parse (SymbolMap.js:74)
./node_modules/mathjax-full/js/input/tex/MapHandler.js.SubHandler.parse (MapHandler.js:78)
./node_modules/mathjax-full/js/input/tex/TexParser.js.TexParser.parse (TexParser.js:104)
./node_modules/mathjax-full/js/input/tex/TexParser.js.TexParser.Parse (TexParser.js:136)
TexParser (TexParser.js:69)
./node_modules/mathjax-full/js/input/tex.js.TeX.compile (tex.js:115)
./node_modules/mathjax-full/js/core/MathItem.js.AbstractMathItem.compile (MathItem.js:56)
(anonymous) (MathDocument.js:115)
./node_modules/mathjax-full/js/core/MathDocument.js.RenderList.renderConvert (MathDocument.js:167)
./node_modules/mathjax-full/js/core/MathItem.js.AbstractMathItem.convert (MathItem.js:52)
./node_modules/mathjax-full/js/core/MathDocument.js.AbstractMathDocument.convert (MathDocument.js:325)
TeXToSVG (TeXToSVG.js:30)
```

### Steps to Reproduce:

1. download [the repository](https://github.com/petrovich2k/nested-nth-root-demo)
2. `npm install`
3. `npm run build`
4. serve the dist folder (`npm run start` or use live server)

### Technical details:

* MathJax Version: 3.2

### Supporting information:

I have created two repositories. [The first one](https://github.com/petrovich2k/nested-nth-root-demo) reproduces the issue. You will see sth like that.
![nth-root-issue](https://user-images.githubusercontent.com/72270591/168702204-2d72207f-8500-47a9-8e01-edf21025f02b.png)

[The second one](https://github.com/petrovich2k/nested-nth-root-demo-fixed) shows that my fix works well.
![nth-root-fix](https://user-images.githubusercontent.com/72270591/168702268-734a0d13-9153-4624-9a74-24c34647067d.png)

Please download them and execute the following commands
1. `npm install`
2. `npm run build`
3. serve the dist folder (`npm run start` or use live server)

I have also opened [a pull-request for my solution](https://github.com/mathjax/MathJax-src/pull/812).