### PR TITLE
Handle \operatorname{} like named functions. (mathjax/MathJax#2899)

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -255,7 +255,7 @@ AmsMethods.HandleOperatorName = function(parser: TexParser, name: string) {
     }
   }
   //
-  parser.Push(mml);
+  parser.Push(parser.itemFactory.create('fn', mml));
 };
 
 /**


### PR DESCRIPTION
This PR makes operators from `\operatorname` and `\DeclareMathOperator` act the same as named functions like `\sin`.  in particular, they get the invisible function apply when followed by an argument.

Resolves issue mathjax/MathJax#2899.