### PR TITLE
Move handling of scrolling to CSS and allow tagged expressions to scroll

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -81,6 +81,7 @@ CommonOutputJax<
    *  The default styles for CommonHTML
    */
   public static commonStyles: CssStyleList = {
+    ...CommonOutputJax.commonStyles,
     'mjx-container[jax="CHTML"]': {
       'white-space': 'nowrap'
     },

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -126,7 +126,16 @@ export abstract class CommonOutputJax<
   /**
    *  The default styles for the output jax
    */
-  public static commonStyles: CssStyleList = {};
+  public static commonStyles: CssStyleList = {
+    'mjx-container[overflow="scroll"][display]': {
+      'overflow-x': 'auto',
+      'min-width': 'initial !important'
+    },
+    'mjx-container[overflow="truncate"][display]': {
+      'overflow-x': 'hidden',
+      'min-width': 'initial !important'
+    }
+  };
 
   /**
    * Used for collecting styles needed for the output jax
@@ -324,11 +333,8 @@ export abstract class CommonOutputJax<
     this.pxPerEm = math.metrics.ex / this.font.params.x_height;
     this.nodeMap = new Map<MmlNode, WW>();
     math.root.attributes.getAllInherited().overflow = this.options.displayOverflow;
-    const overflow = math.root.attributes.get('overflow');
-    if (math.display) {
-      overflow === 'scroll' && this.adaptor.setStyle(node, 'overflow-x', 'auto');
-      overflow === 'truncate' && this.adaptor.setStyle(node, 'overflow-x', 'hidden');
-    }
+    const overflow = math.root.attributes.get('overflow') as string;
+    this.adaptor.setAttribute(node, 'overflow', overflow);
     const linebreak = (overflow === 'linebreak');
     linebreak && this.getLinebreakWidth();
     if (this.options.linebreaks.inline && !math.display && !math.outputData.inlineMarked) {

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -85,6 +85,7 @@ CommonOutputJax<
    *  The default styles for SVG
    */
   public static commonStyles: CssStyleList = {
+    ...CommonOutputJax.commonStyles,
     'mjx-container[jax="SVG"]': {
       direction: 'ltr',
       'white-space': 'nowrap'


### PR DESCRIPTION
Normally, when an expression has equation numbers or tags, the `mjx-container` gets a minimum width wide enough to hold the equation with its numbers (to prevent the numbers from overlapping the equation).  But when the `overflow` attribute is `scroll` or `truncate`, we don't want the minimum width.  This PR moves the settings for scroll and truncate into CSS and overrides the `min-width` in that case.