### PR TITLE
Refactor MathML visitors to make MathMLVisitor work like SerializedMml. (mathjax/MathJax#2920)

### DIFF
--- a/ts/core/MmlTree/MathMLVisitor.ts
+++ b/ts/core/MmlTree/MathMLVisitor.ts
@@ -23,6 +23,8 @@
 
 import {MmlVisitor} from './MmlVisitor.js';
 import {MmlNode, TextNode, XMLNode} from './MmlNode.js';
+import {HtmlNode} from './MmlNodes/HtmlNode.js';
+
 
 /*****************************************************************/
 /**
@@ -30,6 +32,7 @@ import {MmlNode, TextNode, XMLNode} from './MmlNode.js';
  */
 
 export class MathMLVisitor extends MmlVisitor {
+
   /**
    * The document in which the nodes are being made
    */
@@ -67,6 +70,14 @@ export class MathMLVisitor extends MmlVisitor {
   }
 
   /**
+   * @param {HtmlNode} node  The HTML node to visit
+   * @param {Element} parent  The DOM parent to which this node should be added
+   */
+  public visitHtmlNode(node: HtmlNode<any>, parent: Element) {
+    parent.appendChild((node.getHTML() as Element).cloneNode(true));
+  }
+
+  /**
    * Visit an inferred mrow, but don't add the inferred row itself (since
    * it is supposed to be inferred).
    *
@@ -90,22 +101,22 @@ export class MathMLVisitor extends MmlVisitor {
    * @param {Element} parent  The DOM parent to which this node should be added
    */
   public visitDefault(node: MmlNode, parent: Element) {
-    let mml = this.document.createElement(node.kind);
+    let mml = this.document.createElement(this.getKind(node));
     this.addAttributes(node, mml);
     for (const child of node.childNodes) {
       this.visitNode(child, mml);
     }
     parent.appendChild(mml);
   }
+
   /**
    * @param {MmlNode} node  The node who attributes are to be copied
    * @param {Element} mml  The MathML DOM node to which attributes are being added
    */
   public addAttributes(node: MmlNode, mml: Element) {
-    let attributes = node.attributes;
-    let names = attributes.getExplicitNames();
-    for (const name of names) {
-      mml.setAttribute(name, attributes.getExplicit(name).toString());
+    let attributes = this.getAttributeList(node);
+    for (const name of Object.keys(attributes)) {
+      mml.setAttribute(name, attributes[name].toString());
     }
   }
 

--- a/ts/core/MmlTree/MmlVisitor.ts
+++ b/ts/core/MmlTree/MmlVisitor.ts
@@ -111,7 +111,7 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
    */
 
   /**
-   * @param {MmlNode} node  The node whose kind is nedded
+   * @param {MmlNode} node  The node whose kind is needed
    * @return {string}       The MamlML node name for that kind
    */
   protected getKind(node: MmlNode): string {

--- a/ts/core/MmlTree/MmlVisitor.ts
+++ b/ts/core/MmlTree/MmlVisitor.ts
@@ -21,9 +21,15 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {MmlNode, TextNode, XMLNode} from './MmlNode.js';
+import {MmlNode, TextNode, XMLNode, TEXCLASS, TEXCLASSNAMES} from './MmlNode.js';
+import {MmlMi} from './MmlNodes/mi.js';
+import {HtmlNode} from './MmlNodes/HtmlNode.js';
 import {MmlFactory} from './MmlFactory.js';
 import {AbstractVisitor} from '../Tree/Visitor.js';
+import {PropertyList} from '../Tree/Node.js';
+import {lookup} from '../../util/Options.js';
+
+export const DATAMJX = 'data-mjx-';
 
 /*****************************************************************/
 /**
@@ -32,6 +38,34 @@ import {AbstractVisitor} from '../Tree/Visitor.js';
  */
 
 export class MmlVisitor extends AbstractVisitor<MmlNode> {
+
+  /**
+   * MmlNode kinds to replace with other names
+   */
+  public static rename: PropertyList = {
+    TeXAtom: 'mrow'
+  };
+
+  /**
+   * Translations for the internal mathvariants
+   */
+  public static variants: PropertyList = {
+    '-tex-calligraphic':      'script',
+    '-tex-bold-calligraphic': 'bold-script',
+    '-tex-oldstyle':          'normal',
+    '-tex-bold-oldstyle':     'bold',
+    '-tex-mathit':            'italic'
+  };
+
+  /**
+   * Attributes to include on every element of a given kind
+   */
+  public static defaultAttributes: {[kind: string]: PropertyList} = {
+    math: {
+      xmlns: 'http://www.w3.org/1998/Math/MathML'
+    }
+  };
+
   /**
    * @param {MmlFactory} factory  The MmlNode factory (defaults to MmlFactory if not given)
    *
@@ -58,10 +92,95 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
   public visitTextNode(_node: TextNode, ..._args: any[]): any {}
 
   /**
-   * @param {XMLNode} node  The XMLNode to visit
-   * @param {any[]} args  Any arguments needed by the visitor
-   * @return {any}  Any return value needed for the visitor
+   * @param {XMLNode} node   The XMLNode to visit
+   * @param {any[]} args     Any arguments needed by the visitor
+   * @return {any}           Any return value needed for the visitor
    */
   public visitXMLNode(_node: XMLNode, ..._args: any[]): any {}
+
+  /**
+   * @param {HtmlNode} node  The XMLNode to visit
+   * @param {any[]} args     Any arguments needed by the visitor
+   * @return {any}           Any return value needed for the visitor
+   */
+  public visitHtmlNode(_node: HtmlNode<any>, ..._args: any[]): any {}
+
+  /***********************************************/
+  /**
+   * Utilities for handling attributes
+   */
+
+  /**
+   * @param {MmlNode} node  The node whose kind is nedded
+   * @return {string}       The MamlML node name for that kind
+   */
+  protected getKind(node: MmlNode): string {
+    const kind = node.kind;
+    return lookup(kind, (this.constructor as typeof MmlVisitor).rename, kind);
+  }
+
+  /***********************************************/
+  /**
+   * Utilities for handling attributes
+   */
+
+  /**
+   * @param {MmlNode} node    The node whose attributes are to be produced
+   * @return {PropertyList}   The attribute list
+   */
+  protected getAttributeList(node: MmlNode): PropertyList {
+    const CLASS = this.constructor as typeof MmlVisitor;
+    const defaults = lookup(node.kind, CLASS.defaultAttributes, {});
+    const attributes = Object.assign(
+      {},
+      defaults,
+      this.getDataAttributes(node),
+      node.attributes.getAllAttributes()
+    ) as PropertyList;
+    const variants = CLASS.variants;
+    if (attributes.hasOwnProperty('mathvariant') && variants.hasOwnProperty(attributes.mathvariant as string)) {
+      attributes.mathvariant = variants[attributes.mathvariant as string];
+    }
+    return attributes;
+  }
+
+  /**
+   * Create the list of data-mjx-* attributes
+   *
+   * @param {MmlNode} node    The node whose data list is to be generated
+   * @return {PropertyList}   The final class attribute list
+   */
+  protected getDataAttributes(node: MmlNode): PropertyList {
+    const data = {} as PropertyList;
+    const variant = node.attributes.getExplicit('mathvariant') as string;
+    const variants = (this.constructor as typeof MmlVisitor).variants;
+    variant && variants.hasOwnProperty(variant) && this.setDataAttribute(data, 'variant', variant);
+    node.getProperty('variantForm') && this.setDataAttribute(data, 'alternate', '1');
+    node.getProperty('pseudoscript') && this.setDataAttribute(data, 'pseudoscript', 'true');
+    node.getProperty('autoOP') === false && this.setDataAttribute(data, 'auto-op', 'false');
+    const scriptalign = node.getProperty('scriptalign') as string;
+    scriptalign && this.setDataAttribute(data, 'script-align', scriptalign);
+    const texclass = node.getProperty('texClass') as number;
+    if (texclass !== undefined) {
+      let setclass = true;
+      if (texclass === TEXCLASS.OP && node.isKind('mi')) {
+        const name = (node as MmlMi).getText();
+        setclass = !(name.length > 1 && name.match(MmlMi.operatorName));
+      }
+      setclass && this.setDataAttribute(data, 'texclass', texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass]);
+    }
+    node.getProperty('scriptlevel') && node.getProperty('useHeight') === false &&
+      this.setDataAttribute(data, 'smallmatrix', 'true');
+    return data;
+  }
+
+  /**
+   * @param {PropertyList} data   The class attribute list
+   * @param {string} name         The name for the data-mjx-name attribute
+   * @param {string} value        The value of the attribute
+   */
+  protected setDataAttribute(data: PropertyList, name: string, value: string) {
+    data[DATAMJX + name] = value;
+  }
 
 }

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -67,7 +67,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
    */
   public visitTeXAtomNode(node: MmlNode, space: string) {
     if (this.options.texHints) {
-      return super.visitTeXAtomNode(node, space);
+      return super.visitDefault(node, space);
     }
     if (node.childNodes[0] && node.childNodes[0].childNodes.length === 1) {
       return this.visitNode(node.childNodes[0], space);


### PR DESCRIPTION
This PR makes the MathMLVisitor work more like the SerializedMmlVisitor in terms of handling of attributes and converting TeXAtom nodes to mrows.  Common code has been moved to the common MmlVisitor class that is the root for both.  This invalid moving the static data items from SerializedMmlVisitor to MmlVisitor, as well as the protected methods for managing the attribute lists, so the big chunk of additions to MmlVisitor is just moving the code from SerializedMmlVisitor.  The handling of TeXAtom nodes as a special case has been removed in favor of a translation table for the node kind.  Support for the new HTML nodes has been added to the MathMLVisitor.

Resolves issue mathjax/MathJax#2920.