### PR TITLE
Make sure we get the <math> element from mml3 conversion.  (mathjax/MathJax#2879)

### DIFF
--- a/ts/input/mathml/mml3/mml3.ts
+++ b/ts/input/mathml/mml3/mml3.ts
@@ -73,9 +73,10 @@ export class Mml3<N, T, D> {
       const parsed = document.adaptor.parse(Mml3.XSLT, 'text/xml') as any as Node;
       processor.importStylesheet(parsed);
       this.transform = (node: N) => {
-        const div = document.adaptor.node('div', {}, [document.adaptor.clone(node)]);
+        const adaptor = document.adaptor;
+        const div = adaptor.node('div', {}, [adaptor.clone(node)]);
         const mml = processor.transformToDocument(div as any as Node) as any as N;
-        return document.adaptor.firstChild(mml) as N;
+        return adaptor.tags(mml, 'math')[0];
       };
     }
   }


### PR DESCRIPTION
It turns out that the XSLTProcessor produces different results in Firefox and Chrome, and the code that obtained the `<math>` element didn't work in both, leading to an error message about `div` elements.  This PR uses a more robust approach to finding the `<math>` element.  We know here will be one (and only one) because this runs after the initial parsing of the math string, which checks for a single `<math>` element.

Resolves issue mathjax/MathJax#2879.