### PR TITLE
Fix CHTML so that depth is correct for empty mpadded elements.

### DIFF
--- a/ts/output/chtml/Wrappers/mpadded.ts
+++ b/ts/output/chtml/Wrappers/mpadded.ts
@@ -138,8 +138,11 @@ export const ChtmlMpadded = (function <N, T, D>(): ChtmlMpaddedClass<N, T, D> {
       //  Create the HTML with the proper styles and content
       //
       chtml = [this.adaptor.append(chtml[0], this.html('mjx-block', {style: style}, content)) as N];
-      for (const child of this.childNodes) {
-        child.toCHTML([content[0] || chtml[0]]);
+      if (this.childNodes[0].childNodes.length) {
+        this.childNodes[0].toCHTML([content[0] || chtml[0]]);
+      } else if (dh || dd) {
+        // forces margins to take effect
+        this.adaptor.append(content[0] || chtml[0], this.html('mjx-box'));
       }
     }
 


### PR DESCRIPTION
This PR fixes a bug in CHTML output for `mpadded` elements that have no content.  The height and/or depth was not being properly handled in the output unless there was content, so this PR adds an empty box so that the depth shows properly.

For example:

``` html
<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
  <mpadded height="1em" depth="1em" width="1em" background="red" />
  <mi>x</mi>
</math>
```

would not have the proper depth before this PR.