### PR TITLE
Implement \char and add \U for raw unicode characters.

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -251,7 +251,7 @@ namespace ParseUtil {
     let mathvariant = font || parser.stack.env.font;
     let def = (mathvariant ? {mathvariant} : {});
     let mml: MmlNode[] = [], i = 0, k = 0, c, node, match = '', braces = 0;
-    if (text.match(/\\?[${}\\]|\\\(|\\(eq)?ref\s*\{/)) {
+    if (text.match(/\\?[${}\\]|\\\(|\\(?:eq)?ref\s*\{|\\U/)) {
       while (i < text.length) {
         c = text.charAt(i++);
         if (c === '$') {
@@ -325,6 +325,15 @@ namespace ParseUtil {
               // @test Mbox CR
               i--;
               text = text.substr(0, i - 1) + text.substr(i); // remove \ from \$, \{, \}, or \\
+            } else if (c === 'U') {
+              const arg = text.substr(i).match(/^\s*(?:([0-9A-F])|\{\s*([0-9A-F]+)\s*\})/);
+              if (!arg) {
+                throw new TexError('BadRawUnicode',
+                                   'Argument to %1 must a hexadecimal number with 1 to 6 digits', '\\U');
+              }
+              //  Replace \U{...} with specified character
+              const c = String.fromCodePoint(parseInt(arg[1] || arg[2], 16));
+              text = text.substr(0, i - 2) + c + text.substr(i + arg[0].length);
             }
           }
         }

--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -157,7 +157,7 @@ export const AutoloadConfiguration = Configuration.create(
         html: ['data', 'href', 'class', 'style', 'cssId'],
         mhchem: ['ce', 'pu'],
         newcommand: ['newcommand', 'renewcommand', 'newenvironment', 'renewenvironment', 'def', 'let'],
-        unicode: ['unicode'],
+        unicode: ['unicode', 'U', 'char'],
         verb: ['verb']
       })
     },

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -41,6 +41,7 @@ import {em} from '../../../util/lengths.js';
 import {entities} from '../../../util/Entities.js';
 import {lookup} from '../../../util/Options.js';
 import {ColumnState} from '../ColumnParser.js';
+import {replaceUnicode} from '../../../util/string.js';
 
 
 // Namespace
@@ -859,7 +860,7 @@ BaseMethods.MmlToken = function(parser: TexParser, name: string) {
   if (keep.length) {
     def['mjx-keep-attrs'] = keep.join(' ');
   }
-  const textNode = parser.create('text', text);
+  const textNode = parser.create('text', replaceUnicode(text));
   node.appendChild(textNode);
   NodeUtil.setProperties(node, def);
   parser.Push(node);

--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -146,6 +146,8 @@ new CommandMap('text-macros', {
   data:         'CheckAutoload',
   cssId:        'CheckAutoload',
   unicode:      'CheckAutoload',
+  U:            'CheckAutoload',
+  char:         'CheckAutoload',
 
   ref:          ['HandleRef', false],
   eqref:        ['HandleRef', true],

--- a/ts/util/string.ts
+++ b/ts/util/string.ts
@@ -82,3 +82,14 @@ export function isPercent(x: string): boolean {
 export function split(x: string): string[] {
   return x.trim().split(/\s+/);
 }
+
+/**
+ * Replace \U{...} with the specified unicode character
+ *
+ * @param {srting} text   The string to be scanned for \U{...}
+ * @return {string}       The string with the unicode characters in place of \U{...}
+ */
+export function replaceUnicode(text: string): string {
+  return text.replace(/((?:^|[^\\])(?:\\\\)*)\\U\s*(?:([0-9A-F])|\{\s*([0-9A-F]{1,6})\s*\})/g,
+                      (_m, pre, h1, h2) => pre + String.fromCodePoint(parseInt(h1 || h2, 16)));
+}


### PR DESCRIPTION
This PR implements a version of the low-level `\char` command for inserting characters by number (decimal, octal, or hex) or by character (e.g., `\char'\%` or `\char'A`).  In actual TeX, these are font positions in TeX fonts, and are limited to 0 to 127, but here, they are Unicode code points, and can be 1 to 6 hex digits.  So `\char"222B` is the integral sign, for example.  These are mapped to MathML nodes using the `Other()` function from the base methods (so uses the `RANGES` list from the operator dictionary to determine the node type to use).

We also add a `\U` macro for inserting a character into the TeX input string by Unicode hex code point.  So `\U{222B}` is the integral sign.  This is different from `\unicode{x222B}` as the latter always produces an `mtext` node, while the former will be treated as though the unicode character was part of the original TeX string (and `\char"222B` will place the integral sign in an `mo` element without further processing).

Another example of the difference is that `\unicode{x25}` produces `<mtext>%</mtext>`, `\char"25` will produce `<mo>%</mo>`, and `\U{25}` will produce a percent that comments out the rest of the line.

These new macros are available in text mode when `textmacros` is loaded; `\U` is available in text mode without `textmacros`, and in the contents of the second argument to `\mmlToken{}{...}`.  That is, `\mmlToken{mo}{\U{222B}}` would produce `<mo>&#x222B;</mo>`.