### PR TITLE
Verify that math elements are not nested.

### DIFF
--- a/ts/core/MmlTree/MmlNodes/math.ts
+++ b/ts/core/MmlTree/MmlNodes/math.ts
@@ -109,4 +109,14 @@ export class MmlMath extends AbstractMmlLayoutNode {
     super.setChildInheritedAttributes(attributes, display, level, prime);
   }
 
+  /**
+   * @override
+   */
+  public verifyTree(options: PropertyList = null) {
+    super.verifyTree(options);
+    if (this.parent) {
+      this.mError('Improper nesting of math tags', options, true);
+    }
+  }
+
 }


### PR DESCRIPTION
The MathML spec says `math` elements can't be nested, so this PR adds that check to the `verifyTree()` tests.