### PR TITLE
Fix scaling of tooltips when text font is inherited. (mathjax/MathJax#2957)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/maction.ts
+++ b/ts/core/MmlTree/MmlNodes/maction.ts
@@ -131,13 +131,16 @@ export class MmlMaction extends AbstractMmlNode {
     this.attributes.set('selection', selection);
   }
 
+  /**
+   * @override
+   */
   protected setChildInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {
     if ((this.attributes.get('actiontype') as String).toLowerCase() !== 'tooltip') {
       super.setChildInheritedAttributes(attributes, display, level, prime);
       return;
     }
     this.childNodes[0].setInheritedAttributes(attributes, display, level, prime);
-    this.childNodes[1].setInheritedAttributes(attributes, false, 1, prime);
+    this.childNodes[1].setInheritedAttributes(attributes, false, 1, false);
   }
 
 }

--- a/ts/core/MmlTree/MmlNodes/maction.ts
+++ b/ts/core/MmlTree/MmlNodes/maction.ts
@@ -22,7 +22,7 @@
  */
 
 import {PropertyList} from '../../Tree/Node.js';
-import {MmlNode, AbstractMmlNode} from '../MmlNode.js';
+import {MmlNode, AbstractMmlNode, AttributeList} from '../MmlNode.js';
 
 /*****************************************************************/
 /**
@@ -129,6 +129,15 @@ export class MmlMaction extends AbstractMmlNode {
       selection = 1;
     }
     this.attributes.set('selection', selection);
+  }
+
+  protected setChildInheritedAttributes(attributes: AttributeList, display: boolean, level: number, prime: boolean) {
+    if ((this.attributes.get('actiontype') as String).toLowerCase() !== 'tooltip') {
+      super.setChildInheritedAttributes(attributes, display, level, prime);
+      return;
+    }
+    this.childNodes[0].setInheritedAttributes(attributes, display, level, prime);
+    this.childNodes[1].setInheritedAttributes(attributes, false, 1, prime);
   }
 
 }

--- a/ts/core/MmlTree/MmlNodes/maction.ts
+++ b/ts/core/MmlTree/MmlNodes/maction.ts
@@ -139,8 +139,8 @@ export class MmlMaction extends AbstractMmlNode {
       super.setChildInheritedAttributes(attributes, display, level, prime);
       return;
     }
-    this.childNodes[0].setInheritedAttributes(attributes, display, level, prime);
-    this.childNodes[1].setInheritedAttributes(attributes, false, 1, false);
+    this.childNodes[0]?.setInheritedAttributes(attributes, display, level, prime);
+    this.childNodes[1]?.setInheritedAttributes(attributes, false, 1, false);
   }
 
 }

--- a/ts/output/chtml/Wrappers/maction.ts
+++ b/ts/output/chtml/Wrappers/maction.ts
@@ -119,9 +119,9 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
       },
       'mjx-tool > mjx-tip': {
         display: 'inline-block',
+        'line-height': 0,
         padding: '.2em',
         border: '1px solid #888',
-        'font-size': '70%',
         'background-color': '#F8F8F8',
         color: 'black',
         'box-shadow': '2px 2px 5px #AAAAAA'

--- a/ts/output/svg/Wrappers/maction.ts
+++ b/ts/output/svg/Wrappers/maction.ts
@@ -114,9 +114,9 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
       },
       'mjx-tool > mjx-tip': {
         display: 'inline-block',
+        'line-height': 0,
         padding: '.2em',
         border: '1px solid #888',
-        'font-size': '70%',
         'background-color': '#F8F8F8',
         color: 'black',
         'box-shadow': '2px 2px 5px #AAAAAA'


### PR DESCRIPTION
This PR fixes a problem where the scaling for `mtext` elements in tooltips is wrong when `mtextInheritFont` is true (or `mtextFont` is set).  This was due to the CSS `font-size: 70%`, which wasn't being taken into account with the measuring of the font size of the inherited font.  The solution used here is to remove the 70% scaling and setting the `scriptlevel` to 1 (which is a 70.7% scaling).