### PR TITLE
Update dev dependencies.  Fix new type warnings from tsc v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,17 +17,17 @@
       },
       "devDependencies": {
         "copyfiles": "^2.4.1",
-        "diff": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "tape": "^5.5.3",
-        "terser-webpack-plugin": "^5.3.1",
+        "diff": "^5.1.0",
+        "rimraf": "^5.0.1",
+        "tape": "^5.6.3",
+        "terser-webpack-plugin": "^5.3.9",
         "tslint": "^6.1.3",
         "tslint-jsdoc-rules": "^0.2.0",
         "tslint-unix-formatter": "^0.2.0",
-        "typescript": "^4.6.4",
+        "typescript": "^5.1.3",
         "typescript-tools": "^0.3.1",
-        "webpack": "^5.72.1",
-        "webpack-cli": "^4.9.2"
+        "webpack": "^5.85.0",
+        "webpack-cli": "^5.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -72,6 +72,102 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -130,6 +226,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/eslint": {
@@ -317,34 +423,42 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
+      "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
       "dev": true,
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
+      "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
       "dev": true,
-      "dependencies": {
-        "envinfo": "^7.7.3"
+      "engines": {
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
+      "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
       "dev": true,
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
@@ -803,6 +917,12 @@
         "ignored": "bin/ignored"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.417",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.417.tgz",
@@ -1075,6 +1195,22 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fs.realpath": {
@@ -1368,12 +1504,12 @@
       }
     },
     "node_modules/interpret": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/is-arguments": {
@@ -1671,6 +1807,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
+      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -1746,6 +1900,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/mathjax-modern-font": {
       "version": "1.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-1.0.0-beta.5.tgz",
@@ -1802,6 +1965,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mj-context-menu": {
@@ -1973,6 +2145,22 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2028,15 +2216,15 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/rechoir/node_modules/resolve": {
@@ -2130,15 +2318,64 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^10.2.5"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
+      "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2261,6 +2498,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2331,6 +2580,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -2377,6 +2641,19 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -2843,16 +3120,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-tools": {
@@ -2994,42 +3271,40 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.1.tgz",
+      "integrity": "sha512-OLJwVMoXnXYH2ncNGU8gxVpUtm3ybvdioiTvHgUyBuyMLKiVvWy+QObzBsMtp5pH7qQoEuWgeEUQ/sU3ZJFzAw==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.2.0",
-        "@webpack-cli/info": "^1.5.0",
-        "@webpack-cli/serve": "^1.7.0",
+        "@webpack-cli/configtest": "^2.1.0",
+        "@webpack-cli/info": "^2.0.1",
+        "@webpack-cli/serve": "^2.0.4",
         "colorette": "^2.0.14",
-        "commander": "^7.0.0",
+        "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
-        "interpret": "^2.2.0",
-        "rechoir": "^0.7.0",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
         "webpack-merge": "^5.7.3"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x"
+        "webpack": "5.x.x"
       },
       "peerDependenciesMeta": {
         "@webpack-cli/generators": {
-          "optional": true
-        },
-        "@webpack-cli/migrate": {
           "optional": true
         },
         "webpack-bundle-analyzer": {
@@ -3041,12 +3316,12 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">=14"
       }
     },
     "node_modules/webpack-merge": {
@@ -3164,6 +3439,57 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -115,17 +115,17 @@
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",
-    "diff": "^5.0.0",
-    "rimraf": "^3.0.2",
-    "tape": "^5.5.3",
-    "terser-webpack-plugin": "^5.3.1",
+    "diff": "^5.1.0",
+    "rimraf": "^5.0.1",
+    "tape": "^5.6.3",
+    "terser-webpack-plugin": "^5.3.9",
     "tslint": "^6.1.3",
     "tslint-jsdoc-rules": "^0.2.0",
     "tslint-unix-formatter": "^0.2.0",
-    "typescript": "^4.6.4",
+    "typescript": "^5.1.3",
     "typescript-tools": "^0.3.1",
-    "webpack": "^5.72.1",
-    "webpack-cli": "^4.9.2"
+    "webpack": "^5.85.0",
+    "webpack-cli": "^5.1.1"
   },
   "dependencies": {
     "mathjax-modern-font": "^1.0.0-beta.5",

--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -48,472 +48,473 @@ export type TypeRole<T> = {[type: string]: T | {[role: string]: T}};
  */
 export class Collapse {
 
-    /**
-     * A constant to use to indicate no collapsing
-     */
-    public static NOCOLLAPSE: number = 10000000; // really big complexity
+  /**
+   * A constant to use to indicate no collapsing
+   */
+  public static NOCOLLAPSE: number = 10000000; // really big complexity
 
-    /**
-     * The complexity object containing this one
-     */
-    public complexity: ComplexityVisitor;
+  /**
+   * The complexity object containing this one
+   */
+  public complexity: ComplexityVisitor;
 
-    /**
-     * The cutt-off complexity values for when a structure
-     *   of the given type should collapse
-     */
-    public cutoff: TypeRole<number> = {
-        identifier: 3,
-        number: 3,
-        text: 10,
-        infixop: 15,
-        relseq: 15,
-        multirel: 15,
-        fenced: 18,
-        bigop: 20,
-        integral: 20,
-        fraction: 12,
-        sqrt: 9,
-        root: 12,
-        vector: 15,
-        matrix: 15,
-        cases: 15,
-        superscript: 9,
-        subscript: 9,
-        subsup: 9,
-        punctuated: {
-            endpunct: Collapse.NOCOLLAPSE,
-            startpunct: Collapse.NOCOLLAPSE,
-            value: 12
-        }
-    };
-
-    /**
-     *  These are the characters to use for the various collapsed elements
-     *  (if an object, then semantic-role is used to get the character
-     *  from the object)
-     */
-    public marker: TypeRole<string> = {
-        identifier: 'x',
-        number: '#',
-        text: '...',
-        appl: {
-            'limit function': 'lim',
-            value: 'f()'
-        },
-        fraction: '/',
-        sqrt: '\u221A',
-        root: '\u221A',
-        superscript: '\u25FD\u02D9',
-        subscript: '\u25FD.',
-        subsup: '\u25FD:',
-        vector: {
-            binomial: '(:)',
-            determinant: '|:|',
-            value: '\u27E8:\u27E9'
-        },
-        matrix: {
-            squarematrix: '[::]',
-            rowvector: '\u27E8\u22EF\u27E9',
-            columnvector: '\u27E8\u22EE\u27E9',
-            determinant: '|::|',
-            value: '(::)'
-        },
-        cases: '{:',
-        infixop: {
-            addition: '+',
-            subtraction: '\u2212',
-            multiplication: '\u22C5',
-            implicit: '\u22C5',
-            value: '+'
-        },
-        punctuated: {
-            text: '...',
-            value: ','
-        }
-    };
-
-    /**
-     * The type-to-function mapping for semantic types
-     */
-    public collapse: CollapseFunctionMap = new Map([
-
-        //
-        //  For fenced elements, if the contents are collapsed,
-        //    collapse the fence instead.
-        //
-        ['fenced', (node, complexity) => {
-            complexity = this.uncollapseChild(complexity, node, 1);
-            if (complexity > this.cutoff.fenced && node.attributes.get('data-semantic-role') === 'leftright') {
-                complexity = this.recordCollapse(
-                    node, complexity,
-                    this.getText(node.childNodes[0]) +
-                        this.getText(node.childNodes[node.childNodes.length - 1])
-                );
-            }
-            return complexity;
-        }],
-
-        //
-        //  Collapse function applications if the argument is collapsed
-        //    (FIXME: Handle role="limit function" a bit better?)
-        //
-        ['appl', (node, complexity) => {
-            if (this.canUncollapse(node, 2, 2)) {
-                complexity = this.complexity.visitNode(node, false);
-                const marker = this.marker.appl as {[name: string]: string};
-                const text = marker[node.attributes.get('data-semantic-role') as string] || marker.value;
-                complexity = this.recordCollapse(node, complexity, text);
-            }
-            return complexity;
-        }],
-
-        //
-        //  For sqrt elements, if the contents are collapsed,
-        //    collapse the sqrt instead.
-        //
-        ['sqrt', (node, complexity) => {
-            complexity = this.uncollapseChild(complexity, node, 0);
-            if (complexity > this.cutoff.sqrt) {
-                complexity = this.recordCollapse(node, complexity, this.marker.sqrt as string);
-            }
-            return complexity;
-        }],
-        ['root', (node, complexity) => {
-            complexity = this.uncollapseChild(complexity, node, 0, 2);
-            if (complexity > this.cutoff.sqrt) {
-                complexity = this.recordCollapse(node, complexity, this.marker.sqrt as string);
-            }
-            return complexity;
-        }],
-
-        //
-        //  For enclose, include enclosure in collapse
-        //
-        ['enclose', (node, complexity) => {
-            if (this.splitAttribute(node, 'children').length === 1) {
-                const child = this.canUncollapse(node, 1);
-                if (child) {
-                    const marker = child.getProperty('collapse-marker') as string;
-                    this.unrecordCollapse(child);
-                    complexity = this.recordCollapse(node, this.complexity.visitNode(node, false), marker);
-                }
-            }
-            return complexity;
-        }],
-
-        //
-        //  For bigops, get the character to use from the largeop at its core.
-        //
-        ['bigop', (node, complexity) => {
-            if (complexity > this.cutoff.bigop || !node.isKind('mo')) {
-                const id = this.splitAttribute(node, 'content').pop();
-                const op = this.findChildText(node, id);
-                complexity = this.recordCollapse(node, complexity, op);
-            }
-            return complexity;
-        }],
-        ['integral', (node, complexity) => {
-            if (complexity > this.cutoff.integral || !node.isKind('mo')) {
-                const id = this.splitAttribute(node, 'content').pop();
-                const op = this.findChildText(node, id);
-                complexity = this.recordCollapse(node, complexity, op);
-            }
-            return complexity;
-        }],
-
-        //
-        //  For relseq and multirel, use proper symbol
-        //
-        ['relseq', (node, complexity) => {
-            if (complexity > this.cutoff.relseq) {
-                const id = this.splitAttribute(node, 'content')[0];
-                const text = this.findChildText(node, id);
-                complexity = this.recordCollapse(node, complexity, text);
-            }
-            return complexity;
-        }],
-        ['multirel', (node, complexity) => {
-            if (complexity > this.cutoff.relseq) {
-                const id = this.splitAttribute(node, 'content')[0];
-                const text = this.findChildText(node, id) + '\u22EF';
-                complexity = this.recordCollapse(node, complexity, text);
-            }
-            return complexity;
-        }],
-
-        //
-        //  Include super- and subscripts into a collapsed base
-        //
-        ['superscript', (node, complexity) => {
-            complexity = this.uncollapseChild(complexity, node, 0, 2);
-            if (complexity > this.cutoff.superscript) {
-                complexity = this.recordCollapse(node, complexity, this.marker.superscript as string);
-            }
-            return complexity;
-        }],
-        ['subscript', (node, complexity) => {
-            complexity = this.uncollapseChild(complexity, node, 0, 2);
-            if (complexity > this.cutoff.subscript) {
-                complexity = this.recordCollapse(node, complexity, this.marker.subscript as string);
-            }
-            return complexity;
-        }],
-        ['subsup', (node, complexity) => {
-            complexity = this.uncollapseChild(complexity, node, 0, 3);
-            if (complexity > this.cutoff.subsup) {
-                complexity = this.recordCollapse(node, complexity, this.marker.subsup as string);
-            }
-            return complexity;
-        }]
-
-    ] as [string, CollapseFunction][]);
-
-    /**
-     * The highest id number used for mactions so far
-     */
-    private idCount = 0;
-
-    /**
-     * @param {ComplexityVisitor} visitor  The visitor for computing complexities
-     */
-    constructor(visitor: ComplexityVisitor) {
-        this.complexity = visitor;
+  /**
+   * The cutt-off complexity values for when a structure
+   *   of the given type should collapse
+   */
+  public cutoff: TypeRole<number> = {
+    identifier: 3,
+    number: 3,
+    text: 10,
+    infixop: 15,
+    relseq: 15,
+    multirel: 15,
+    fenced: 18,
+    bigop: 20,
+    integral: 20,
+    fraction: 12,
+    sqrt: 9,
+    root: 12,
+    vector: 15,
+    matrix: 15,
+    cases: 15,
+    superscript: 9,
+    subscript: 9,
+    subsup: 9,
+    punctuated: {
+      endpunct: Collapse.NOCOLLAPSE,
+      startpunct: Collapse.NOCOLLAPSE,
+      value: 12
     }
+  };
 
-    /**
-     * Check if a node should be collapsible and insert the
-     *  maction node to handle that.  Return the updated
-     *  complexity.
-     *
-     * @param {MmlNode} node        The node to check
-     * @param {number} complexity   The current complexity of the node
-     * @return {number}             The revised complexity
-     */
-    public check(node: MmlNode, complexity: number): number {
-        const type = node.attributes.get('data-semantic-type') as string;
-        if (this.collapse.has(type)) {
-            return this.collapse.get(type).call(this, node, complexity);
-        }
-        if (this.cutoff.hasOwnProperty(type)) {
-            return this.defaultCheck(node, complexity, type);
-        }
-        return complexity;
+  /**
+   *  These are the characters to use for the various collapsed elements
+   *  (if an object, then semantic-role is used to get the character
+   *  from the object)
+   */
+  public marker: TypeRole<string> = {
+    identifier: 'x',
+    number: '#',
+    text: '...',
+    appl: {
+      'limit function': 'lim',
+      value: 'f()'
+    },
+    fraction: '/',
+    sqrt: '\u221A',
+    root: '\u221A',
+    superscript: '\u25FD\u02D9',
+    subscript: '\u25FD.',
+    subsup: '\u25FD:',
+    vector: {
+      binomial: '(:)',
+      determinant: '|:|',
+      value: '\u27E8:\u27E9'
+    },
+    matrix: {
+      squarematrix: '[::]',
+      rowvector: '\u27E8\u22EF\u27E9',
+      columnvector: '\u27E8\u22EE\u27E9',
+      determinant: '|::|',
+      value: '(::)'
+    },
+    cases: '{:',
+    infixop: {
+      addition: '+',
+      subtraction: '\u2212',
+      multiplication: '\u22C5',
+      implicit: '\u22C5',
+      value: '+'
+    },
+    punctuated: {
+      text: '...',
+      value: ','
     }
+  };
 
-    /**
-     * Check if the complexity exceeds the cutoff value for the type
-     *
-     * @param {MmlNode} node        The node to check
-     * @param {number} complexity   The current complexity of the node
-     * @param {string} type         The semantic type of the node
-     * @return {number}             The revised complexity
-     */
-    protected defaultCheck(node: MmlNode, complexity: number, type: string): number {
-        const role = node.attributes.get('data-semantic-role') as string;
-        const check = this.cutoff[type];
-        const cutoff = (typeof check === 'number' ? check : check[role] || check.value);
-        if (complexity > cutoff) {
-            const marker = this.marker[type] || '??';
-            const text = (typeof marker === 'string' ? marker : marker[role] || marker.value);
-            complexity = this.recordCollapse(node, complexity, text);
-        }
-        return complexity;
-    }
+  /**
+   * The type-to-function mapping for semantic types
+   */
+  public collapse: CollapseFunctionMap = new Map([
 
-    /**
-     * @param {MmlNode} node       The node to check
-     * @param {number} complexity  The current complexity of the node
-     * @param {string} text        The text to use for the collapsed node
-     * @return {number}            The revised complexity for the collapsed node
-     */
-    protected recordCollapse(node: MmlNode, complexity: number, text: string): number {
-        text = '\u25C2' + text + '\u25B8';
-        node.setProperty('collapse-marker', text);
-        node.setProperty('collapse-complexity', complexity);
-        return text.length * this.complexity.complexity.text;
-    }
+    //
+    //  For fenced elements, if the contents are collapsed,
+    //    collapse the fence instead.
+    //
+    ['fenced', (node, complexity) => {
+      complexity = this.uncollapseChild(complexity, node, 1);
+      if (complexity > (this.cutoff.fenced as number) &&
+          node.attributes.get('data-semantic-role') === 'leftright') {
+        complexity = this.recordCollapse(
+          node, complexity,
+          this.getText(node.childNodes[0]) +
+            this.getText(node.childNodes[node.childNodes.length - 1])
+        );
+      }
+      return complexity;
+    }],
 
-    /**
-     * Remove collapse markers (to move them to a parent node)
-     *
-     * @param {MmlNode} node   The node to uncollapse
-     */
-    protected unrecordCollapse(node: MmlNode) {
-        const complexity = node.getProperty('collapse-complexity');
-        if (complexity != null) {
-            node.attributes.set('data-semantic-complexity', complexity);
-            node.removeProperty('collapse-complexity');
-            node.removeProperty('collapse-marker');
-        }
-    }
+    //
+    //  Collapse function applications if the argument is collapsed
+    //    (FIXME: Handle role="limit function" a bit better?)
+    //
+    ['appl', (node, complexity) => {
+      if (this.canUncollapse(node, 2, 2)) {
+        complexity = this.complexity.visitNode(node, false);
+        const marker = this.marker.appl as {[name: string]: string};
+        const text = marker[node.attributes.get('data-semantic-role') as string] || marker.value;
+        complexity = this.recordCollapse(node, complexity, text);
+      }
+      return complexity;
+    }],
 
-    /**
-     * @param {MmlNode} node    The node to check if its child is collapsible
-     * @param {number} n        The position of the child node to check
-     * @param {number=} m       The number of children node must have
-     * @return {MmlNode|null}   The child node that was collapsed (or null)
-     */
-    protected canUncollapse(node: MmlNode, n: number, m: number = 1): MmlNode | null {
-        if (this.splitAttribute(node, 'children').length === m) {
-            const mml = (node.childNodes.length === 1 &&
-                         node.childNodes[0].isInferred ? node.childNodes[0] : node);
-            if (mml && mml.childNodes[n]) {
-                const child = mml.childNodes[n];
-                if (child.getProperty('collapse-marker')) {
-                    return child;
-                }
-            }
-        }
-        return null;
-    }
+    //
+    //  For sqrt elements, if the contents are collapsed,
+    //    collapse the sqrt instead.
+    //
+    ['sqrt', (node, complexity) => {
+      complexity = this.uncollapseChild(complexity, node, 0);
+      if (complexity > (this.cutoff.sqrt as number)) {
+        complexity = this.recordCollapse(node, complexity, this.marker.sqrt as string);
+      }
+      return complexity;
+    }],
+    ['root', (node, complexity) => {
+      complexity = this.uncollapseChild(complexity, node, 0, 2);
+      if (complexity > (this.cutoff.sqrt as number)) {
+        complexity = this.recordCollapse(node, complexity, this.marker.sqrt as string);
+      }
+      return complexity;
+    }],
 
-    /**
-     * @param {number} complexity   The current complexity
-     * @param {MmlNode} node        The node to check
-     * @param {number} n            The position of the child node to check
-     * @param {number=} m           The number of children the node must have
-     * @return {number}             The updated complexity
-     */
-    protected uncollapseChild(complexity: number, node: MmlNode, n: number, m: number = 1): number {
-        const child = this.canUncollapse(node, n, m);
+    //
+    //  For enclose, include enclosure in collapse
+    //
+    ['enclose', (node, complexity) => {
+      if (this.splitAttribute(node, 'children').length === 1) {
+        const child = this.canUncollapse(node, 1);
         if (child) {
-            this.unrecordCollapse(child);
-            if (child.parent !== node) {
-                child.parent.attributes.set('data-semantic-complexity', undefined);
-            }
-            complexity = this.complexity.visitNode(node, false) as number;
+          const marker = child.getProperty('collapse-marker') as string;
+          this.unrecordCollapse(child);
+          complexity = this.recordCollapse(node, this.complexity.visitNode(node, false), marker);
         }
-        return complexity;
-    }
+      }
+      return complexity;
+    }],
 
-    /**
-     * @param {MmlNode} node   The node whose attribute is to be split
-     * @param {string} id      The name of the data-semantic attribute to split
-     * @return {string[]}      Array of ids in the attribute split at commas
-     */
-    protected splitAttribute(node: MmlNode, id: string): string[] {
-        return (node.attributes.get('data-semantic-' + id) as string || '').split(/,/);
-    }
+    //
+    //  For bigops, get the character to use from the largeop at its core.
+    //
+    ['bigop', (node, complexity) => {
+      if (complexity > (this.cutoff.bigop as number) || !node.isKind('mo')) {
+        const id = this.splitAttribute(node, 'content').pop();
+        const op = this.findChildText(node, id);
+        complexity = this.recordCollapse(node, complexity, op);
+      }
+      return complexity;
+    }],
+    ['integral', (node, complexity) => {
+      if (complexity > (this.cutoff.integral as number) || !node.isKind('mo')) {
+        const id = this.splitAttribute(node, 'content').pop();
+        const op = this.findChildText(node, id);
+        complexity = this.recordCollapse(node, complexity, op);
+      }
+      return complexity;
+    }],
 
-    /**
-     * @param {MmlNode} node   The node whose text content is needed
-     * @return{string}         The text of the node (and its children), combined
-     */
-    protected getText(node: MmlNode): string {
-        if (node.isToken) return (node as AbstractMmlTokenNode).getText();
-        return node.childNodes.map((n: MmlNode) => this.getText(n)).join('');
-    }
+    //
+    //  For relseq and multirel, use proper symbol
+    //
+    ['relseq', (node, complexity) => {
+      if (complexity > (this.cutoff.relseq as number)) {
+        const id = this.splitAttribute(node, 'content')[0];
+        const text = this.findChildText(node, id);
+        complexity = this.recordCollapse(node, complexity, text);
+      }
+      return complexity;
+    }],
+    ['multirel', (node, complexity) => {
+      if (complexity > (this.cutoff.relseq as number)) {
+        const id = this.splitAttribute(node, 'content')[0];
+        const text = this.findChildText(node, id) + '\u22EF';
+        complexity = this.recordCollapse(node, complexity, text);
+      }
+      return complexity;
+    }],
 
-    /**
-     * @param {MmlNode} node   The node whose child text is needed
-     * @param {string} id      The (semantic) id of the child needed
-     * @return {string}        The text of the specified child node
-     */
-    protected findChildText(node: MmlNode, id: string): string {
-        const child = this.findChild(node, id);
-        return this.getText(child.coreMO() || child);
-    }
+    //
+    //  Include super- and subscripts into a collapsed base
+    //
+    ['superscript', (node, complexity) => {
+      complexity = this.uncollapseChild(complexity, node, 0, 2);
+      if (complexity > (this.cutoff.superscript as number)) {
+        complexity = this.recordCollapse(node, complexity, this.marker.superscript as string);
+      }
+      return complexity;
+    }],
+    ['subscript', (node, complexity) => {
+      complexity = this.uncollapseChild(complexity, node, 0, 2);
+      if (complexity > (this.cutoff.subscript as number)) {
+        complexity = this.recordCollapse(node, complexity, this.marker.subscript as string);
+      }
+      return complexity;
+    }],
+    ['subsup', (node, complexity) => {
+      complexity = this.uncollapseChild(complexity, node, 0, 3);
+      if (complexity > (this.cutoff.subsup as number)) {
+        complexity = this.recordCollapse(node, complexity, this.marker.subsup as string);
+      }
+      return complexity;
+    }]
 
-    /**
-     * @param {MmlNode} node    The node whose child is to be located
-     * @param {string} id       The (semantic) id of the child to be found
-     * @return {MmlNode|null}   The child node (or null if not found)
-     */
-    protected findChild(node: MmlNode, id: string): MmlNode | null {
-        if (!node || node.attributes.get('data-semantic-id') === id) return node;
-        if (!node.isToken) {
-            for (const mml of node.childNodes) {
-                const child = this.findChild(mml, id);
-                if (child) return child;
-            }
+  ] as [string, CollapseFunction][]);
+
+  /**
+   * The highest id number used for mactions so far
+   */
+  private idCount = 0;
+
+  /**
+   * @param {ComplexityVisitor} visitor  The visitor for computing complexities
+   */
+  constructor(visitor: ComplexityVisitor) {
+    this.complexity = visitor;
+  }
+
+  /**
+   * Check if a node should be collapsible and insert the
+   *  maction node to handle that.  Return the updated
+   *  complexity.
+   *
+   * @param {MmlNode} node        The node to check
+   * @param {number} complexity   The current complexity of the node
+   * @return {number}             The revised complexity
+   */
+  public check(node: MmlNode, complexity: number): number {
+    const type = node.attributes.get('data-semantic-type') as string;
+    if (this.collapse.has(type)) {
+      return this.collapse.get(type).call(this, node, complexity);
+    }
+    if (this.cutoff.hasOwnProperty(type)) {
+      return this.defaultCheck(node, complexity, type);
+    }
+    return complexity;
+  }
+
+  /**
+   * Check if the complexity exceeds the cutoff value for the type
+   *
+   * @param {MmlNode} node        The node to check
+   * @param {number} complexity   The current complexity of the node
+   * @param {string} type         The semantic type of the node
+   * @return {number}             The revised complexity
+   */
+  protected defaultCheck(node: MmlNode, complexity: number, type: string): number {
+    const role = node.attributes.get('data-semantic-role') as string;
+    const check = this.cutoff[type];
+    const cutoff = (typeof check === 'number' ? check : check[role] || check.value);
+    if (complexity > cutoff) {
+      const marker = this.marker[type] || '??';
+      const text = (typeof marker === 'string' ? marker : marker[role] || marker.value);
+      complexity = this.recordCollapse(node, complexity, text);
+    }
+    return complexity;
+  }
+
+  /**
+   * @param {MmlNode} node       The node to check
+   * @param {number} complexity  The current complexity of the node
+   * @param {string} text        The text to use for the collapsed node
+   * @return {number}            The revised complexity for the collapsed node
+   */
+  protected recordCollapse(node: MmlNode, complexity: number, text: string): number {
+    text = '\u25C2' + text + '\u25B8';
+    node.setProperty('collapse-marker', text);
+    node.setProperty('collapse-complexity', complexity);
+    return text.length * this.complexity.complexity.text;
+  }
+
+  /**
+   * Remove collapse markers (to move them to a parent node)
+   *
+   * @param {MmlNode} node   The node to uncollapse
+   */
+  protected unrecordCollapse(node: MmlNode) {
+    const complexity = node.getProperty('collapse-complexity');
+    if (complexity != null) {
+      node.attributes.set('data-semantic-complexity', complexity);
+      node.removeProperty('collapse-complexity');
+      node.removeProperty('collapse-marker');
+    }
+  }
+
+  /**
+   * @param {MmlNode} node    The node to check if its child is collapsible
+   * @param {number} n        The position of the child node to check
+   * @param {number=} m       The number of children node must have
+   * @return {MmlNode|null}   The child node that was collapsed (or null)
+   */
+  protected canUncollapse(node: MmlNode, n: number, m: number = 1): MmlNode | null {
+    if (this.splitAttribute(node, 'children').length === m) {
+      const mml = (node.childNodes.length === 1 &&
+                   node.childNodes[0].isInferred ? node.childNodes[0] : node);
+      if (mml && mml.childNodes[n]) {
+        const child = mml.childNodes[n];
+        if (child.getProperty('collapse-marker')) {
+          return child;
         }
-        return null;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param {number} complexity   The current complexity
+   * @param {MmlNode} node        The node to check
+   * @param {number} n            The position of the child node to check
+   * @param {number=} m           The number of children the node must have
+   * @return {number}             The updated complexity
+   */
+  protected uncollapseChild(complexity: number, node: MmlNode, n: number, m: number = 1): number {
+    const child = this.canUncollapse(node, n, m);
+    if (child) {
+      this.unrecordCollapse(child);
+      if (child.parent !== node) {
+        child.parent.attributes.set('data-semantic-complexity', undefined);
+      }
+      complexity = this.complexity.visitNode(node, false) as number;
+    }
+    return complexity;
+  }
+
+  /**
+   * @param {MmlNode} node   The node whose attribute is to be split
+   * @param {string} id      The name of the data-semantic attribute to split
+   * @return {string[]}      Array of ids in the attribute split at commas
+   */
+  protected splitAttribute(node: MmlNode, id: string): string[] {
+    return (node.attributes.get('data-semantic-' + id) as string || '').split(/,/);
+  }
+
+  /**
+   * @param {MmlNode} node   The node whose text content is needed
+   * @return{string}         The text of the node (and its children), combined
+   */
+  protected getText(node: MmlNode): string {
+    if (node.isToken) return (node as AbstractMmlTokenNode).getText();
+    return node.childNodes.map((n: MmlNode) => this.getText(n)).join('');
+  }
+
+  /**
+   * @param {MmlNode} node   The node whose child text is needed
+   * @param {string} id      The (semantic) id of the child needed
+   * @return {string}        The text of the specified child node
+   */
+  protected findChildText(node: MmlNode, id: string): string {
+    const child = this.findChild(node, id);
+    return this.getText(child.coreMO() || child);
+  }
+
+  /**
+   * @param {MmlNode} node    The node whose child is to be located
+   * @param {string} id       The (semantic) id of the child to be found
+   * @return {MmlNode|null}   The child node (or null if not found)
+   */
+  protected findChild(node: MmlNode, id: string): MmlNode | null {
+    if (!node || node.attributes.get('data-semantic-id') === id) return node;
+    if (!node.isToken) {
+      for (const mml of node.childNodes) {
+        const child = this.findChild(mml, id);
+        if (child) return child;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Add maction nodes to the nodes in the tree that can collapse
+   *
+   * @paramn {MmlNode} node   The root of the tree to check
+   */
+  public makeCollapse(node: MmlNode) {
+    const nodes: MmlNode[] = [];
+    node.walkTree((child: MmlNode) => {
+      if (child.getProperty('collapse-marker')) {
+        nodes.push(child);
+      }
+    });
+    this.makeActions(nodes);
+  }
+
+  /**
+   * @param {MmlNode[]} nodes   The list of nodes to replace by maction nodes
+   */
+  public makeActions(nodes: MmlNode[]) {
+    for (const node of nodes) {
+      this.makeAction(node);
+    }
+  }
+
+  /**
+   * @return {string}   A unique id string.
+   */
+  private makeId(): string {
+    return 'mjx-collapse-' + this.idCount++;
+  }
+
+  /**
+   * @param {MmlNode} node   The node to make collapsible by replacing with an maction
+   */
+  public makeAction(node: MmlNode) {
+    if (node.isKind('math')) {
+      node = this.addMrow(node);
+    }
+    const factory = this.complexity.factory;
+    const marker = node.getProperty('collapse-marker') as string;
+    const parent = node.parent;
+    let maction = factory.create('maction', {
+      actiontype: 'toggle',
+      selection: 2,
+      'data-collapsible': true,
+      id: this.makeId(),
+      'data-semantic-complexity': node.attributes.get('data-semantic-complexity')
+    }, [
+      factory.create('mtext', {mathcolor: 'blue'}, [
+        (factory.create('text') as TextNode).setText(marker)
+      ])
+    ]);
+    maction.inheritAttributesFrom(node);
+    node.attributes.set('data-semantic-complexity', node.getProperty('collapse-complexity'));
+    node.removeProperty('collapse-marker');
+    node.removeProperty('collapse-complexity');
+    parent.replaceChild(maction, node);
+    maction.appendChild(node);
+  }
+
+  /**
+   * If the <math> node is to be collapsible, add an mrow to it instead so that we can wrap it
+   *  in an maction (can't put one around the <math> node).
+   *
+   * @param {MmlNode} node  The math node to create an mrow for
+   * @return {MmlNode}      The newly created mrow
+   */
+  public addMrow(node: MmlNode): MmlNode {
+    const mrow = this.complexity.factory.create('mrow', null, node.childNodes[0].childNodes);
+    node.childNodes[0].setChildren([mrow]);
+
+    const attributes = node.attributes.getAllAttributes();
+    for (const name of Object.keys(attributes)) {
+      if (name.substr(0, 14) === 'data-semantic-') {
+        mrow.attributes.set(name, attributes[name]);
+        delete attributes[name];
+      }
     }
 
-    /**
-     * Add maction nodes to the nodes in the tree that can collapse
-     *
-     * @paramn {MmlNode} node   The root of the tree to check
-     */
-    public makeCollapse(node: MmlNode) {
-        const nodes: MmlNode[] = [];
-        node.walkTree((child: MmlNode) => {
-            if (child.getProperty('collapse-marker')) {
-                nodes.push(child);
-            }
-        });
-        this.makeActions(nodes);
-    }
-
-    /**
-     * @param {MmlNode[]} nodes   The list of nodes to replace by maction nodes
-     */
-    public makeActions(nodes: MmlNode[]) {
-        for (const node of nodes) {
-            this.makeAction(node);
-        }
-    }
-
-    /**
-     * @return {string}   A unique id string.
-     */
-    private makeId(): string {
-        return 'mjx-collapse-' + this.idCount++;
-    }
-
-    /**
-     * @param {MmlNode} node   The node to make collapsible by replacing with an maction
-     */
-    public makeAction(node: MmlNode) {
-        if (node.isKind('math')) {
-            node = this.addMrow(node);
-        }
-        const factory = this.complexity.factory;
-        const marker = node.getProperty('collapse-marker') as string;
-        const parent = node.parent;
-        let maction = factory.create('maction', {
-            actiontype: 'toggle',
-            selection: 2,
-            'data-collapsible': true,
-            id: this.makeId(),
-            'data-semantic-complexity': node.attributes.get('data-semantic-complexity')
-        }, [
-            factory.create('mtext', {mathcolor: 'blue'}, [
-                (factory.create('text') as TextNode).setText(marker)
-            ])
-        ]);
-        maction.inheritAttributesFrom(node);
-        node.attributes.set('data-semantic-complexity', node.getProperty('collapse-complexity'));
-        node.removeProperty('collapse-marker');
-        node.removeProperty('collapse-complexity');
-        parent.replaceChild(maction, node);
-        maction.appendChild(node);
-    }
-
-    /**
-     * If the <math> node is to be collapsible, add an mrow to it instead so that we can wrap it
-     *  in an maction (can't put one around the <math> node).
-     *
-     * @param {MmlNode} node  The math node to create an mrow for
-     * @return {MmlNode}      The newly created mrow
-     */
-    public addMrow(node: MmlNode): MmlNode {
-        const mrow = this.complexity.factory.create('mrow', null, node.childNodes[0].childNodes);
-        node.childNodes[0].setChildren([mrow]);
-
-        const attributes = node.attributes.getAllAttributes();
-        for (const name of Object.keys(attributes)) {
-            if (name.substr(0, 14) === 'data-semantic-') {
-                mrow.attributes.set(name, attributes[name]);
-                delete attributes[name];
-            }
-        }
-
-        mrow.setProperty('collapse-marker', node.getProperty('collapse-marker'));
-        mrow.setProperty('collapse-complexity', node.getProperty('collapse-complexity'));
-        node.removeProperty('collapse-marker');
-        node.removeProperty('collapse-complexity');
-        return mrow;
-    }
+    mrow.setProperty('collapse-marker', node.getProperty('collapse-marker'));
+    mrow.setProperty('collapse-complexity', node.getProperty('collapse-complexity'));
+    node.removeProperty('collapse-marker');
+    node.removeProperty('collapse-complexity');
+    return mrow;
+  }
 }

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -657,7 +657,7 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
       return '';
     }
     let space = TEXSPACE[prevClass][texClass];
-    if ((this.prevLevel > 0 || this.attributes.get('scriptlevel') > 0) && space >= 0) {
+    if ((this.prevLevel > 0 || (this.attributes.get('scriptlevel') as number) > 0) && space >= 0) {
       return '';
     }
     return TEXSPACELENGTH[Math.abs(space)];

--- a/ts/input/tex/base/BaseConfiguration.ts
+++ b/ts/input/tex/base/BaseConfiguration.ts
@@ -107,7 +107,7 @@ function filterNonscript({data}: {data: ParseOptions}) {
     //  This is the list of mspace elements or mrow > mstyle > mspace
     //    that followed \nonscript macros to be tested for removal.
     //
-    if (mml.attributes.get('scriptlevel') > 0) {
+    if (mml.attributes.get('scriptlevel') as number > 0) {
       //
       //  The mspace needs to be removed, since we are in a script style.
       //  Remove it from the DOM and from the list of mspace elements.

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -936,7 +936,7 @@ export class CommonWrapper<
     // Get the lspace and rspace
     //
     const attributes = node.attributes;
-    const isScript = (attributes.get('scriptlevel') > 0);
+    const isScript = (attributes.get('scriptlevel') as number > 0);
     this.bbox.L = (attributes.isSet('lspace') ?
                    Math.max(0, this.length2em(attributes.get('lspace'))) :
                    MathMLSpace(isScript, node.lspace));

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -718,7 +718,7 @@ export function CommonMtableMixin<
       //
       // Make sure cWidth reflects the size of the broken columns
       //
-      if (w > this.cWidths[i]) {
+      if (w > (this.cWidths[i] as number)) {
         this.cWidths[i] = w;
       }
     }


### PR DESCRIPTION
This PR updates the dependencies to their latest versions, and in particular updates to Typescript v5 (in order to handle the `moduleResolution` of `nodenext` that we set in the ES6-modules branch).  This update causes a few warnings about comparing a number to a value of type `number | string`, so the other changes are to handle those situations.