### PR TITLE
Add HTMLCollection to Window instance not constructor prototype

### DIFF
--- a/ts/adaptors/linkedomAdaptor.ts
+++ b/ts/adaptors/linkedomAdaptor.ts
@@ -66,6 +66,6 @@ export class LinkedomAdaptor extends NodeMixin<HTMLElement, Text, Document, HTML
  */
 export function linkedomAdaptor(parseHTML: any, options: OptionList = null): LinkedomAdaptor {
   const window = parseHTML('<html></html>');
-  window.constructor.prototype.HTMLCollection = class {};  // add fake class for missing HTMLCollecton
+  window.HTMLCollection = class {};  // add fake class for missing HTMLCollecton
   return new LinkedomAdaptor(window, options);
 }


### PR DESCRIPTION
This PR changes how the missing `HTMLCollection` is added to windows for linkedom.  In the past it was added to the Window class's prototype, but that seemed to interfere with SRE for some reason.  This is changed to add it to the window instance itself, as that is really all MathJax needs (it is used in `mathjax.document()` to determine if the data passed to it is an `HTMLCollection` as one of the options).