### PR TITLE
Allow separate formatting for \eqref{}.  (mathjax/MathJax#2736)

### DIFF
--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -145,6 +145,13 @@ export interface Tags {
   formatTag(tag: string): string;
 
   /**
+   * How to format references to tags.
+   * @param {string} tag The tag string.
+   * @return {string} The formatted numbered tag.
+   */
+  formatRef(tag: string): string;
+
+  /**
    * How to format URLs for references.
    * @param {string} id The reference id.
    * @param {string} base The base URL in the reference.
@@ -372,6 +379,13 @@ export class AbstractTags implements Tags {
    */
   public formatTag(tag: string) {
     return '(' + tag + ')';
+  }
+
+  /**
+   * @override
+   */
+  public formatRef(tag: string) {
+    return this.formatTag(tag);
   }
 
   /**

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1567,7 +1567,7 @@ BaseMethods.HandleRef = function(parser: TexParser, name: string, eqref: boolean
   let tag = ref.tag;
   if (eqref) {
     // @test Eqref
-    tag = parser.tags.formatTag(tag);
+    tag = parser.tags.formatRef(tag);
   }
   let node = parser.create('node', 'mrow', ParseUtil.internalMath(parser, tag), {
     href: parser.tags.formatUrl(ref.id, parser.options.baseURL), 'class': 'MathJax_ref'

--- a/ts/input/tex/tagformat/TagFormatConfiguration.ts
+++ b/ts/input/tex/tagformat/TagFormatConfiguration.ts
@@ -80,6 +80,14 @@ export function tagformatConfig(config: ParserConfiguration, jax: TeX<any, any, 
     /**
      * @override
      */
+    public formatRef(tag: string) {
+      const ref = jax.parseOptions.options.tagformat.ref;
+      return (ref ? ref(tag) : this.formatTag(tag));
+    }
+
+    /**
+     * @override
+     */
     public formatId(id: string) {
       return jax.parseOptions.options.tagformat.id(id);
     }
@@ -116,6 +124,7 @@ export const TagFormatConfiguration = Configuration.create(
       tagformat: {
         number: (n: number) => n.toString(),
         tag:    (tag: string) => '(' + tag + ')',
+        ref:    '',      // means use the tag function
         id:     (id: string) => 'mjx-eqn:' + id.replace(/\s/g, '_'),
         url:    (id: string, base: string) => base + '#' + encodeURIComponent(id),
       }


### PR DESCRIPTION
This adds a separate function for formatting the output for `\eqref`.  The default is to use the `formatTag()` function unless that is overridden with the `ref option in the `tagformat` configuration block.

Resolves issue mathjax/MathJax#2736.