### PR TITLE
Add \underline and several other macros to textmacros. (mathjax/MathJax#2969)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -149,4 +149,16 @@ new CommandMap('text-macros', {
   ref:          ['HandleRef', false],
   eqref:        ['HandleRef', true],
 
+  underline:    ['UnderOver', '2015'],
+
+  llap:         'Lap',
+  rlap:         'Lap',
+
+  phantom:      'Phantom',
+  vphantom:     ['Phantom', 1, 0],
+  hphantom:     ['Phantom', 0, 1],
+  smash:        'Smash',
+
+  mmlToken:     'MmlToken'
+
 }, TextMacrosMethods);

--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -281,7 +281,11 @@ export const TextMacrosMethods = {
   Hskip: BaseMethods.Hskip,
   rule: BaseMethods.rule,
   Rule: BaseMethods.Rule,
-  HandleRef: BaseMethods.HandleRef
+  HandleRef: BaseMethods.HandleRef,
+  UnderOver: BaseMethods.UnderOver,
+  Lap: BaseMethods.Lap,
+  Phantom: BaseMethods.Phantom,
+  Smash: BaseMethods.Smash,
+  MmlToken: BaseMethods.MmlToken
 
 };
-


### PR DESCRIPTION
This PR adds `\underline`, `\llap`, `\rlap`, the phantom and `\smash` macros, and `\mmlToken` to the `textmacros` package so they can be used in text mode, as they are allowed in LaTeX text-mode.

Resolve issue mathjax/Mathjax#2969.