### PR TITLE
Parse link protocol containing newlines correctly in ui/safe

### DIFF
--- a/ts/ui/safe/SafeMethods.ts
+++ b/ts/ui/safe/SafeMethods.ts
@@ -41,7 +41,7 @@ export const SafeMethods: {[name: string]: FilterFunction<any, any, any>} = {
    * @template D  The Document class
    */
   filterURL<N, T, D>(safe: Safe<N, T, D>, url: string): string | null {
-    const protocol = (url.match(/^\s*([a-z\n\r]+):/i) || [null, ''])[1].toLowerCase();
+    const protocol = (url.match(/^\s*([a-z\n\r]+):/i) || [null, ''])[1].replace(/[\n\r]/g, '').toLowerCase();
     const allow = safe.allow.URLs;
     return (allow === 'all' || (allow === 'safe' &&
                                 (safe.options.safeProtocols[protocol] || !protocol))) ? url : null;

--- a/ts/ui/safe/SafeMethods.ts
+++ b/ts/ui/safe/SafeMethods.ts
@@ -41,7 +41,7 @@ export const SafeMethods: {[name: string]: FilterFunction<any, any, any>} = {
    * @template D  The Document class
    */
   filterURL<N, T, D>(safe: Safe<N, T, D>, url: string): string | null {
-    const protocol = (url.match(/^\s*([a-z]+):/i) || [null, ''])[1].toLowerCase();
+    const protocol = (url.match(/^\s*([a-z\n\r]+):/i) || [null, ''])[1].toLowerCase();
     const allow = safe.allow.URLs;
     return (allow === 'all' || (allow === 'safe' &&
                                 (safe.options.safeProtocols[protocol] || !protocol))) ? url : null;


### PR DESCRIPTION
https://github.com/mathjax/MathJax/issues/2885

If a href protocol contains `\n` or `\r` characters before `:`, the ui/safe newline parsing will interpret the protocol as `''`  and allow it. However, the browser will ignore the newline characters and interpret the protocol as the full word, allowing users to submit MathJax links with `javascript:` hrefs.

This commit updates the protocol-parsing regex to include new line characters, just as the browser does.

Example codepen that shows the bug: https://codepen.io/sgoedecke/pen/KKQJyPw

<details>
<summary>Example notebook</summary>

```
{
 "cells": [
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "$\\href{java\nscript:alert(1)}{Click Me}$"
   ]
  }
 ],
 "metadata": {
  "kernelspec": {
   "display_name": "Python 2",
   "language": "python",
   "name": "python2"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 2
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython2",
   "version": "2.7.11"
  }
 },
 "nbformat": 4,
 "nbformat_minor": 0
}
```
</details>