### PR TITLE
Make it easier to find a specific input jax by name

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -73,6 +73,11 @@ export type COMMONJAX = CommonOutputJax<any, any, any, any, any, any, any, any, 
 export type TEX = TeX<any, any, any>;
 
 /**
+ * Array of InputJax also with keys using name of jax
+ */
+export type JAXARRAY = INPUTJAX[] & {[name: string]: INPUTJAX};
+
+/**
  * A function to extend a handler class
  */
 export type HandlerExtension = (handler: HANDLER) => HANDLER;
@@ -84,7 +89,7 @@ export interface MathJaxObject extends MJObject {
   config: MathJaxConfig;
   startup: {
     constructors: {[name: string]: any};
-    input: INPUTJAX[];
+    input: JAXARRAY;
     output: OUTPUTJAX;
     handler: HANDLER;
     adaptor: DOMADAPTOR;
@@ -107,7 +112,7 @@ export interface MathJaxObject extends MJObject {
     makeOutputMethods(iname: string, oname: string, input: INPUTJAX): void;
     makeMmlMethods(name: string, input: INPUTJAX): void;
     makeResetMethod(name: string, input: INPUTJAX): void;
-    getInputJax(): INPUTJAX[];
+    getInputJax(): JAXARRAY;
     getOutputJax(): OUTPUTJAX;
     getAdaptor(): DOMADAPTOR;
     getHandler(): HANDLER;
@@ -142,7 +147,7 @@ export namespace Startup {
   /**
    * The array of InputJax instances (created after everything is loaded)
    */
-  export let input: INPUTJAX[] = [];
+  export let input: JAXARRAY = [] as JAXARRAY;
 
   /**
    * The OutputJax instance (created after everything is loaded)
@@ -473,14 +478,15 @@ export namespace Startup {
   }
 
   /**
-   * @return {INPUTJAX[]}  The array of instances of the registered input jax
+   * @return {JAXARRAY}  The array of instances of the registered input jax
    */
-  export function getInputJax(): INPUTJAX[] {
-    const jax = [] as INPUTJAX[];
+  export function getInputJax(): JAXARRAY {
+    const jax = [] as JAXARRAY;
     for (const name of CONFIG.input) {
       const inputClass = constructors[name];
       if (inputClass) {
-        jax.push(new inputClass(MathJax.config[name]));
+        jax[name] = new inputClass(MathJax.config[name]);
+        jax.push(jax[name]);
       } else {
         throw Error('Input Jax "' + name + '" is not defined (has it been loaded?)');
       }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -779,8 +779,9 @@ export class Menu {
   protected applySettings() {
     this.setTabOrder(this.settings.inTabOrder);
     this.document.options.enableAssistiveMml = this.settings.assistiveMml;
-    const promise = (this.settings.renderer !== this.defaultSettings.renderer ?
-                     this.setRenderer(this.settings.renderer, false) :
+    const renderer = this.settings.renderer.replace(/[^a-zA-Z0-9]/g, '') || 'CHTML';
+    const promise = (renderer !== this.defaultSettings.renderer ?
+                     this.setRenderer(renderer, false) :
                      Promise.resolve());
     promise.then(() => {
       this.document.outputJax.options.scale = parseFloat(this.settings.scale);
@@ -822,7 +823,7 @@ export class Menu {
    *                               and rerendering complete
    */
   protected setRenderer(jax: string, rerender: boolean = true): Promise<void> {
-    if (this.jax[jax]) {
+    if (this.jax.hasOwnProperty(jax) && this.jax[jax]) {
       return this.setOutputJax(jax, rerender);
     }
     const name = jax.toLowerCase();


### PR DESCRIPTION
This PR alters the `inputJax` array of the `MathDocument` to include named keys (as well was indices) for accessing the various input jax.  That way you can use `doc.inputJax.TeX` or `doc.inputJax.MathML` to access the needed input jax, rather than assuming it is `doc.inputJax[0]` or `doc.inputJax[1]`.  I leave the array as is, since it is itterable and some places loop through the jax.  Also, the output jax name is filtered when used to construct the URL for loading the jax when menu initialization causes an alternative jax to be loaded, for security.