### PR TITLE
Fix potential crash with linebreaks.  (mathjax/MathJax#3015)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -591,7 +591,8 @@ export class CommonWrapper<
           line.R = this.getBBox().R;
         }
       } else {
-        this.lineBBox[i] = LineBBox.from(this.getOuterBBox(), this.linebreakOptions.lineleading);
+        const obox = this.getOuterBBox();
+        this.lineBBox[i] = LineBBox.from(obox, this.linebreakOptions.lineleading);
       }
     }
     return this.lineBBox[i];
@@ -722,7 +723,7 @@ export class CommonWrapper<
    * @param {boolean} bubble   True to invalidate parent BBoxes
    */
   public invalidateBBox(bubble: boolean = true) {
-    if (this.bboxComputed) {
+    if (this.bboxComputed || this._breakCount >= 0) {
       this.bboxComputed = false;
       this.lineBBox = [];
       this._breakCount = -1;


### PR DESCRIPTION
This PR fixes an issue that can cause a crash during line-breaking when a fraction or square root needs to be broken and it is inside an `mstyle` element that is also broken.  For example

``` xml
<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
  <mstyle>
    <mtext>aaaaaa</mtext>
    <mo>+</mo>
    <msqrt>
      <mi>x</mi>
      <mo>+</mo>
      <mi>y</mi>
      <mo>+</mo>
      <mi>z</mi>
      <mo>+</mo>
      <mi>z</mi>
      <mo>+</mo>
      <mi>z</mi>
      <mo>+</mo>
      <mi>z</mi>
    </msqrt>
  </mstyle>
</math>
```

when the container is smaller than the width of the square root.

The change at 594 prevents `this.lineBBox[i]` from being undefined, which it seems to be when the `getOuterBBox()` call is in the `LineBBox.from()` for some reason.  I could not figure out why.  It happened for the outermost `math` element with the example above, and adding `console.log(this.lineBBox[i])` right after the original line 594 would output `undefined`.  but breaking it into two lines works.  It is a mystery.

Resolves issue mathjax/MathJax#3015.