### PR TITLE
Update use of skew values from accents to allow better placement. (mathjax/MathJax#3051)

### DIFF
--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -133,7 +133,7 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
       const basebox = this.baseChild.getOuterBBox();
       const underbox = this.scriptChild.getOuterBBox();
       const k = this.getUnderKV(basebox, underbox)[0];
-      const delta = (this.isLineBelow ? 0 : this.getDelta(true));
+      const delta = (this.isLineBelow ? 0 : this.getDelta(this.scriptChild, true));
       this.adaptor.setStyle(under, 'paddingTop', this.em(k));
       this.setDeltaW([base, under], this.getDeltaW([basebox, underbox], [0, -delta]));
       this.adjustUnderDepth(under, underbox);
@@ -232,7 +232,7 @@ export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
       const basebox = this.baseChild.getOuterBBox();
       this.adjustBaseHeight(base, basebox);
       const k = this.getOverKU(basebox, overbox)[0];
-      const delta = (this.isLineAbove ? 0 : this.getDelta());
+      const delta = (this.isLineAbove ? 0 : this.getDelta(this.scriptChild));
       this.adaptor.setStyle(over, 'paddingBottom', this.em(k));
       this.setDeltaW([base, over], this.getDeltaW([basebox, overbox], [0, delta]));
       this.adjustOverDepth(over, overbox);
@@ -343,12 +343,13 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<N, T,
       this.adjustBaseHeight(base, basebox);
       const ok = this.getOverKU(basebox, overbox)[0];
       const uk = this.getUnderKV(basebox, underbox)[0];
-      const delta = this.getDelta();
+      const odelta = this.getDelta(this.overChild);
+      const udelta = this.getDelta(this.underChild, true);
       this.adaptor.setStyle(over, 'paddingBottom', this.em(ok));
       this.adaptor.setStyle(under, 'paddingTop', this.em(uk));
       this.setDeltaW([base, under, over],
                      this.getDeltaW([basebox, underbox, overbox],
-                                    [0, this.isLineBelow ? 0 : -delta, this.isLineAbove ? 0 : delta]));
+                                    [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta]));
       this.adjustOverDepth(over, overbox);
       this.adjustUnderDepth(under, underbox);
     }

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -741,13 +741,11 @@ export class CommonWrapper<
    */
   protected copySkewIC(bbox: BBox) {
     const first = this.childNodes[0];
-    if (first) {
-      if (first.bbox.sk) {
-        bbox.sk = first.bbox.sk;
-      }
-      if (first.bbox.dx) {
-        bbox.dx = first.bbox.dx;
-      }
+    if (first?.bbox?.sk) {
+      bbox.sk = first.bbox.sk;
+    }
+    if (first?.bbox?.dx) {
+      bbox.dx = first.bbox.dx;
     }
     const last = this.childNodes[this.childNodes.length - 1];
     if (last?.bbox?.ic) {

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -741,14 +741,16 @@ export class CommonWrapper<
    */
   protected copySkewIC(bbox: BBox) {
     const first = this.childNodes[0];
-    if (first?.bbox.sk) {
-      bbox.sk = first.bbox.sk;
-    }
-    if (first?.bbox.dx) {
-      bbox.dx = first.bbox.dx;
+    if (first) {
+      if (first.bbox.sk) {
+        bbox.sk = first.bbox.sk;
+      }
+      if (first.bbox.dx) {
+        bbox.dx = first.bbox.dx;
+      }
     }
     const last = this.childNodes[this.childNodes.length - 1];
-    if (last?.bbox.ic) {
+    if (last?.bbox?.ic) {
       bbox.ic = last.bbox.ic;
       bbox.w += bbox.ic;
     }

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -153,7 +153,7 @@ export function CommonMunderMixin<
       const basebox = this.baseChild.getOuterBBox();
       const underbox = this.scriptChild.getOuterBBox();
       const v = this.getUnderKV(basebox, underbox)[1];
-      const delta = (this.isLineBelow ? 0 : this.getDelta(true));
+      const delta = (this.isLineBelow ? 0 : this.getDelta(this.scriptChild, true));
       const [bw, uw] = this.getDeltaW([basebox, underbox], [0, -delta]);
       bbox.combine(basebox, bw, 0);
       bbox.combine(underbox, uw, v);
@@ -291,7 +291,7 @@ export function CommonMoverMixin<
         basebox.h = Math.max(basebox.h, this.font.params.x_height * this.baseScale);
       }
       const u = this.getOverKU(basebox, overbox)[1];
-      const delta = (this.isLineAbove ? 0 : this.getDelta());
+      const delta = (this.isLineAbove ? 0 : this.getDelta(this.scriptChild));
       const [bw, ow] = this.getDeltaW([basebox, overbox], [0, delta]);
       bbox.combine(basebox, bw, 0);
       bbox.combine(overbox, ow, u);
@@ -470,9 +470,10 @@ export function CommonMunderoverMixin<
       }
       const u = this.getOverKU(basebox, overbox)[1];
       const v = this.getUnderKV(basebox, underbox)[1];
-      const delta = this.getDelta();
+      const odelta = this.getDelta(this.overChild);
+      const udelta = this.getDelta(this.underChild, true);
       const [bw, uw, ow] = this.getDeltaW([basebox, underbox, overbox],
-                                          [0, this.isLineBelow ? 0 : -delta, this.isLineAbove ? 0 : delta]);
+                                          [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta]);
       bbox.combine(basebox, bw, 0);
       bbox.combine(overbox, ow, u);
       bbox.combine(underbox, uw, v);

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -259,10 +259,11 @@ export interface CommonScriptbase<
   getDeltaW(boxes: BBox[], delta?: number[]): number[];
 
   /**
+   * @param {WW} script         The child that is above or below the base
    * @param {boolean=} noskew   Whether to ignore the skew amount
    * @return {number}           The offset for under and over
    */
-  getDelta(noskew?: boolean): number;
+  getDelta(script: WW, noskew?: boolean): number;
 
   /**
    * Handle horizontal stretching of children to match greatest width
@@ -717,9 +718,12 @@ export function CommonScriptbaseMixin<
     /**
      * @override
      */
-    public getDelta(noskew: boolean = false): number {
+    public getDelta(script: WW, noskew: boolean = false): number {
       const accent = this.node.attributes.get('accent');
-      const {sk, ic} = this.baseCore.getOuterBBox();
+      let {sk, ic} = this.baseCore.getOuterBBox();
+      if (accent) {
+        sk -= script.getOuterBBox().sk;
+      }
       return ((accent && !noskew ? sk : 0) + this.font.skewIcFactor * ic) * this.baseScale;
     }
 

--- a/ts/output/svg/Wrappers/munderover.ts
+++ b/ts/output/svg/Wrappers/munderover.ts
@@ -106,7 +106,7 @@ export const SvgMunder = (function <N, T, D>(): SvgMunderClass<N, T, D> {
       base.toSVG(svg);
       script.toSVG(svg);
 
-      const delta = (this.isLineBelow ? 0 : this.getDelta(true));
+      const delta = (this.isLineBelow ? 0 : this.getDelta(this.scriptChild, true));
       const v = this.getUnderKV(bbox, sbox)[1];
       const [bx, sx] = this.getDeltaW([bbox, sbox], [0, -delta]);
 
@@ -191,7 +191,7 @@ export const SvgMover = (function <N, T, D>(): SvgMoverClass<N, T, D> {
       base.toSVG(svg);
       script.toSVG(svg);
 
-      const delta = (this.isLineAbove ? 0 : this.getDelta());
+      const delta = (this.isLineAbove ? 0 : this.getDelta(this.scriptChild));
       const u = this.getOverKU(bbox, sbox)[1];
       const [bx, sx] = this.getDeltaW([bbox, sbox], [0, delta]);
 
@@ -277,11 +277,12 @@ export const SvgMunderover = (function <N, T, D>(): SvgMunderoverClass<N, T, D> 
       under.toSVG(svg);
       over.toSVG(svg);
 
-      const delta = this.getDelta();
+      const odelta = this.getDelta(this.overChild);
+      const udelta = this.getDelta(this.underChild, true);
       const u = this.getOverKU(bbox, obox)[1];
       const v = this.getUnderKV(bbox, ubox)[1];
       const [bx, ux, ox] = this.getDeltaW([bbox, ubox, obox],
-                                          [0, this.isLineBelow ? 0 : -delta, this.isLineAbove ? 0 : delta]);
+                                          [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta]);
 
       base.place(bx, 0);
       under.place(ux, v);


### PR DESCRIPTION
This PR adjusts how some accents are placed.  The skew values stored in the font are used to move an accent to its proper position over a base character (e.g., to move the accent over the point in *A* rather than over the center of the width of the *A*).  These values re being taken from the Opentype MATH table accent data, but that table specifies that both the base skew and the accent skew should be used (these two skewed positions are to be aligned).  But currently, MathJax only uses the base skew.  This PR adds the ability to use the accent skew as well.  It also fixes an error where the skewed position for the top accent was also used for the bottom character in `munderover` causing the bottom to the improperly shifted to the left.

his makes it possible to resolve issue mathjax/MathJax#3051.