### PR TITLE
Initialize the output jax when switching renderers for the first time. (mathjax/MathJax#2924)

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -709,6 +709,8 @@ export class Menu {
         if (name in startup.constructors) {
           startup.useOutput(name, true);
           startup.output = startup.getOutputJax();
+          startup.output.setAdaptor(this.document.adaptor);
+          startup.output.initialize();
           this.jax[jax] = startup.output;
           this.setOutputJax(jax);
         }


### PR DESCRIPTION
This PR makes sure the SVG global font cache is set up when you switch renderers using the contextual menu.  It does so by calling the `initialize()` method for the output jax when it is first loaded.

To test, use the lab and set the font cache to global in the SVG output options, then go back to CHTML and "keep" the page.  Switch to SVG after it is released.  Without the patch, there should be an error message in the console, but with the patch, the change of renderers should occur properly.

Resolves issue mathjax/MathJax#2924.