### PR TITLE
Add a tooltip for MathML verification short errors to show the full error.

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -840,13 +840,16 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
     }
     let merror = this.factory.create('merror');
     merror.attributes.set('data-mjx-message', message);
-    if (options['fullErrors'] || short) {
+    if (options.fullErrors || short) {
       let mtext = this.factory.create('mtext');
       let text = this.factory.create('text') as any as TextNode;
-      text.setText(options['fullErrors'] ? message : this.kind);
+      text.setText(options.fullErrors ? message : this.kind);
       mtext.appendChild(text);
       merror.appendChild(mtext);
       this.parent.replaceChild(merror, this);
+      if (!options.fullErrors) {
+        merror.attributes.set('title', message);
+      }
     } else {
       this.parent.replaceChild(merror, this);
       merror.appendChild(this);


### PR DESCRIPTION
This PR adds a tooltip to the `merror` element that gives the full error message when short errors are being used.  This brings it in line with the "Math input error" and "Math output error" messages, which show the full message as a tooltip.