### PR TITLE
Add version check to entities component.

### DIFF
--- a/components/src/input/mml/entities/entities.js
+++ b/components/src/input/mml/entities/entities.js
@@ -1,2 +1,6 @@
 import '../../../../../js/util/entities/all.js';
+import {VERSION} from '../../../../../js/components/version.js';
 
+if (MathJax.loader) {
+  MathJax.loader.checkVersion('input/mml/entities', VERSION, 'input/mml/entities');
+}


### PR DESCRIPTION
This PR adds the version check to the entities component (which is usually added in the `lib` file from the `build.json` file, but this component doesn't have one, so it must be added manually).  This will avoid a warning message about the component not having a version number.

This resolves part of mathjax/MathJax-demos-node#51.