### PR TITLE
Properly handle arrays with dashed frame borders. (mathjax/MathJax#2972)

### DIFF
--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -43,8 +43,8 @@ export type ColumnState = {
   cwidth: string[];                     // the explicit column widths
   cspace: string[];                     // the column spacing
   clines: string[];                     // the column lines
-  cstart: string[];                     // the '>' declarations (not currently used)
-  cend:   string[];                     // the '<' declarations (not currently used)
+  cstart: string[];                     // the '>' declarations
+  cend:   string[];                     // the '<' declarations
   cextra: boolean[];                    // the extra columns from '@' and '!' declarations
   ralign: [number, string, string][];   // the row alignment and column width/align when specified
 }
@@ -206,11 +206,10 @@ export class ColumnParser {
    */
   protected setPadding(state: ColumnState, array: ArrayItem) {
     if (!state.cextra[0] && !state.cextra[state.calign.length - 1]) return;
+    const i = state.calign.length - 1;
     const cspace = state.cspace;
-    array.arraydef['data-array-padding'] = [
-      cspace[0] || '.5em',
-      cspace[state.calign.length - 1] || '.5em'
-    ].join(' ');
+    const space = (!state.cextra[i] ? null : cspace[i]);
+    array.arraydef['data-array-padding'] = `${cspace[0] || '.5em'} ${space || '.5em'}`;
   }
 
   /**

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -131,60 +131,86 @@ export class ColumnParser {
       this.columnHandler[c](state);
     }
     //
-    // Set the column alignments
+    // Set array definition values
     //
-    const calign = state.calign;
-    array.arraydef.columnalign = calign.join(' ');
-    //
-    // Set the column widths, if needed
-    //
-    if (state.cwidth.length) {
-      const cwidth = [...state.cwidth];
-      if (cwidth.length < calign.length) {
-        cwidth.push('auto');
-      }
-      array.arraydef.columnwidth = cwidth.map(w => w || 'auto').join(' ');
+    this.setColumnAlign(state, array);
+    this.setColumnWidths(state, array);
+    this.setColumnSpacing(state, array);
+    this.setColumnLines(state, array);
+    this.setPadding(state, array);
+  }
+
+  /**
+   * @param {ColumnState} state   The current state of the parser
+   * @param {ArrayItem} array     The array stack item to adjust
+   */
+  protected setColumnAlign(state: ColumnState, array: ArrayItem) {
+    array.arraydef.columnalign = state.calign.join(' ');
+  }
+
+  /**
+   * @param {ColumnState} state   The current state of the parser
+   * @param {ArrayItem} array     The array stack item to adjust
+   */
+  protected setColumnWidths(state: ColumnState, array: ArrayItem) {
+    if (!state.cwidth.length) return;
+    const cwidth = [...state.cwidth];
+    if (cwidth.length < state.calign.length) {
+      cwidth.push('auto');
     }
-    //
-    // Set the column spacing
-    //
-    if (state.cspace.length) {
-      const cspace = [...state.cspace];
-      if (cspace.length < calign.length) {
-        cspace.push('1em');
-      }
-      array.arraydef.columnspacing = cspace.slice(1).map(d => d || '1em').join(' ');
+    array.arraydef.columnwidth = cwidth.map(w => w || 'auto').join(' ');
+  }
+
+  /**
+   * @param {ColumnState} state   The current state of the parser
+   * @param {ArrayItem} array     The array stack item to adjust
+   */
+  protected setColumnSpacing(state: ColumnState, array: ArrayItem) {
+    if (!state.cspace.length) return;
+    const cspace = [...state.cspace];
+    if (cspace.length < state.calign.length) {
+      cspace.push('1em');
     }
-    //
-    // Set the column lines and table frame
-    //
-    if (state.clines.length) {
-      const clines = [...state.clines];
-      if (clines[0]) {
-        // @test Enclosed left right, Enclosed left
-        array.frame.push('left');
-        array.dashed = (clines[0] === 'dashed');
-      }
-      if (clines.length > calign.length) {
-        // @test Enclosed left right, Enclosed right
-        array.frame.push('right');
-        clines.pop();
-      } else if (clines.length < calign.length) {
-        clines.push('none');
-      }
+    array.arraydef.columnspacing = cspace.slice(1).map(d => d || '1em').join(' ');
+  }
+
+  /**
+   * @param {ColumnState} state   The current state of the parser
+   * @param {ArrayItem} array     The array stack item to adjust
+   */
+  protected setColumnLines(state: ColumnState, array: ArrayItem) {
+    if (!state.clines.length) return;
+    const clines = [...state.clines];
+    if (clines[0]) {
+      // @test Enclosed left right, Enclosed left
+      array.frame.push(['left', clines[0]]);
+    }
+    if (clines.length > state.calign.length) {
+      // @test Enclosed left right, Enclosed right
+      array.frame.push(['right', clines.pop()]);
+    } else if (clines.length < state.calign.length) {
+      clines.push('none');
+    }
+    if (clines.length > 1) {
       // @test Enclosed left right
       array.arraydef.columnlines =
         clines.slice(1)
-              .map(l => l || 'none')
-              .join(' ');
+        .map(l => l || 'none')
+        .join(' ');
     }
-    if (state.cextra[0] || state.cextra[calign.length - 1]) {
-      const cspace = state.cspace;
-      array.arraydef['data-array-padding'] = [
-        cspace[0] || '.5em',
-        cspace[calign.length - 1] || '.5em'
-      ].join(' ');
-    }
+  }
+
+  /**
+   * @param {ColumnState} state   The current state of the parser
+   * @param {ArrayItem} array     The array stack item to adjust
+   */
+  protected setPadding(state: ColumnState, array: ArrayItem) {
+    if (!state.cextra[0] && !state.cextra[state.calign.length - 1]) return;
+    const cspace = state.cspace;
+    array.arraydef['data-array-padding'] = [
+      cspace[0] || '.5em',
+      cspace[state.calign.length - 1] || '.5em'
+    ].join(' ');
   }
 
   /**

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -36,7 +36,7 @@ import NodeUtil from '../NodeUtil.js';
 import {Property, PropertyList} from '../../../core/Tree/Node.js';
 import StackItemFactory from '../StackItemFactory.js';
 import {CheckType, BaseItem, StackItem, EnvList} from '../StackItem.js';
-
+import {TRBL} from '../../../util/Styles.js';
 
 /**
  * Initial item on the stack. It's pushed when parsing begins.
@@ -925,10 +925,10 @@ export class ArrayItem extends BaseItem {
   public row: MmlNode[] = [];
 
   /**
-   * Frame specification as a list of strings.
-   * @type {string[]}
+   * Frame specification as a list of pairs of strings [side, style].
+   * @type {[string, string][]}
    */
-  public frame: string[] = [];
+  public frame: [string, string][] = [];
 
   /**
    * Hfill value.
@@ -966,12 +966,6 @@ export class ArrayItem extends BaseItem {
    * Row alignments to specify on particular columns
    */
   public ralign: [number, string, string][] = [];
-
-  /**
-   * True if separators are dashed.
-   * @type {boolean}
-   */
-  public dashed: boolean = false;
 
   /**
    * The TeX parser that created this item
@@ -1051,37 +1045,55 @@ export class ArrayItem extends BaseItem {
       mml.setProperty('scriptlevel', scriptlevel);
     }
     if (this.getProperty('arrayPadding')) {
-      NodeUtil.setAttribute(mml, 'frame', '');   // empty frame forces fspacing to be used in MathJax
+      NodeUtil.setAttribute(mml, 'data-frame-styles', '');   // empty frame-styles forces framespacing to be used
       NodeUtil.setAttribute(mml, 'framespacing', this.getProperty('arrayPadding') as string);
     }
-    if (this.frame.length === 4) {
-      // @test Enclosed frame solid, Enclosed frame dashed
-      NodeUtil.setAttribute(mml, 'frame', this.dashed ? 'dashed' : 'solid');
-    } else if (this.frame.length) {
-      // @test Enclosed left right
-      if (this.arraydef['rowlines']) {
-        // @test Enclosed dashed row, Enclosed solid row,
-        this.arraydef['rowlines'] =
-          (this.arraydef['rowlines'] as string).replace(/none( none)+$/, 'none');
-      }
-      // @test Enclosed left right
-      if (!this.getProperty('arrayPadding')) {
-        NodeUtil.removeAttribute(mml, 'frame');
-      }
-      mml = this.create('node', 'menclose', [mml], {notation: this.frame.join(' ')});
-      if ((this.arraydef['columnlines'] || 'none') !== 'none' ||
-          (this.arraydef['rowlines'] || 'none') !== 'none') {
-        // @test Enclosed dashed row, Enclosed solid row
-        // @test Enclosed dashed column, Enclosed solid column
-        NodeUtil.setAttribute(mml, 'data-padding', 0);
-      }
-    }
+    mml = this.handleFrame(mml);
     if (this.getProperty('open') || this.getProperty('close')) {
       // @test Cross Product Formula
       mml = ParseUtil.fenced(this.factory.configuration,
                              this.getProperty('open') as string, mml,
                              this.getProperty('close') as string);
     }
+    return mml;
+  }
+
+  /**
+   * @param {MmlNode} mml  The mtable to frame
+   */
+  protected handleFrame(mml: MmlNode): MmlNode {
+    if (!this.frame.length) return mml;
+    //
+    // Map sides to their styles
+    //
+    const sides = new Map(this.frame);
+    //
+    // If all style are the same,
+    //   If all four sides are present, use a frame of the correct type
+    //   Otherwise, if the given sides are solid, use menclosed (with no padding)
+    //
+    const fstyle = this.frame.reduce((fstyle, [, style]) => style === fstyle ? style : '', this.frame[0][1]);
+    if (fstyle) {
+      if (this.frame.length === 4) {
+        NodeUtil.setAttribute(mml, 'frame', fstyle);
+        NodeUtil.removeAttribute(mml, 'data-frame-styles');
+        return mml;
+      }
+      if (fstyle === 'solid') {
+        mml = this.create('node', 'menclose', [mml], {
+          notation: Array.from(sides.keys()).join(' '),
+          'data-padding': 0
+        });
+        return mml;
+      }
+    }
+    //
+    //  Otherwise (some sides are dashed), use styles, which is implemented in
+    //    the common output jax so that we get the proper line width (it may be
+    //    customizable via output options in the future).
+    //
+    const styles = TRBL.map(side => sides.get(side) || 'none').join(' ');
+    NodeUtil.setAttribute(mml, 'data-frame-styles', styles);
     return mml;
   }
 
@@ -1273,22 +1285,25 @@ export class ArrayItem extends BaseItem {
    * Finishes line layout if not already given.
    */
   public checkLines() {
-    if (this.arraydef['rowlines']) {
-      const lines = (this.arraydef['rowlines'] as string).split(/ /);
+    if (this.arraydef.rowlines) {
+      const lines = (this.arraydef.rowlines as string).split(/ /);
       if (lines.length === this.table.length) {
-        this.frame.push('bottom');
-        lines.pop();
-        this.arraydef['rowlines'] = lines.join(' ');
+        this.frame.push(['bottom', lines.pop()]);
+        if (lines.length) {
+          this.arraydef.rowlines = lines.join(' ');
+        } else {
+          delete this.arraydef.rowlines;
+        }
       } else if (lines.length < this.table.length - 1) {
-        this.arraydef['rowlines'] += ' none';
+        this.arraydef.rowlines+= ' none';
       }
     }
     if (this.getProperty('rowspacing')) {
-      const rows = (this.arraydef['rowspacing'] as string).split(/ /);
+      const rows = (this.arraydef.rowspacing as string).split(/ /);
       while (rows.length < this.table.length) {
         rows.push(this.getProperty('rowspacing') + 'em');
       }
-      this.arraydef['rowspacing'] = rows.join(' ');
+      this.arraydef.rowspacing = rows.join(' ');
     }
   }
 

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -1072,7 +1072,10 @@ export class ArrayItem extends BaseItem {
     //   If all four sides are present, use a frame of the correct type
     //   Otherwise, if the given sides are solid, use menclosed (with no padding)
     //
-    const fstyle = this.frame.reduce((fstyle, [, style]) => style === fstyle ? style : '', this.frame[0][1]);
+    const fstyle = this.frame.reduce(
+      (fstyle, [, style]) => style === fstyle ? style : '',
+      this.frame[0][1]
+    );
     if (fstyle) {
       if (this.frame.length === 4) {
         NodeUtil.setAttribute(mml, 'frame', fstyle);
@@ -1080,6 +1083,7 @@ export class ArrayItem extends BaseItem {
         return mml;
       }
       if (fstyle === 'solid') {
+        NodeUtil.setAttribute(mml, 'data-frame-styles', '');
         mml = this.create('node', 'menclose', [mml], {
           notation: Array.from(sides.keys()).join(' '),
           'data-padding': 0
@@ -1193,13 +1197,13 @@ export class ArrayItem extends BaseItem {
         if (braces || envs) continue;
         i -= match[2].length;
         let entry = parser.string.slice(parser.i, i).trim();
-        const prefix = entry.match(/^(?:\s*\\(?:hline|hfil{1,3}|rowcolor\s*\{.*?\}))+/);
+        const prefix = entry.match(/^(?:\s*\\(?:h(?:dash)?line|hfil{1,3}|rowcolor\s*\{.*?\}))+/);
         if (prefix) {
           entry = entry.slice(prefix[0].length);
         }
         parser.string = parser.string.slice(i);
         parser.i = 0;
-        return [prefix?.[0] ||'', entry, match[2], true];
+        return [prefix?.[0] || '', entry, match[2], true];
       }
     }
     return fail;

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1432,7 +1432,7 @@ BaseMethods.HLine = function(parser: TexParser, _name: string, style: string) {
   }
   if (!top.table.length) {
     // @test Enclosed top, Enclosed top bottom
-    top.frame.push('top');
+    top.frame.push(['top', style]);
   } else {
     // @test Enclosed bottom, Enclosed top bottom
     const lines = (top.arraydef['rowlines'] ? (top.arraydef['rowlines'] as string).split(/ /) : []);

--- a/ts/input/tex/colortbl/ColortblConfiguration.ts
+++ b/ts/input/tex/colortbl/ColortblConfiguration.ts
@@ -93,8 +93,12 @@ export class ColorArrayItem extends ArrayItem {
     if (table.isKind('menclose')) {
       table = table.childNodes[0].childNodes[0];
     }
-    if (this.hasColor && table.attributes.get('frame') === 'none') {
-      table.attributes.set('frame', '');
+    if (this.hasColor) {
+      const attributes = table.attributes;
+      if (attributes.get('frame') === 'none' &&
+          attributes.get('data-frame-styles') === undefined) {
+        attributes.set('data-frame-styles', '');
+      }
     }
     return mml;
   }

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -268,7 +268,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     protected handleColumnSpacing() {
       const scale = (this.childNodes[0] ? 1 / this.childNodes[0].getBBox().rscale : 1);
       const spacing = this.getEmHalfSpacing([this.fSpace[0], this.fSpace[2]], this.cSpace, scale);
-      const frame = this.frame;
+      const frame = this.fframe;
       //
       //  For each row...
       //
@@ -341,7 +341,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     protected handleRowSpacing() {
       const scale = (this.childNodes[0] ? 1 / this.childNodes[0].getBBox().rscale : 1);
       const spacing = this.getEmHalfSpacing([this.fSpace[1], this.fSpace[1]], this.rSpace, scale);
-      const frame = this.frame;
+      const frame = this.fframe;
       //
       //  For each row...
       //
@@ -472,7 +472,8 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
      */
     protected handleFrame() {
       if (this.frame && this.fLine) {
-        this.adaptor.setStyle(this.itable, 'border', '.07em ' + this.node.attributes.get('frame'));
+        const frame = this.node.attributes.get('frame');
+        this.adaptor.setStyle(this.itable, 'border', `${this.em(this.fLine)} ${frame}`);
       }
     }
 

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -31,6 +31,7 @@ import {BBox} from '../../../util/BBox.js';
 import {DIRECTION} from '../FontData.js';
 import {split, isPercent} from '../../../util/string.js';
 import {sum, max} from '../../../util/numeric.js';
+import {Styles, TRBL} from '../../../util/Styles.js';
 
 /*****************************************************************/
 /**
@@ -1265,8 +1266,10 @@ export function CommonMtableMixin<
       // Get the frame, row, and column parameters
       //
       const attributes = this.node.attributes;
-      this.frame = attributes.get('frame') !== 'none';
-      this.fLine = (this.frame && attributes.get('frame') ? .07 : 0);
+      const frame = attributes.get('frame');
+      const fstyles = attributes.get('data-frame-styles') !== undefined;
+      this.frame = frame !== 'none' || fstyles;
+      this.fLine = (frame && frame !== 'none' || fstyles ? .07 : 0);
       this.fSpace = this.getFrameSpacing();
       this.cSpace = this.convertLengths(this.getColumnAttributes('columnspacing'));
       this.rSpace = this.convertLengths(this.getRowAttributes('rowspacing'));
@@ -1279,6 +1282,26 @@ export function CommonMtableMixin<
       //
       this.stretchColumns();
       this.stretchRows();
+    }
+
+    /**
+     * Turn data-frame-styles into actual border styles
+     *
+     * @override
+     */
+    public getStyles() {
+      super.getStyles();
+      const frame = this.node.attributes.get('data-frame-styles') as string;
+      if (!frame) return;
+      if (!this.styles) {
+        this.styles = new Styles('');
+      }
+      const fstyles = frame.split(/ /);
+      for (const i of TRBL.keys()) {
+        const style = fstyles[i];
+        if (style === 'none') continue;
+        this.styles.set(`border-${TRBL[i]}`, `.07em ${style}`);
+      }
     }
 
     /**

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -126,6 +126,10 @@ export interface CommonMtable<
    */
   frame: boolean;
   /**
+   * True if there is a frame or data-frame-styles
+   */
+  fframe: boolean;
+  /**
    * The size of the frame line (or 0 if none)
    */
   fLine: number;
@@ -530,6 +534,10 @@ export function CommonMtableMixin<
      * @override
      */
     public frame: boolean;
+    /**
+     * @override
+     */
+    public fframe: boolean;
     /**
      * @override
      */
@@ -1130,7 +1138,7 @@ export function CommonMtableMixin<
      * @override
      */
     public getFrameSpacing(): number[] {
-      const fspace = (this.frame ? this.convertLengths(this.getAttributeArray('framespacing')) : [0, 0]);
+      const fspace = (this.fframe ? this.convertLengths(this.getAttributeArray('framespacing')) : [0, 0]);
       fspace[2] = fspace[0];
       const padding = this.node.attributes.get('data-array-padding') as string;
       if (padding) {
@@ -1267,9 +1275,9 @@ export function CommonMtableMixin<
       //
       const attributes = this.node.attributes;
       const frame = attributes.get('frame');
-      const fstyles = attributes.get('data-frame-styles') !== undefined;
-      this.frame = frame !== 'none' || fstyles;
-      this.fLine = (frame && frame !== 'none' || fstyles ? .07 : 0);
+      this.frame = frame !== 'none';
+      this.fframe = this.frame || attributes.get('data-frame-styles') !== undefined;
+      this.fLine = (this.frame ? .07 : 0);
       this.fSpace = this.getFrameSpacing();
       this.cSpace = this.convertLengths(this.getColumnAttributes('columnspacing'));
       this.rSpace = this.convertLengths(this.getRowAttributes('rowspacing'));

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -540,10 +540,13 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    */
 
   public drawBBox() {
-    let {w, h, d}  = this.getBBox();
-    const box = this.svg('g', {style: {
-      opacity: .25
-    }}, [
+    let {w, h, d} = this.getOuterBBox();
+    const L = (this.styleData?.border?.width || [0, 0, 0, 0])[3];
+    const def = {style: {opacity: .25}} as OptionList;
+    if (L) {
+      def.transform = `translate(${this.fixed(-L)}, 0)`;
+    }
+    const box = this.svg('g', def, [
       this.svg('rect', {
         fill: 'red',
         height: this.fixed(h),

--- a/ts/util/Styles.ts
+++ b/ts/util/Styles.ts
@@ -45,8 +45,8 @@ export type connections = {[name: string]: connection};
 /**
  * Some common children arrays
  */
-const TRBL = ['top', 'right', 'bottom', 'left'];
-const WSC = ['width', 'style', 'color'];
+export const TRBL = ['top', 'right', 'bottom', 'left'];
+export const WSC = ['width', 'style', 'color'];
 
 /**
  * Split a style at spaces (taking quotation marks and commas into account)


### PR DESCRIPTION
This PR allows tables to have frames where some sides are dashed rather than solid.  In the past, if all four sides of the table frame were included, they all had the style of the left edge (solid or dashed).  If not all the sides where included, then they were all solid.  Now that border CSS styles are implemented in both output jax, we use dashed or solid borders when needed.  When all the borders are included and the same style, the `frame` attribute is used, as before.  If not all the sides are included, but they are all solid, we use the `menclose` element with the proper sides, as before.  Otherwise (mixed styles, or all are dashed but not all side are included), we use a new `data-frame-style` to record the styles.  These are converted to real styles in the common output jax.  The reason to do it in the output jax is that it knows the width of the lines that it is using elsewhere, and I plan to allow that to be configurable; the TeX input jax has no knowledge of the output jax or its options, so can't set he proper border width itself, so we mark that borders should be used, and le the output jax take care of it.  This does mean that native MathML renderers will not have the border in that case (they will if they are all solid, but not in the mixed case).  One could use a TeX input jax post-filter to modify the `mtable` elements to have actual `style` attributes if one needed to have native MathML output, or one could use CSS targeting the `data-frame-style` attribute to do it (it would take 15 styles).  But I'm not that concerned about native MathML, since mathML core doesn't handle most of the `mtable` attributes anyway.

This PR also refactors some of the ColumnParser code to break up the `process()` method into smaller pieces (the diff doesn't do such a good job of making that clear), and includes fixes to remove some blank attributes (`columnlines` and `rowlines`) when there is a frame but no internal lines.

Resolves issue mathjax/MathJax#2972.