### PR TITLE
Allow semantic-enrich to enrich HTML-in-MML

### DIFF
--- a/components/src/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/src/a11y/semantic-enrich/semantic-enrich.js
@@ -10,5 +10,5 @@ if (MathJax.loader) {
 }
 
 if (MathJax.startup) {
-  MathJax.startup.extendHandler(handler => EnrichHandler(handler, new MathML()));
+  MathJax.startup.extendHandler(handler => EnrichHandler(handler, new MathML({allowHtmlInTokenNodes: true})));
 }


### PR DESCRIPTION
This PR prevents errors on re-parsing the enriched MathML when the original MathML includes embedded HTML.