### PR TITLE
Updates to the latest version of the context menu.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "esm": "^3.2.25",
         "mathjax-modern-font": "^1.0.0-beta.2",
         "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
+        "mj-context-menu": "^0.9.0",
         "speech-rule-engine": "^4.1.0-beta.3"
       },
       "devDependencies": {
@@ -3548,9 +3548,9 @@
       "dev": true
     },
     "node_modules/mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.9.0.tgz",
+      "integrity": "sha512-kwnTzixaDm0EjzTHpeWwKVQuPjACIXY9cZO4VMw6OWRmo0KYKp7D3xEEhler01WodF2ApdPD0TJcraWm8H3AUQ=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -7646,9 +7646,9 @@
       "dev": true
     },
     "mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.9.0.tgz",
+      "integrity": "sha512-kwnTzixaDm0EjzTHpeWwKVQuPjACIXY9cZO4VMw6OWRmo0KYKp7D3xEEhler01WodF2ApdPD0TJcraWm8H3AUQ=="
     },
     "mkdirp": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "esm": "^3.2.25",
     "mathjax-modern-font": "^1.0.0-beta.2",
     "mhchemparser": "^4.1.0",
-    "mj-context-menu": "^0.6.1",
+    "mj-context-menu": "^0.9.0",
     "speech-rule-engine": "^4.1.0-beta.3"
   }
 }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -44,7 +44,7 @@ import * as MenuUtil from './MenuUtil.js';
 import {Info} from 'mj-context-menu/js/info.js';
 import {Parser} from 'mj-context-menu/js/parse.js';
 import {Rule} from 'mj-context-menu/js/item_rule.js';
-import {CssStyles} from 'mj-context-menu/js/css_util.js';
+import * as CssStyles from 'mj-context-menu/js/css_util.js';
 import {Submenu} from 'mj-context-menu/js/item_submenu.js';
 
 


### PR DESCRIPTION
`v0.9.0` of the context menu removes all namespace, which leads to a single line change in MathJax.