### PR TITLE
Better handling of multiple children from \operatorname{} (mathjax/MathJax#2991).

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -230,8 +230,9 @@ AmsMethods.HandleOperatorName = function(parser: TexParser, name: string) {
   let mml = new TexParser(op, {
     ...parser.stack.env,
     font: TexConstant.Variant.NORMAL,
-    multiLetterIdentifiers: /^[-*a-z]+/i as any,
-    operatorLetters: true
+    multiLetterIdentifiers: /^[-*a-zA-Z]+/ as any,
+    operatorLetters: true,
+    noAutoOP: true
   }, parser.configuration).mml();
   //
   //  If we get something other than a single mi, wrap in a TeXAtom.


### PR DESCRIPTION
Currently, `\operatorname{atan2}` renders with a space between `atan` and `2`.  This is due to the multi-letter identifier getting TeX class OP automatically.  This PR adds the `noAutpOP` flag to the processing of the operator name to avoid that.

Resolves issue mathjax/MathJax#2991.