### PR TITLE
Properly locate speech string when not in first child element. (mathjax/MathJax#2911)

### DIFF
--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -181,7 +181,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       }
       for (let child of node.childNodes) {
         let value = this.getSpeech(child as MmlNode);
-        if (value != null) {
+        if (value) {
           return value;
         }
       }


### PR DESCRIPTION
Fix problem with semantic-enrich's `getSpeech()` method.  It currently only checks the first child node (recursively to the bottom of the tree), as the termination condition will end the loop when the child node returns an empty string, so the second and subsequent children are never checked.

Resolves issue mathjax/MathJax#2911.