### PR TITLE
Map \models to correct Unicode point, and don't use variant form for \vDash (mathjax/MathJax#2543)

### DIFF
--- a/ts/input/tex/ams/AmsMappings.ts
+++ b/ts/input/tex/ams/AmsMappings.ts
@@ -299,7 +299,7 @@ new sm.CharacterMap('AMSsymbols-mathchar0mo', ParseMethods.mathchar0mo, {
   unlhd:                  '\u22B4',
   trianglerighteq:        '\u22B5',
   unrhd:                  '\u22B5',
-  vDash:                  ['\u22A8', {variantForm: true}],
+  vDash:                  '\u22A8',
   Vdash:                  '\u22A9',
   Vvdash:                 '\u22AA',
   smallsmile:             ['\u2323', {variantForm: true}],

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -263,7 +263,7 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   cong:         '\u2245',
   doteq:        '\u2250',
   bowtie:       '\u22C8',
-  models:       '\u22A8',
+  models:       '\u22A7',
 
   notChar:      '\u29F8',
 


### PR DESCRIPTION
This PR corrects the unicode value for `\models` and removes the variant form from `\vDash` (this will be correct once we go to the mathjax-modern font).

Note, however, that the TeX/LaTeX version of `\models` does not appear the same as the U+22A7 glyph in the mathjax-modern font.  TeX uses the equivalent of `\def\models{\mathrel{|\!=}}`; should we do that as well?

Resolves issue mathjax/MathJax#2543.