### PR TITLE
Handle newlines as spaces in text mode. (mathjax/MathJax#2993)

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -358,7 +358,7 @@ namespace ParseUtil {
    */
   export function internalText(parser: TexParser, text: string, def: EnvList): MmlNode {
     // @test Label, Fbox, Hbox
-    text = text.replace(/^\s+/, entities.nbsp).replace(/\s+$/, entities.nbsp);
+    text = text.replace(/\n+/g, ' ').replace(/^\s+/, entities.nbsp).replace(/\s+$/, entities.nbsp);
     let textNode = parser.create('text', text);
     return parser.create('node', 'mtext', [], def, textNode);
   }


### PR DESCRIPTION
This PR makes sure that newlines in text-mode are treated as spaces.  Currently they are preserved as newlines, but that isn't how TeX would treat them.

Resolves issue mathjax/MathJax#2993