### PR TITLE
Use left alignment and no indent for forced inline breaks when inline breaking is off. (mathjax/MathJax#3005)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1027,6 +1027,9 @@ export class CommonWrapper<
     shift: string = '',
     width: number = this.metrics.containerWidth
   ): [string, number] {
+    if (!this.jax.math.display) {
+      return ['left', 0];
+    }
     if (!align || align === 'auto') {
       align = this.jax.math.outputData.inlineMarked ? 'left' : this.jax.options.displayAlign;
     }


### PR DESCRIPTION
When automatic inline breaking is turned off, a forced line break in an inline expression ends up using the `displayAlign` and `displayIndent` values rather than being left aligned and unindented.  This PR forces left alignment and 0 indent in that case.

Resolves one issue from mathjax/MathJax#3005.