### PR TITLE
Don't remap U+0060 to U+2035 so \grave works properly

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -96,7 +96,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    * Pattern for when contents is a collection of primes
    */
    protected static primes = new RegExp([
-     '^["\'`',
+     '^["\'',
      '\u2018-\u201F',        // Various double and single quotation marks (up and down)
      ']+$'
    ].join(''));
@@ -107,7 +107,6 @@ export class MmlMo extends AbstractMmlTokenNode {
   protected static remapPrimes: {[n: number]: number} = {
      0x0022: 0x2033,   // double quotes
      0x0027: 0x2032,   // single quote
-     0x0060: 0x2035,   // back quote
      0x2018: 0x2035,   // open single quote
      0x2019: 0x2032,   // close single quote
      0x201A: 0x2032,   // low open single quote


### PR DESCRIPTION
This PR prevents `` ` ``  from being translated to U+2035 so that `\grave` accents work properly.