### PR TITLE
Update CSS for assistive-mml. (mathjax/MathJax#2936)

### DIFF
--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -189,7 +189,9 @@ B extends MathDocumentConstructor<AbstractMathDocument<N, T, D>>>(
       'mjx-assistive-mml': {
         position: 'absolute !important',
         top: '0px', left: '0px',
+        bottom: '0px', right: '0px',
         clip: 'rect(1px, 1px, 1px, 1px)',
+        'clip-path': 'polygon(0 0, 0 1px, 1px 1px, 1px 0)',
         padding: '1px 0px 0px 0px !important',
         border: '0px !important',
         display: 'block !important',


### PR DESCRIPTION
This PR adjusts the CSS for the assistive MathML output so that it fits the space of the math expression exactly, as the current arrangement sometimes allows it to be larger than the MathJax output.  It also adds a `clip-path` since `clip` is deprecated.  Leaving the `clip` CSS allows for support of IE11 (though I'm not sure how much of MathJax still works in IE).