### PR TITLE
Honor the rule_thickness and surd_height font parameters

### DIFF
--- a/ts/output/chtml/Wrappers/mfrac.ts
+++ b/ts/output/chtml/Wrappers/mfrac.ts
@@ -165,7 +165,7 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
         'box-sizing': 'border-box',
         'min-height': '1px',
         height: '.06em',               // t = rule_thickness
-        'border-top': '.06em solid',   // t
+        'border-top': '.075em solid',  // t * rule_factor (extra thickness as borders tend to be thin)
         margin: '.06em -.1em',         // t
         overflow: 'hidden'
       },
@@ -225,10 +225,11 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
       const tex = this.font.params;
       if (t !== .06) {
         const a = tex.axis_height;
+        const r = this.font.params.rule_factor;
         const tEm = this.em(t);
         const {T, u, v} = this.getTUV(display, t);
         const m = (display ? this.em(3 * t) : tEm) + ' -.1em';
-        attr.style = {height: tEm, 'border-top': tEm + ' solid', margin: m};
+        attr.style = {height: tEm, 'border-top': this.em(t * r) + ' solid', margin: m};
         const nh = this.em(Math.max(0, u));
         nsattr.style = {height: nh, 'vertical-align': '-' + nh};
         dsattr.style = {height: this.em(Math.max(0, v))};

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -120,7 +120,8 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       },
 
       'mjx-stretchy-v': {
-        display: 'inline-block'
+        display: 'inline-block',
+        'text-align': 'center'
       },
       'mjx-stretchy-v > *': {
         display: 'block'

--- a/ts/output/chtml/Wrappers/msqrt.ts
+++ b/ts/output/chtml/Wrappers/msqrt.ts
@@ -101,10 +101,12 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
       },
       'mjx-sqrt': {
         display: 'inline-block',
-        'padding-top': '.07em'
+        'padding-top': '.075em'
       },
       'mjx-sqrt > mjx-box': {
-        'border-top': '.07em solid'
+        'border-top': '.075em solid',
+        'padding-left': '.03em',
+        'margin-left': '-.03em'
       },
       'mjx-sqrt.mjx-tall > mjx-box': {
         'padding-left': '.3em',
@@ -124,21 +126,25 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
       const sbox = surd.getBBox();
       const bbox = base.getOuterBBox();
       const [ , q] = this.getPQ(sbox);
-      const t = this.font.params.rule_thickness;
+      const t = this.font.params.surd_height;
       const H = bbox.h + q + t;
+      const adaptor = this.adaptor;
       //
       //  Create the HTML structure for the root
       //
       const CHTML = this.standardChtmlNodes(parents);
       let SURD, BASE, ROOT, root;
       if (this.root != null) {
-        ROOT = this.adaptor.append(CHTML[0], this.html('mjx-root')) as N;
+        ROOT = adaptor.append(CHTML[0], this.html('mjx-root')) as N;
         root = this.childNodes[this.root];
       }
-      const SQRT = this.adaptor.append(CHTML[0], this.html('mjx-sqrt', {}, [
+      const SQRT = adaptor.append(CHTML[0], this.html('mjx-sqrt', {}, [
         SURD = this.html('mjx-surd'),
         BASE = this.html('mjx-box', {style: {paddingTop: this.em(q)}})
       ])) as N;
+      if (t !== .06) {
+        adaptor.setStyle(BASE, 'border-top-width', this.em(t * this.font.params.rule_factor));
+      }
       //
       //  Add the child content
       //
@@ -151,7 +157,7 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
         // top is hard to align with the horizontal line, so overlap them
         // using CSS.
         //
-        this.adaptor.addClass(SQRT, 'mjx-tall');
+        adaptor.addClass(SQRT, 'mjx-tall');
       }
     }
 

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -220,6 +220,7 @@ export type FontParameters = {
   delimiterfactor: number,
   delimitershortfall: number,
 
+  rule_factor: number,
   min_rule_thickness: number,
   separation_factor: number,
   extra_ic: number
@@ -467,13 +468,14 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     big_op_spacing4:  .6,
     big_op_spacing5:  .1,
 
-    surd_height:      .075,
+    surd_height:      .06,
 
     scriptspace:         .05,
     nulldelimiterspace:  .12,
     delimiterfactor:     901,
     delimitershortfall:   .3,
 
+    rule_factor:         1.25,     // multiply surd_height and rule_thickness by this for CHTML
     min_rule_thickness:  1.25,     // in pixels
     separation_factor:   1.75,     // expansion factor for spacing e.g. between accents and base
     extra_ic:            .033      // extra spacing for scripts (compensate for not having actual ic values)

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1178,11 +1178,8 @@ export class CommonWrapper<
       scale = this.bbox.scale;
     }
     const t = this.font.params.rule_thickness;
-    return lookup(length as string, {
-        medium: () => t,
-        thin: () => (2 / 3) * t,
-        thick: () => (5 / 3) * t
-    }, () => LENGTHS.length2em(length as string, size, scale, this.jax.pxPerEm))();
+    const factor = lookup(length as string, {medium: 1, thin: 2 / 3, thick: 5 / 3}, 0);
+    return factor ? factor * t : LENGTHS.length2em(length as string, size, scale, this.jax.pxPerEm);
   }
 
   /**

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -30,7 +30,7 @@ import {unicodeChars} from '../../util/string.js';
 import * as LENGTHS from '../../util/lengths.js';
 import {Styles} from '../../util/Styles.js';
 import {StyleList, CssStyles} from '../../util/StyleList.js';
-import {OptionList} from '../../util/Options.js';
+import {OptionList, lookup} from '../../util/Options.js';
 import {CommonOutputJax} from '../common.js';
 import {CommonWrapperFactory} from './WrapperFactory.js';
 import {CommonMo} from './Wrappers/mo.js';
@@ -1178,16 +1178,11 @@ export class CommonWrapper<
       scale = this.bbox.scale;
     }
     const t = this.font.params.rule_thickness;
-    if (length === 'medium') {
-      return t;
-    }
-    if (length === 'thin') {
-      return (2 / 3) * t;
-    }
-    if (length === 'thick') {
-      return (5 / 3) * t;
-    }
-    return LENGTHS.length2em(length as string, size, scale, this.jax.pxPerEm);
+    return lookup(length as string, {
+        medium: () => t,
+        thin: () => (2 / 3) * t,
+        thick: () => (5 / 3) * t
+    }, () => LENGTHS.length2em(length as string, size, scale, this.jax.pxPerEm))();
   }
 
   /**

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1177,6 +1177,16 @@ export class CommonWrapper<
     if (scale === null) {
       scale = this.bbox.scale;
     }
+    const t = this.font.params.rule_thickness;
+    if (length === 'medium') {
+      return t;
+    }
+    if (length === 'thin') {
+      return (2 / 3) * t;
+    }
+    if (length === 'thick') {
+      return (5 / 3) * t;
+    }
     return LENGTHS.length2em(length as string, size, scale, this.jax.pxPerEm);
   }
 

--- a/ts/output/common/Wrappers/msqrt.ts
+++ b/ts/output/common/Wrappers/msqrt.ts
@@ -214,10 +214,11 @@ export function CommonMsqrtMixin<
      */
     public getPQ(sbox: BBox): [number, number] {
       const t = this.font.params.rule_thickness;
+      const s = this.font.params.surd_height;
       const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
       const q = (sbox.h + sbox.d > this.surdH ?
-                 ((sbox.h + sbox.d) - (this.surdH - 2 * t - p / 2)) / 2 :
-                 t + p / 4);
+                 ((sbox.h + sbox.d) - (this.surdH - t - s - p / 2)) / 2 :
+                 s + p / 4);
       return [p, q];
     }
 
