### PR TITLE
Handle bracket arguments for align environments more like LaTeX.

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -426,17 +426,23 @@ namespace ParseUtil {
    * Sets alignment in array definitions.
    * @param {ArrayItem} array The array item.
    * @param {string} align The alignment string.
+   * @param {TexParser?} parser The current tex parser.
+   * @param {number?} i The position to return to if the alignment isn't t, b, or c.
    * @return {ArrayItem} The altered array item.
    */
-  export function setArrayAlign(array: ArrayItem, align: string): ArrayItem {
+  export function setArrayAlign(array: ArrayItem, align: string, parser?: TexParser, i?: number): ArrayItem {
     // @test Array1, Array2, Array Test
-    align = ParseUtil.trimSpaces(align || '');
+    if (!parser) {
+      align = ParseUtil.trimSpaces(align || '');
+    }
     if (align === 't') {
       array.arraydef.align = 'baseline 1';
     } else if (align === 'b') {
       array.arraydef.align = 'baseline -1';
     } else if (align === 'c') {
       array.arraydef.align = 'axis';
+    } else if (parser) {
+      parser.i = i;
     } else if (align) {
       array.arraydef.align = align;
     } // FIXME: should be an error?

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -61,9 +61,10 @@ AmsMethods.AmsEqnArray = function(parser: TexParser, begin: StackItem,
                                       align: string, spacing: string,
                                       style: string) {
   // @test Aligned, Gathered
-  const args = (parser.getCodePoint() === '[' ? parser.GetBrackets('\\begin{' + begin.getName() + '}') : '');
+  const i = parser.i;
+  const args = parser.GetBrackets('\\begin{' + begin.getName() + '}');
   const array = BaseMethods.EqnArray(parser, begin, numbered, taggable, align, spacing, style);
-  return ParseUtil.setArrayAlign(array as ArrayItem, args);
+  return ParseUtil.setArrayAlign(array as ArrayItem, args, parser, i);
 };
 
 
@@ -78,16 +79,17 @@ AmsMethods.AmsEqnArray = function(parser: TexParser, begin: StackItem,
 AmsMethods.AlignAt = function(parser: TexParser, begin: StackItem,
                               numbered: boolean, taggable: boolean) {
   const name = begin.getName();
-  let n, valign, align = '', spacing = [];
+  let n, valign, align = '', spacing = [], i;
   if (!taggable) {
     // @test Alignedat
-    valign = (parser.getCodePoint() === '[' ? parser.GetBrackets('\\begin{' + name + '}') : '');
+    i = parser.i;
+    valign = parser.GetBrackets('\\begin{' + name + '}');
   }
   n = parser.GetArgument('\\begin{' + name + '}');
   if (n.match(/[^0-9]/)) {
     // @test PositiveIntegerArg
     throw new TexError('PositiveIntegerArg',
-                        'Argument to %1 must me a positive integer',
+                        'Argument to %1 must be a positive integer',
                         '\\begin{' + name + '}');
   }
   let count = parseInt(n, 10);
@@ -103,7 +105,7 @@ AmsMethods.AlignAt = function(parser: TexParser, begin: StackItem,
   }
   // @test Alignedat
   let array = AmsMethods.EqnArray(parser, begin, numbered, taggable, align, spaceStr);
-  return ParseUtil.setArrayAlign(array as ArrayItem, valign);
+  return ParseUtil.setArrayAlign(array as ArrayItem, valign, !taggable ? parser : null, i);
 };
 
 
@@ -145,7 +147,7 @@ AmsMethods.XalignAt = function(parser: TexParser, begin: StackItem,
   let n = parser.GetArgument('\\begin{' + begin.getName() + '}');
   if (n.match(/[^0-9]/)) {
     throw new TexError('PositiveIntegerArg',
-                       'Argument to %1 must me a positive integer',
+                       'Argument to %1 must be a positive integer',
                        '\\begin{' + begin.getName() + '}');
   }
   const align = (padded ? 'crl' : 'rlc');


### PR DESCRIPTION
This PR corrects #832 for mathjax/MathJax#2888 so that the behavior is more consistent with LaTeX.  It's not that the bracket is only scanned if it is immediately after the environment name (as in #832), but rather than it is only removed and used for alignment when it is exactly one of `[t]`, `[b]`, or `[c]`.  Otherwise, it is retained and processed normally.

The fix is handled in `setArrayAlign()` by adding `parser` and `i` arguments that, if present, will cause `parser.i` to be set to `i` if the bracket is not one of the allowed values.

There is also a typo (in two places) in an error message that is corrected here.