### PR TITLE
Properly set parent for newly created mtd

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -549,7 +549,7 @@ namespace ParseUtil {
       options.addNode(n.kind, n);
       const lists = (n.getProperty('in-lists') as string || '').split(/,/);
       for (const list of lists) {
-        options.addNode(list, n);
+        list && options.addNode(list, n);
       }
     });
     return tree;

--- a/ts/input/tex/empheq/EmpheqUtil.ts
+++ b/ts/input/tex/empheq/EmpheqUtil.ts
@@ -152,7 +152,7 @@ export const EmpheqUtil = {
     for (const row of table.childNodes.slice(0).reverse()) {
       mtd = parser.create('node', 'mtd');
       row.childNodes.unshift(mtd);
-      row.replaceChild(mtd, mtd);   // make sure parent is set
+      mtd.parent = row;
       if (row.isKind('mlabeledtr')) {
         row.childNodes[0] = row.childNodes[1];
         row.childNodes[1] = mtd;


### PR DESCRIPTION
This PR fixes a problem in `EmpheqUtils` where an `mtd` element is created and inserted into an `mtr` child list without properly setting the parent node.  There was a line that was supposed to do that, but apparently wan't working.  This PR replaces that line with one that sets the parent explicitly (not sure why I didn't do that originally).

It also fixes an issue where nodes could be added to the ParseOptions' `nodeList` for a list with an empty name (when the `in-lists` string is empty, the `split(/,/)` produces an array with an empty entry).

This resolves the issue Peter was having with his `subnumcases` environment.