### PR TITLE
Handle multiple spaces in \text{}.

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -243,8 +243,13 @@ namespace ParseUtil {
    * @param {string} font The mathvariant to use
    * @return {MmlNode[]} The nodes corresponding to the internal math expression.
    */
-  export function internalMath(parser: TexParser, text: string,
-                               level?: number | string, font?: string): MmlNode[] {
+  export function internalMath(
+    parser: TexParser,
+    text: string,
+    level?: number | string,
+    font?: string
+  ): MmlNode[] {
+    text = text.replace(/ +/g, ' ');
     if (parser.configuration.options.internalMath) {
       return parser.configuration.options.internalMath(parser, text, level, font);
     }

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -694,13 +694,13 @@ new sm.CommandMap('macros', {
   TeX:               ['Macro', 'T\\kern-.14em\\lower.5ex{E}\\kern-.115em X'],
   LaTeX:             ['Macro', 'L\\kern-.325em\\raise.21em' +
                       '{\\scriptstyle{A}}\\kern-.17em\\TeX'],
-  ' ':               ['Macro', '\\text{ }'],
 
   //  Specially handled
   not:                'Not',
   dots:               'Dots',
   space:              'Tilde',
   '\u00A0':           'Tilde',
+  ' ':                'Tilde',
 
 
   //  LaTeX


### PR DESCRIPTION
This PR reduces multiple spaces to a single space in `\text{}` and other math-mode material, as would happen in actual TeX, and simplifies the definition of `\ ` (since TeX doesn't seem to break expressions at this space, it can be teated as a non-breaking space in math mode).