### PR TITLE
Add nulldelimiterspace for null delimiters.  (mathjax/MathJax#985)

### DIFF
--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -315,7 +315,8 @@ export function CommonMoMixin<
       //
       if (bbox.w === 0 && this.node.attributes.getExplicit('fence') &&
           (this.node as MmlMo).getText() === '' &&
-          (this.node.texClass === TEXCLASS.OPEN || this.node.texClass === TEXCLASS.CLOSE)) {
+          (this.node.texClass === TEXCLASS.OPEN || this.node.texClass === TEXCLASS.CLOSE) &&
+          !this.jax.options.mathmlSpacing) {
         bbox.R = this.font.params.nulldelimiterspace;
       }
       this.copySkewIC(bbox);

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -25,7 +25,7 @@ import {CommonWrapper, CommonWrapperClass, CommonWrapperConstructor} from '../Wr
 import {CommonWrapperFactory} from '../WrapperFactory.js';
 import {CharOptions, VariantData, DelimiterData, FontData, FontDataClass} from '../FontData.js';
 import {CommonOutputJax} from '../../common.js';
-import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
+import {MmlNode, TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 import {BBox} from '../../../util/BBox.js';
 import {LineBBox} from '../LineBBox.js';
@@ -310,6 +310,14 @@ export function CommonMoMixin<
       }
       if (stretchy && this.size < 0) return;
       super.computeBBox(bbox);
+      //
+      //  Check for a null delimiter and add the null-delimiter space
+      //
+      if (bbox.w === 0 && this.node.attributes.getExplicit('fence') &&
+          (this.node as MmlMo).getText() === '' &&
+          (this.node.texClass === TEXCLASS.OPEN || this.node.texClass === TEXCLASS.CLOSE)) {
+        bbox.R = this.font.params.nulldelimiterspace;
+      }
       this.copySkewIC(bbox);
     }
 


### PR DESCRIPTION
This PR causes null delimiters to get the font's `nulldelimiterspace` that TeX specifies should be used in place of the null delimiter.  We identify a null delimiter as one whose width is 0 (easy first check that will rule out most delimiters), whose text is blank, show TeX class is OPEN or CLOSE, and that has an explicit `fence` attribute (which will have come from the `\left..\right` processing).  We add the extra `nulldelimiterspace` to the box on the right.

Resolves issue mathjax/MathJax#985