### PR TITLE
More reliable handling of stretchy assemblies

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -362,24 +362,21 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     const Hb = this.addDelimiterVPart(styles, c, 'beg', beg, begV, HDW);
     this.addDelimiterVPart(styles, c, 'ext', ext, extV, HDW);
     const He = this.addDelimiterVPart(styles, c, 'end', end, endV, HDW);
-    const css: StyleData = {};
     if (mid) {
       const Hm = this.addDelimiterVPart(styles, c, 'mid', mid, midV, HDW);
-      css.height = '50%';
-      styles['mjx-stretchy-v' + c + ' > mjx-mid'] = {
-        'margin-top': this.em(-Hm / 2),
-        'margin-bottom': this.em(-Hm / 2)
+      const m = this.em(Hm / 2 - .03);
+      styles[`mjx-stretchy-v${c} > mjx-ext:first-of-type`] = {
+        height: '50%',
+        'border-width': `${this.em0(Hb - .03)} 0 ${m}`
       };
-    }
-    if (Hb) {
-      css['border-top-width'] = this.em0(Hb - .03);
-    }
-    if (He) {
-      css['border-bottom-width'] = this.em0(He - .03);
-      styles['mjx-stretchy-v' + c + ' > mjx-end'] = {'margin-top': this.em(-He)};
-    }
-    if (Object.keys(css).length) {
-      styles['mjx-stretchy-v' + c + ' > mjx-ext'] = css;
+      styles[`mjx-stretchy-v${c} > mjx-ext:last-of-type`] = {
+        height: '50%',
+        'border-width': `${m} 0 ${this.em0(He - .03)}`
+      };
+    } else if (He || Hb) {
+      styles['mjx-stretchy-v' + c + ' > mjx-ext'] = {
+        'border-width': `${this.em0(Hb - .03)} 0 ${this.em0(He - .03)}`
+      };
     }
   }
 
