### PR TITLE
Make sure a11y.speechRules in initialized

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -293,7 +293,11 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
       }
       const visitor = new SerializedMmlVisitor(this.mmlFactory);
       const toMathML = ((node: MmlNode) => visitor.visitTree(node));
-      this.options.MathItem = ExplorerMathItemMixin(this.options.MathItem, toMathML);
+      const options = this.options;
+      if (!options.a11y.speechRules) {
+        options.a11y.speechRules = `${options.sre.domain}-${options.sre.style}`;
+      }
+      options.MathItem = ExplorerMathItemMixin(options.MathItem, toMathML);
       // TODO: set backward compatibility options here.
       this.explorerRegions = initExplorerRegions(this);
     }


### PR DESCRIPTION
This PR fixes a problem where the explorer domain and style menus are not initialized when first activated.  The problem is that the `a11y.speechRules` option, which is a compound of the `sre.domain` and `sre.style` options, is not initialized.  The fix is to initialize it during the creation of the explorer document based on the `sre` options.