### PR TITLE
Remove backward-compatibility code from previous version

### DIFF
--- a/ts/input/tex/ams/AmsConfiguration.ts
+++ b/ts/input/tex/ams/AmsConfiguration.ts
@@ -64,15 +64,6 @@ export const AmsConfiguration = Configuration.create(
     },
     tags: {'ams': AmsTags},
     init: init,
-    config: (_config: ParserConfiguration, jax: any)  => {
-      //
-      //  Move multlineWidth from old location to ams block (remove in next version)
-      //
-      if (jax.parseOptions.options.multlineWidth) {
-        jax.parseOptions.options.ams.multlineWidth = jax.parseOptions.options.multlineWidth;
-      }
-      delete jax.parseOptions.options.multlineWidth;
-    },
     options: {
       multlineWidth: '',
       ams: {


### PR DESCRIPTION
This PR removes backward-compatibility code from a previous version that would move the `multlineWidth` option to its new location in that version.  This is not needed for v4.