### PR TITLE
Correct typo in RANGES array affecting CJK characters in U+20000 to U-2FA1F.  (mathjax/MathJax#2893)

### DIFF
--- a/ts/core/MmlTree/OperatorDictionary.ts
+++ b/ts/core/MmlTree/OperatorDictionary.ts
@@ -130,7 +130,7 @@ export const RANGES: RangeDef[] = [
   [0x1DF00, 0x1F7FF, TEXCLASS.ORD, 'mo'], // Mahjong Tiles (through) Geometric Shapes Extended
   [0x1F800, 0x1F8FF, TEXCLASS.REL, 'mo'], // Supplemental Arrows-C
   [0x1F900, 0x1F9FF, TEXCLASS.ORD, 'mo'], // Supplemental Symbols and Pictographs
-  [0x20000, 0x2FA1F, TEXCLASS.ORD, 'mi', 'normnal'], // CJK Unified Ideographs Ext. B (through) CJK Sompatibility Ideographs Supp.
+  [0x20000, 0x2FA1F, TEXCLASS.ORD, 'mi', 'normal'], // CJK Unified Ideographs Ext. B (through) CJK Sompatibility Ideographs Supp.
 ];
 
 /**


### PR DESCRIPTION
This PR fixes a typo in the operator dictionary RANGES array that causes output errors for characters in the range U+20000 to U-2FA1F.

Resolves issue mathjax/MathJax#2893.