### PR TITLE
Make sure the scriptspace CSS is included for any script class

### DIFF
--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -350,16 +350,6 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<N, T,
       this.adjustUnderDepth(under, underbox);
     }
 
-    /**
-     * Make sure styles get output when called from munderover with movable limits
-     *
-     * @override
-     */
-    public markUsed() {
-      super.markUsed();
-      this.jax.wrapperUsage.add(ChtmlMsubsup.kind);
-    }
-
   };
 
 })<any, any, any>();

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -30,6 +30,7 @@ import {ChtmlWrapperFactory} from '../WrapperFactory.js';
 import {ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData,
         ChtmlFontData, ChtmlFontDataClass} from '../FontData.js';
 import {CommonScriptbase, CommonScriptbaseClass, CommonScriptbaseMixin} from '../../common/Wrappers/scriptbase.js';
+import {ChtmlMsubsup} from './msubsup.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {BBox} from '../../../util/BBox.js';
 import {StyleData} from '../../../util/StyleList.js';
@@ -130,6 +131,16 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<N, T,
       }
       this.baseChild.toCHTML(this.dom);
       this.scriptChild.toCHTML(this.adaptor.append(this.dom, this.html('mjx-script', {style})) as N);
+    }
+
+    /**
+     * Make sure styles get output for any script subclass
+     *
+     * @override
+     */
+    public markUsed() {
+      super.markUsed();
+      this.jax.wrapperUsage.add(ChtmlMsubsup.kind);
     }
 
     /**


### PR DESCRIPTION
With CHTML's dynamic CSS handling, the CSS needed for properly handling the `scriptspace` font parameter was only being output when `msubsup` or `mmultiscripts` was used.  This PR make sure the CSS is present for any script-based class (`msub`, `msup`, `munderover`, etc.).