### PR TITLE
Allow space for labels when deciding on a table's width for line breaking its columns.

### DIFF
--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -899,9 +899,10 @@ export function CommonMtableMixin<
      * @override
      */
     public adjustWideTable() {
-      if (this.node.attributes.get('width') !== 'auto') return;
-      const sep = this.length2em(this.node.attributes.get('minlabelspacing'));
-      const W = this.containerWidth - this.getTableData().L - sep;
+      const attributes = this.node.attributes;
+      if (attributes.get('width') !== 'auto') return;
+      const [pad, align] = this.getPadAlignShift(attributes.get('side') as string);
+      const W = Math.max(this.containerWidth / 10, this.containerWidth - pad - (align === 'center' ? pad : 0));
       this.naturalWidth() > W && this.adjustColumnWidths(W);
     }
 


### PR DESCRIPTION
This PR takes the label and padding properly into account for deciding the width for a table when determining column break widths.  In particular, it does the right thing for centered tables.