### PR TITLE
Fix issue where lazy typesetting would re-typeset expressions unnecessarily.  (mathjax/MathJax#2873)

### DIFF
--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -216,6 +216,15 @@ export function LazyMathItemMixin<N, T, D, B extends Constructor<HTMLMathItem<N,
     }
 
     /**
+     * Only update the state if restore is true or false (null is used for setting lazy states)
+     * @override
+     */
+    public state(state: number = null, restore: boolean = false) {
+      if (restore !== null) super.state(state, restore);
+      return super.state();
+    }
+
+    /**
      * Initially, just insert a marker for where the math will go, and
      *   track it in the lazy list.  Then, when it comes into view,
      *   typeset it properly.
@@ -616,7 +625,7 @@ B extends MathDocumentConstructor<HTMLDocument<N, T, D>>>(
       let compile = false;
       for (const item of this.math) {
         const earlier = item as LazyMathItem<N, T, D>;
-        if (earlier === math || !earlier?.lazyCompile) {
+        if (earlier === math || !earlier?.lazyCompile || !earlier.lazyTex) {
           break;
         }
         earlier.lazyCompile = false;


### PR DESCRIPTION
The changes to the lazy typesetting in v3.2.1 introduced an error where previously typeset expressions were re-typeset when they shouldn't be.  This lead to errors about labels already existing, in addition to the overhead caused by re-typesetting expression that didn't need it (more and more as you scroll).

This was caused by the fact that setting the document's state forced the math elements to be set to that state as well, whereas we only want to change the sate of the elements that have appeared on screen.  This is fixed here by restoring the `state()` method that was removed in 3.2.1.  It uses `restore === null` to determine whether the state is being changed by the lazy loader (and so prevents state changes on MathItems that should not be updated).

We also ignore non-TeX expressions when looking for the earlier TeX expressions that might need to be compiled.

Resolve issue mathjax/MathJax#2873.