### PR TITLE
Handle labels nested in aligned environments (mathjax/MathJax#2889)

### DIFF
--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -307,7 +307,9 @@ export class AbstractTags implements Tags {
     if (this.currentTag) {
       this.stack.push(this.currentTag);
     }
+    const label = this.label;
     this.currentTag = new TagInfo(env, taggable, defaultTags);
+    this.label = label;
   }
 
   public get env() {
@@ -320,7 +322,11 @@ export class AbstractTags implements Tags {
    */
   public end() {
     this.history.push(this.currentTag);
+    const label = this.label;
     this.currentTag = this.stack.pop();
+    if (label && !this.label) {
+      this.label = label;
+    }
   }
 
 
@@ -402,7 +408,6 @@ export class AbstractTags implements Tags {
    * @override
    */
   public clearTag() {
-    this.label = '';
     this.tag(null, true);
     this.currentTag.tagId = '';
   }
@@ -447,6 +452,7 @@ export class AbstractTags implements Tags {
     this.counter = this.allCounter = offset;
     this.allLabels = {};
     this.allIds = {};
+    this.label = '';
   }
 
   /**
@@ -531,6 +537,7 @@ export class AbstractTags implements Tags {
     this.makeId();
     if (this.label) {
       this.labels[this.label] = new Label(this.currentTag.tag, this.currentTag.tagId);
+      this.label = '';
     }
     let mml = new TexParser('\\text{' + this.currentTag.tagFormat + '}', {},
                             this.configuration).mml();


### PR DESCRIPTION
This PR allows labels nested within `aligned`, `split`, and `gather` environments to apply to the outer equation.  It does so by bubbling the `label` property up to the outer `TagInfo` object in the `end()` method, if there isn't already a label in that one (and carrying a label down into the new `TagInfo` in the `start()` method), and clearing the label when a tag is assigned to it.

This resolves issue mathjax/MathJax#2889.