### PR TITLE
Fix problems with horizontal stretchy characters (mathjax/MathJax#2981)

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -150,8 +150,9 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
   }
 
   /**
-   * @param {string[]} fonts   The IDs for the fonts to add CSS for
-   * @param {string} root      The root URL for the fonts (can be set by extensions)
+   * @param {StyleList} styles   The style object to add styles to
+   * @param {string[]} fonts     The IDs for the fonts to add CSS for
+   * @param {string} root        The root URL for the fonts (can be set by extensions)
    */
   public static addDynamicFontCss(styles: StyleList, fonts: string[], root: string) {
     const fontStyles: StyleList = {};

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -106,6 +106,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
         '/* IE */ overflow': 'hidden',
         '/* others */ overflow': 'clip visible',
         width: '100%',
+        'max-width': '0px',                // allows ext to be smaller than its character's width
         'text-align': 'center'
       },
       'mjx-stretchy-h > mjx-ext > mjx-c': {

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -392,6 +392,7 @@ export function CommonMoMixin<
       this.size = i;
       const schar = (delim.schar ? delim.schar[Math.min(i, delim.schar.length - 1)] || c : c);
       this.stretch = {...delim, c: schar};
+      this.childNodes[0].invalidateBBox();
     }
 
     /**


### PR DESCRIPTION
This PR fixes two problems with stretchy characters.  

The first is that when a character stretches to one of the fixed-size alternatives, its bounding box needs to be recomputed, but that wasn't the case.  This caused the incorrect offset reported in mathjax/MathJax#2981, e.g., for `\xrightarrow{ab}`.

The second is when a multi-character assembly is needed for horizontal stretchy character:  if the size needed for the extenders is smaller than the width of the character used for the extender, then in CHTML, the extender would be too large (the size of the original character).  For example, with `\overparen{xxxxxxxx}` and `\overbrace{xxxxxxxx}`.  The CSS change solves that problem.

Finally, there was a missing jsdoc parameter in a FontData file.

Resolves second issue from mathjax/MathJax#2981.