### PR TITLE
Update handling of brackets in algined environments to current LaTeX behavior (mathjax/MathJax#2888)

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -61,7 +61,7 @@ AmsMethods.AmsEqnArray = function(parser: TexParser, begin: StackItem,
                                       align: string, spacing: string,
                                       style: string) {
   // @test Aligned, Gathered
-  const args = parser.GetBrackets('\\begin{' + begin.getName() + '}');
+  const args = (parser.getCodePoint() === '[' ? parser.GetBrackets('\\begin{' + begin.getName() + '}') : '');
   const array = BaseMethods.EqnArray(parser, begin, numbered, taggable, align, spacing, style);
   return ParseUtil.setArrayAlign(array as ArrayItem, args);
 };
@@ -81,7 +81,7 @@ AmsMethods.AlignAt = function(parser: TexParser, begin: StackItem,
   let n, valign, align = '', spacing = [];
   if (!taggable) {
     // @test Alignedat
-    valign = parser.GetBrackets('\\begin{' + name + '}');
+    valign = (this.getCodePoint() === '[' ? parser.GetBrackets('\\begin{' + name + '}') : '');
   }
   n = parser.GetArgument('\\begin{' + name + '}');
   if (n.match(/[^0-9]/)) {


### PR DESCRIPTION
This PR updates the aligned and alignedat environments to handle the optional bracket argument consistent with current versions of LaTeX, where no spaces are allowed before the bracket argument.

Resolves issue mathjax/MathJax#2888.