### PR TITLE
Fix defaultPageReady() return type

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -99,7 +99,7 @@ export interface MathJaxObject extends MJObject {
     extendHandler(extend: HandlerExtension): void;
     toMML(node: MmlNode): string;
     defaultReady(): void;
-    defaultPageReady(): void,
+    defaultPageReady(): Promise<void>;
     getComponents(): void;
     makeMethods(): void;
     makeTypesetMethods(): void;


### PR DESCRIPTION
Hi @dpvc,
I used the wrong return type in PR #746 (`void` vs `Promise<void>`). Sorry about that.
Thanks @NicolasCarpi for pointing it out.