### PR TITLE
Expose `StyleList` value contained in `Styles` object

### DIFF
--- a/ts/util/Styles.ts
+++ b/ts/util/Styles.ts
@@ -405,6 +405,13 @@ export class Styles {
   }
 
   /**
+   * @return {StyleList} The object to map style names to the values
+   */
+  public get styleList(): StyleList {
+    return {...this.styles};
+  }
+
+  /**
    * @param {string} name   The name of the style to set
    * @param {string|number|boolean} value The value to set it to
    */


### PR DESCRIPTION
Today I have created a library to render Mathjax LiteDOM into React element tree.

https://github.com/rhysd/react-mathjax-component

One problem I'm facing is that there is no way to access to the key-value pairs of style value stored in `Styles` object. Since React element requires to specify styles through an object like `{maxWidth: '100px'}`, CSS text does not work. But `Styles` object only provides a way to get CSS styles as string. Currently my package [re-parses](https://github.com/rhysd/react-mathjax-component/blob/721b674b236786ad0517f897797df3b81f5bc8c5/litedom.ts#L14) the CSS text returned from `Styles` object but this is redundant (`Styles` generates a CSS string and my package restores the original key-value pairs of style object).

This PR fixes the problem by exposing the internal `StyleList` object.