### PR TITLE
Add <html>, <head>, and <body> tags to mathml when parsing as HTML

### DIFF
--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -137,6 +137,9 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
     let mml = math.start.node;
     if (!mml || !math.end.node || this.options['forceReparse'] || this.adaptor.kind(mml) === '#text') {
       let mathml = this.executeFilters(this.preFilters, math, document, (math.math || '<math></math>').trim());
+      if (this.options['parseAs'] === 'html') {
+        mathml = `<html><head></head><body>${mathml}</body></html>`;
+      }
       let doc = this.checkForErrors(this.adaptor.parse(mathml, 'text/' + this.options['parseAs']));
       let body = this.adaptor.body(doc);
       if (this.adaptor.childNodes(body).length !== 1) {


### PR DESCRIPTION
The `linkedom` adaptor fails to parse MathML as an HTML snippet, so this PR adds tags to the MathML to make sure it is parsable as HTML.  This should not interfere with parsing in the browser or in LiteDOM, and is probably a good idea in any case.