### PR TITLE
Fix memory leak in textmacros package.  (mathjax/MathJax#3061)

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -88,6 +88,7 @@ function internalMath(parser: TexParser, text: string, level?: number | string, 
   if (!(parser instanceof TextParser)) {
     config.texParser = parser;
   }
+  config.parseOptions.clear();
   return [(new TextParser(text, mathvariant ? {mathvariant} : {}, config.parseOptions, level)).mml()];
 }
 

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -98,9 +98,8 @@ export class TextParser extends TexParser {
    */
   protected copyLists() {
     const parseOptions = this.texParser.configuration;
-    const lists = this.configuration.nodeLists;
-    for (const name of Object.keys(lists)) {
-      for (const node of lists[name]) {
+    for (const [name, list] of Object.keys(this.configuration.nodeLists)) {
+      for (const node of list) {
         parseOptions.addNode(name, node);
       }
     }

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -86,9 +86,25 @@ export class TextParser extends TexParser {
    * @override
    */
   public mml() {
+    this.copyLists();
+    this.configuration.popParser();
     return (this.level != null ?
             this.create('node', 'mstyle', this.nodes, {displaystyle: false, scriptlevel: this.level}) :
             this.nodes.length === 1 ? this.nodes[0] : this.create('node', 'mrow', this.nodes));
+  }
+
+  /**
+   * Copy the node list from the text parser to the TeX parser
+   */
+  protected copyLists() {
+    const parseOptions = this.texParser.configuration;
+    const lists = this.configuration.nodeLists;
+    for (const name of Object.keys(lists)) {
+      for (const node of lists[name]) {
+        parseOptions.addNode(name, node);
+      }
+    }
+    this.configuration.nodeLists = {};
   }
 
   /**


### PR DESCRIPTION
This PR fixes a memory leak that occurs when the `textmacros` extension is used.  It was caused by not clearing the node lists that are part of the `ParseOptions` object, and not removing the parsers from the `parsers` list when they are done.  That means these will continue to build up over time.  We fix the problem by clearing these lists when the `mml()` function is called, and clearing the configuration itself when `internalMath` first starts parsing text-mode material.

In addition, since we are using a separate `ParseOptions` object, and the node lists are stored there, the nodes created for text elements are not being added to the main `TexParser` node lists, so we add code to copy the lists over from our parser to the parent TeX parser.

Resolves issue mathjax/MathJax#3061.