### PR TITLE
Remove forced breaks that SVG inserted when switching to CHTML

### DIFF
--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -440,9 +440,13 @@ export abstract class CommonOutputJax<
     child.setProperty('breakable', true);
     if (forcebreak && linebreak !== 'newline') {
       child.setProperty('forcebreak', true);
-      if (mo) {
-        mo.setProperty('forcebreak', true);
-      }
+      mo?.setProperty('forcebreak', true);
+    } else {
+      //
+      //  If we switched from SVG to CHTML, we need to remove the forcebreak that SVG added
+      //
+      child.removeProperty('forcebreak');
+      mo?.removeProperty('forcebreak');
     }
     if (!marked) {
       node.setProperty('process-breaks', true);


### PR DESCRIPTION
This PR removes the `force break` property that SVG uses to manage in-line line breaks so that when switching from SVG to CHTML, we don't get unwanted line breaks.

To test, use an in-line expression with potential line breaks using SVG output and use the menu to switch to CHTML.  Without this PR, the CHTML in-line expression will have forced breaks at each potential break.  With the PR, it should render properly in CHTML.