### PR TITLE
Properly place super- and subscripts for stretched operators. (mathjax/MathJax#3049)

### DIFF
--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -29,6 +29,7 @@ import {CommonWrapperFactory} from '../WrapperFactory.js';
 import {CharOptions, VariantData, DelimiterData, FontData, FontDataClass} from '../FontData.js';
 import {CommonOutputJax} from '../../common.js';
 import {CommonMunderover} from './munderover.js';
+import {CommonMo} from './mo.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {MmlMsubsup} from '../../../core/MmlTree/MmlNodes/msubsup.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
@@ -605,8 +606,10 @@ export function CommonScriptbaseMixin<
      */
     public baseCharZero(n: number): number {
       const largeop = !!this.baseCore.node.attributes.get('largeop');
+      const sized = !!(this.baseCore.node.isKind('mo') &&
+                        (this.baseCore as any as CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>).size);
       const scale = this.baseScale;
-      return (this.baseIsChar && !largeop && scale === 1 ? 0 : n);
+      return (this.baseIsChar && !largeop && !sized && scale === 1 ? 0 : n);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a problem where superscripts and subscripts aren't placed properly on an operator that has been stretched.  There is an example in the initial issue

Resolves issue mathjax/MathJax#3049.