### PR TITLE
Fix several issues with inline breaks. (mathjax/MathJax#3005)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -234,8 +234,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    * @override
    */
   public hasSpacingAttributes() {
-    return this.attributes.isSet('lspace') ||
-      this.attributes.isSet('rspace');
+    return this.attributes.isSet('lspace') || this.attributes.isSet('rspace');
   }
 
   /**
@@ -272,8 +271,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    */
   public setTeXclass(prev: MmlNode): MmlNode {
     let {form, fence} = this.attributes.getList('form', 'fence') as {form: string, fence: string};
-    if (this.getProperty('texClass') === undefined &&
-        (this.attributes.isSet('lspace') || this.attributes.isSet('rspace'))) {
+    if (this.getProperty('texClass') === undefined && this.hasSpacingAttributes()) {
       return null;
     }
     if (fence && this.texClass === TEXCLASS.REL) {

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -281,9 +281,9 @@ CommonWrapper<
       const [dimen, name, margin, i] = data as [number, string, string, number];
       if (dimen) {
         const space = this.em(dimen);
-        if (breakable) {
+        if (breakable && name === 'space') {
           const node = adaptor.node('mjx-break', SPACE[space] ? {size: SPACE[space]} :
-                                    {style: {'font-size': (dimen * 400).toFixed(1) + '%'}});
+                                    {style: `letter-spacing: ${this.em(dimen - 1)}`});
           adaptor.insert(node, this.dom[i]);
         } else {
           if (SPACE[space]) {
@@ -292,8 +292,6 @@ CommonWrapper<
             adaptor.setStyle(this.dom[i], margin, space);
           }
         }
-      } else if (breakable && name == 'space') {
-        adaptor.insert(adaptor.node('mjx-break', {style: {'font-size': 0}}), this.dom[i]);
       }
     }
   }

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -125,29 +125,28 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
         'justify-content': 'right'
       },
       //
-      //  For inline breakpoints, use a scaled space and make it breakable
-      //    (The space is .25em, so make everything 4 times the usual.
-      //     This will need to be adjusted when we do other fonts: we will
-      //     need one where the space is 1em)
+      //  For inline breakpoints, use a space that is 1em width, make it breakable,
+      //    and then set the letter-spacing to make the sace the proper size.
       //
-      'mjx-break::after': {
+      'mjx-container[jax="CHTML"] mjx-break::after': {
         content: '" "',
-        'white-space': 'normal'
+        'white-space': 'normal',
+        'font-family': 'MJX-BRK'
       },
       'mjx-break[size="1"]': {
-        'font-size': '44.4%'
+        'letter-spacing': (.111 - 1) + 'em'
       },
       'mjx-break[size="2"]': {
-        'font-size': '66.8%'
+        'letter-spacing': (.167 - 1) + 'em'
       },
       'mjx-break[size="3"]': {
-        'font-size': '88.8%'
+        'letter-spacing': (.222 - 1) + 'em'
       },
       'mjx-break[size="4"]': {
-        'font-size': '111.2%'
+        'letter-spacing': (.278 - 1) + 'em'
       },
       'mjx-break[size="5"]': {
-        'font-size': '133.2%'
+        'letter-spacing': (.333 - 1) + 'em'
       },
       'mjx-math[breakable]': {
         display: 'inline'
@@ -231,7 +230,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
     protected handleAttributes() {
       super.handleAttributes();
       const adaptor = this.adaptor;
-      if (this.node.getProperty('breakable')) {
+      if (this.node.getProperty('process-breaks')) {
         this.dom.forEach(dom => adaptor.setAttribute(dom, 'breakable', 'true'));
       }
     }

--- a/ts/output/chtml/Wrappers/mrow.ts
+++ b/ts/output/chtml/Wrappers/mrow.ts
@@ -100,15 +100,27 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
         display: 'inline-table',
         width: '100%'
       },
-      'mjx-linestack[data-mjx-breakable]': {
-        display: 'inline',
-        width: 'initial',
-      },
-      'mjx-linestack[data-mjx-breakable] > mjx-linebox': {
+      'mjx-linestack[breakable]': {
         display: 'inline'
       },
-      'mjx-break[newline]::after': {
-        display: 'block'
+      'mjx-linestack[breakable] > mjx-linebox': {
+        display: 'inline'
+      },
+      'mjx-linestack[breakable] > mjx-linebox::before': {
+        'white-space': 'pre',
+        content: '"\\A"'
+      },
+      'mjx-linestack[breakable] > mjx-linebox::after': {
+        'white-space': 'normal',
+        content: '" "',
+        'letter-spacing': '-.999em',
+        'font-family': 'MJX-BRK'
+      },
+      'mjx-linestack[breakable] > mjx-linebox:first-of-type::before': {
+        display: 'none'
+      },
+      'mjx-linestack[breakable] > mjx-linebox:last-of-type::after': {
+        display: 'none'
       },
       'mjx-linebox': {
         display: 'block'
@@ -169,7 +181,9 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
           adaptor.setStyle(parents[i], 'position', 'relative');
           adaptor.setStyle(parents[i], 'left', this.em(shift));
         }
-        i < n && adaptor.setStyle(parents[i], 'margin-bottom', this.em(bbox.lineLeading));
+        if (i < n && this.jax.math.display) {
+          adaptor.setStyle(parents[i], 'margin-bottom', this.em(bbox.lineLeading));
+        }
       }
     }
 
@@ -199,6 +213,9 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       if (kind === 'mjx-mrow' && !this.isStack) {
         adaptor.setAttribute(this.dom[0], 'break-top', 'true');
       }
+      if (this.node.getProperty('process-breaks')) {
+        adaptor.setAttribute(this.dom[0], 'breakable', 'true');
+      }
       //
       // Add an href anchor, if needed, and insert the linestack/mrow
       //
@@ -207,12 +224,8 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       //  Add the line boxes
       //
       const chtml = Array(n) as N[];
-      const inlineBreaks = this.node.getProperty('breakable');
       for (let i = 0; i <= n; i++) {
         chtml[i] = adaptor.append(this.dom[0], this.html('mjx-linebox', {'lineno': i})) as N;
-        if (inlineBreaks) {
-          adaptor.append(this.dom[0], this.html('mjx-break', {newline: true}));
-        }
       }
       //
       //  Return the line boxes as the parent nodes for their contents

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -215,8 +215,8 @@ CommonOutputJax<
   }
 
   /**
-   * @param {WW} wrapper   The MML node wrapper whose SVG is to be produced
-   * @param {N} parent     The HTML node to contain the SVG
+   * @param {SvgWrapper<N, T, D>} wrapper   The MML node wrapper whose SVG is to be produced
+   * @param {N} parent                      The HTML node to contain the SVG
    */
   public processMath(wrapper: SvgWrapper<N, T, D>, parent: N) {
     //
@@ -344,8 +344,9 @@ CommonOutputJax<
   }
 
   /**
-   * @param {N} svg    The SVG node that is breaking
-   * @param {N} g      The group in which the math is typeset
+   * @param {SvgWrapper<N,T,D>} wrapper   The MML node wrapper whose SVG gets inline breaks
+   * @param {N} svg                       The SVG node that is breaking
+   * @param {N} g                         The group in which the math is typeset
    */
   protected handleInlineBreaks(wrapper: SvgWrapper<N, T, D>, svg: N, g: N) {
     const n = wrapper.childNodes[0].breakCount;
@@ -379,19 +380,17 @@ CommonOutputJax<
       //
       const [mml, mo] = wrapper.childNodes[0].getBreakNode(line);
       const forced = !!(mo && mo.node.getProperty('forcebreak'));
-      if (i || forced) {
+      if (forced && mo.node.attributes.get('linebreakstyle') === 'after') {
+        const k = mml.parent.node.childIndex(mml.node) + 1;
+        const next = mml.parent.childNodes[k+1];
+        const dimen = (next ? next.getLineBBox(0).originalL : 0);
+        if (dimen) {
+          this.addInlineBreak(nsvg, dimen, forced);
+        }
+      } else if (forced || i) {
         const dimen = (mml && !newline ? mml.getLineBBox(0).originalL : 0);
         if (dimen || !forced) {
-          const space = LENGTHS.em(dimen);
-          adaptor.insert(
-            adaptor.node(
-              'mjx-break',
-              !forced ? {newline: true} :
-              SPACE[space] ? {size: SPACE[space]} :
-              {style: {'font-size': dimen.toFixed(1) + '%'}}
-            ),
-            nsvg
-          );
+          this.addInlineBreak(nsvg, dimen, forced);
         }
       }
       //
@@ -406,6 +405,27 @@ CommonOutputJax<
       adaptor.append(adaptor.firstChild(adaptor.parent(svg)) as N, adaptor.firstChild(svg));
     }
     adaptor.remove(svg);
+  }
+
+  /**
+   * @param {N} nsvg           The svg where the break is to be added
+   * @param {number} dimen     The size of the break
+   * @param {boolean} forced   Whether the break is forced or not
+   */
+  protected addInlineBreak(nsvg: N, dimen: number, forced: boolean) {
+    const adaptor = this.adaptor;
+    const space = LENGTHS.em(dimen);
+    if (!forced) {
+      adaptor.insert(adaptor.node('mjx-break', {prebreak: true}), nsvg);
+    }
+    adaptor.insert(
+      adaptor.node(
+        'mjx-break',
+        !forced ? {newline: true} :
+        SPACE[space] ? {size: SPACE[space]} : {style: `letter-spacing: ${LENGTHS.em(1 - dimen)}`}
+      ),
+      nsvg
+    );
   }
 
   /**

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -382,7 +382,7 @@ CommonOutputJax<
       const forced = !!(mo && mo.node.getProperty('forcebreak'));
       if (forced && mo.node.attributes.get('linebreakstyle') === 'after') {
         const k = mml.parent.node.childIndex(mml.node) + 1;
-        const next = mml.parent.childNodes[k+1];
+        const next = mml.parent.childNodes[k + 1];
         const dimen = (next ? next.getLineBBox(0).originalL : 0);
         if (dimen) {
           this.addInlineBreak(nsvg, dimen, forced);

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -108,35 +108,39 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
         'justify-content': 'right'
       },
       //
-      //  For inline breakpoints, use a scaled space and make it breakable
-      //    (The space is .25em, so make everything 4 times the usual.
-      //     This will need to be adjusted when we do other fonts: we will
-      //     need one where the space is 1em)
+      //  For inline breakpoints, use a space that is 1em width, make it breakable,
+      //    and then set the letter-spacing to make the sace the proper size.
       //
-      'mjx-break::after': {
+      'mjx-container[jax="SVG"] mjx-break::after': {
         content: '" "',
         'white-space': 'normal',
-      },
-      'mjx-break': {
+        'line-height': '0',
         'font-family': 'MJX-ZERO'
       },
       'mjx-break[size="1"]': {
-        'font-size': '11.1%'
+        'letter-spacing': (.111 - 1) + 'em'
       },
       'mjx-break[size="2"]': {
-        'font-size': '16.7%'
+        'letter-spacing': (.167 - 1) + 'em'
       },
       'mjx-break[size="3"]': {
-        'font-size': '22.2%'
+        'letter-spacing': (.222 - 1) + 'em'
       },
       'mjx-break[size="4"]': {
-        'font-size': '27.8%'
+        'letter-spacing': (.278 - 1) + 'em'
       },
       'mjx-break[size="5"]': {
-        'font-size': '33.3%'
+        'letter-spacing': (.333 - 1) + 'em'
       },
-      'mjx-break[newline]::after': {
-        display: 'block'
+      'mjx-container[jax="SVG"] mjx-break[newline]::before': {
+        'white-space': 'pre',
+        content: '"\\A"'
+      },
+      'mjx-break[newline] + svg[width="0.054ex"]': {
+        'margin-right': '-1px'
+      },
+      'mjx-break[prebreak]': {
+        'letter-spacing': '-.999em'
       },
       '@font-face /* zero */': {
         'font-family': 'MJX-ZERO',

--- a/ts/output/svg/Wrappers/mrow.ts
+++ b/ts/output/svg/Wrappers/mrow.ts
@@ -112,11 +112,12 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
      */
     protected placeLines(parents: N[]) {
       const lines = this.lineBBox;
+      const display = this.jax.math.display;
       let y = 0;
       for (const k of parents.keys()) {
         const lbox = lines[k];
         this.place(lbox.L || 0, y, parents[k]);
-        y -= Math.max(.25, lbox.d) + lbox.lineLeading + Math.max(.75, lines[k + 1]?.h || 0);
+        y -= Math.max(.25, lbox.d) + (display ? lbox.lineLeading : 0) + Math.max(.75, lines[k + 1]?.h || 0);
       }
     }
 


### PR DESCRIPTION
This PR fixes a number of problems with inline breaks in SVG and CHTML output.

* The old approach of using `font-size` to scale a 1em space to the proper size turns out not to work as well as hoped, since it runs into the minimum font size settings of most browsers.  Instead, we now use `letter-spacing` to adjust the size of the space without scaling.  The space is still 1em, so we are usually removing space from it.

* For CHTML output, the `mjx-linestack` and `mjx-linebox` nodes were not being set to `display: inline` as needed for inline breaks because the math node wasn't setting the `breakable` attribute on its children.  This was due to a change in the property name from `breakable` to `process-breaks` in an earlier PR that missed changing the name in the math wrapper, and also to the fact that some CSS was using `data-mjx-breakable` rather than just `breakable`.

* We now use CSS to process explicit breaks in CHTML using `::before` and `::after` selectors on the line boxes that are produced for explicit breaks rather than adding `mjx-break` elements for that.  (Note that the space character is 1em wide in the MJX-BRK font, so `letter-spacing: -.999em` makes it nearly 0 width, but still allowing a break to occur there.  It has to be non-zero width for that in some browsers.)

* The marking of breakpoints in `common.ts` has been modified to include `mspace` elements (moving common code to a helper function), to handle `linebreakstyle="after"` to be honored, and to allow breaks when `lspace` or `rspace` have been specified, none of which were handled before.  The `svg.ts` handling of breaks is modified in a similar way to accommodate the changes.

* Finally, the handling of the line spacing for inline breaks is improved.

Resolves issues from mathjax/MathJax#3005