### PR TITLE
Vertical spacing for horizontal stretchy characters more like TeX

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -435,9 +435,20 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
    * @param {ChtmlDelimiterData} data  The data for the delimiter whose CSS is to be added
    */
   protected addDelimiterHStyles(styles: StyleList, n: number, c: string, data: ChtmlDelimiterData) {
-    const HDW = data.HDW as ChtmlCharData;
+    const HDW = [...data.HDW] as ChtmlCharData;
     const [beg, ext, end, mid] = data.stretch;
     const [begV, extV, endV, midV] = this.getStretchVariants(n);
+    if (data.hd && !this.options.mathmlSpacing) {
+      //
+      // Interpolate between full character height/depth and that of the extender,
+      //   which is what TeX uses, but TeX's fonts are set up to have extra height
+      //   or depth for some extenders, so this factor helps get spacing that is closer
+      //   to TeX spacing.
+      //
+      const t = this.params.extender_factor;
+      HDW[0] = HDW[0] * (1 - t) + data.hd[0] * t;
+      HDW[1] = HDW[1] * (1 - t) + data.hd[1] * t;
+    }
     const Wb = this.addDelimiterHPart(styles, c, 'beg', beg, begV, HDW);
     this.addDelimiterHPart(styles, c, 'ext', ext, extV, HDW);
     const We = this.addDelimiterHPart(styles, c, 'end', end, endV, HDW);

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -247,6 +247,7 @@ export abstract class CommonOutputJax<
     this.factory.jax = this;
     this.cssStyles = this.options.cssStyles || new CssStyles();
     this.font = font || new fontClass(fontOptions);
+    this.font.setOptions({mathmlSpacing: this.options.mathmlSpacing});
     this.unknownCache = new Map();
     const linebreaks = (this.options.linebreaks.LinebreakVisitor || LinebreakVisitor) as typeof Linebreaks;
     this.linebreaks = new linebreaks(this.factory);

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -41,6 +41,7 @@ export interface CharOptions {
   dx?: number;                  // offset for combining characters
   unknown?: boolean;            // true if not found in the given variant
   smp?: number;                 // Math Alphanumeric codepoint this char is mapped to
+  hd?: [number, number];        // the original height and depth for an extender
 }
 
 /****************************************************************************/
@@ -137,6 +138,7 @@ export type DelimiterData = {
   stretchv?: number[];  // the variants to use for the stretchy characters (index into variant name array)
   HDW?: number[];       // [h, d, w] (for vertical, h and d are the normal size, w is the multi-character width,
                         //            for horizontal, h and d are the multi-character ones, w is for the normal size).
+  hd?: number[];        // The extender's original [h, d] values
   min?: number;         // The minimum size a multi-character version can be
   c?: number;           // The character number (for aliased delimiters)
   fullExt?: [number, number]  // When present, extenders must be full sized, and the first number is
@@ -223,7 +225,8 @@ export type FontParameters = {
 
   min_rule_thickness: number,
   separation_factor: number,
-  extra_ic: number
+  extra_ic: number,
+  extender_factor: number,
 };
 
 /**
@@ -583,7 +586,8 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
 
     min_rule_thickness:  1.25,     // in pixels
     separation_factor:   1.75,     // expansion factor for spacing e.g. between accents and base
-    extra_ic:            .033      // extra spacing for scripts (compensate for not having actual ic values)
+    extra_ic:            .033,     // extra spacing for scripts (compensate for not having actual ic values)
+    extender_factor:     .333      // factor to adjust between full stretchy height/depth and extender height/depth
   };
 
 
@@ -830,6 +834,13 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     this.defineRemap('mn', CLASS.defaultMnMap);
     this.defineDynamicCharacters(CLASS.dynamicFiles);
     CLASS.dynamicExtensions.forEach(data => this.defineDynamicCharacters(data.files));
+  }
+
+  /**
+   * @param {OptionList} options   The options to merge into the font options
+   */
+  public setOptions(options: OptionList) {
+    mergeOptions(this.options, options);
   }
 
   /**

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -438,6 +438,17 @@ export function CommonMoMixin<
         [h, d] = this.getBaseline(WHD, D, C);
       } else {
         w = D;
+        if (this.stretch.hd && !this.jax.options.mathmlSpacing) {
+          //
+          // Interpolate between full character height/depth and that of the extender,
+          //   which is what TeX uses, but TeX's fonts are set up to have extra height
+          //   or depth for some extenders, so this factor helps get spacing that is closer
+          //   to TeX spacing.
+          //
+          const t = this.font.params.extender_factor;
+          h = h * (1 - t) + this.stretch.hd[0] * t;
+          d = d * (1 - t) + this.stretch.hd[1] * t;
+        }
       }
       this.bbox.h = h;
       this.bbox.d = d;


### PR DESCRIPTION
This PR changes the vertical spacing for horizontal stretchy assemblies.  In TeX, these have the height and depth of the extender character, but in MathML, they are the maximum height and depth of any character in the assembly.  MathJax implements the latter, but this makes things like `\overrightarrow` have more height and separation from the base than TeX does.  In the TeX fonts, some of the characters used for extenders have height/depth that is different from their inked area in order to adjust the spacing, but the fonts used in MathJax don't have that (though potentially it could be added by hand).

This PR adds a font parameter that controls how MathJax uses the extender height/depth versus the total assembly's.  Its value is a linear interpolation value between the two values, defaulting to 1/3 of the extender's value and 2/3 of the total, which seems to do pretty well for the mathjax-modern and mathjax-stix2 fonts.  This factor is only used when `mathmlSpacing` is false; for MathML spacing, the fully assembly height is always used.

To test this, you need a new copy of the fonts that has the needed extender data, but I haven't made the npmjs packages for that, yet.  Let me know if you want to try it out, and I'll publish one.