### PR TITLE
Make vertical bar have the correct TeX class.  (mathjax/MathJax#2938)

### DIFF
--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -63,6 +63,7 @@ new sm.MacroMap('special', {
   '~':   'Tilde',
   '^':   'Superscript',
   '_':   'Subscript',
+  '|':   'Bar',
   ' ':   'Space',
   '\t':  'Space',
   '\r':  'Space',

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -76,6 +76,15 @@ BaseMethods.Close = function(parser: TexParser, _c: string) {
   parser.Push(parser.itemFactory.create('close'));
 };
 
+/**
+ * Handle |
+ * @param {TexParser} parser The calling parser.
+ * @param {string} c The parsed character.
+ */
+BaseMethods.Bar = function(parser: TexParser, c: string) {
+  parser.Push(parser.create('token', 'mo', {texClass: TEXCLASS.ORD}, c));
+}
+
 
 /**
  * Handle tilde and spaces.


### PR DESCRIPTION
When used in prefix or postfix positions, the operator dictionary gives `|` TeX class of OPEN or CLOSE, but TeX creates it as ORD in these locations.  This PR forces the TeX input jax to make it ORD, while still allowing MathML to treat them as OPEN and CLOSE in a construction like `<mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow>` that corresponds to `\left|x\right|` (where they *do* have OPEN and CLOSE class).

Resolves issue mathjax/MathJax#2938 and part of mathjax/MathJax#2894.