### PR TITLE
Prevent vertical bar from being stretchy unless used as a delimiter.

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -85,7 +85,7 @@ BaseMethods.Close = function(parser: TexParser, _c: string) {
  * @param {string} c The parsed character.
  */
 BaseMethods.Bar = function(parser: TexParser, c: string) {
-  parser.Push(parser.create('token', 'mo', {texClass: TEXCLASS.ORD}, c));
+  parser.Push(parser.create('token', 'mo', {stretchy: false, texClass: TEXCLASS.ORD}, c));
 }
 
 


### PR DESCRIPTION
This PR makes `|` non-stretchy when not used as a delimiter, restoring its behavior from before #907, which implemented the `Bar` method for it.