### PR TITLE
Remove Safari hack that is not needed with v4.  (mathjax/MathJax#3023)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -131,14 +131,6 @@ CommonOutputJax<
     },
     'mjx-mphantom': {
       visibility: 'hidden'
-    },
-
-    //
-    //  WebKit-specific CSS to handle bug with clipped characters.
-    //  (test found at https://browserstrangeness.bitbucket.io/css_hacks.html#safari)
-    //
-    '_::-webkit-full-page-media, _:future, :root mjx-container': {
-      'will-change': 'opacity'
     }
   };
 


### PR DESCRIPTION
This CSS hack is no longer needed in v4.  See issue mathjax/MathJax#3023.