### PR TITLE
Allow SVG character stroke-width to be specified. (mathjax/MathJax#2859)

### DIFF
--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -515,7 +515,7 @@ export abstract class CommonOutputJax<
    * @param {CssStyles} styles            The style object to add to.
    */
   protected addClassStyles(CLASS: typeof CommonWrapper, styles: CssStyles) {
-    styles.addStyles(CLASS.styles);
+    CLASS.addStyles<CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>>(styles, this);
   }
 
   /*****************************************************************/

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -29,7 +29,7 @@ import {Property} from '../../core/Tree/Node.js';
 import {unicodeChars} from '../../util/string.js';
 import * as LENGTHS from '../../util/lengths.js';
 import {Styles} from '../../util/Styles.js';
-import {StyleList} from '../../util/StyleList.js';
+import {StyleList, CssStyles} from '../../util/StyleList.js';
 import {OptionList} from '../../util/Options.js';
 import {CommonOutputJax} from '../common.js';
 import {CommonWrapperFactory} from './WrapperFactory.js';
@@ -162,6 +162,14 @@ export interface CommonWrapperClass<
   ITALICVARIANTS: {[name: string]: StringMap};
 
   /**
+   * Add any styles for this wrapper class
+   *
+   * @param {CssStyles} styles   The styles object to extend
+   * @param {JX} jax             The output jax whose style sheet is being modified (in case options are needed)
+   */
+  addStyles<JX>(styles: CssStyles, jax: JX): void;
+
+  /**
    * override
    */
   new (factory: WF, node: MmlNode, parent?: WW): WW;
@@ -270,6 +278,16 @@ export class CommonWrapper<
       'sans-serif-bold-italic': 'bold-sans-serif'
     }
   };
+
+  /**
+   * Add any styles for this wrapper class
+   *
+   * @param {CssStyles} styles   The styles object to extend
+   * @param {JX} _jax            The output jax whose style sheet is being modified (in case options are needed)
+   */
+  public static addStyles<JX>(styles: CssStyles, _jax: JX) {
+    styles.addStyles(this.styles);
+  }
 
   /**
    * The factory used to create more wrappers

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -280,10 +280,7 @@ export class CommonWrapper<
   };
 
   /**
-   * Add any styles for this wrapper class
-   *
-   * @param {CssStyles} styles   The styles object to extend
-   * @param {JX} _jax            The output jax whose style sheet is being modified (in case options are needed)
+   * @override
    */
   public static addStyles<JX>(styles: CssStyles, _jax: JX) {
     styles.addStyles(this.styles);

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -73,6 +73,7 @@ CommonOutputJax<
    */
   public static OPTIONS: OptionList = {
     ...CommonOutputJax.OPTIONS,
+    blacker: 3,                     // the stroke-width to use for SVG character paths
     internalSpeechTitles: true,     // insert <title> tags with speech content
     titleID: 0,                     // initial id number to use for aria-labeledby titles
     fontCache: 'local',             // or 'global' or 'none'

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -27,7 +27,7 @@ import {SvgWrapperFactory} from '../WrapperFactory.js';
 import {SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass} from '../FontData.js';
 import {CommonTextNode, CommonTextNodeClass, CommonTextNodeMixin} from '../../common/Wrappers/TextNode.js';
 import {MmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
-import {StyleList, CssStyles} from '../../../util/StyleList.js';
+import {CssStyles} from '../../../util/StyleList.js';
 
 /*****************************************************************/
 /**

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -27,7 +27,7 @@ import {SvgWrapperFactory} from '../WrapperFactory.js';
 import {SvgCharOptions, SvgVariantData, SvgDelimiterData, SvgFontData, SvgFontDataClass} from '../FontData.js';
 import {CommonTextNode, CommonTextNodeClass, CommonTextNodeMixin} from '../../common/Wrappers/TextNode.js';
 import {MmlNode, TextNode} from '../../../core/MmlTree/MmlNode.js';
-import {StyleList} from '../../../util/StyleList.js';
+import {StyleList, CssStyles} from '../../../util/StyleList.js';
 
 /*****************************************************************/
 /**
@@ -86,11 +86,13 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
     /**
      * @override
      */
-    public static styles: StyleList = {
-      'mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c]': {
-        'stroke-width': 3
-      }
-    };
+    public static addStyles<JX extends SVG<any, any, any>>(styles: CssStyles, jax: JX) {
+      styles.addStyles({
+        'mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c]': {
+          'stroke-width': jax.options.blacker
+        }
+      });
+    }
 
     /**
      * @override


### PR DESCRIPTION
This PR provides a configuration option that controls the stroke-width used for characters in SVG output.  This allows the author to adjust the thickness to better match he surrounding font, if needed.  The current default is 3, but I prefer values more like 10 or even 15 on MacOS.  But the AMS would like to use 0.

This is accomplished by providing a per-wrapper function that adds the wrapper-specific CSS so that it can use the output jax options to control the styles.

Resolves isses mathjax/MathJax#2859.