### PR TITLE
Provide an option for placement of equation numbers in TeX input.  (mathjax/MathJax#2977)

### DIFF
--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -541,8 +541,10 @@ export class AbstractTags implements Tags {
     }
     let mml = new TexParser('\\text{' + this.currentTag.tagFormat + '}', {},
                             this.configuration).mml();
-    return this.configuration.nodeFactory.create('node', 'mtd', [mml],
-                                                 {id: this.currentTag.tagId});
+    return this.configuration.nodeFactory.create('node', 'mtd', [mml], {
+      id: this.currentTag.tagId,
+      rowalign: this.configuration.options.tagAlign
+    });
   }
 
 }
@@ -629,7 +631,9 @@ export namespace TagsFactory {
     // If false it uses the actual number N that is displayed: mjx-eqn:N
     useLabelIds: true,
     // Set to true in order to prevent error messages for duplicate label ids
-    ignoreDuplicateLabels: false
+    ignoreDuplicateLabels: false,
+    // The rowalign value to use for tag cells.
+    tagAlign: 'baseline'
   };
 
 


### PR DESCRIPTION
This PR adds an option to specify the vertical placement of tags in TeX expressions.  The main purpose is to center the tags for long expressions that have line breaks.

Resolves issue mathjax/MathJax#2977.