### PR TITLE
Updates to support alternate fonts in CHTML

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -315,7 +315,11 @@ function processPackage(lines, space, dir) {
   // Create the string defining the object that loads all the needed files into the proper places
   //
   if (dir === '.') return packages.join(',\n    ');
-  return path.basename(dir) + ': {\n' + INDENT + space + packages.join(',\n' + INDENT + space) + '\n' + space + '}';
+  let name = path.basename(dir);
+  if (name.match(/[^a-zA-Z0-9]/)) {
+    name = `"${name}"`;
+  }
+  return name + ': {\n' + INDENT + space + packages.join(',\n' + INDENT + space) + '\n' + space + '}';
 }
 
 /**

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -170,15 +170,16 @@ CommonOutputJax<
    */
   public styleSheet(html: MathDocument<N, T, D>) {
     if (this.chtmlStyles) {
+      const styles = new CssStyles();
       if (this.options.adaptiveCSS) {
         //
         // Update the style sheet rules
         //
-        const styles = new CssStyles();
         this.addWrapperStyles(styles);
         this.updateFontStyles(styles);
-        this.adaptor.insertRules(this.chtmlStyles, styles.getStyleRules());
       }
+      styles.addStyles(this.font.updateDynamicStyles());
+      this.adaptor.insertRules(this.chtmlStyles, styles.getStyleRules());
       return this.chtmlStyles;  // stylesheet is already added to the document
     }
     const sheet = this.chtmlStyles = super.styleSheet(html);

--- a/ts/output/chtml/DynamicFonts.ts
+++ b/ts/output/chtml/DynamicFonts.ts
@@ -26,7 +26,7 @@ import {ChtmlCharMap, ChtmlCharData} from './FontData.js';
 /**
  * Used by dynamic font extensions to add font identifiers to ranges of characters in given variants
  */
-export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharMap}}) {
+export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharMap}}, prefix?: string) {
   const data: {[variant: string]: ChtmlCharMap} = {};
   for (const id of Object.keys(ranges)) {
     const map = ranges[id];
@@ -41,7 +41,11 @@ export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharM
           if (!data[3]) {
             data[3] = {};
           }
-          data[3].f = id;
+          if (prefix) {
+            data[3].F = prefix + '-' + id;
+          } else {
+            data[3].f = id;
+          }
         }
       }
       Object.assign(data[variant], chars);

--- a/ts/output/chtml/DynamicFonts.ts
+++ b/ts/output/chtml/DynamicFonts.ts
@@ -25,14 +25,17 @@ import {ChtmlCharMap, ChtmlCharData} from './FontData.js';
 
 /**
  * Used by dynamic font extensions to add font identifiers to ranges of characters in given variants
+ *
+ * @param {{[variant: string]: {[id: string]: ChtmlCharMap}}} ranges  The variant data to be added
+ * @param {string?} prefix  The prefix for when this is used from a font extension
  */
 export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharMap}}, prefix?: string) {
-  const data: {[variant: string]: ChtmlCharMap} = {};
+  const variants: {[variant: string]: ChtmlCharMap} = {};
   for (const id of Object.keys(ranges)) {
     const map = ranges[id];
     for (const variant of Object.keys(map)) {
-      if (!data[variant]) {
-        data[variant] = {};
+      if (!variants[variant]) {
+        variants[variant] = {};
       }
       const chars = map[variant];
       if (id) {
@@ -42,14 +45,14 @@ export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharM
             data[3] = {};
           }
           if (prefix) {
-            data[3].F = prefix + '-' + id;
+            data[3].ff = prefix + '-' + id;
           } else {
             data[3].f = id;
           }
         }
       }
-      Object.assign(data[variant], chars);
+      Object.assign(variants[variant], chars);
     }
   }
-  return data;
+  return variants;
 }