@@ -240,9 +241,10 @@ export function CommonMsqrtMixin<
      */
     public getStretchedSurd() {
       const t = this.font.params.rule_thickness;
+      const s = this.font.params.surd_height;
       const p = (this.node.attributes.get('displaystyle') ? this.font.params.x_height : t);
       const {h, d} = this.childNodes[this.base].getOuterBBox();
-      this.surdH = h + d + 2 * t + p / 4;
+      this.surdH = h + d + t + s + p / 4;
       this.surd.getStretchedVariant([this.surdH - d, d], true);
     }
 
@@ -268,9 +270,10 @@ export function CommonMsqrtMixin<
       const basebox = new BBox(this.childNodes[this.base].getOuterBBox());
       const q = this.getPQ(surdbox)[1];
       const t = this.font.params.rule_thickness;
+      const s = this.font.params.surd_height;
       const H = basebox.h + q + t;
       const [x] = this.getRootDimens(surdbox, H);
-      bbox.h = H + t;
+      bbox.h = H + s;
       this.combineRootBBox(bbox, surdbox, H);
       bbox.combine(surdbox, x, H - surdbox.h);
       bbox.combine(basebox, x + surdbox.w, 0);

--- a/ts/output/svg/Wrappers/msqrt.ts
+++ b/ts/output/svg/Wrappers/msqrt.ts
@@ -125,7 +125,7 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
       const sbox = surd.getBBox();
       const bbox = base.getOuterBBox();
       const q = this.getPQ(sbox)[1];
-      const t = this.font.params.rule_thickness * this.bbox.scale;
+      const t = this.font.params.surd_height * this.bbox.scale;
       const H = bbox.h + q + t;
       //
       //  Create the SVG structure for the root


### PR DESCRIPTION
This PR improves the handling of the `rule_thickness` and `surd_height` font parameters.  In the past, the `rule_thickness` was used where `surd_height` should be (TeX uses `rule_thickness` for both, but we allow them to be different), and the rule in fractions was not using `rule_thickness` since the MathML default for the `linethickness` attribute is `medium`, which was fixed at .06em.

Here, we modify the `length2em()` method of the `common/Wrapper.ts` to use the font's `rule_thickness` as the default for `medium` (and use percentages to get `thin` and `thick` values).  This allows `mfrac` to get the correct line thickness.  We also change the `msqrt` wrappers to use `surd_height` for the thickness of the line over the radicand.

It turns out that the results in CHTML is thinner than in SVG output, so we introduce a `rule_factor` to multiply the CHTML thicknesses by in order to get a comparable visual thickness.  Since this is in the font parameters, it can be adjusted to suit the font properly.  