### PR TITLE
Properly handle italic correction for -tex-mit, and for subscripts with multi-character bases

### DIFF
--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -497,6 +497,9 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     const font = options.ff || (letter ? `${this.cssFontPrefix}-${letter}` : '');
     const selector = 'mjx-c' + this.charSelector(n) + (font ? '.' + font : '');
     styles[selector] = {padding: this.padding(data, options.ic || 0)} as StyleData;
+    if (options.oc) {
+      styles[selector + ':last-child'] = {'padding-right': this.em(data[2] + options.oc)};
+    }
     this.checkCombiningChar(options, styles[selector]);
   }
 

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -496,9 +496,9 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     const letter = (options.f !== undefined ? options.f : vletter);
     const font = options.ff || (letter ? `${this.cssFontPrefix}-${letter}` : '');
     const selector = 'mjx-c' + this.charSelector(n) + (font ? '.' + font : '');
-    styles[selector] = {padding: this.padding(data, options.ic || 0)} as StyleData;
+    styles[selector] = {padding: this.padding(data, options.oc || options.ic || 0)} as StyleData;
     if (options.oc) {
-      styles[selector + ':last-child'] = {'padding-right': this.em(data[2] + options.oc)};
+      styles[selector + '[noic]'] = {'padding-right': this.em(data[2])};
     }
     this.checkCombiningChar(options, styles[selector]);
   }

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -496,7 +496,8 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     const letter = (options.f !== undefined ? options.f : vletter);
     const font = options.ff || (letter ? `${this.cssFontPrefix}-${letter}` : '');
     const selector = 'mjx-c' + this.charSelector(n) + (font ? '.' + font : '');
-    styles[selector] = {padding: this.padding(data, options.oc || options.ic || 0)} as StyleData;
+    const padding = options.oc || options.ic || 0;
+    styles[selector] = {padding: this.padding(data, padding)} as StyleData;
     if (options.oc) {
       styles[selector + '[noic]'] = {'padding-right': this.em(data[2])};
     }

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -115,14 +115,17 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
       const variant = this.parent.variant;
       const text = (this.node as TextNode).getText();
       if (text.length === 0) return;
