### PR TITLE
Use proper scaling factors for placement of top and bottom when scaled (mathjax/MathJax#2983)

### DIFF
--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -185,7 +185,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<N, T,
      */
     public adjustBaseHeight(base: N, basebox: BBox) {
       if (this.node.attributes.get('accent')) {
-        const minH = this.font.params.x_height * basebox.scale;
+        const minH = this.font.params.x_height * this.baseScale;
         if (basebox.h < minH) {
           this.adaptor.setStyle(base, 'paddingTop', this.em(minH - basebox.h));
           basebox.h = minH;

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -288,7 +288,7 @@ export function CommonMoverMixin<
       const basebox = this.baseChild.getOuterBBox();
       const overbox = this.scriptChild.getOuterBBox();
       if (this.node.attributes.get('accent')) {
-        basebox.h = Math.max(basebox.h, this.font.params.x_height * basebox.scale);
+        basebox.h = Math.max(basebox.h, this.font.params.x_height * this.baseScale);
       }
       const u = this.getOverKU(basebox, overbox)[1];
       const delta = (this.isLineAbove ? 0 : this.getDelta());
@@ -466,7 +466,7 @@ export function CommonMunderoverMixin<
       const basebox = this.baseChild.getOuterBBox();
       const underbox = this.underChild.getOuterBBox();
       if (this.node.attributes.get('accent')) {
-        basebox.h = Math.max(basebox.h, this.font.params.x_height * basebox.scale);
+        basebox.h = Math.max(basebox.h, this.font.params.x_height * this.baseScale);
       }
       const u = this.getOverKU(basebox, overbox)[1];
       const v = this.getUnderKV(basebox, underbox)[1];

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -698,7 +698,7 @@ export function CommonScriptbaseMixin<
           dw[i] += m;
         }
       }
-      [1, 2].map(i => dw[i] += (boxes[i] ? boxes[i].dx * boxes[0].scale : 0));
+      [1, 2].map(i => dw[i] += (boxes[i] ? boxes[i].dx * boxes[0].rscale : 0));
       return dw;
     }
 


### PR DESCRIPTION
The placement of top and bottom in `munderover` and related constructs were not correct if the `munderover` is scaled, as in `\huge\vec x`.  This was due to the use of the wrong scaling factors in determining the height of the base and the horizontal position of the super- or subscript.  This PR uses the correct scaling factors.

Resolve issue mathjax/MathJax#2983.