### PR TITLE
Upgrades to latest version of SRE.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "mathjax-modern-font": "^1.0.0-beta.5",
         "mhchemparser": "^4.2.1",
         "mj-context-menu": "^0.8.1",
-        "speech-rule-engine": "^4.1.0-beta.5"
+        "speech-rule-engine": "^4.1.0-beta.7"
       },
       "devDependencies": {
         "copyfiles": "^2.4.1",
@@ -464,6 +464,14 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.0-beta.8.tgz",
+      "integrity": "sha512-Q5bFbYxRJKTYP7S1a0HIlumTmJRHHMGrNvBp8F1mUEyyGTeCs0g8+FKAaA6tU+YFsZgHKA0eRKzZhYdhpgAHAw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -2530,13 +2538,13 @@
       }
     },
     "node_modules/speech-rule-engine": {
-      "version": "4.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.0-beta.5.tgz",
-      "integrity": "sha512-agFKDoZbo/Po9Ls7OedLcbjlrjC/W5r7bn9i2zmDysQyHIIunElROglhTbp6UT7FLWvJzha2fqXRwcDIlN3VIA==",
+      "version": "4.1.0-beta.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.0-beta.7.tgz",
+      "integrity": "sha512-e9QntjrfSKDa/w0baCXsoPQRPD9uY0r7q86Jr8ud/5zElzdG0Beiz4mc38kFb/E53c4RuYyZKSKyug8e5cVrpQ==",
       "dependencies": {
+        "@xmldom/xmldom": "0.9.0-beta.8",
         "commander": "10.0.0",
-        "wicked-good-xpath": "1.3.0",
-        "xmldom-sre": "^0.9.0-beta.7"
+        "wicked-good-xpath": "1.3.0"
       },
       "bin": {
         "sre": "bin/sre"
@@ -3529,14 +3537,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xmldom-sre": {
-      "version": "0.9.0-beta.7",
-      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.9.0-beta.7.tgz",
-      "integrity": "sha512-4xlknhWYLHPm06WjIhZDt8ys5aljgP5Pf7jygUF8pw+cgC4QBEQIUFBjHhHUbykaHHi+KfbdzO47Wv/k7A+5DQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
     "mathjax-modern-font": "^1.0.0-beta.5",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.8.1",
-    "speech-rule-engine": "^4.1.0-beta.5"
+    "speech-rule-engine": "^4.1.0-beta.7"
   }
 }

--- a/ts/a11y/SpeechMenu.ts
+++ b/ts/a11y/SpeechMenu.ts
@@ -204,7 +204,7 @@ export function localeMenu(menu: MJContextMenu, sub: Submenu) {
   let radios: {type: string, id: string,
                content: string, variable: string}[] = [];
   for (let lang of Sre.locales.keys()) {
-    if (lang === 'nemeth') continue;
+    if (lang === 'nemeth' || lang === 'euro') continue;
     radios.push({type: 'radio', id: lang,
                  content: Sre.locales.get(lang) || lang, variable: 'locale'});
   }

--- a/tsconfig/cjs.json
+++ b/tsconfig/cjs.json
@@ -10,7 +10,7 @@
       "#root/*": ["../ts/components/cjs/*"],
       "#mml3/*": ["../ts/input/mathml/mml3/cjs/*"],
       "#menu/*": ["../node_modules/mj-context-menu/cjs/*"],
-      "#sre/*": ["../node_modules/speech-rule-engine/js/*"],
+      "#sre/*": ["../node_modules/speech-rule-engine/cjs/*"],
       "#mhchem/*": ["../node_modules/mhchemparser/dist/*"],
       "#default-font/*": ["../node_modules/mathjax-modern-font/cjs/*"]
     }


### PR DESCRIPTION
Upgrades to `SRE v4.1.0-beta.7`. I had to deprecate `beta.6` as the `prepublish` scripts did not work as expected and it was published without the `mathmaps`.
* Reroutes `commonjs` sources to the correct directory.
* A little fix to avoid Euro Braille showing up as a speech locale.
* Otherwise we now have Korean!
