### PR TITLE
Fix vertical separation for x-arrows (#mathjax/MathJax#2981).

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -418,7 +418,7 @@ AmsMethods.xArrow = function(parser: TexParser, name: string,
   let def = {width: '+' + ParseUtil.Em((l + r) / 18), lspace: ParseUtil.Em(l / 18)};
   let bot = parser.GetBrackets(name);
   let first = parser.ParseArg(name);
-  let dstrut = parser.create('node', 'mspace', [], {depth: '.25em'});
+  let dstrut = parser.create('node', 'mspace', [], {depth: '.2em'});
   let arrow = parser.create('token',
     'mo', {stretchy: true, texClass: TEXCLASS.REL}, String.fromCodePoint(chr));
   arrow = parser.create('node', 'mstyle', [arrow], {scriptlevel: 0});


### PR DESCRIPTION
This PR fixes the vertical separation between `\xrightarrow` and the item above it.  It was due to the depth of the strut used to make sure that all the over items are aligned vertically on their baselines, but the value of the depth was based on earlier font handling, where the stretchy characters had the height of their extender, not the assembly as a whole.  The new font settings have all elements in the assembly having the same height and depth in order to improve alignment among the parts, and that is the maximum of the heights and depths of all the parts.  That makes the arrows taller than they were, and so a smaller strut is needed.

Resolves issue mathjax/MathJax#2981.