### PR TITLE
Makes sure that MathJax waits for the correct promise.

### DIFF
--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -129,7 +129,9 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
         if (document.options.sre.speech !== currentSpeech) {
           currentSpeech = document.options.sre.speech;
-          mathjax.retryAfter(Sre.setupEngine(document.options.sre));
+          mathjax.retryAfter(
+            Sre.setupEngine(document.options.sre).then(
+              () => Sre.sreReady()));
         }
         const math = new document.options.MathItem('', MmlJax);
         try {


### PR DESCRIPTION
PR ensures that MathJax waits for the correct promise from SRE. 
SRE now allows locales to inherit from each other and therefore needs to load them hierarchically. Therefore, we need to wait for all locales to be loaded (with `sreReady`) not just then one requested by `setupEngine`.

