### PR TITLE
Allow (embellished) operators in \underset, \overset, and \underoverset to specify accent="true"

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -626,11 +626,10 @@ BaseMethods.Overset = function(parser: TexParser, name: string) {
   // @test Overset
   const top = parser.ParseArg(name);
   const base = parser.ParseArg(name);
+  const topMo = top.coreMO();
+  const accent = (topMo.isKind('mo') && NodeUtil.getAttribute(topMo, 'accent') === true);
   ParseUtil.checkMovableLimits(base);
-  if (top.isKind('mo')) {
-    NodeUtil.setAttribute(top, 'accent', false);
-  }
-  const node = parser.create('node', 'mover', [base, top]);
+  const node = parser.create('node', 'mover', [base, top], {accent});
   parser.Push(node);
 };
 
@@ -644,11 +643,10 @@ BaseMethods.Underset = function(parser: TexParser, name: string) {
   // @test Underset
   const bot = parser.ParseArg(name);
   const base = parser.ParseArg(name);
+  const botMo = bot.coreMO();
+  const accentunder = (botMo.isKind('mo') && NodeUtil.getAttribute(botMo, 'accent') === true);
   ParseUtil.checkMovableLimits(base);
-  if (bot.isKind('mo')) {
-    NodeUtil.setAttribute(bot, 'accent', false);
-  }
-  const node = parser.create('node', 'munder', [base, bot], {accentunder: false});
+  const node = parser.create('node', 'munder', [base, bot], {accentunder});
   parser.Push(node);
 };
 
@@ -662,14 +660,12 @@ BaseMethods.Overunderset = function(parser: TexParser, name: string) {
   const top = parser.ParseArg(name);
   const bot = parser.ParseArg(name);
   const base = parser.ParseArg(name);
+  const topMo = top.coreMO();
+  const botMo = bot.coreMO();
+  const accent = (topMo.isKind('mo') && NodeUtil.getAttribute(topMo, 'accent') === true);
+  const accentunder = (botMo.isKind('mo') && NodeUtil.getAttribute(botMo, 'accent') === true);
   ParseUtil.checkMovableLimits(base);
-  if (top.isKind('mo')) {
-    NodeUtil.setAttribute(top, 'accent', false);
-  }
-  if (bot.isKind('mo')) {
-    NodeUtil.setAttribute(bot, 'accent', false);
-  }
-  const node = parser.create('node', 'munderover', [base, bot, top], {accent: false, accentunder: false});
+  const node = parser.create('node', 'munderover', [base, bot, top], {accent, accentunder});
   parser.Push(node);
 };
 


### PR DESCRIPTION
Currently, `\underset`, `\overset`, and `\underoverset` force `accent="false"` on `mo` elements that are set on top or bottom of the base.  This PR allows a (possibly embellished) operator that has an explicit `accent="true"` to set the `accent` or `accentunder` attributes of the `munder`, `mover`, or `munderover` that is produced.  That allows, for example

``` latex
\underset{\mmlToken{mo}[accent="true"]{⎵}}{abcabc}
```

to properly handle the underbrace as an accent (i.e., without reducing its scale).   (Without this PR, the accent always gets `accent="false"`, and so is reduced in size.  There is an additional but where that causes the stretchy character not to stretch sufficiently, but that is treated in the fix-stretchy-widths` branch.)