### PR TITLE
Use the correct font for closing parentheses in physics package. (mathjax/MathJax#2921)

### DIFF
--- a/ts/input/tex/physics/PhysicsMethods.ts
+++ b/ts/input/tex/physics/PhysicsMethods.ts
@@ -926,7 +926,7 @@ function makeDiagMatrix(elements: string[], anti: boolean) {
  * @param {number} texclass The TeX class.
  */
 PhysicsMethods.AutoClose = function(parser: TexParser, fence: string, _texclass: number) {
-  const mo = parser.create('token', 'mo', {stretchy: false}, fence);
+  const mo = parser.create('token', 'mo', {...ParseUtil.getFontDef(parser), stretchy: false}, fence);
   const item = parser.itemFactory.create('mml', mo).
     setProperties({autoclose: fence});
   parser.Push(item);


### PR DESCRIPTION
This PR make sure closing parentheses get the proper `mathvariant`.

Resolves issue mathjax/MathJax#2921.