### PR TITLE
Don't treat \overrightarrow as a mathaccent.  (mathjax/MathJax#3010)

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -675,6 +675,7 @@ BaseMethods.Accent = function(parser: TexParser, name: string, accent: string, s
 BaseMethods.UnderOver = function(parser: TexParser, name: string, c: string, stack: boolean) {
   const entity = NodeUtil.createEntity(c);
   const mo = parser.create('token', 'mo', {stretchy: true, accent: true}, entity);
+  mo.setProperty('mathaccent', false);
   const pos = (name.charAt(1) === 'o' ? 'over' : 'under');
   const base = parser.ParseArg(name);
   parser.Push(ParseUtil.underOver(parser, base, mo, pos, stack));


### PR DESCRIPTION
This PR prevents `\overrightarrow` and similar macros from treating the stretchy character as a math accent (which doesn't contribute to the width even if it extends beyond the base).  The arrow should count in the width when the base is smaller than the arrow.

Resolves issue mathjax/MathJax#3010.