--- a/ts/output/chtml/DynamicFonts.ts
+++ b/ts/output/chtml/DynamicFonts.ts
@@ -1,0 +1,51 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017-2022 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @fileoverview  Implements functions needed by dynamic font files.
+ *
+ * @author dpvc@mathjax.org (Davide Cervone)
+ */
+
+import {ChtmlCharMap, ChtmlCharData} from './FontData.js';
+
+/**
+ * Used by dynamic font extensions to add font identifiers to ranges of characters in given variants
+ */
+export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharMap}}) {
+  const data: {[variant: string]: ChtmlCharMap} = {};
+  for (const id of Object.keys(ranges)) {
+    const map = ranges[id];
+    for (const variant of Object.keys(map)) {
+      if (!data[variant]) {
+        data[variant] = {};
+      }
+      const chars = map[variant];
+      if (id) {
+        for (const c of Object.keys(chars)) {
+          const data = chars[parseInt(c)] as ChtmlCharData;
+          if (!data[3]) {
+            data[3] = {};
+          }
+          data[3].f = id;
+        }
+      }
+      Object.assign(data[variant], chars);
+    }
+  }
+  return data;
+}

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -36,9 +36,9 @@ export * from '../common/FontData.js';
  * Add the extra data needed for CharOptions in CHTML
  */
 export interface ChtmlCharOptions extends CharOptions {
-  c?: string;                   // the content value (for css)
-  f?: string;                   // the font postfix (for css)
-  F?: string;                   // the full font css class (for extensions)
+  c?: string;    // the content value (for css)
+  f?: string;    // the font postfix (for css)
+  ff?: string;   // the full font css class (for extensions)
 }
 
 /**
@@ -443,7 +443,7 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
   protected addCharStyles(styles: StyleList, vletter: string, n: number, data: ChtmlCharData) {
     const options = data[3] as ChtmlCharOptions;
     const letter = (options.f !== undefined ? options.f : vletter);
-    const font = options.F || (letter ? `${this.cssFontPrefix}-${letter}` : '');
+    const font = options.ff || (letter ? `${this.cssFontPrefix}-${letter}` : '');
     const selector = 'mjx-c' + this.charSelector(n) + (font ? '.' + font : '');
     styles[selector] = {padding: this.padding(data, 0, options.ic || 0)};
   }

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -499,29 +499,3 @@ export function AddCSS(font: ChtmlCharMap, options: CharOptionsMap): ChtmlCharMa
   }
   return font;
 }
-
-
-/**
- * Used by dynamic font extensions to add font identifiers to ranges of characters in given variants
- */
-export function AddFontIds(ranges: {[variant: string]: {[id: string]: ChtmlCharMap}}) {
-  const data: {[variant: string]: ChtmlCharMap} = {};
-  for (const id of Object.keys(ranges)) {
-    const map = ranges[id];
-    for (const variant of Object.keys(map)) {
-      if (!data[variant]) {
-        data[variant] = {};
-      }
-      const chars = map[variant];
-      for (const c of Object.keys(chars)) {
-        const data = chars[parseInt(c)] as ChtmlCharData;
-        if (!data[3]) {
-          data[3] = {};
-        }
-        data[3].f = id;
-      }
-      Object.assign(data[variant], chars);
-    }
-  }
-  return data;
-}

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -51,7 +51,6 @@ export type ChtmlCharData = CharDataArray<ChtmlCharOptions>;
  * The extra data needed for a Variant in CHTML output
  */
 export interface ChtmlVariantData extends VariantData<ChtmlCharOptions> {
-  classes?: string;             // the classes to use for this variant
   letter: string;               // the font letter(s) for the default font for this variant
 }
 
@@ -90,11 +89,6 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    * @override
    */
   public static JAX = 'CHTML';
-
-  /**
-   * The default class names to use for each variant
-   */
-  protected static defaultVariantClasses: StringMap = {};
 
   /**
    * The default font letter to use for each variant
@@ -209,9 +203,7 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    */
   public createVariant(name: string, inherit: string = null, link: string = null) {
     super.createVariant(name, inherit, link);
-    let CLASS = (this.constructor as ChtmlFontDataClass);
-    this.variant[name].classes = CLASS.defaultVariantClasses[name];
-    this.variant[name].letter = CLASS.defaultVariantLetters[name];
+    this.variant[name].letter = (this.constructor as ChtmlFontDataClass).defaultVariantLetters[name];
   }
 
   /**

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -174,7 +174,6 @@ CommonWrapper<
     this.markUsed();
     const chtml = this.createChtmlNodes(parents);
     this.handleStyles();
-    this.handleVariant();
     this.handleScale();
     this.handleBorders();
     this.handleColor();
@@ -229,19 +228,6 @@ CommonWrapper<
       if (family) {
         this.dom.forEach(dom => adaptor.setStyle(dom, 'font-family', this.font.cssFamilyPrefix + ', ' + family));
       }
-    }
-  }
-
-  /**
-   * Set the CSS for the math variant
-   */
-  protected handleVariant() {
-    if (this.node.isToken && this.variant !== '-explicitFont') {
-      const adaptor = this.adaptor;
-      this.dom.forEach(
-        dom => adaptor.setAttribute(dom, 'class',
-                                    (this.font.getVariant(this.variant) || this.font.getVariant('normal')).classes)
-      );
     }
   }
 

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -227,7 +227,7 @@ CommonWrapper<
       this.dom.forEach(dom => adaptor.setAttribute(dom, 'style', styles));
       const family = this.styles.get('font-family');
       if (family) {
-        this.dom.forEach(dom => adaptor.setStyle(dom, 'font-family', 'MJXZERO, ' + family));
+        this.dom.forEach(dom => adaptor.setStyle(dom, 'font-family', this.font.cssFamilyPrefix + ', ' + family));
       }
     }
   }
