### PR TITLE
Use mspace for \allowbreak, etc., and fix issues with mspace breaking.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/ts/core/MmlTree/MmlNodes/mspace.ts
@@ -89,12 +89,22 @@ export class MmlMspace extends AbstractMmlTokenNode {
    * @override
    */
   public get hasNewline() {
+    const linebreak = this.attributes.get('linebreak');
+    return (this.canBreak && (linebreak === 'newline' || linebreak === 'indentingnewline'));
+  }
+
+  /**
+   * @return {boolean}   True if mspace is allowed to break, i.e.,
+   *                     no height/depth, no styles, and no background color.
+   */
+  public get canBreak(): boolean {
     const attributes = this.attributes;
-    const linebreak = attributes.get('linebreak');
-    return (attributes.getExplicit('width') == null &&
-            attributes.getExplicit('height') == null &&
-            attributes.getExplicit('depth') == null &&
-            (linebreak === 'newline' || linebreak === 'indentingnewline'));
+    return (/*attributes.getExplicit('width') === undefined &&*/  // we break spaces with width ...
+            attributes.getExplicit('height') === undefined &&
+            attributes.getExplicit('depth') === undefined &&
+            attributes.getExplicit('style') === undefined &&      //   ... but not ones with styles
+            attributes.getExplicit('mathbackground') === undefined &&
+            attributes.getExplicit('background') === undefined);
   }
 
 }

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -524,7 +524,7 @@ export class BreakItem extends BaseItem {
         }
       }
     }
