### PR TITLE
Fix parsing of vertical bar delimiters in physics package (mathjax/MathJax#2973)

### DIFF
--- a/ts/input/tex/physics/PhysicsItems.ts
+++ b/ts/input/tex/physics/PhysicsItems.ts
@@ -97,6 +97,14 @@ export class AutoOpen extends BaseItem {
    * @override
    */
   public checkItem(item: StackItem): CheckType {
+    let close = item.getProperty('autoclose');
+    if (close && close === this.getProperty('close') && !this.openCount--) {
+      if (this.getProperty('ignore')) {
+        this.Clear();
+        return [[], true];
+      }
+      return [[this.toMml()], true];
+    }
     //
     //  Check for nested open delimiters (#2831)
     //
@@ -105,14 +113,6 @@ export class AutoOpen extends BaseItem {
       if (mml.isKind('mo') && (mml as AbstractMmlTokenNode).getText() === this.getProperty('open')) {
         this.openCount++;
       }
-    }
-    let close = item.getProperty('autoclose');
-    if (close && close === this.getProperty('close') && !this.openCount--) {
-      if (this.getProperty('ignore')) {
-        this.Clear();
-        return [[], true];
-      }
-      return [[this.toMml()], true];
     }
     return super.checkItem(item);
   }


### PR DESCRIPTION
This PR fixes the parsing of `|` delimiters in the physics package.  The code that tests for nested delimiters was considering the closing `|` to be the opening delimiter of a nested set of `|` delimiters, leading to an error about missing close delimiters.  The solution is to put the check for nested delimiters *after* the check for closing delimiter to allow for open and close delimiters to be the same character.

Resolves issue mathjax/MathJax#2973.