@@ -284,7 +284,7 @@ CommonWrapper<
         const space = this.em(dimen);
         if (breakable) {
           const node = adaptor.node('mjx-break', SPACE[space] ? {size: SPACE[space]} :
-                                    {style: {'font-size': (dimen * 400).toFixed(1) + '%'}});
+                                    {style: {'font-size': dimen.toFixed(1) + '%'}});
           adaptor.insert(node, this.dom[i]);
         } else {
           if (SPACE[space]) {

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -126,7 +126,7 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
             utext += String.fromCodePoint(n);
           } else {
             utext = this.addUtext(utext, variant, parent);
-            const font = data.F || (data.f ? `${this.font.cssFontPrefix}-${data.f}` : '');
+            const font = data.ff || (data.f ? `${this.font.cssFontPrefix}-${data.f}` : '');
             adaptor.append(parent, this.html('mjx-c', {class: this.char(n) + (font ? ' ' + font : '')}, [
               this.text(data.c || String.fromCodePoint(n))
             ]));

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -126,8 +126,8 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
             utext += String.fromCodePoint(n);
           } else {
             utext = this.addUtext(utext, variant, parent);
-            const font = (data.f ? ` ${this.font.cssFontPrefix}-${data.f}` : '');
-            adaptor.append(parent, this.html('mjx-c', {class: this.char(n) + font}, [
+            const font = data.F || (data.f ? `${this.font.cssFontPrefix}-${data.f}` : '');
+            adaptor.append(parent, this.html('mjx-c', {class: this.char(n) + (font ? ' ' + font : '')}, [
               this.text(data.c || String.fromCodePoint(n))
             ]));
             this.font.charUsage.add([variant, n]);

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -126,7 +126,7 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
             utext += String.fromCodePoint(n);
           } else {
             utext = this.addUtext(utext, variant, parent);
-            const font = (data.f ? ' TEX-' + data.f : '');
+            const font = (data.f ? ` ${this.font.cssFontPrefix}-${data.f}` : '');
             adaptor.append(parent, this.html('mjx-c', {class: this.char(n) + font}, [
               this.text(data.c || String.fromCodePoint(n))
             ]));

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -135,19 +135,19 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
         'white-space': 'normal'
       },
       'mjx-break[size="1"]': {
-        'font-size': '44.4%'
+        'font-size': '11.1%'
       },
       'mjx-break[size="2"]': {
-        'font-size': '66.8%'
+        'font-size': '16.7%'
       },
       'mjx-break[size="3"]': {
-        'font-size': '88.8%'
+        'font-size': '22.2%'
       },
       'mjx-break[size="4"]': {
-        'font-size': '111.2%'
+        'font-size': '27.8%'
       },
       'mjx-break[size="5"]': {
-        'font-size': '133.2%'
+        'font-size': '33.3%'
       },
       'mjx-math[breakable]': {
         display: 'inline'
@@ -215,7 +215,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
       } else {
         this.handleInline(parents[0]);
       }
-      adaptor.addClass(this.dom[0], 'MJX-TEX');
+      adaptor.addClass(this.dom[0], `${this.font.cssFontPrefix}-N`);
     }
 
     /**

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -255,10 +255,11 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       if (n) {
         const options = this.font.getChar(v, n)[3];
         const letter = options.f || (v === 'normal' ? '' : this.font.getVariant(v).letter);
+        const font = options.F || (letter ? `${this.font.cssFontPrefix}-${letter}` : '');
         let c = (options.c as string || String.fromCodePoint(n))
           .replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
         content.push(this.html(part, {}, [
-          this.html('mjx-c', letter ? {class: `${this.font.cssFontPrefix}-${letter}`} : {}, [this.text(c)])
+          this.html('mjx-c', font ? {class: font} : {}, [this.text(c)])
         ]));
       }
     }

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -253,9 +253,13 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
      */
     protected createPart(part: string, n: number, v: string, content: N[]) {
       if (n) {
-        let c = (this.font.getChar(v, n)[3].c as string || String.fromCodePoint(n))
+        const options = this.font.getChar(v, n)[3];
+        const letter = options.f || (v === 'normal' ? '' : this.font.getVariant(v).letter);
+        let c = (options.c as string || String.fromCodePoint(n))
           .replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
-        content.push(this.html(part, {}, [this.html('mjx-c', {}, [this.text(c)])]));
+        content.push(this.html(part, {}, [
+          this.html('mjx-c', letter ? {class: `${this.font.cssFontPrefix}-${letter}`} : {}, [this.text(c)])
+        ]));
       }
     }
 

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -255,7 +255,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       if (n) {
         const options = this.font.getChar(v, n)[3];
         const letter = options.f || (v === 'normal' ? '' : this.font.getVariant(v).letter);
-        const font = options.F || (letter ? `${this.font.cssFontPrefix}-${letter}` : '');
+        const font = options.ff || (letter ? `${this.font.cssFontPrefix}-${letter}` : '');
         let c = (options.c as string || String.fromCodePoint(n))
           .replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
         content.push(this.html(part, {}, [

--- a/ts/output/chtml/fonts/tex.ts
+++ b/ts/output/chtml/fonts/tex.ts
@@ -177,7 +177,7 @@ export class TeXFont extends Base {
   protected static defaultStyles = {
     ...ChtmlFontData.defaultStyles,
 
-    '.MJX-TEX': {
+    '.TEX-N': {
       'font-family': 'MJXZERO, MJXTEX'
     },
 
@@ -377,6 +377,11 @@ export class TeXFont extends Base {
       src: 'url("%%URL%%/MathJax_Vector-Bold.woff") format("woff")'
     },
   };
+
+  /**
+   * @override
+   */
+  public cssFontPrefix: string = 'TEX';
 
   /**
    * @override

--- a/ts/output/chtml/fonts/tex.ts
+++ b/ts/output/chtml/fonts/tex.ts
@@ -76,36 +76,6 @@ export class TeXFont extends Base {
   protected static defaultCssFamilyPrefix = 'MJXZERO';
 
   /**
-   * The classes to use for each variant
-   */
-  protected static defaultVariantClasses: StringMap = {
-    'normal': 'mjx-n',
-    'bold': 'mjx-b',
-    'italic': 'mjx-i',
-    'bold-italic': 'mjx-b mjx-i',
-    'double-struck': 'mjx-ds mjx-b',
-    'fraktur': 'mjx-fr',
-    'bold-fraktur': 'mjx-fr mjx-b',
-    'script': 'mjx-sc mjx-i',
-    'bold-script': 'mjx-sc mjx-b mjx-i',
-    'sans-serif': 'mjx-ss',
-    'bold-sans-serif': 'mjx-ss mjx-b',
-    'sans-serif-italic': 'mjx-ss mjx-i',
-    'sans-serif-bold-italic': 'mjx-ss mjx-b mjx-i',
-    'monospace': 'mjx-ty',
-    '-smallop': 'mjx-sop',
-    '-largeop': 'mjx-lop',
-    '-size3': 'mjx-s3',
-    '-size4': 'mjx-s4',
-    '-tex-calligraphic': 'mjx-cal mjx-i',
-    '-tex-bold-calligraphic': 'mjx-cal mjx-b',
-    '-tex-mathit': 'mjx-mit mjx-i',
-    '-tex-oldstyle': 'mjx-os',
-    '-tex-bold-oldstyle': 'mjx-os mjx-b',
-    '-tex-variant': 'mjx-var'
-  };
-
-  /**
    * The letters that identify the default font for each varaint
    */
   protected static defaultVariantLetters: StringMap = {

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -208,7 +208,6 @@ export abstract class CommonOutputJax<
    */
   protected unknownCache: UnknownVariantMap;
 
-
   /*****************************************************************/
 
   /**

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -208,6 +208,7 @@ export abstract class CommonOutputJax<
    */
   protected unknownCache: UnknownVariantMap;
 
+
   /*****************************************************************/
 
   /**

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -925,7 +925,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     let variant = {
       linked: [] as CharMap<C>[],
       chars: Object.create(inherit ? this.variant[inherit].chars : {}) as CharMap<C>
-    } as any as V;
+    } as unknown as V;
     if (this.variant[link]) {
       Object.assign(variant.chars, this.variant[link].chars);
       this.variant[link].linked.push(variant.chars);

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -308,7 +308,7 @@ export type DynamicCharMap = {[name: number]: DynamicFile};
  * @template C  The CharOptions type
  * @template D  The DelimiterData type
  */
-export type FontExtensionData<C extends CharOptions, D extends DelimiterData> = {
+export interface FontExtensionData<C extends CharOptions, D extends DelimiterData> {
   name: string;
   options?: OptionList;
   variants?: string[][] | {'[+]'?: string[][], '[-]'?: string[][]};
@@ -1151,9 +1151,10 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   /**
    * Implemented in subclasses
    *
-   * @parap {string[]} _fonts   The IDs for the fonts to add CSS for
+   * @param {string[]} _fonts   The IDs for the fonts to add CSS for
+   * @param {string} _root      The root URL for the fonts (can be set by extensions)
    */
-  public addDynamicFontCss(_fonts: string[]) {
+  public addDynamicFontCss(_fonts: string[], _root?: string) {
   }
 
   /**

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -236,9 +236,14 @@ export type FontParameterList = {
 /****************************************************************************/
 
 /**
+ * Generic Font data
+ */
+export type Font = FontData<CharOptions, VariantData<CharOptions>, DelimiterData>;
+
+/**
  * A function for setting up an additional character-data file
  */
-export type DynamicSetup = ((font: FontData<CharOptions, VariantData<CharOptions>, DelimiterData>) => void);
+export type DynamicSetup = ((font: Font) => void);
 
 /**
  * Character numbers or ranges of numbers that cause a dynamic file to be laoded
@@ -648,6 +653,11 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public cssFamilyPrefix: string;
 
   /**
+   * The prefix to use for font names (e.g., 'TEX')
+   */
+  public cssFontPrefix: string = '';
+
+  /**
    * The character maps
    */
   protected remapChars: RemapMapMap = {};
@@ -719,7 +729,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @template D  The DelimiterData type
    */
   public static dynamicSetup<C extends CharOptions, D extends DelimiterData>(
-    extension: string, file: string, variants: CharMapMap<C>, delimiters: DelimiterMap<D> = {}
+    extension: string, file: string,
+    variants: CharMapMap<C>, delimiters: DelimiterMap<D> = {},
+    fonts: string[] = null
   ) {
     const data = (extension ? this.dynamicExtensions.get(extension) : null);
     const files = (extension ? data.files : this.dynamicFiles);
@@ -727,6 +739,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
       Object.keys(variants).forEach(name => font.defineChars(name, variants[name]));
       font.defineDelimiters(delimiters);
       extension && this.adjustDelimiters(font.delimiters, Object.keys(delimiters), data.sizeN, data.stretchN);
+      fonts && font.addDynamicFontCss(fonts);
     };
   }
 
@@ -734,7 +747,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @param {DelimiterMap<DelimiteData>} delimiters   The delimiter list to modify
    * @param {string[]} keys                           The ids of the delimiters to check
    * @param {number} sizeN                            The original number of size variants
-   * @param {number} stretcN                          The original number ot stretch variants
+   * @param {number} stretchN                         The original number ot stretch variants
    */
   public static adjustDelimiters(delimiters: DelimiterMap<DelimiterData>, keys: string[],
                                  sizeN: number, stretchN: number) {
@@ -752,7 +765,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   }
 
   /**
-   * @param {number[]} list   The list of nunbers to adjust
+   * @param {number[]} list   The list of numbers to adjust
    * @param {number} N        The pivot number
    */
   protected static adjustArrayIndices(list: number[], N: number) {
@@ -911,9 +924,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public createVariant(name: string, inherit: string = null, link: string = null) {
     let variant = {
       linked: [] as CharMap<C>[],
-      chars: (inherit ? Object.create(this.variant[inherit].chars) : {}) as CharMap<C>
-    } as V;
-    if (link && this.variant[link]) {
+      chars: Object.create(inherit ? this.variant[inherit].chars : {}) as CharMap<C>
+    } as any as V;
+    if (this.variant[link]) {
       Object.assign(variant.chars, this.variant[link].chars);
       this.variant[link].linked.push(variant.chars);
       variant.chars = Object.create(variant.chars);
@@ -1136,6 +1149,14 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   }
 
   /**
+   * Implemented in subclasses
+   *
+   * @parap {string[]} _fonts   The IDs for the fonts to add CSS for
+   */
+  public addDynamicFontCss(_fonts: string[]) {
+  }
+
+  /**
    * @param {number} n  The delimiter character number whose data is desired
    * @return {DelimiterData}  The data for that delimiter (or undefined)
    */
@@ -1252,7 +1273,7 @@ export interface FontDataClass<C extends CharOptions, V extends VariantData<C>, 
   defineDynamicFiles(dynamicFiles: DynamicFileDef[], prefix?: string): DynamicFileList;
   /* tslint:disable-next-line:jsdoc-require */
   dynamicSetup<C extends CharOptions, D extends DelimiterData>(
-    font: string, file: string, variants: CharMapMap<C>, delimiters?: DelimiterMap<D>
+    font: string, file: string, variants: CharMapMap<C>, delimiters?: DelimiterMap<D>, fonts?: string[]
   ): void;
   /* tslint:disable-next-line:jsdoc-require */
   addExtension(data: FontExtensionData<C, D>, prefix?: string): void;

--- a/ts/output/common/Wrappers/mspace.ts
+++ b/ts/output/common/Wrappers/mspace.ts
@@ -192,14 +192,6 @@ export function CommonMspaceMixin<
       return bbox;
     }
 
-    /**
-     * No contents, so no need for variant class
-     *
-     * @override
-     */
-    public handleVariant() {
-    }
-
   } as any as B;
 
 }

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -368,7 +368,7 @@ CommonOutputJax<
       const [mml, mo] = wrapper.childNodes[0].getBreakNode(line);
       const forced = !!(mml && mml.node.getProperty('forcebreak'));
       if (i || forced) {
-        const space = (mml && !newline ? mml.getLineBBox(0).originalL : 0) * 400;
+        const space = (mml && !newline ? mml.getLineBBox(0).originalL : 0);
         (space || !forced) && adaptor.insert(
           adaptor.node('mjx-break', forced ? {style: {'font-size': space.toFixed(1) + '%'}} : {newline: true}),
           nsvg

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -117,19 +117,19 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
         'white-space': 'normal'
       },
       'mjx-break[size="1"]': {
-        'font-size': '44.4%'
+        'font-size': '11.1%'
       },
       'mjx-break[size="2"]': {
-        'font-size': '66.8%'
+        'font-size': '16.7%'
       },
       'mjx-break[size="3"]': {
-        'font-size': '88.8%'
+        'font-size': '22.2%'
       },
       'mjx-break[size="4"]': {
-        'font-size': '111.2%'
+        'font-size': '27.8%'
       },
       'mjx-break[size="5"]': {
-        'font-size': '133.2%'
+        'font-size': '33.3%'
       },
       'mjx-break[newline]::after': {
         display: 'block'


### PR DESCRIPTION
This PR finalizes the updates needed for additional font support by updating the CHTML output to handle the alternate fonts being prepared in the fonts repository.

* Provide for updating the CSS when a new font is loaded
* Creates an `addFontIds()` function that inserts the needed font ID data into a font definition (to save hading the same `f` option in each of the character's data).
* Updates the creation of CSS for the stretchy characters to include the font explicitly, when needed
* Assumes the ZERO font will have a space that is one em wide (making it easier to handle in-line breakpoints for linebreaking).  This affects both SVG and CHTML output, and it will make it not work with the current MathJax_Zero font, whose space is .25 em, so the spacing will be too small when used with that font.  (It will be replaced in the next release, as the while MathJax TeX font set will be replaced by a new one.)
* Adds support for CHTML font extensions (making sure the CSS is properly updated).
* Removes `defaultVariantClasses` as they are never actually used (no CSS is created for these classes)
* Fix an issue with the `build` command so that file names with no alphanumeric characters are handled properly (the new additional fonts have such names).