### PR TITLE
Make version.ts use a constant and create the file during the build process.  (#818)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - 17
 sudo: false
 script:
+- components/bin/version
 - npm install
 - npm run compile
 - npm run make-components

--- a/components/bin/version
+++ b/components/bin/version
@@ -1,0 +1,60 @@
+#! /usr/bin/env node
+
+/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Creates the version.ts file from the package version number
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+
+const fs = require('fs');
+const path = require('path');
+
+const package = path.resolve(__dirname, '..', '..', 'package.json');
+const version = require(package).version;
+
+const lines = `/*************************************************************
+ *
+ *  Copyright (c) 2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  The version of MathJax (used to tell what version a component
+ *                was compiled against).
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+export const VERSION = '${version}';
+`;
+
+fs.writeFileSync(path.resolve(__dirname, '..', '..', 'ts', 'components', 'version.ts'), lines);

--- a/components/webpack.common.js
+++ b/components/webpack.common.js
@@ -46,14 +46,12 @@ function quoteRE(string) {
 const PLUGINS = function (js, dir) {
   const mjdir = path.resolve(__dirname, '..', 'js');
   const jsdir = path.resolve(dir, js);
-  const package = path.resolve(__dirname, '..', 'package.json');
 
   //
   //  Record the js directory for the pack command
   //
   return [new webpack.DefinePlugin({
-    __JSDIR__: jsdir,
-    PACKAGE_VERSION: `'${require(package).version}'`
+    __JSDIR__: jsdir
   })];
 };
 

--- a/ts/components/version.ts
+++ b/ts/components/version.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2018-2022 The MathJax Consortium
+ *  Copyright (c) 2022 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,23 +22,4 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-declare const PACKAGE_VERSION: string;  // provided by webpack via DefinePlugin
-
-export const VERSION = (
-  typeof PACKAGE_VERSION === 'undefined' ?
-    //
-    //  This will not be included in the webpack version, so only runs in node
-    //
-    (function () {
-      //
-      //  Look up the version from the package.json file
-      //
-      /* tslint:disable-next-line:no-eval */
-      const load = eval('require');
-      /* tslint:disable-next-line:no-eval */
-      const dirname = eval('__dirname');
-      const path = load('path');
-      return load(path.resolve(dirname, '..', '..', 'package.json')).version;
-    })() :
-  PACKAGE_VERSION
-);
+export const VERSION = '3.2.1';


### PR DESCRIPTION
This PR resolves the build issue that was reported with v3.2.1 due to the dynamic lookup of the version number by creating the `version.ts` file via `components/bin/version`, which is run during the travis-ci publish process (and can be run by hand at any point).

Resolve issue #818