### PR TITLE
Update mj-context-menu to 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
       "dependencies": {
         "mathjax-modern-font": "^1.0.0-beta.5",
         "mhchemparser": "^4.2.1",
-        "mj-context-menu": "^0.8.1",
         "speech-rule-engine": "^4.1.0-beta.5"
       },
       "devDependencies": {
         "copyfiles": "^2.4.1",
         "diff": "^5.1.0",
+        "mj-context-menu": "^0.9.0",
         "rimraf": "^5.0.1",
         "tape": "^5.6.3",
         "terser-webpack-plugin": "^5.3.9",
@@ -1977,9 +1977,10 @@
       }
     },
     "node_modules/mj-context-menu": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.8.1.tgz",
-      "integrity": "sha512-Cp0dmdNaz2MKJvcw2N26mskCRjiHUwFkbgwqekxWa8AMudgjbzMtBn1QV+jWF97wJI8ZoN+da+0QL9oSeH26nA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.9.0.tgz",
+      "integrity": "sha512-kwnTzixaDm0EjzTHpeWwKVQuPjACIXY9cZO4VMw6OWRmo0KYKp7D3xEEhler01WodF2ApdPD0TJcraWm8H3AUQ==",
+      "dev": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   "devDependencies": {
     "copyfiles": "^2.4.1",
     "diff": "^5.1.0",
+    "mj-context-menu": "^0.9.0",
     "rimraf": "^5.0.1",
     "tape": "^5.6.3",
     "terser-webpack-plugin": "^5.3.9",
@@ -130,7 +131,6 @@
   "dependencies": {
     "mathjax-modern-font": "^1.0.0-beta.5",
     "mhchemparser": "^4.2.1",
-    "mj-context-menu": "^0.8.1",
     "speech-rule-engine": "^4.1.0-beta.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "devDependencies": {
     "copyfiles": "^2.4.1",
     "diff": "^5.1.0",
-    "mj-context-menu": "^0.9.0",
+    "mj-context-menu": "^0.9.1",
     "rimraf": "^5.0.1",
     "tape": "^5.6.3",
     "terser-webpack-plugin": "^5.3.9",

--- a/ts/ui/menu/mj-context-menu.ts
+++ b/ts/ui/menu/mj-context-menu.ts
@@ -30,7 +30,7 @@ export {Radio} from '#menu/item_radio.js';
 export {Rule} from '#menu/item_rule.js';
 export {ParserFactory} from '#menu/parser_factory.js'
 export {Parser} from '#menu/parse.js';
-export {CssStyles} from '#menu/css_util.js';
+export * as CssStyles from '#menu/css_util.js';
 export {HtmlClasses} from '#menu/html_classes.js';
 
 export {Menu} from '#menu/menu.js';


### PR DESCRIPTION
This PR replaces #963 since it had file conflicts due to the ES6/ES5 updates.  Here we are updating the mj-context-menu to version 0.9.0.