### PR TITLE
Better checking of improperly nested AMS environments. (mathjax/MathJax#1892)

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -535,12 +535,18 @@ namespace ParseUtil {
   /**
    *  Check for bad nesting of equation environments
    */
-  export function checkEqnEnv(parser: TexParser) {
-    if (parser.stack.global.eqnenv) {
-      // @test ErroneousNestingEq
+  export function checkEqnEnv(parser: TexParser, nestable: boolean = true) {
+    const top = parser.stack.Top();
+    const first = top.First;
+    //
+    // The gather environment can include align and others, but only one level deep.
+    //
+    if (top.getProperty('nestable') && nestable && !first) {
+      return;
+    }
+    if (!top.isKind('start') || first) {
       throw new TexError('ErroneousNestingEq', 'Erroneous nesting of equation structures');
     }
-    parser.stack.global.eqnenv = true;
   }
 
   /**

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -115,8 +115,8 @@ AmsMethods.AlignAt = function(parser: TexParser, begin: StackItem,
  */
 AmsMethods.Multline = function (parser: TexParser, begin: StackItem, numbered: boolean) {
   // @test Shove*, Multline
-  parser.Push(begin);
   ParseUtil.checkEqnEnv(parser);
+  parser.Push(begin);
   const item = parser.itemFactory.create('multline', numbered, parser.stack) as ArrayItem;
   item.arraydef = {
     displaystyle: true,
@@ -170,8 +170,8 @@ AmsMethods.XalignAt = function(parser: TexParser, begin: StackItem,
 AmsMethods.FlalignArray = function(parser: TexParser, begin: StackItem, numbered: boolean,
                                   padded: boolean, center: boolean, align: string,
                                   width: string, zeroWidthLabel: boolean = false) {
-  parser.Push(begin);
   ParseUtil.checkEqnEnv(parser);
+  parser.Push(begin);
   align = align
     .split('')
     .join(' ')

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1468,8 +1468,8 @@ BaseMethods.AlignedArray = function(parser: TexParser, begin: StackItem) {
  * @param {boolean} numbered True if environment is numbered.
  */
 BaseMethods.Equation = function (parser: TexParser, begin: StackItem, numbered: boolean) {
-  parser.Push(begin);
   ParseUtil.checkEqnEnv(parser);
+  parser.Push(begin);
   return parser.itemFactory.create('equation', numbered).
     setProperty('name', begin.getName());
 };
@@ -1488,13 +1488,15 @@ BaseMethods.EqnArray = function(parser: TexParser, begin: StackItem,
                                 numbered: boolean, taggable: boolean,
                                 align: string, spacing: string) {
   // @test The Lorenz Equations, Maxwell's Equations, Cubic Binomial
-  parser.Push(begin);
+  let name = begin.getName();
+  let isGather = (name === 'gather' || name === 'gather*');
   if (taggable) {
-    ParseUtil.checkEqnEnv(parser);
+    ParseUtil.checkEqnEnv(parser, !isGather);
   }
+  parser.Push(begin);
   align = align.replace(/[^clr]/g, '').split('').join(' ');
   align = align.replace(/l/g, 'left').replace(/r/g, 'right').replace(/c/g, 'center');
-  let newItem = parser.itemFactory.create('eqnarray', begin.getName(),
+  let newItem = parser.itemFactory.create('eqnarray', name,
                                           numbered, taggable, parser.stack.global) as sitem.ArrayItem;
   newItem.arraydef = {
     displaystyle: true,
@@ -1504,6 +1506,9 @@ BaseMethods.EqnArray = function(parser: TexParser, begin: StackItem,
     side: parser.options['tagSide'],
     minlabelspacing: parser.options['tagIndent']
   };
+  if (isGather) {
+    newItem.setProperty('nestable', true);
+  }
   return newItem;
 };
 

--- a/ts/input/tex/empheq/EmpheqConfiguration.ts
+++ b/ts/input/tex/empheq/EmpheqConfiguration.ts
@@ -77,12 +77,12 @@ export const EmpheqMethods = {
       parser.Push(parser.itemFactory.create('end').setProperty('name', 'empheq'));
     } else {
       ParseUtil.checkEqnEnv(parser);
-      delete parser.stack.global.eqnenv;
       const opts = parser.GetBrackets('\\begin{' + begin.getName() + '}') || '';
       const [env, n] = (parser.GetArgument('\\begin{' + begin.getName() + '}') || '').split(/=/);
       if (!EmpheqUtil.checkEnv(env)) {
         throw new TexError('UnknownEnv', 'Unknown environment "%1"', env);
       }
+      begin.setProperty('nestable', true);
       if (opts) {
         begin.setProperties(EmpheqUtil.splitOptions(opts, {left: 1, right: 1}));
       }

--- a/ts/input/tex/mathtools/MathtoolsMethods.ts
+++ b/ts/input/tex/mathtools/MathtoolsMethods.ts
@@ -184,6 +184,7 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
       //
       const spread = parser.GetDimen(`\\begin{${begin.getName()}}`);
       begin.setProperty('spread', spread);
+      begin.setProperty('nestable', true);
       parser.Push(begin);
     }
   },


### PR DESCRIPTION
This PR redoes the check for improperly nested AMS environments, which currently allows them to be used in situations where they are not allowed in LaTeX (e.g., there is no error if they are not a top-level environments, so `align` can be used inside an array, for example, where it shouldn't be allowed).  So we introduce a test for being at the top level (the task top must be a `start` item with no stored nodes).

On the other hand, `gather` should allow nested `align` and other environments (but not another `gather`), so we use a `nestable` property and ad an extra parameter to tell if the current environment is a second `gather`.

All of this makes the `eqnenv` global property no longer necessary.

Resolves issue mathjax/MathJax#1892.