### PR TITLE
Properly include prefix in build paths

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -170,7 +170,8 @@ function processParts(parts) {
  */
 function processLines(file, objects) {
   if (objects.length === 0) return [];
-  const dir = path.join(PREFIX, path.dirname(file).replace(/^\.$/, ''));
+  const base = path.dirname(file).replace(/^\.$/, '');
+  const dir = (PREFIX ? path.join(PREFIX, base) : base);
   const dots = dir.replace(/[^\/]+/g, '..') || '.';
   const relative = path.join(dots, '..', JS, dir, path.basename(file)).replace(/\.ts$/, '.js');
   const name = path.parse(file).name;

--- a/components/bin/build
+++ b/components/bin/build
@@ -222,7 +222,8 @@ function makeDir(dir) {
  */
 function makeFile(file, lines) {
   if (!lines.length) return;
-  const [dir, name] = [path.join(PREFIX, path.dirname(file)), path.basename(file)];
+  const basedir = path.dirname(file);
+  const [dir, name] = [PREFIX ? path.join(PREFIX, basedir) : basedir, path.basename(file)];
   makeDir(dir);
   fs.writeFileSync(path.resolve(LIB, dir, name.replace(/\.ts$/, '.js')), lines.join('\n') + '\n');
 }

--- a/components/bin/build
+++ b/components/bin/build
@@ -165,12 +165,12 @@ function processParts(parts) {
  * Create the lines of the lib file using the object names from the file.
  *
  * @param {string} name       The path of the file relative to the root .ts directory
- * @param {string[]} objects  Array of names of the object exported by the file
+ * @param {string[]} objects  Array of names of the objects exported by the file
  * @return {string[]}         Array of lines for the contents of the library file
  */
 function processLines(file, objects) {
   if (objects.length === 0) return [];
-  const dir = path.dirname(file).replace(/^\.$/, '');
+  const dir = path.join(PREFIX, path.dirname(file).replace(/^\.$/, ''));
   const dots = dir.replace(/[^\/]+/g, '..') || '.';
   const relative = path.join(dots, '..', JS, dir, path.basename(file)).replace(/\.ts$/, '.js');
   const name = path.parse(file).name;
@@ -221,7 +221,7 @@ function makeDir(dir) {
  */
 function makeFile(file, lines) {
   if (!lines.length) return;
-  const [dir, name] = [path.dirname(file), path.basename(file)];
+  const [dir, name] = [path.join(PREFIX, path.dirname(file)), path.basename(file)];
   makeDir(dir);
   fs.writeFileSync(path.resolve(LIB, dir, name.replace(/\.ts$/, '.js')), lines.join('\n') + '\n');
 }


### PR DESCRIPTION
This PR fixes a problem with the `prefix` option added in commit d34a9bb by making sure the prefix is included in the directory path when the `lib` files are created.