### PR TITLE
Remove lineWidth from the Metrics object, since it is never used.

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -711,9 +711,9 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
    * @override
    */
   public convert(math: string, options: OptionList = {}) {
-    let {format, display, end, ex, em, containerWidth, lineWidth, scale, family} = userOptions({
+    let {format, display, end, ex, em, containerWidth, scale, family} = userOptions({
       format: this.inputJax[0].name, display: true, end: STATE.LAST,
-      em: 16, ex: 8, containerWidth: null, lineWidth: 1000000, scale: 1, family: ''
+      em: 16, ex: 8, containerWidth: null, scale: 1, family: ''
     }, options);
     if (containerWidth === null) {
       containerWidth = 80 * ex;
@@ -721,7 +721,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     const jax = this.inputJax.reduce((jax, ijax) => (ijax.name === format ? ijax : jax), null);
     const mitem = new this.options.MathItem(math, jax, display);
     mitem.start.node = this.adaptor.body(this.document);
-    mitem.setMetrics(em, ex, containerWidth, lineWidth, scale);
+    mitem.setMetrics(em, ex, containerWidth, scale);
     if (this.outputJax.options.mtextInheritFont) {
       mitem.outputData.mtextFamily = family;
     }

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -52,7 +52,6 @@ export type Metrics = {
   em: number;
   ex: number;
   containerWidth: number;
-  lineWidth: number;
   scale: number;
 };
 
@@ -178,10 +177,9 @@ export interface MathItem<N, T, D> {
    * @param {number} em      The size of 1 em in pixels
    * @param {number} ex      The size of 1 ex in pixels
    * @param {number} cwidth  The container width in pixels
-   * @param {number} lwidth  The line breaking width in pixels
    * @param {number} scale   The scaling factor (unitless)
    */
-  setMetrics(em: number, ex: number, cwidth: number, lwidth: number, scale: number): void;
+  setMetrics(em: number, ex: number, cwidth: number, scale: number): void;
 
   /**
    * Set or return the current processing state of this expression,
@@ -390,11 +388,10 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public setMetrics(em: number, ex: number, cwidth: number, lwidth: number, scale: number) {
+  public setMetrics(em: number, ex: number, cwidth: number, scale: number) {
     this.metrics = {
       em: em, ex: ex,
       containerWidth: cwidth,
-      lineWidth: lwidth,
       scale: scale
     };
   }

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -453,8 +453,8 @@ export abstract class CommonOutputJax<
       const parent = adaptor.parent(math.start.node);
       if (math.state() < STATE.METRICS && parent) {
         const map = maps[math.display ? 1 : 0];
-        const {em, ex, containerWidth, lineWidth, scale, family} = map.get(parent);
-        math.setMetrics(em, ex, containerWidth, lineWidth, scale);
+        const {em, ex, containerWidth, scale, family} = map.get(parent);
+        math.setMetrics(em, ex, containerWidth, scale);
         if (this.options.mtextInheritFont) {
           math.outputData.mtextFamily = family;
         }
@@ -592,8 +592,7 @@ export abstract class CommonOutputJax<
                             adaptor.nodeBBox(adaptor.firstChild(node) as N).left - 2);
     const scale = Math.max(this.options.minScale,
                            this.options.matchFontHeight ? ex / this.font.params.x_height / em : 1);
-    const lineWidth = 1000000;      // no linebreaking (otherwise would be a percentage of cwidth)
-    return {em, ex, containerWidth, lineWidth, scale, family};
+    return {em, ex, containerWidth, scale, family};
   }
 
   /*****************************************************************/


### PR DESCRIPTION
This PR removes `lineWidth` from the `Metrics` object, since it is never used (it was targeted for line-breaking, but it turns out that it wasn't needed).

This will need documentation.