### PR TITLE
Fix infinite loop when <tex-html> is used more than once (mathjax/MathJax#2948)

### DIFF
--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -55,12 +55,12 @@ export const HtmlNodeMethods: Record<string, ParseMethod> = {
     //
     parser.i += match[0].length;
     const end = (match[1] ? `<!${match[1]}>` : '') + '</tex-html>';
-    const i = parser.string.indexOf(end);
+    const i = parser.string.slice(parser.i).indexOf(end);
     if (i < 0) {
       throw new TexError('TokenNotFoundForCommand', 'Could not find %1 for %2', end, '<' + match[0]);
     }
-    const html = parser.string.substr(parser.i, i - parser.i).trim();
-    parser.i = i + 11 + (match[1] ? 3 + match[1].length : 0);
+    const html = parser.string.substr(parser.i, i).trim();
+    parser.i += i + 11 + (match[1] ? 3 + match[1].length : 0);
     //
     // Parse the HTML and check that there is something there
     //


### PR DESCRIPTION
This PR fixes a problem where an infinite loop occurs when `<tex-html>...</tex-html>` is used more than once in an equation.

Resolves issue mathjax/MathJax#2948.