-    const mml = this.create('token', 'mo', {linebreak});
+    const mml = this.create('token', 'mspace', {linebreak});
     return [[this.factory.create('mml', mml), item], true];
   }
 

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -372,7 +372,7 @@ BaseMethods.DiscretionaryTimes = function (parser: TexParser, _name: string) {
  * @param {string} _name The macro name.
  */
 BaseMethods.AllowBreak = function (parser: TexParser, _name: string) {
-  parser.Push(parser.create('token', 'mo', {'data-allowbreak': true}));
+  parser.Push(parser.create('token', 'mspace'));
 }
 
 /**
@@ -382,7 +382,7 @@ BaseMethods.AllowBreak = function (parser: TexParser, _name: string) {
  * @param {string} _name The macro name.
  */
 BaseMethods.Break = function (parser: TexParser, _name: string) {
-  parser.Push(parser.create('token', 'mo', {linebreak: TexConstant.LineBreak.NEWLINE}));
+  parser.Push(parser.create('token', 'mspace', {linebreak: TexConstant.LineBreak.NEWLINE}));
 }
 
 /**

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -279,18 +279,16 @@ CommonWrapper<
     for (const data of [[this.getLineBBox(0).L, 'space',  'marginLeft', 0],
                         [this.getLineBBox(n).R, 'rspace', 'marginRight', n]]) {
       const [dimen, name, margin, i] = data as [number, string, string, number];
-      if (dimen) {
-        const space = this.em(dimen);
-        if (breakable && name === 'space') {
-          const node = adaptor.node('mjx-break', SPACE[space] ? {size: SPACE[space]} :
-                                    {style: `letter-spacing: ${this.em(dimen - 1)}`});
-          adaptor.insert(node, this.dom[i]);
+      const space = this.em(dimen);
+      if (breakable && name === 'space') {
+        const node = adaptor.node('mjx-break', SPACE[space] ? {size: SPACE[space]} :
+                                  {style: `letter-spacing: ${this.em(dimen - 1)}`});
+        adaptor.insert(node, this.dom[i]);
+      } else if (dimen) {
+        if (SPACE[space]) {
+          adaptor.setAttribute(this.dom[i], name, SPACE[space]);
         } else {
-          if (SPACE[space]) {
-            adaptor.setAttribute(this.dom[i], name, SPACE[space]);
-          } else {
-            adaptor.setStyle(this.dom[i], margin, space);
-          }
+          adaptor.setStyle(this.dom[i], margin, space);
         }
       }
     }

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -133,6 +133,9 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
         'white-space': 'normal',
         'font-family': 'MJX-BRK'
       },
+      'mjx-break[size="0"]': {
+        'letter-spacing': (.001 - 1) + 'em'
+      },
       'mjx-break[size="1"]': {
         'letter-spacing': (.111 - 1) + 'em'
       },

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -397,7 +397,7 @@ export abstract class CommonOutputJax<
         const linebreakstyle = mo.attributes.get('linebreakstyle') as string;
         if ((texClass === TEXCLASS.BIN || texClass === TEXCLASS.REL ||
              (texClass === TEXCLASS.ORD && mo.hasSpacingAttributes()) ||
-             mo.attributes.get('data-allowbreak') || linebreak !== 'auto') && linebreak !== 'nobreak') {
+             linebreak !== 'auto') && linebreak !== 'nobreak') {
           if (linebreakstyle === 'before') {
             marked = this.markInlineBreak(marked, forcebreak, linebreak, node, child, mo);
           } else {

--- a/ts/output/common/LinebreakVisitor.ts
+++ b/ts/output/common/LinebreakVisitor.ts
@@ -213,10 +213,11 @@ export class LinebreakVisitor<
     //
     // Adjust for mspace width
     //
-    space: (p, mspace) => {
-      if (mspace.node.attributes.getExplicit('style')) return NOBREAK;
+    space: (p, node) => {
+      const mspace = node as any as CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+      if (!mspace.canBreak) return NOBREAK;
       const w = mspace.getBBox().w;
-      return (w <= 0 ? NOBREAK : w < 1 ? p : p - 100 * (w + 4));
+      return (w < 0 ? NOBREAK : w < 1 ? p : p - 100 * (w + 4));
     },
     //
     // Adjust for a separator (TeX doesn't break at commas, for example)
@@ -512,11 +513,9 @@ export class LinebreakVisitor<
    */
   public visitMspaceNode(wrapper: WW, i: number) {
     const bbox = wrapper.getLineBBox(i);
-    const attributes = wrapper.node.attributes;
-    if (/*attributes.getExplicit('width') === undefined &&*/
-        attributes.getExplicit('height') === undefined &&
-        attributes.getExplicit('depth') === undefined) {
-      const penalty = this.mspacePenalty(wrapper as any as CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>);
+    const mspace = wrapper as any as CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+    if (mspace.canBreak) {
+      const penalty = this.mspacePenalty(mspace);
       bbox.getIndentData(wrapper.node);
       const dw = wrapper.processIndent('', bbox.indentData[1][1], '', bbox.indentData[0][1], this.state.width)[1];
       this.pushBreak(wrapper, penalty, dw - bbox.w, null);

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -67,6 +67,7 @@ function MathMLSpace(script: boolean, size: number): number {
  */
 export const SPACE: StringMap = {
   /* tslint:disable:whitespace */
+  [LENGTHS.em(0)]:    '0',
   [LENGTHS.em(2/18)]: '1',
   [LENGTHS.em(3/18)]: '2',
   [LENGTHS.em(4/18)]: '3',

--- a/ts/output/common/Wrappers/mspace.ts
+++ b/ts/output/common/Wrappers/mspace.ts
@@ -61,6 +61,11 @@ export interface CommonMspace<
 > extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
 
   /**
+   * True when mspace is allowed to break
+   */
+  canBreak: boolean;
+
+  /**
    * The linebreak style
    */
   breakStyle: string;
@@ -142,6 +147,13 @@ export function CommonMspaceMixin<
     /**
      * @override
      */
+    get canBreak() {
+      return (this.node as MmlMspace).canBreak;
+    }
+
+    /**
+     * @override
+     */
     public breakStyle: string;
 
     /**
@@ -155,7 +167,9 @@ export function CommonMspaceMixin<
      * @override
      */
     public setBreakStyle(linebreak: string = '') {
-      this.breakStyle = (linebreak || ((this.node as MmlMspace).hasNewline ? 'before' : ''));
+      this.breakStyle = (linebreak ||
+                         (((this.node as MmlMspace).hasNewline ||
+                           this.node.getProperty('forcebreak')) ? 'before' : ''));
     }
 
     /***************************************************/

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -390,7 +390,7 @@ CommonOutputJax<
       } else if (forced || i) {
         const dimen = (mml && !newline ? mml.getLineBBox(0).originalL : 0);
         if (dimen || !forced) {
-          this.addInlineBreak(nsvg, dimen, forced);
+          this.addInlineBreak(nsvg, dimen, forced || !!mml.node.getProperty('forcebreak'));
         }
       }
       //
@@ -422,7 +422,7 @@ CommonOutputJax<
       adaptor.node(
         'mjx-break',
         !forced ? {newline: true} :
-        SPACE[space] ? {size: SPACE[space]} : {style: `letter-spacing: ${LENGTHS.em(1 - dimen)}`}
+        SPACE[space] ? {size: SPACE[space]} : {style: `letter-spacing: ${LENGTHS.em(dimen - 1)}`}
       ),
       nsvg
     );

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -117,6 +117,9 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
         'line-height': '0',
         'font-family': 'MJX-ZERO'
       },
+      'mjx-break[size="0"]': {
+        'letter-spacing': (.001 - 1) + 'em'
+      },
       'mjx-break[size="1"]': {
         'letter-spacing': (.111 - 1) + 'em'
       },


### PR DESCRIPTION
This PR changes `\allowbreak`, `\goodbreak`, etc. to use `mspace` elements rather than `mo` elements, since `mo` can become embellished, which can cause strange behavior.  In particular since `mtext` elements are space-like (because they can sometimes be all spaces, but the spec doesn't make an exception for when they contain non-space characters), that means that `\text{abc}\break\text{def}` would produce `<mtext>abc</mtext><mo linebreak="newline"/><mtext>def</mtext>`, and that would be an embellished operator, and the break would occur *outside* the embellished operator, so *before* the first `mtext`.  That is not what most people would intend.  Using `mspace` avoids that problem.

This has been a perennial problem with how `mtext` is treated as space-like even it is not all space characters.  I'm wondering if we should ignore the specification on this and make `mtext` only be space-like if it only contains whitespace characters?  I'm already ignoring the fact that `space` is only supposed to be breakable when its width is 0, and allow breaks at `mspace` even with non-zero width.

In any case, this also fixes a number of problems with breaking at `mspace` that turned up when trying to make this change:

* Separate out the check for whether `mspace` can be broken, to avoid duplicate code.
* Allow breaks when the width is zero (this was only partially correct).
* Fix problems with SVG inline breaks at `mspace`.
* Remove use of `data-allowbreak` attribute, which is not needed (now that we handle zero-width `mspace`)