### PR TITLE
Don't typeset within <select> or <option> nodes. (mathjax/MathJax#3006)

### DIFF
--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -48,7 +48,8 @@ export class HTMLDomStrings<N, T, D> {
    * The default options for string processing
    */
   public static OPTIONS: OptionList = {
-    skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'annotation', 'annotation-xml'],
+    skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code',
+                   'annotation', 'annotation-xml', 'select', 'option'],
                                         // The names of the tags whose contents will not be
                                         // scanned for math delimiters
 

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -49,7 +49,8 @@ export class HTMLDomStrings<N, T, D> {
    */
   public static OPTIONS: OptionList = {
     skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code',
-                   'annotation', 'annotation-xml', 'select', 'option'],
+                   'annotation', 'annotation-xml', 'select', 'option',
+                   'mjx-container'],
                                         // The names of the tags whose contents will not be
                                         // scanned for math delimiters
 


### PR DESCRIPTION
This PR adds `<select>` and `<option>` tags to the `skipHtmlTag` list, since the contents of `<option>` is text-only, and shouldn't be modified by MathJax.

Resolves issue mathjax/MathJax#3006.