### PR TITLE
Use handleRetries() to handle issue with rerender after explorer is enabled

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -885,7 +885,9 @@ export class Menu {
       this.document.processed = document.processed;
       if (!Menu._loadingPromise) {
         this.document.outputJax.reset();
-        this.rerender(component === 'complexity' || noEnrich ? STATE.COMPILED : STATE.TYPESET);
+        mathjax.handleRetriesFor(() => {
+          this.rerender(component === 'complexity' || noEnrich ? STATE.COMPILED : STATE.TYPESET);
+        });
       }
     });
   }


### PR DESCRIPTION
This PR resolves an issue where enabling the explorer for the first time causes an error (due to the dynamic loading of maps?).  The retry caused by SRE needs to be trapped by `handleRetriesFor()`, which is what this PR does.