### PR TITLE
:bug: Ceil the width of `mjx-math` (Fix mathjax/MathJax#2936)

### DIFF
--- a/ts/output/chtml/Wrappers/mrow.ts
+++ b/ts/output/chtml/Wrappers/mrow.ts
@@ -101,7 +101,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       if (hasNegative) {
         const {w} = this.getBBox();
         if (w) {
-          this.adaptor.setStyle(chtml, 'width', this.em(Math.max(0, w)));
+          this.adaptor.setStyle(chtml, 'width', this.em(Math.max(0, w + .001)));
           if (w < 0) {
             this.adaptor.setStyle(chtml, 'marginRight', this.em(w));
           }


### PR DESCRIPTION
Fixed mathjax/MathJax#2936, I know it looks like a trick, but I do think it's the easiest way to fix this.
Consider the width is affected by `scale` set by parent, then we can calculate the scale like this:
![image](https://user-images.githubusercontent.com/16933298/192151860-a88aa8a0-aa12-4c4f-8bef-5269bc045600.png)

In my case, content boxes total width is:
![image](https://user-images.githubusercontent.com/16933298/192152289-998e28d2-cdad-4b67-bff7-dee3194cddcb.png)

To fulfill the content, the outer element should be wider than or equal to `50.33 (16 * 1.131 * 2.781330085889911 = 50.33094923426383)`.

However, after `em` function called, the result will only be `50.324976px`.

I noticed that there is an unused function called `emRounded`, after I get the scale variable from above code, I can call it to get the width, though after I calculated, this value is still fit.

The scale I got is `1.1312217194570136`, then font size of `mjx-container` is `113.1%`, 
And `emRounded` the result will be `50.053536px`:
![image](https://user-images.githubusercontent.com/16933298/192152977-da70def5-6053-49d7-899a-552b4cdae16c.png)

I think here we should have a function called `emCeiled`, for fixing other related issues? But for now, I think this fix will be enough, if you have any idea, feel free to share, thanks.
