### PR TITLE
Better handling of scriptminsize (mathjax/MathJax#2975)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/math.ts
+++ b/ts/core/MmlTree/MmlNodes/math.ts
@@ -53,7 +53,7 @@ export class MmlMath extends AbstractMmlLayoutNode {
     alttext: '',
     cdgroup: '',
     scriptsizemultiplier: 1 / Math.sqrt(2),
-    scriptminsize: '8px',        // Should be 8pt, but that's too big
+    scriptminsize: '.4em',       // Should be 8pt, but that's too big
     infixlinebreakstyle: 'before',
     lineleading: '1ex',
     linebreakmultchar: '\u2062', // Invisible times

--- a/ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -40,7 +40,7 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
     scriptlevel: INHERIT,
     displaystyle: INHERIT,
     scriptsizemultiplier: 1 / Math.sqrt(2),
-    scriptminsize: '8px',  // should be 8pt, but that is too large
+    scriptminsize: '.4em',      // should be 8pt, but that is too large
     mathbackground: INHERIT,
     mathcolor: INHERIT,
     dir: INHERIT,

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -586,8 +586,6 @@ export class CommonWrapper<
     //
     if (scriptlevel !== 0) {
       scale = Math.pow(attributes.get('scriptsizemultiplier') as number, scriptlevel);
-      let scriptminsize = this.length2em(attributes.get('scriptminsize'), .8, 1);
-      if (scale < scriptminsize) scale = scriptminsize;
     }
     //
     // If there is style="font-size:...", and not fontsize attribute, use that as fontsize
@@ -606,6 +604,13 @@ export class CommonWrapper<
     //
     if (mathsize !== '1') {
       scale *= this.length2em(mathsize, 1, 1);
+    }
+    //
+    // Use scriptminsize as minimum size for scripts
+    //
+    if (scriptlevel !== 0) {
+      let scriptminsize = this.length2em(attributes.get('scriptminsize'), .4, 1);
+      if (scale < scriptminsize) scale = scriptminsize;
     }
     //
     // Record the scaling factors and set the element's CSS


### PR DESCRIPTION
This PR moves the checking of `scriptminsize` to later in the calculation of the scaling factor so that `mathsize` and `font-size` CSS are included in the test, and also changes the default value to a better one (see mathjax/MathJax#2975).

Resolves issue mathjax/MathJax#2975.