### PR TITLE
Handle dash during font-change in `\operatorname`. (mathjax/MathJax#3038)

### DIFF
--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -43,7 +43,7 @@ namespace ParseMethods {
     const def = ParseUtil.getFontDef(parser);
     const env = parser.stack.env;
     if (env.multiLetterIdentifiers && env.font !== '') {
-      c = parser.string.substr(parser.i - 1).match(env.multiLetterIdentifiers as any as RegExp)[0];
+      c = parser.string.substr(parser.i - 1).match(env.multiLetterIdentifiers as any as RegExp)?.[0] || c;
       parser.i += c.length - 1;
       if (def.mathvariant === MATHVARIANT.NORMAL && env.noAutoOP && c.length > 1) {
         def.autoOP = false;

--- a/ts/input/tex/ams/AmsConfiguration.ts
+++ b/ts/input/tex/ams/AmsConfiguration.ts
@@ -67,6 +67,7 @@ export const AmsConfiguration = Configuration.create(
     options: {
       multlineWidth: '',
       ams: {
+        operatornamePattern: /^[-*a-zA-Z]+/,  // multiLetterIdentifier for \operatorname
         multlineWidth: '100%',  // The width to use for multline environments.
         multlineIndent: '1em',  // The margin to use on both sides of multline environments.
       }

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -238,7 +238,7 @@ AmsMethods.HandleOperatorName = function(parser: TexParser, name: string) {
   let mml = new TexParser(op, {
     ...parser.stack.env,
     font: TexConstant.Variant.NORMAL,
-    multiLetterIdentifiers: /^[-*a-zA-Z]+/ as any,
+    multiLetterIdentifiers: parser.options.ams.operatornamePattern,
     operatorLetters: true,
     noAutoOP: true
   }, parser.configuration).mml();

--- a/ts/input/tex/base/BaseConfiguration.ts
+++ b/ts/input/tex/base/BaseConfiguration.ts
@@ -192,7 +192,7 @@ export const BaseConfiguration: Configuration = Configuration.create(
     },
     options: {
       maxMacros: 1000,
-      identifierPattern: /^[a-zA-Z]+/,  // pattern for multLetterIdentifiers in \mathrm, etc.
+      identifierPattern: /^[a-zA-Z]+/,  // pattern for multiLetterIdentifiers in \mathrm, etc.
       baseURL: (typeof(document) === 'undefined' ||
                 document.getElementsByTagName('base').length === 0) ?
                 '' : String(document.location).replace(/#.*$/, '')

--- a/ts/input/tex/base/BaseConfiguration.ts
+++ b/ts/input/tex/base/BaseConfiguration.ts
@@ -192,6 +192,7 @@ export const BaseConfiguration: Configuration = Configuration.create(
     },
     options: {
       maxMacros: 1000,
+      identifierPattern: /^[a-zA-Z]+/,  // pattern for multLetterIdentifiers in \mathrm, etc.
       baseURL: (typeof(document) === 'undefined' ||
                 document.getElementsByTagName('base').length === 0) ?
                 '' : String(document.location).replace(/#.*$/, '')

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -311,9 +311,9 @@ BaseMethods.Hash = function(_parser: TexParser, _c: string) {
 BaseMethods.MathFont = function(parser: TexParser, name: string, variant: string) {
   const text = parser.GetArgument(name);
   let mml = new TexParser(text, {
+    multiLetterIdentifiers: /^[a-zA-Z]+/ as any,
     ...parser.stack.env,
     font: variant,
-    multiLetterIdentifiers: /^[a-zA-Z]+/ as any,
     noAutoOP: true
   }, parser.configuration).mml();
   parser.Push(parser.create('node', 'TeXAtom', [mml]));

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -311,7 +311,7 @@ BaseMethods.Hash = function(_parser: TexParser, _c: string) {
 BaseMethods.MathFont = function(parser: TexParser, name: string, variant: string) {
   const text = parser.GetArgument(name);
   let mml = new TexParser(text, {
-    multiLetterIdentifiers: /^[a-zA-Z]+/ as any,
+    multiLetterIdentifiers: parser.options.identifierPattern,
     ...parser.stack.env,
     font: variant,
     noAutoOP: true


### PR DESCRIPTION
This PR fixes a conflict with the usage of `multiLetterIdentifiers` between `\operatorname` and font-changing macros like `\mathsf`.  The solution is to preserve the `multiLetterIdentifiers` value if it exists when the font changes, so that an outer `\operatorname` setting will be inherited by an inner font change.

I've also added a check for a failing match of the `multiLetterIdentifiers`, though that really shouldn't happen (but did in this case because of the wrong pattern being used).

Resolves issue mathjax/MathJax#3038.