### PR TITLE
Add checks for valid mathvariant

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -828,7 +828,7 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
     }
     if (options.checkMathvariants) {
       const variant = this.attributes.getExplicit('mathvariant') as string;
-      if (variant && !MATHVARIANTS.has(variant)) {
+      if (variant && !MATHVARIANTS.has(variant) && !this.getProperty('ignore-variant')) {
         this.mError(`Invalid mathvariant: ${variant}`, options, true);
       }
     }

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -71,6 +71,18 @@ const TEXSPACE = [
 ];
 
 /**
+ * The valid mathvariants
+ */
+
+export const MATHVARIANTS = new Set([
+  'normal', 'bold', 'italic', 'bold-italic',
+  'double-struck', 'fraktur', 'bold-fraktur', 'script', 'bold-script',
+  'sans-serif', 'bold-sans-serif', 'sans-serif-italic', 'sans-serif-bold-italic',
+  'monospace',
+  'inital', 'tailed', 'looped', 'stretched'
+]);
+
+/**
  * Attributes used to determine indentation and shifting
  */
 export const indentAttributes = [
@@ -303,6 +315,7 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
   public static verifyDefaults: PropertyList = {
     checkArity: true,
     checkAttributes: false,
+    checkMathvariants: true,
     fullErrors: false,
     fixMmultiscripts: true,
     fixMtables: true
@@ -798,7 +811,7 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
    * @param {PropertyList} options   The options telling how much to verify
    */
   protected verifyAttributes(options: PropertyList) {
-    if (options['checkAttributes']) {
+    if (options.checkAttributes) {
       const attributes = this.attributes;
       const bad = [];
       for (const name of attributes.getExplicitNames()) {
@@ -811,6 +824,12 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
       }
       if (bad.length) {
         this.mError('Unknown attributes for ' + this.kind + ' node: ' + bad.join(', '), options);
+      }
+    }
+    if (options.checkMathvariants) {
+      const variant = this.attributes.getExplicit('mathvariant') as string;
+      if (variant && !MATHVARIANTS.has(variant)) {
+        this.mError(`Invalid mathvariant: ${variant}`, options, true);
       }
     }
   }

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -194,6 +194,7 @@ export class MathMLCompile<N, T, D> {
           break;
         case 'variant':
           mml.attributes.set('mathvariant', value);
+          mml.setProperty('ignore-variant', true);
           ignoreVariant = true;
           break;
         case 'smallmatrix':

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -812,7 +812,12 @@ export class CommonWrapper<
     if (!this.node.isToken) return;
     const attributes = this.node.attributes;
     let variant = attributes.get('mathvariant') as string;
-    if (!attributes.getExplicit('mathvariant')) {
+    if (attributes.getExplicit('mathvariant')) {
+      if (!this.font.getVariant(variant)) {
+        console.warn(`Invalid variant: ${variant}`);
+        variant = 'normal';
+      }
+    } else {
       const values = attributes.getList('fontfamily', 'fontweight', 'fontstyle') as StringMap;
       if (this.removedStyles) {
         const style = this.removedStyles;


### PR DESCRIPTION
Because the mathvariant is critical to the operation of the output jax, having an incorrect math variant will lead to "Math output error" messages.  This PR adds checks within the MathML input jax and the common output jax to make sure that the variant exists in the output font in use.  This allows the output to be produced, but still gives the user information that something is wrong.