### PR TITLE
Allow borders to inherit surrounding color in SVG (mathjax/MathJax#2939)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -761,7 +761,7 @@ export class CommonWrapper<
         hasBorder = true;
         width[i] = Math.max(0, this.length2em(w, 1));
         style[i] = this.styles.get(key + 'Style') || 'solid';
-        color[i] = this.styles.get(key + 'Color') || 'currentColor';
+        color[i] = this.styles.get(key + 'Color');
       }
       const p = this.styles.get('padding' + name);
       if (p) {

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -318,9 +318,11 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   protected addBorderSolid(path: number[][], color: string, child: N, parent: N, dx: number) {
     const border = this.svg('polygon', {
       points: path.map(([x, y]) => `${this.fixed(x - dx)},${this.fixed(y)}`).join(' '),
-      stroke: 'none',
-      fill: color
+      stroke: 'none'
     });
+    if (color) {
+      this.adaptor.setAttribute(border, 'fill', color);
+    }
     if (child) {
       this.adaptor.insert(border, child);
     } else {


### PR DESCRIPTION
This PR resolves a problem where borders that don't specify an explicit color were getting the wrong color in SVG output due to using 'currentColor', which caused them to get the color of the text surrounding the math as a whole.  Instead, they should just not set the fill color and let it be inherited.

Resolves issue mathjax/MathJax#2939.