+      const bbox = this.getBBox();
       if (variant === '-explicitFont') {
         const {scale} = this.parent.getBBox();
-        adaptor.append(parent, this.jax.unknownText(text, variant, this.getBBox().w, scale));
+        adaptor.append(parent, this.jax.unknownText(text, variant, bbox.w, scale));
       } else {
         let utext = '';
         const chars = this.remappedText(text, variant);
         const H = (chars.length > 1 ? this.em(this.parent.getBBox().h) : '');
-        for (const n of chars) {
+        const m = chars.length;
+        for (let i = 0; i < m; i++) {
+          const n = chars[i];
           const data = (this.getVariantChar(variant, n) as ChtmlCharData)[3];
           if (data.unknown) {
             utext += String.fromCodePoint(n);
@@ -132,6 +135,9 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<N, T, D> 
             const node = adaptor.append(parent, this.html('mjx-c', {class: this.char(n) + (font ? ' ' + font : '')}, [
               this.text(data.c || String.fromCodePoint(n))
             ]));
+            if (i < m - 1 || bbox.oc) {
+              adaptor.setAttribute(node as N, 'noic', 'true');
+            }
             if (H) {
               //
               //  Work around WebKit alignment bug by making all letters in

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -243,6 +243,9 @@ export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
       const ic = this.getAdjustedIc();
       if (ic) {
         adaptor.setStyle(sup.dom[0], 'marginLeft', this.em(ic / sup.bbox.rscale));
+        if (!this.baseIsChar) {
+          adaptor.setStyle(sub.dom[0], 'marginLeft', this.em(ic / sup.bbox.rscale));
+        }
       }
       if (this.baseRemoveIc) {
         adaptor.setStyle(stack, 'marginLeft', this.em(-this.baseIc));

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -37,6 +37,7 @@ export {DIRECTION} from './Direction.js';
  */
 export interface CharOptions {
   ic?: number;                  // italic correction value
+  oc?: number;                  // original ic for -tex-mit font
   sk?: number;                  // skew value
   dx?: number;                  // offset for combining characters
   unknown?: boolean;            // true if not found in the given variant

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -164,10 +164,10 @@ export function CommonTextNodeMixin<
         //
         // Loop through the characters and add them in one by one
         //
-        for (const char of chars) {
-          let [h, d, w, data] = this.getVariantChar(variant, char);
+        for (let i = 0; i < chars.length; i++) {
+          let [h, d, w, data] = this.getVariantChar(variant, chars[i]);
           if (data.unknown) {
-            utext += String.fromCodePoint(char);
+            utext += String.fromCodePoint(chars[i]);
           } else {
             utext = this.addUtextBBox(bbox, utext, variant);
             //
@@ -177,9 +177,16 @@ export function CommonTextNodeMixin<
             bbox.ic = data.ic || 0;
             bbox.sk = data.sk || 0;
             bbox.dx = data.dx || 0;
+            if (!data.oc || i < chars.length - 1) continue;
             const children = this.parent.childNodes;
-            if (data.oc && this.node === children[children.length - 1].node) {
+            if (this.node !== children[children.length - 1].node) continue;
+            const parent = this.parent.parent.node;
+            const next = (parent.isKind('mrow') || parent.isInferred ?
+                          parent.childNodes[parent.childIndex(this.parent.node) + 1] : null);
+            if (!next || next.attributes.get('mathvariant') !== variant) {
               bbox.ic = data.oc;
+            } else {
+              bbox.oc = data.oc;
             }
           }
         }

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -177,6 +177,10 @@ export function CommonTextNodeMixin<
             bbox.ic = data.ic || 0;
             bbox.sk = data.sk || 0;
             bbox.dx = data.dx || 0;
+            const children = this.parent.childNodes;
+            if (data.oc && this.node === children[children.length - 1].node) {
+              bbox.ic = data.oc;
+            }
           }
         }
         this.addUtextBBox(bbox, utext, variant);

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -27,6 +27,7 @@ import {CharOptions, VariantData, DelimiterData, FontData, FontDataClass} from '
 import {CommonOutputJax} from '../../common.js';
 import {BBox} from '../../../util/BBox.js';
 import {TextNode} from '../../../core/MmlTree/MmlNode.js';
+import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 
 /*****************************************************************/
 /**
@@ -181,8 +182,11 @@ export function CommonTextNodeMixin<
             const children = this.parent.childNodes;
             if (this.node !== children[children.length - 1].node) continue;
             const parent = this.parent.parent.node;
-            const next = (parent.isKind('mrow') || parent.isInferred ?
-                          parent.childNodes[parent.childIndex(this.parent.node) + 1] : null);
+            let next = (parent.isKind('mrow') || parent.isInferred ?
+                        parent.childNodes[parent.childIndex(this.parent.node) + 1] : null);
+            if (next?.isKind('mo') && (next as MmlMo).getText() === '\u2062') {
+              next = parent.childNodes[parent.childIndex(next) + 1];
+            }
             if (!next || next.attributes.get('mathvariant') !== variant) {
               bbox.ic = data.oc;
             } else {

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -143,7 +143,8 @@ export function CommonMsubMixin<
      * @override
      */
     public getOffset() {
-      return [0, -this.getV()];
+      const x = (this.baseIsChar ? 0 : this.getAdjustedIc());
+      return [x, -this.getV()];
     }
 
   } as any as B;
@@ -469,7 +470,7 @@ export function CommonMsubsupMixin<
       const x = this.getAdjustedIc();
       const [u, v] = this.getUVQ();
       const y = bbox.d - this.baseChild.getLineBBox(this.baseChild.breakCount).d;
-      bbox.combine(subbox, w, v - y);
+      bbox.combine(subbox, w + (this.baseIsChar ? 0 : x), v - y);
       bbox.combine(supbox, w + x, u - y);
       bbox.w += this.font.params.scriptspace;
       return bbox;

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -542,8 +542,7 @@ export function CommonScriptbaseMixin<
      * @override
      */
     public getAdjustedIc(): number {
-      const bbox = this.baseCore.getOuterBBox();
-      return (bbox.ic ? 1.05 * bbox.ic + .05 : 0) * this.baseScale;
+      return (this.baseIc ? 1.05 * this.baseIc + .05 : 0);
     }
 
     /**

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -220,7 +220,7 @@ export const SvgMsubsup = (function <N, T, D>(): SvgMsubsupClass<N, T, D> {
       sub.toSVG(tail);
 
       base.place(0, 0);
-      sub.place(w, v);
+      sub.place(w + (this.baseIsChar ? 0 : x), v);
       sup.place(w + x, u);
     }
 

--- a/ts/util/BBox.ts
+++ b/ts/util/BBox.ts
@@ -63,6 +63,7 @@ export class BBox {
   public R: number;      // extra space on the right
   public pwidth: string; // percentage width (for tables)
   public ic: number;     // italic correction
+  public oc: number;     // alternate italic correction for -tex-mit variant
   public sk: number;     // skew
   public dx: number;     // offset for combining characters as accents
   /* tslint:enable */
@@ -90,7 +91,7 @@ export class BBox {
     this.w = def.w || 0;
     this.h = ('h' in def ? def.h : -BIGDIMEN);
     this.d = ('d' in def ? def.d : -BIGDIMEN);
-    this.L = this.R = this.ic = this.sk = this.dx = 0;
+    this.L = this.R = this.ic = this.oc = this.sk = this.dx = 0;
     this.scale = this.rscale = 1;
     this.pwidth = '';
   }


### PR DESCRIPTION
This PR fixes spacing issues with the `-tex-mit` pseudo variant used for `\mathit` and `\it` by adding italic correction information in a property `oc` (other correction) that is only used by the last character in a string of characters in that variant.  That is, `\mathit{office}` and `{\it office}` will have the italic correction only on the last letter rather than between every letter, as in `office`, where the spacing between the f's is too wide, for example.  This allows superscripts and subscripts to be placed properly after such characters (e.g., `\mathit{f}^0` used to be too close).

This PR also fixes an inconsistency with TeX's placement of super and subscripts when the base is multi-character.  In TeX, `{UU}_0^1` has the scripts vertically aligned above each other, whereas in `U_0^1` they are offset to match the italic correction.  Before this patch, MathJax would use italic correction offsets in both places; after the patch, it works as in TeX.

This PR also requires a new copy of the fonts in order to include the needed `oc` data.  If you want to run it, I will publish a new npm package with the needed data.