### PR TITLE
Allow \columncolor in the array preamble.  (mathjax/MathJax#2955)

### DIFF
--- a/ts/input/tex/colortbl/ColortblConfiguration.ts
+++ b/ts/input/tex/colortbl/ColortblConfiguration.ts
@@ -131,8 +131,8 @@ new CommandMap('colortbl', {
     //  Check the position of the macro and save the color.
     //
     if (type === 'col') {
-      if (top.table.length) {
-        throw new TexError('ColumnColorNotTop', '%1 must be in the top row', name);
+      if (top.table.length && top.color.col[top.row.length] !== color) {
+        throw new TexError('ColumnColorNotTop', '%1 must be in the top row or preamble', name);
       }
       top.color.col[top.row.length] = color;
       //


### PR DESCRIPTION
This PR allows `\columncolor` to be used in an array environment preamble (where it is supposed to be used).  We allowed it in the top row in previous versions because we were not processing all the preamble options until now.  This PR allows it to be used both in the preamble and the first row of the array.

Resolves issue mathjax/MathJax#2955.