### PR TITLE
Convert to XML and replace &nbsp; to avoid WebKit bug. (mathjax/MathJax#3030)

### DIFF
--- a/ts/input/mathml/mml3/mml3.ts
+++ b/ts/input/mathml/mml3/mml3.ts
@@ -75,8 +75,9 @@ export class Mml3<N, T, D> {
       this.transform = (node: N) => {
         const adaptor = document.adaptor;
         const div = adaptor.node('div', {}, [adaptor.clone(node)]);
-        const mml = processor.transformToDocument(div as any as Node) as any as N;
-        return adaptor.tags(mml, 'math')[0];
+        const dom = adaptor.parse(adaptor.outerHTML(div).replace(/&nbsp;/g, '&#xA0;'), 'text/xml');
+        const mml = processor.transformToDocument(dom as any as Node) as any as N;
+        return (mml ? adaptor.tags(mml, 'math')[0] : node);
       };
     }
   }

--- a/ts/input/mathml/mml3/mml3.ts
+++ b/ts/input/mathml/mml3/mml3.ts
@@ -75,7 +75,7 @@ export class Mml3<N, T, D> {
       this.transform = (node: N) => {
         const adaptor = document.adaptor;
         const div = adaptor.node('div', {}, [adaptor.clone(node)]);
-        const dom = adaptor.parse(adaptor.outerHTML(div).replace(/&nbsp;/g, '&#xA0;'), 'text/xml');
+        const dom = adaptor.parse(adaptor.serializeXML(div), 'text/xml');
         const mml = processor.transformToDocument(dom as any as Node) as any as N;
         return (mml ? adaptor.tags(mml, 'math')[0] : node);
       };


### PR DESCRIPTION
This PR addresses a problem with WebKit/Blink browsers where MathML that contains `&#xA0;` fails to be processed by the XSLT transform used by the `mml3` extension.  The issue seems to affect parsing of HTML, but not XML, so the solution seems to be to convert the HTML to XML.  But doing that converts `&#xA0;` to `&nbsp;`, which isn't parsed in XML, and so we also have to convert `&nbsp;` back to `&#xA0;` before parsing as XML.

I'm not sure if this is compatible with the new HTML-in-MathML extension, but since `mml3` is experimental, I think that is OK.  It is better to have this work on input that has `&#xA0;`.

Note that this PR also includes a change that if the transformation fails, the original MathML is used.

Resolves issue mathjax/MathJax#3030.