### PR TITLE
Handle mrow with class INNER as a unit.  (mathjax/MathJax#3018)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mrow.ts
+++ b/ts/core/MmlTree/MmlNodes/mrow.ts
@@ -152,7 +152,7 @@ export class MmlMrow extends AbstractMmlNode {
   /**
    * @override
    */
-  public setTeXclass(prev: MmlNode) {
+  public setTeXclass(prev: MmlNode): MmlNode {
     if (this.getProperty('open') != null || this.getProperty('close') != null) {
       //
       // <mrow> looks like it came from \left...\right
@@ -169,6 +169,7 @@ export class MmlMrow extends AbstractMmlNode {
       if (this.texClass == null) {
         this.texClass = TEXCLASS.INNER;
       }
+      return this;
     } else {
       //
       //  Normal <mrow>, so treat as though mrow is not there

--- a/ts/core/MmlTree/MmlNodes/mrow.ts
+++ b/ts/core/MmlTree/MmlNodes/mrow.ts
@@ -170,16 +170,15 @@ export class MmlMrow extends AbstractMmlNode {
         this.texClass = TEXCLASS.INNER;
       }
       return this;
-    } else {
-      //
-      //  Normal <mrow>, so treat as though mrow is not there
-      //
-      for (const child of this.childNodes) {
-        prev = child.setTeXclass(prev);
-      }
-      if (this.childNodes[0]) {
-        this.updateTeXclass(this.childNodes[0]);
-      }
+    }
+    //
+    //  Normal <mrow>, so treat as though mrow is not there
+    //
+    for (const child of this.childNodes) {
+      prev = child.setTeXclass(prev);
+    }
+    if (this.childNodes[0]) {
+      this.updateTeXclass(this.childNodes[0]);
     }
     return prev;
   }


### PR DESCRIPTION
This PR fixes a problem where an `mrow` that comes from `\left...\right` isn't treated as TeX class `INNER` by the item that follows it.  The fix is to return the `mrow` itself (not the last child of the `mrow`) in the `setTeXclass()` method.

For example, the spacing is wrong for `a\left(b\right)c` without this PR.

Resolves issue mathjax/MathJax#3018