### PR TITLE
Add requested macros and environments now that we can support them.

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -176,8 +176,8 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    */
   public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode {
     this.parseOptions.clear();
+    this.parseOptions.mathItem = math;
     this.executeFilters(this.preFilters, math, document, this.parseOptions);
-    let display = math.display;
     this.latex = math.math;
     let node: MmlNode;
     this.parseOptions.tags.startEquation(math);
@@ -185,7 +185,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     let parser;
     try {
       parser = new TexParser(this.latex,
-                             {display: display, isInner: false},
+                             {display: math.display, isInner: false},
                              this.parseOptions);
       node = parser.mml();
       globalEnv = parser.stack.global;
@@ -200,7 +200,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     if (globalEnv?.indentalign) {
       NodeUtil.setAttribute(node, 'indentalign', globalEnv.indentalign);
     }
-    if (display) {
+    if (math.display) {
       NodeUtil.setAttribute(node, 'display', 'block');
     }
     this.parseOptions.tags.finishEquation(math);

--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -28,6 +28,7 @@ import {SubHandlers} from './MapHandler.js';
 import {NodeFactory} from './NodeFactory.js';
 import NodeUtil from './NodeUtil.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {MathItem} from '../../core/MathItem.js';
 import TexParser from './TexParser.js';
 import {defaultOptions, OptionList} from '../../util/Options.js';
 import {ParserConfiguration} from './Configuration.js';
@@ -89,6 +90,10 @@ export default class ParseOptions {
    */
   public parsers: TexParser[] = [];
 
+  /**
+   * The current MathItem
+   */
+  public mathItem: MathItem<any, any, any>;
 
   /**
    * The current root node.

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -116,6 +116,7 @@ new sm.CharacterMap('mathchar0mi', ParseMethods.mathchar0mi, {
   varphi:       '\u03C6',
 
   // Ord symbols
+  AA:            '\u212B',
   S:            ['\u00A7', {mathvariant: VARIANT.NORMAL}],
   aleph:        ['\u2135', {mathvariant: VARIANT.NORMAL}],
   hbar:         ['\u210F', {variantForm: true}],
@@ -134,7 +135,7 @@ new sm.CharacterMap('mathchar0mi', ParseMethods.mathchar0mi, {
   bot:          ['\u22A5', {mathvariant: VARIANT.NORMAL}],
   angle:        ['\u2220', {mathvariant: VARIANT.NORMAL}],
   triangle:     ['\u25B3', {mathvariant: VARIANT.NORMAL}],
-  backslash:    ['\u2216', {mathvariant: VARIANT.NORMAL}],
+  backslash:    ['\\', {mathvariant: VARIANT.NORMAL}],
   forall:       ['\u2200', {mathvariant: VARIANT.NORMAL}],
   exists:       ['\u2203', {mathvariant: VARIANT.NORMAL}],
   neg:          ['\u00AC', {mathvariant: VARIANT.NORMAL}],
@@ -156,36 +157,26 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   surd:         '\u221A',
 
   // big ops
-  coprod:       ['\u2210', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigvee:       ['\u22C1', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigwedge:     ['\u22C0', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  biguplus:     ['\u2A04', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigcap:       ['\u22C2', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigcup:       ['\u22C3', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  'int':        ['\u222B', {texClass: TEXCLASS.OP}],
-  intop:        ['\u222B', {texClass: TEXCLASS.OP,
-                            movesupsub: true, movablelimits: true}],
-  iint:         ['\u222C', {texClass: TEXCLASS.OP}],
-  iiint:        ['\u222D', {texClass: TEXCLASS.OP}],
-  prod:         ['\u220F', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  sum:          ['\u2211', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigotimes:    ['\u2A02', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigoplus:     ['\u2A01', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  bigodot:      ['\u2A00', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
-  oint:         ['\u222E', {texClass: TEXCLASS.OP}],
-  bigsqcup:     ['\u2A06', {texClass: TEXCLASS.OP,
-                            movesupsub: true}],
+  coprod:       ['\u2210', {movesupsub: true}],
+  bigvee:       ['\u22C1', {movesupsub: true}],
+  bigwedge:     ['\u22C0', {movesupsub: true}],
+  biguplus:     ['\u2A04', {movesupsub: true}],
+  bigcap:       ['\u22C2', {movesupsub: true}],
+  bigcup:       ['\u22C3', {movesupsub: true}],
+  'int':         '\u222B',
+  intop:        ['\u222B', {movesupsub: true, movablelimits: true}],
+  iint:          '\u222C',
+  iiint:         '\u222D',
+  prod:         ['\u220F', {movesupsub: true}],
+  sum:          ['\u2211', {movesupsub: true}],
+  bigotimes:    ['\u2A02', {movesupsub: true}],
+  bigoplus:     ['\u2A01', {movesupsub: true}],
+  bigodot:      ['\u2A00', {movesupsub: true}],
+  oint:          '\u222E',
+  ointop:       ['\u222E', {movesupsub: true, movablelimits: true}],
+  oiint:         '\u222F',
+  oiiint:        '\u2230',
+  bigsqcup:     ['\u2A06', {movesupsub: true}],
   smallint:     ['\u222B', {largeop: false}],
 
   // binary operations
@@ -307,6 +298,7 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   cdots:            '\u22EF',
   vdots:            '\u22EE',
   ddots:            '\u22F1',
+  iddots:           '\u22F0',
   dotsc:            '\u2026',  // dots with commas
   dotsb:            '\u22EF',  // dots with binary ops and relations
   dotsm:            '\u22EF',  // dots with multiplication
@@ -640,6 +632,8 @@ new sm.CommandMap('macros', {
   acute:             ['Accent', '00B4'],  // or 0301 or 02CA
   grave:             ['Accent', '0060'],  // or 0300 or 02CB
   ddot:              ['Accent', '00A8'],  // or 0308
+  dddot:             ['Accent', '20DB'],
+  ddddot:            ['Accent', '20DC'],
   tilde:             ['Accent', '007E'],  // or 0303 or 02DC
   bar:               ['Accent', '00AF'],  // or 0304 or 02C9
   breve:             ['Accent', '02D8'],  // or 0306
@@ -719,7 +713,10 @@ new sm.CommandMap('macros', {
  * Macros for LaTeX environments.
  */
 new sm.EnvironmentMap('environment', ParseMethods.environment, {
+  displaymath:   ['Equation', null, false],
+  math:          ['Equation', null, false, false],
   array:         ['AlignedArray'],
+  darray:        ['AlignedArray', null, 'D'],
   equation:      ['Equation', null, true],
   eqnarray:      ['EqnArray', null, true, true, 'rcl',
                   ParseUtil.cols(0, MATHSPACE.thickmathspace), '.5em'],

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1649,7 +1649,6 @@ BaseMethods.Equation = function (
   numbered: boolean,
   display: boolean = true
 ) {
-  ParseUtil.checkEqnEnv(parser);
   parser.configuration.mathItem.display = display;
   parser.stack.env.display = display;
   parser.Push(begin);
@@ -1800,4 +1799,3 @@ BaseMethods.MathChoice = function(parser: TexParser, name: string) {
 
 
 export default BaseMethods;
-

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1512,8 +1512,7 @@ BaseMethods.BeginEnd = function(parser: TexParser, name: string) {
   }
   ParseUtil.checkMaxMacros(parser, false);
   parser.parse('environment', [parser, env]);
-};
-
+ };
 
 /**
  * Handle array environment.
@@ -1581,11 +1580,12 @@ BaseMethods.Array = function(parser: TexParser, begin: StackItem,
  * Handle aligned arrays.
  * @param {TexParser} parser The calling parser.
  * @param {StackItem} begin The opening stackitem.
+ * @param {string=} style The display style to use
  */
-BaseMethods.AlignedArray = function(parser: TexParser, begin: StackItem) {
+BaseMethods.AlignedArray = function(parser: TexParser, begin: StackItem, style: string = '') {
   // @test Array1, Array2, Array Test
   const align = parser.GetBrackets('\\begin{' + begin.getName() + '}');
-  let item = BaseMethods.Array(parser, begin);
+  let item = BaseMethods.Array(parser, begin, null, null, null, null, null, style);
   return ParseUtil.setArrayAlign(item as sitem.ArrayItem, align);
 };
 
@@ -1641,8 +1641,17 @@ BaseMethods.IndentAlign = function (parser: TexParser, begin: StackItem) {
  * @param {TexParser} parser The calling parser.
  * @param {StackItem} begin The opening stackitem.
  * @param {boolean} numbered True if environment is numbered.
+ * @param {boolean=} display True if environment is a block display.
  */
-BaseMethods.Equation = function (parser: TexParser, begin: StackItem, numbered: boolean) {
+BaseMethods.Equation = function (
+  parser: TexParser,
+  begin: StackItem,
+  numbered: boolean,
+  display: boolean = true
+) {
+  ParseUtil.checkEqnEnv(parser);
+  parser.configuration.mathItem.display = display;
+  parser.stack.env.display = display;
   parser.Push(begin);
   ParseUtil.checkEqnEnv(parser);
   return parser.itemFactory.create('equation', numbered).
@@ -1791,3 +1800,4 @@ BaseMethods.MathChoice = function(parser: TexParser, name: string) {
 
 
 export default BaseMethods;
+


### PR DESCRIPTION
This PR adds a number of macros and environments that have been requested in the past, now that we have fonts that contain the needed characters.  These include `\AA`, `\iddots`, `\oiint` and `\oiiint`, plus I added `\dddot` and `\ddddot` accents, and the missing `\ointop`.  The `TEXCLASS.OP` has been removed from the big operators, since those will be inherited from the operator dictionary, so no need to waste the space on redundant values.  The unicode value for `\backslash` has been changed to just `\`. 

The new environments are `darray` for an array in display mode, and `math` and `displaymath`.  Since `\begin{xyz}...\end{xyz}` are parsed as math-mode delimiters, and these default to display mode, the `math` environment requires the ability to change the MathItem's `display` property to `false` for this environment.  That required adding the active MathItem to the ParseOptions instance so that the `math` environment could change it.  In turn, that means the TeX input jax can't cache the `display` value, since it can change during the parsing process.

Resolves:
* mathjax/MathJax#566
* mathjax/MathJax#795
* mathjax/MathJax#996
* mathjax/MathJax#1269
* mathjax/MathJax#1937
* mathjax/MathJax#2838
* mathjax/MathJax#2878