### PR TITLE
Fix mathvariant bug introduced by #900

### DIFF
--- a/ts/input/tex/base/BaseConfiguration.ts
+++ b/ts/input/tex/base/BaseConfiguration.ts
@@ -63,7 +63,7 @@ export function Other(parser: TexParser, char: string) {
   // @test Other Remap
   let mo = parser.create('token', type, def, (remap ? remap.char : char));
   const variant = (range?.[4] ||
-                   ParseUtil.isLatinOrGreekChar(char) ? parser.configuration.mathStyle(char, true) : '');
+                   (ParseUtil.isLatinOrGreekChar(char) ? parser.configuration.mathStyle(char, true) : ''));
   if (variant) {
     mo.attributes.set('mathvariant', variant);
   }


### PR DESCRIPTION
This fixes a bug introduced by #900 where the `mathvariant` for unmapped characters in ranges that specify a variant wasn't being used.  This was due to missing parentheses that cause the `||` to be part of the hypothesis for the `?` rather than the `?:` structure being the second argument for `||`.

This prevented Chinese characters from being rendered in normal variant, for example.