### PR TITLE
Handle missing and invalid brackets in alignedat like LaTeX does.

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -427,10 +427,9 @@ namespace ParseUtil {
    * @param {ArrayItem} array The array item.
    * @param {string} align The alignment string.
    * @param {TexParser?} parser The current tex parser.
-   * @param {number?} i The position to return to if the alignment isn't t, b, or c.
    * @return {ArrayItem} The altered array item.
    */
-  export function setArrayAlign(array: ArrayItem, align: string, parser?: TexParser, i?: number): ArrayItem {
+  export function setArrayAlign(array: ArrayItem, align: string, parser?: TexParser): ArrayItem {
     // @test Array1, Array2, Array Test
     if (!parser) {
       align = ParseUtil.trimSpaces(align || '');
@@ -441,11 +440,14 @@ namespace ParseUtil {
       array.arraydef.align = 'baseline -1';
     } else if (align === 'c') {
       array.arraydef.align = 'axis';
-    } else if (parser) {
-      parser.i = i;
     } else if (align) {
-      array.arraydef.align = align;
-    } // FIXME: should be an error?
+      if (parser) {
+        parser.string = `[${align}]` + parser.string.slice(parser.i);
+        parser.i = 0;
+      } else {
+        array.arraydef.align = align;
+      }
+    }
     return array;
   }
 

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -61,10 +61,9 @@ AmsMethods.AmsEqnArray = function(parser: TexParser, begin: StackItem,
                                       align: string, spacing: string,
                                       style: string) {
   // @test Aligned, Gathered
-  const i = parser.i;
   const args = parser.GetBrackets('\\begin{' + begin.getName() + '}');
   const array = BaseMethods.EqnArray(parser, begin, numbered, taggable, align, spacing, style);
-  return ParseUtil.setArrayAlign(array as ArrayItem, args, parser, i);
+  return ParseUtil.setArrayAlign(array as ArrayItem, args, parser);
 };
 
 
@@ -79,10 +78,9 @@ AmsMethods.AmsEqnArray = function(parser: TexParser, begin: StackItem,
 AmsMethods.AlignAt = function(parser: TexParser, begin: StackItem,
                               numbered: boolean, taggable: boolean) {
   const name = begin.getName();
-  let n, valign, align = '', spacing = [], i;
+  let n, valign, align = '', spacing = [];
   if (!taggable) {
     // @test Alignedat
-    i = parser.i;
     valign = parser.GetBrackets('\\begin{' + name + '}');
   }
   n = parser.GetArgument('\\begin{' + name + '}');
@@ -105,7 +103,7 @@ AmsMethods.AlignAt = function(parser: TexParser, begin: StackItem,
   }
   // @test Alignedat
   let array = AmsMethods.EqnArray(parser, begin, numbered, taggable, align, spaceStr);
-  return ParseUtil.setArrayAlign(array as ArrayItem, valign, !taggable ? parser : null, i);
+  return ParseUtil.setArrayAlign(array as ArrayItem, valign, !taggable ? parser : null);
 };
 
 


### PR DESCRIPTION
This PR fixes a problem reported by Peter where `alignedat` would typeset its number argument when there is no bracket argument.  It also handles invalid bracket arguments like LaTeX does (the number argument is parsed after the brackets, then the brackets are typeset).  These issues were introduced by #842, which would reset the `parser.i` value to before the brackets when they were empty to invalid.  Now we re-insert the bracket argument if it is non-empty and invalid (like LaTeX does).

After #842,

``` latex
\begin{alignedat}{2} a \end{alignedat}
```

would typeset as `2a` when it should just be `a`.  This PR should resolve that.

Also,

``` latex
\begin{alignedat}[x]{2} a \end{alignedat}
```

would produce `[x]2a`, but now should produce `[x]a` as LaTeX does.