### PR TITLE
Properly handle \over within braket and physics packages. (mathjax/MathJax#3000)

### DIFF
--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -316,12 +316,12 @@ export class OverItem extends BaseItem {
         NodeUtil.setAttribute(mml, 'linethickness',
                               this.getProperty('thickness') as string);
       }
-      if (this.getProperty('open') || this.getProperty('close')) {
+      if (this.getProperty('ldelim') || this.getProperty('rdelim')) {
         // @test Choose
         NodeUtil.setProperty(mml, 'withDelims', true);
         mml = ParseUtil.fixedFence(this.factory.configuration,
-                                   this.getProperty('open') as string, mml,
-                                   this.getProperty('close') as string);
+                                   this.getProperty('ldelim') as string, mml,
+                                   this.getProperty('rdelim') as string);
       }
       return [[this.factory.create('mml', mml), item], true];
     }

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -442,12 +442,12 @@ BaseMethods.Over = function(parser: TexParser, name: string, open: string, close
   const mml = parser.itemFactory.create('over').setProperty('name', parser.currentCS) ;
   if (open || close) {
     // @test Choose
-    mml.setProperty('open', open);
-    mml.setProperty('close', close);
+    mml.setProperty('ldelim', open);
+    mml.setProperty('rdelim', close);
   } else if (name.match(/withdelims$/)) {
     // @test Over With Delims, Above With Delims
-    mml.setProperty('open', parser.GetDelimiter(name));
-    mml.setProperty('close', parser.GetDelimiter(name));
+    mml.setProperty('ldelim', parser.GetDelimiter(name));
+    mml.setProperty('rdelim', parser.GetDelimiter(name));
   }
   if (name.match(/^\\above/)) {
     // @test Above, Above With Delims

--- a/ts/input/tex/braket/BraketItems.ts
+++ b/ts/input/tex/braket/BraketItems.ts
@@ -26,7 +26,9 @@
 import {CheckType, BaseItem, StackItem} from '../StackItem.js';
 import {TEXCLASS, MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import ParseUtil from '../ParseUtil.js';
+import {MATHSPACE, em} from '../../../util/lengths.js';
 
+const THINSPACE = em(MATHSPACE.thinmathspace);
 
 /**
  * A bra-ket command. Collates elements from the opening brace to the closing
@@ -91,18 +93,30 @@ export class BraketItem extends BaseItem {
     }
     let open = this.getProperty('open') as string;
     let close = this.getProperty('close') as string;
+    //
+    // Add any saved bar nodes
+    //
     if (this.barNodes.length) {
       inner = this.create('node', 'inferredMrow', [...this.barNodes, inner]);
     }
     if (this.getProperty('stretchy')) {
+      //
+      //  Add spacing, if requested
+      //
+      if (this.getProperty('space')) {
+        inner = this.create('node', 'inferredMrow', [
+          this.create('token', 'mspace', {width: THINSPACE}),
+          inner,
+          this.create('token', 'mspace', {width: THINSPACE})
+        ]);
+      }
       return ParseUtil.fenced(this.factory.configuration, open, inner, close);
     }
     let attrs = {fence: true, stretchy: false, symmetric: true, texClass: TEXCLASS.OPEN};
     let openNode = this.create('token', 'mo', attrs, open);
     attrs.texClass = TEXCLASS.CLOSE;
     let closeNode = this.create('token', 'mo', attrs, close);
-    let mrow = this.create('node', 'mrow', [openNode, inner, closeNode],
-                         {open: open, close: close, texClass: TEXCLASS.INNER});
+    let mrow = this.create('node', 'mrow', [openNode, inner, closeNode], {open: open, close: close});
     return mrow;
   }
 

--- a/ts/input/tex/braket/BraketMappings.ts
+++ b/ts/input/tex/braket/BraketMappings.ts
@@ -37,7 +37,7 @@ new CommandMap('Braket-macros', {
   Bra: ['Macro', '{\\left\\langle {#1} \\right\\vert}', 1],
   Ket: ['Macro', '{\\left\\vert {#1} \\right\\rangle}', 1],
   Braket: ['Braket', '\u27E8', '\u27E9', true, Infinity],
-  Set: ['Braket', '{', '}', true, 1],
+  Set: ['Braket', '{', '}', true, 1, true],
   // Not part of the LaTeX package:
   ketbra: ['Macro', '{\\vert {#1} \\rangle\\langle {#2} \\vert}', 2],
   Ketbra: ['Macro', '{\\left\\vert {#1} \\right\\rangle\\left\\langle {#2} \\right\\vert}', 2],

--- a/ts/input/tex/braket/BraketMethods.ts
+++ b/ts/input/tex/braket/BraketMethods.ts
@@ -22,11 +22,12 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import {ParseMethod} from '../Types.js';
+import {ParseMethod, ParseResult} from '../Types.js';
 import BaseMethods from '../base/BaseMethods.js';
 import TexParser from '../TexParser.js';
 import {TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
 import TexError from '../TexError.js';
+import {BraketItem} from './BraketItems.js';
 
 
 let BraketMethods: Record<string, ParseMethod> = {};
@@ -66,33 +67,44 @@ BraketMethods.Braket = function(parser: TexParser, _name: string,
  * Generate a bar. If inside a bra-ket expressions it's handled accordingly.
  * @param {TexParser} parser The current TeX parser.
  * @param {string} name Name of the current control sequence.
+ * @return {ParseResult} False if the bar isn't to be processed here.
  */
-BraketMethods.Bar = function(parser: TexParser, name: string) {
-  let c = name === '|' ? '|' : '\u2225';
-  let top = parser.stack.Top();
-  if (top.kind !== 'braket' ||
-      top.getProperty('barcount') >= top.getProperty('barmax')) {
-    let mml = parser.create('token', 'mo', {texClass: TEXCLASS.ORD, stretchy: false}, c);
-    parser.Push(mml);
-    return;
+BraketMethods.Bar = function(parser: TexParser, name: string): ParseResult {
+  let c = name === '|' ? '|' : '\u2016';
+  let top = parser.stack.Top() as BraketItem;
+  if (top.isKind('over')) {
+    // If the top item is from \over, use the previous one
+    top = parser.stack.Top(2) as BraketItem;
+  }
+  if (!top.isKind('braket') || top.getProperty('barcount') >= top.getProperty('barmax')) {
+    return false;
   }
   if (c === '|' && parser.GetNext() === '|') {
     parser.i++;
-    c = '\u2225';
+    c = '\u2016';
   }
   let stretchy = top.getProperty('stretchy');
   if (!stretchy) {
-    let node = parser.create('token', 'mo', {stretchy: false, braketbar: true}, c);
+    let node = parser.create('token', 'mo', {stretchy: false, 'data-braketbar': true, texClass: TEXCLASS.ORD}, c);
     parser.Push(node);
     return;
   }
-  let node = parser.create('node', 'TeXAtom', [], {texClass: TEXCLASS.CLOSE});
-  parser.Push(node);
+  //
+  // Close any pending \over constructs using a specially marked CloseItem
+  //
+  let close = parser.itemFactory.create('close').setProperty('braketbar', true);
+  parser.Push(close);
+  //
+  // Push a CLOSE atom, the bar as a BIN, and an OPEN atom onto the barNodes,
+  //  which will be added into the toMml() output.  This allows \over to be used
+  //  after any bars
+  //
+  top.barNodes.push(
+    parser.create('node', 'TeXAtom', [], {texClass: TEXCLASS.CLOSE}),
+    parser.create('token', 'mo', {stretchy: true, 'data-braketbar': true, texClass: TEXCLASS.BIN}, c),
+    parser.create('node', 'TeXAtom', [], {texClass: TEXCLASS.OPEN})
+  );
   top.setProperty('barcount', top.getProperty('barcount') as number + 1);
-  node = parser.create('token', 'mo', {stretchy: true, braketbar: true}, c);
-  parser.Push(node);
-  node = parser.create('node', 'TeXAtom', [], {texClass: TEXCLASS.OPEN});
-  parser.Push(node);
 };
 
 

--- a/ts/input/tex/braket/BraketMethods.ts
+++ b/ts/input/tex/braket/BraketMethods.ts
@@ -43,10 +43,11 @@ BraketMethods.Macro = BaseMethods.Macro;
  * @param {string} close Closing delimiter.
  * @param {boolean} stretchy Is it stretchy.
  * @param {number} barmax Maximum number of bars allowed.
+ * @param {boolean} space True to add space inside the delimiters
  */
 BraketMethods.Braket = function(parser: TexParser, _name: string,
                                 open: string, close: string,
-                                stretchy: boolean, barmax: number) {
+                                stretchy: boolean, barmax: number, space: boolean = false) {
   let next = parser.GetNext();
   if (next === '') {
     throw new TexError('MissingArgFor', 'Missing argument for %1', parser.currentCS);
@@ -58,8 +59,7 @@ BraketMethods.Braket = function(parser: TexParser, _name: string,
   }
   parser.Push(
     parser.itemFactory.create('braket')
-      .setProperties({barmax: barmax, barcount: 0, open: open,
-                      close: close, stretchy: stretchy, single: single}));
+      .setProperties({barcount: 0, barmax, open, close, stretchy, single, space}));
 };
 
 

--- a/ts/input/tex/physics/PhysicsItems.ts
+++ b/ts/input/tex/physics/PhysicsItems.ts
@@ -27,7 +27,8 @@ import {CheckType, BaseItem, StackItem} from '../StackItem.js';
 import ParseUtil from '../ParseUtil.js';
 import NodeUtil from '../NodeUtil.js';
 import TexParser from '../TexParser.js';
-import {AbstractMmlTokenNode} from '../../../core/MmlTree/MmlNode.js';
+import {AbstractMmlTokenNode, MmlNode} from '../../../core/MmlTree/MmlNode.js';
+
 
 export class AutoOpen extends BaseItem {
 
@@ -42,7 +43,7 @@ export class AutoOpen extends BaseItem {
    * The number of unpaired open delimiters that need to be matched before
    *   a close delimiter will close this item. (#2831)
    */
-  protected openCount: number = 0;
+  public openCount: number = 0;
 
   /**
    * @override
@@ -63,7 +64,14 @@ export class AutoOpen extends BaseItem {
   /**
    * @override
    */
-  public toMml() {
+  public toMml(inferred: boolean = true, forceRow?: boolean) {
+    if (!inferred) {
+      //
+      // When toMml() is being called from processing an \over item, we don't want to
+      // add the delimiters, so just do the super toMml() method. (Issue #3000)
+      //
+      return super.toMml(inferred, forceRow);
+    }
     // Smash and right/left
     let parser = this.factory.configuration.parser;
     let right = this.getProperty('right') as string;
@@ -94,11 +102,27 @@ export class AutoOpen extends BaseItem {
   }
 
   /**
+   * Test whether a fence is a closing one for this item,
+   *   decrementing the open count if appropriate.
+   */
+  public closing(fence: string) {
+    return (fence === this.getProperty('close') && !this.openCount--);
+  }
+
+  /**
    * @override
    */
   public checkItem(item: StackItem): CheckType {
-    let close = item.getProperty('autoclose');
-    if (close && close === this.getProperty('close') && !this.openCount--) {
+    //
+    // If we are closing \over items, we are done
+    //
+    if (item.getProperty('pre-autoclose')) {
+      return BaseItem.fail;
+    }
+    //
+    // If this is the closing fence, produce the proper output
+    //
+    if (item.getProperty('autoclose')) {
       if (this.getProperty('ignore')) {
         this.Clear();
         return [[], true];
@@ -114,6 +138,9 @@ export class AutoOpen extends BaseItem {
         this.openCount++;
       }
     }
+    //
+    // Do the default check
+    //
     return super.checkItem(item);
   }
 

--- a/ts/input/tex/physics/PhysicsItems.ts
+++ b/ts/input/tex/physics/PhysicsItems.ts
@@ -27,7 +27,7 @@ import {CheckType, BaseItem, StackItem} from '../StackItem.js';
 import ParseUtil from '../ParseUtil.js';
 import NodeUtil from '../NodeUtil.js';
 import TexParser from '../TexParser.js';
-import {AbstractMmlTokenNode, MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {AbstractMmlTokenNode} from '../../../core/MmlTree/MmlNode.js';
 
 
 export class AutoOpen extends BaseItem {


### PR DESCRIPTION
This PR modifies the braket and physics packages so that they properly handle `\over` constructs as the actual LaTeX packages do.  Although `\frac` is recommended, `\over` can still be used, and the current code for these packages doesn't handle that properly.  (For bracket, `\Set{a\over b}` includes braces around the a as well as the whole fraction, and for physics, `\sin(a\over b)` generates an error message about missing delimiters.)  This PR also fixes some spacing issues with `\Set`.

Because braket and physics use `BraketItem` and `AutoOpen` items that have `isOpen` set to `true`, they act as delimiters for `\over`, and need to take that into account.  Because `\over` works by collecting the current node list from the preceding open `StackItem` using its `toMml()` method, and saving that in the `num` (numerator) property of the `StackItem`, the `BraketItem` and `AutoOpen` items need to take that behavior into account.  This PR uses the `inferred` argument to `toMml()` (which is set to false when the `OverItem` calls it) to tell whether to just do the super `toMml()`, or to do its full version (which adds the delimiters).

We also need to have the braket package have vertical bars mark the ends of `\over` constructs, and for physics, the closing delimiters must also end the `\over` construction.  So this PR modifies the `Bar` and `AutoClose` methods to handle an `OverItem` as the top item, and to use a fake `CloseItem` to end the fraction.  For braket items, the material up to the last bar is stored in a `barNodes` list (similar to the `num` property for `\over`) so that additional fractions can occur between bars, and after the last bar.  The `toMml()` method then re-inserts that list into the final MathML.

A similar fake close item is used in the physics case, but because parenthesis balancing is being done, that has to be taken into account, so that `\sin(a(b\over c))` will properly handle the faction (which should produce the equivalent of `\sin(\frac{a(b}{c)})` with the inner parentheses being part of the fraction, and only the outer ones being stretchy).

Finally, the spacing for `\Set` and its bar (if any) is corrected.

Resolves issue mathjax/MathJax#3000.

