### PR TITLE
Make sure stretchy embellished operators use the proper scaling when determineing their widths

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -969,7 +969,7 @@ export class CommonWrapper<
    * @return {number}   The cumulative relative scaling for an embellised mo's core mo
    */
   public coreRScale(): number {
-    let rscale = 1;
+    let rscale = this.bbox.rscale;
     let node = this.coreMO() as any as WW;
     while (node !== (this as any as WW) && node) {
       rscale *= node.bbox.rscale;

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -966,6 +966,19 @@ export class CommonWrapper<
   }
 
   /**
+   * @return {number}   The cumulative relative scaling for an embellised mo's core mo
+   */
+  public coreRScale(): number {
+    let rscale = 1;
+    let node = this.coreMO() as any as WW;
+    while (node !== (this as any as WW) && node) {
+      rscale *= node.bbox.rscale;
+      node = node.parent;
+    }
+    return rscale;
+  }
+
+  /**
    * @return {string}   For a token node, the combined text content of the node's children
    */
   public getText(): string {

--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -181,7 +181,8 @@ export function CommonMrowMixin<
         //  Stretch the stretchable children
         //
         for (const child of stretchy) {
-          child.coreMO().getStretchedVariant([H, D]);
+          const rscale = child.coreRScale();
+          child.coreMO().getStretchedVariant([H / rscale, D / rscale]);
         }
       }
     }

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -681,7 +681,7 @@ export function CommonMtableMixin<
         //  Stretch the stretchable children
         //
         for (const child of stretchy) {
-          child.coreMO().getStretchedVariant([W]);
+          child.coreMO().getStretchedVariant([Math.max(W, child.getBBox().w) / child.coreRScale()]);
         }
       }
     }

--- a/ts/output/common/Wrappers/mtr.ts
+++ b/ts/output/common/Wrappers/mtr.ts
@@ -242,7 +242,8 @@ export function CommonMtrMixin<
         //  Stretch the stretchable children
         //
         for (const child of stretchy) {
-          child.coreMO().getStretchedVariant(HD);
+          const rscale = child.coreRScale();
+          child.coreMO().getStretchedVariant(HD.map(x => x * rscale));
         }
       }
     }

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -755,7 +755,7 @@ export function CommonScriptbaseMixin<
         //  Stretch the stretchable children
         //
         for (const child of stretchy) {
-          child.coreMO().getStretchedVariant([W / child.bbox.rscale]);
+          child.coreMO().getStretchedVariant([W / child.coreRScale()]);
         }
       }
     }

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -755,7 +755,10 @@ export function CommonScriptbaseMixin<
         //  Stretch the stretchable children
         //
         for (const child of stretchy) {
-          child.coreMO().getStretchedVariant([W / child.coreRScale()]);
+          const core = child.coreMO();
+          if (core.size === null) {
+            core.getStretchedVariant([W / child.coreRScale()]);
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes a problem reported by Peter where some horizontally stretched characters are stretched to the wrong length.  For example:

``` latex
\bbox[red]{\begin{smallmatrix}
 - \otimes _k tk \\
  \xleftarrow {\hspace{50pt}}\\
  \xleftarrow {\hspace{50pt}}\\
  \xleftarrow {\hspace{50pt}}\\
  \operatorname {Hom}_k(tk,-)
\end{smallmatrix}}
```

in SVG output.  An incorrect relative scaling value was being used (with an embellished operator, the relative scaling of the core has to include all the nesting parent elements).