@@ -397,19 +394,36 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     v: string, HDW: ChtmlCharData
   ): number {
     if (!n) return 0;
-    const data = this.getChar(v, n);
-    const dw = (HDW[2] - data[2]) / 2;
-    const css: StyleData = {};
+    const [h, d, w] = this.getChar(v, n);
+    const css: StyleData = {width: this.em0(w)};
     if (part !== 'ext') {
-      css.padding = this.padding(data, dw);
-    } else {
-      css.width = this.em0(HDW[2]);
-      if (dw) {
-        css['padding-left'] = this.em0(dw);
+      //
+      // If the non-extender is wider than the assembly,
+      //   use negative margins to center over the assembly
+      //
+      if (w > HDW[2]) {
+        css.margin = `0 ${this.em((HDW[2] - w) / 2)}`;
       }
+      //
+      // Non-extenders are 0 height, so place properly
+      //
+      const y = (part === 'beg' ? h : part === 'end' ? -d : (h - d) / 2);
+      if (y > 0) {
+        css['padding-top'] = this.em(y);
+      } else if (y < 0) {
+        css.transform = `translateY(${this.em(y)})`;
+      }
+    } else {
+      //
+      //  Put one fifth above the top of the extender (to avoid ragged ends)
+      //  and then scale with origin at the top of the extender (so most extends down)
+      //
+      const y = h - (h + d) / 5;
+      css.transform = `translateY(${this.em(y)}) scaleY(500)`;
+      css['transform-origin'] = `center ${this.em(.03 - y)}`;
     }
-    styles['mjx-stretchy-v' + c + ' mjx-' + part + ' mjx-c'] = css;
-    return data[0] + data[1];
+    styles[`mjx-stretchy-v${c} mjx-${part} mjx-c`] = css;
+    return h + d;
   }
 
   /*******************************************************/
@@ -421,15 +435,27 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    * @param {ChtmlDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
   protected addDelimiterHStyles(styles: StyleList, n: number, c: string, data: ChtmlDelimiterData) {
+    const HDW = data.HDW as ChtmlCharData;
     const [beg, ext, end, mid] = data.stretch;
     const [begV, extV, endV, midV] = this.getStretchVariants(n);
-    const HDW = data.HDW as ChtmlCharData;
-    this.addDelimiterHPart(styles, c, 'beg', beg, begV, HDW);
+    const Wb = this.addDelimiterHPart(styles, c, 'beg', beg, begV, HDW);
     this.addDelimiterHPart(styles, c, 'ext', ext, extV, HDW);
-    this.addDelimiterHPart(styles, c, 'end', end, endV, HDW);
+    const We = this.addDelimiterHPart(styles, c, 'end', end, endV, HDW);
     if (mid) {
-      this.addDelimiterHPart(styles, c, 'mid', mid, midV, HDW);
-      styles['mjx-stretchy-h' + c + ' > mjx-ext'] = {width: '50%'};
+      const Wm = this.addDelimiterHPart(styles, c, 'mid', mid, midV, HDW);
+      const m = this.em0(Wm / 2 - .03);
+      styles[`mjx-stretchy-h${c} > mjx-ext:first-of-type`] = {
+        width: '50%',
+        'border-width': `0 ${m} 0 ${this.em0(Wb - .03)}`
+      };
+      styles[`mjx-stretchy-h${c} > mjx-ext:last-of-type`] = {
+        width: '50%',
+        'border-width': `0 ${this.em0(We - .03)} 0 ${m}`
+      };
+    } else if (Wb || We) {
+      styles[`mjx-stretchy-h${c} > mjx-ext`] = {
+        'border-width': `0 ${this.em0(We - .03)} 0 ${this.em0(Wb - .03)}`
+      }
     }
   }
 
@@ -442,10 +468,19 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    * @param {ChtmlCharData} HDW The height-depth-width data for the stretchy character
    */
   protected addDelimiterHPart(styles: StyleList, c: string, part: string, n: number, v: string, HDW: ChtmlCharData) {
-    if (!n) return;
-    const w = this.getChar(v, n)[2];
-    const css: StyleData = {padding: this.padding(HDW as ChtmlCharData, 0, w - HDW[2])};
-    styles['mjx-stretchy-h' + c + ' mjx-' + part + ' mjx-c'] = css;
+    if (!n) return 0;
+    const [ , , w, options] = this.getChar(v, n);
+    const css: StyleData = {
+      padding: this.padding(HDW as ChtmlCharData, w - HDW[2])
+    };
+    if (part === 'end') {
+      css['margin-left'] = this.em(-w);
+    } else if (part === 'mid') {
+      css['margin-left'] = this.em(-w / 2);
+    }
+    this.checkCombiningChar(options, css);
+    styles[`mjx-stretchy-h${c} mjx-${part} mjx-c`] = css;
+    return w;
   }
 
   /*******************************************************/
@@ -461,18 +496,27 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     const letter = (options.f !== undefined ? options.f : vletter);
     const font = options.ff || (letter ? `${this.cssFontPrefix}-${letter}` : '');
     const selector = 'mjx-c' + this.charSelector(n) + (font ? '.' + font : '');
-    const def = styles[selector] = {padding: this.padding(data, 0, options.ic || 0)} as StyleData;
-    if (options.cmb) {
-      //
-      //  Some browsers now handle combining characters as 0-width even when they aren't, so
-      //  we adjust the CSS to handle both automatic 0-width as well as non-zero width characters.
-      //
-      const pad = (def.padding as string).split(/ /);
-      def.width = pad[1];
-      pad[1] = '0px';
-      def.padding = pad.join(' ');
-      def['text-align'] = 'right';
+    styles[selector] = {padding: this.padding(data, options.ic || 0)} as StyleData;
+    this.checkCombiningChar(options, styles[selector]);
+  }
+
+  /**
+   * @param {ChtmlCharoptions} options   The character options
+   * @param {StyleData} css              The style object to adjust
+   */
+  protected checkCombiningChar(options: ChtmlCharOptions, css: StyleData) {
+    if (!options.cmb) return;
+    //
+    //  Some browsers now handle combining characters as 0-width even when they aren't, so
+    //  we adjust the CSS to handle both automatic 0-width as well as non-zero width characters.
+    //
+    const pad = (css.padding as string).split(/ /);
+    css.width = pad[1];
+    pad[1] = '0';
+    if (!pad[3]) {
+      pad.pop();
     }
+    css.padding = pad.join(' ');
   }
 
   /***********************************************************************/
@@ -495,12 +539,11 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
 
   /**
    * @param {ChtmlCharData} data   The [h, d, w] data for the character
-   * @param {number} dw            The (optional) left offset of the glyph
    * @param {number} ic            The (optional) italic correction value
    * @return {string}              The padding string for the h, d, w.
    */
-  public padding([h, d, w]: ChtmlCharData, dw: number = 0, ic: number = 0): string {
-    return [h, w + ic, d, dw].map(this.em0).join(' ');
+  public padding([h, d, w]: ChtmlCharData, ic: number = 0): string {
+    return [h, w + ic, d, 0].map(this.em0).join(' ');
   }
 
   /**

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -96,7 +96,8 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
     public static styles: StyleList = {
       'mjx-c': {
         display: 'inline-block',
-        width: 0
+        width: 0,
+        'text-align': 'right'
       },
       'mjx-utext': {
         display: 'inline-block',

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -91,64 +91,38 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
      */
     public static styles: StyleList = {
       'mjx-stretchy-h': {
-        display: 'inline-table',
-        width: '100%'
+        display: 'inline-block',
       },
       'mjx-stretchy-h > *': {
-        display: 'table-cell',
-        width: 0
-      },
-      'mjx-stretchy-h > * > mjx-c': {
         display: 'inline-block',
-        transform: 'scalex(1.0000001)'      // improves blink positioning
+        width: 0
       },
       'mjx-stretchy-h > mjx-ext': {
         '/* IE */ overflow': 'hidden',
         '/* others */ overflow': 'clip visible',
         width: '100%',
-        'max-width': '0px',                // allows ext to be smaller than its character's width
+        border: '0px solid transparent',
+        'box-sizing': 'border-box',
         'text-align': 'center'
       },
       'mjx-stretchy-h > mjx-ext > mjx-c': {
         transform: 'scalex(500)',
         width: 0
       },
-      'mjx-stretchy-h > mjx-beg > mjx-c': {
-        'margin-right': '-.1em'
-      },
-      'mjx-stretchy-h > mjx-end > mjx-c': {
-        'margin-left': '-.1em'
-      },
 
       'mjx-stretchy-v': {
         display: 'inline-block'
       },
       'mjx-stretchy-v > *': {
-        display: 'block'
-      },
-      'mjx-stretchy-v > mjx-beg': {
+        display: 'block',
         height: 0
       },
-      'mjx-stretchy-v > mjx-end > mjx-c': {
-        display: 'block'
-      },
-      'mjx-stretchy-v > * > mjx-c': {
-        transform: 'scaley(1.0000001)',       // improves Firefox and blink positioning
-        'transform-origin': 'left center',
-      },
       'mjx-stretchy-v > mjx-ext': {
-        display: 'block',
-        height: '100%',
-        'box-sizing': 'border-box',
-        border: '0px solid transparent',
         '/* IE */ overflow': 'hidden',
         '/* others */ overflow': 'visible clip',
-      },
-      'mjx-stretchy-v > mjx-ext > mjx-c': {
-        width: 'auto',
-        'box-sizing': 'border-box',
-        transform: 'scaleY(500) translateY(.075em)',
-        overflow: 'visible'
+        height: '100%',
+        border: '0px solid transparent',
+        'box-sizing': 'border-box'
       },
       'mjx-mark': {
         display: 'inline-block',

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -158,8 +158,8 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       const B = this.addBot(stretch[2], variant[2], d, w);
       if (stretch.length === 4) {
         const [H, D] = this.addMidV(stretch[3], variant[3], w);
-        this.addExtV(stretch[1], variant[1], h, 0, T, H, w);
-        this.addExtV(stretch[1], variant[1], 0, d, D, B, w);
+        this.addExtV(stretch[1], variant[1], h, -H, T, 0, w);
+        this.addExtV(stretch[1], variant[1], -D, d, 0, B, w);
       } else {
         this.addExtV(stretch[1], variant[1], h, d, T, B, w);
       }
@@ -250,8 +250,8 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       const [h, d, w] = this.getChar(n, v);
       const Y = H + D - T - B;                 // The height of the extender
       const s = 1.5 * Y / (h + d);             // Scale height by 1.5 to avoid bad ends
-      //   (glyphs with rounded or anti-aliased ends don't stretch well,
-      //    so this makes for sharper ends)
+                                               //   (glyphs with rounded or anti-aliased ends don't stretch well,
+                                               //    so this makes for sharper ends)
       const y = (s * (h - d) - Y) / 2;         // The bottom point to clip the extender
       if (Y <= 0) return;
       const svg = this.svg('svg', {


### PR DESCRIPTION
This PR improves the handling of multi-character assemblies for stretchy characters, mostly in CHTML output, but a small change in SVG.  It makes the horizontal and vertical stretchies work more consistently (horizontals used to be fake tables).  Now both are handled using extenders that are 100% (or 50% for assemblies with a middle piece like braces), with transparent borders of the proper size where the end pieces go.  The ends are in 0-height or width boxes and are positioned to overlap the borders properly.  When there is a middle piece, the two extenders are 50% width, and the borders have to cover half the middle piece (this wasn't being properly handled before).

For CHTML, if a combining character is used in the assembly, we run into the issue with some browsers handling non-zero-width combining characters as zero width while others don't, so must use the trick of right-aligning the character in a `mjx-c` node of the proper width that we introduced earlier for single-character accents.  That code was refactored in order to be able to reuse it here.

These changes allow the CHTML css styles to be simplified.