### PR TITLE
Allow inline-breaking within top-level nodes added by SRE

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -115,6 +115,8 @@ CommonOutputJax<
     'mjx-row': {display: 'table-row'},
     'mjx-row > *': {display: 'table-cell'},
 
+    'mjx-container [inline-breaks]': {display: 'inline'},
+
     //
     //  These don't have Wrapper subclasses, so add their styles here
     //

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -355,6 +355,9 @@ CommonWrapper<
         this.dom.forEach(dom => adaptor.addClass(dom, name));
       }
     }
+    if (this.node.getProperty('inline-breaks')) {
+      this.dom.forEach(dom => adaptor.setAttribute(dom, 'inline-breaks', 'true'));
+    }
   }
 
   /**

--- a/ts/output/chtml/Wrappers/mrow.ts
+++ b/ts/output/chtml/Wrappers/mrow.ts
@@ -177,13 +177,13 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       this.getBBox(); // make sure we have linebreak information
       const lines = this.lineBBox;
       const adaptor = this.adaptor;
-      const [alignfirst, shiftfirst] = lines[1].indentData[0];
+      const [alignfirst, shiftfirst] = lines[1].indentData?.[0] || ['left', '0'];
       for (const i of parents.keys()) {
         const bbox = lines[i];
         let [indentalign, indentshift] = (
           i === 0 ?
             [alignfirst, shiftfirst] :
-            bbox.indentData[i === n ? 2 : 1]
+            bbox.indentData?.[i === n ? 2 : 1] || ['left', '0']
         );
         const [align, shift] = this.processIndent(indentalign, indentshift, alignfirst, shiftfirst);
         adaptor.setAttribute(parents[i], 'align', align);

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -396,12 +396,15 @@ export abstract class CommonOutputJax<
     if (!node) return;
     const forcebreak = this.forceInlineBreaks;
     let marked = false;
-    let markNext = null as [MmlNode, string];
-    for (const child of node.childNodes.slice(1)) {
+    let markNext = '';
+    for (const child of node.childNodes) {
       if (markNext) {
-        marked = this.markInlineBreak(marked, forcebreak, markNext[1], node, child, markNext[0]);
-        markNext = null;
+        marked = this.markInlineBreak(marked, forcebreak, markNext, node, child);
+        markNext = '';
       } else if (child.isEmbellished) {
+        if (child === node.childNodes[0]) {
+          continue;
+        }
         const mo = child.coreMO();
         const texClass = mo.texClass;
         const linebreak = mo.attributes.get('linebreak') as string;
@@ -412,7 +415,7 @@ export abstract class CommonOutputJax<
           if (linebreakstyle === 'before') {
             marked = this.markInlineBreak(marked, forcebreak, linebreak, node, child, mo);
           } else {
-            markNext = [mo, linebreak];
+            markNext = linebreak;
           }
         }
       } else if (child.isKind('mspace')) {
@@ -420,9 +423,20 @@ export abstract class CommonOutputJax<
         if (linebreak !== 'nobreak') {
           marked = this.markInlineBreak(marked, forcebreak, linebreak, node, child);
         }
-      } else if ((child.isKind('mstyle') && !child.attributes.get('style')) ||
-                 child.isKind('semantics') || child.isKind('MathChoice')) {
+      } else if ((child.isKind('mstyle') && !child.attributes.get('style') &&
+                  !child.attributes.getExplicit('mathbackground')) || child.isKind('semantics')) {
         this.markInlineBreaks(child.childNodes[0]);
+        if (child.getProperty('process-breaks')) {
+          child.setProperty('inline-breaks', true);
+          child.childNodes[0].setProperty('inline-breaks', true);
+          node.parent.setProperty('process-breaks', 'true');
+        }
+      } else if (child.isKind('mrow') && child.attributes.get('data-semantic-added')) {
+        this.markInlineBreaks(child);
+        if (child.getProperty('process-breaks')) {
+          child.setProperty('inline-breaks', true);
+          node.parent.setProperty('process-breaks', 'true');
+        }
       }
     }
   }

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -626,9 +626,14 @@ export class CommonWrapper<
    */
   public getBreakNode(bbox: LineBBox): [WW, WW] {
     const [i, j] = bbox.start || [0, 0];
-    if (this.node.isEmbellished) return [this, this.coreMO()] as any as [WW, WW];
-    if (this.node.isToken || !this.childNodes[i]) return [this, null] as any as [WW, WW];
-    return this.childNodes[i].getBreakNode(this.childNodes[i].getLineBBox(j));
+    if (this.node.isEmbellished) {
+      return [this, this.coreMO()] as any as [WW, WW];
+    }
+    const childNodes = (this.childNodes?.[0]?.node?.isInferred ? this.childNodes[0].childNodes : this.childNodes);
+    if (this.node.isToken || !childNodes[i]) {
+      return [this, null] as any as [WW, WW];
+    }
+    return childNodes[i].getBreakNode(childNodes[i].getLineBBox(j));
   }
 
   /**

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -629,7 +629,7 @@ export class CommonWrapper<
     if (this.node.isEmbellished) {
       return [this, this.coreMO()] as any as [WW, WW];
     }
-    const childNodes = (this.childNodes?.[0]?.node?.isInferred ? this.childNodes[0].childNodes : this.childNodes);
+    const childNodes = (this.childNodes[0]?.node?.isInferred ? this.childNodes[0].childNodes : this.childNodes);
     if (this.node.isToken || !childNodes[i]) {
       return [this, null] as any as [WW, WW];
     }

--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -358,10 +358,11 @@ export function CommonMrowMixin<
     protected shiftLines(W: number) {
       const lines = this.lineBBox;
       const n = lines.length - 1;
-      const [alignfirst, shiftfirst] = lines[1].indentData[0];
+      const [alignfirst, shiftfirst] = lines[1].indentData?.[0] || ['left', '0'];
       for (const i of lines.keys()) {
         const bbox = lines[i];
-        let [indentalign, indentshift] = (i === 0 ? [alignfirst, shiftfirst] : bbox.indentData[i === n ? 2 : 1]);
+        let [indentalign, indentshift] = (i === 0 ? [alignfirst, shiftfirst] :
+                                          bbox.indentData?.[i === n ? 2 : 1] || ['left', '0']);
         const [align, shift] = this.processIndent(indentalign, indentshift, alignfirst, shiftfirst, W);
         bbox.L = 0;
         bbox.L = this.getAlignX(W, bbox, align) + shift;

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -264,6 +264,7 @@ CommonOutputJax<
    * @param {number} h   The height of the SVG to create
    * @param {number} d   The depth of the SVG to create
    * @param {number} w   The width of the SVG to create
+   * @return [N, N]      The svg element and its initial g child
    */
   protected createSVG(h: number, d: number, w: number): [N, N] {
     const px = this.math.metrics.em / 1000;
@@ -366,11 +367,12 @@ CommonOutputJax<
     //
     // Make each line a separate SVG containing the line's children
     //
-    let newline = true;
     for (let i = 0; i <= n; i++) {
       const line = lineBBox[i] || wrapper.childNodes[0].getLineBBox(i);
       const {h, d, w} = line;
-      const [nsvg, ng] = this.createSVG(h, d, w);
+      const [mml, mo] = wrapper.childNodes[0].getBreakNode(line);
+      const {scale} = mml.getBBox();
+      const [nsvg, ng] = this.createSVG(h * scale, d * scale, w * scale);
       const nmath = adaptor.append(ng, adaptor.clone(math, false)) as N;
       for (const child of adaptor.childNodes(lines[i])) {
         adaptor.append(nmath, child);
@@ -379,25 +381,20 @@ CommonOutputJax<
       //
       // If the line is not the first one (or not a forced break), add a break node of the correct size
       //
-      const [mml, mo] = wrapper.childNodes[0].getBreakNode(line);
       const forced = !!(mo && mo.node.getProperty('forcebreak'));
       if (forced && mo.node.attributes.get('linebreakstyle') === 'after') {
         const k = mml.parent.node.childIndex(mml.node) + 1;
-        const next = mml.parent.childNodes[k + 1];
-        const dimen = (next ? next.getLineBBox(0).originalL : 0);
+        const next = mml.parent.childNodes[k];
+        const dimen = (next ? next.getLineBBox(0).originalL : 0) * scale;
         if (dimen) {
           this.addInlineBreak(nsvg, dimen, forced);
         }
       } else if (forced || i) {
-        const dimen = (mml && !newline ? mml.getLineBBox(0).originalL : 0);
+        const dimen = (mml && i ? mml.getLineBBox(0).originalL : 0) * scale;
         if (dimen || !forced) {
           this.addInlineBreak(nsvg, dimen, forced || !!mml.node.getProperty('forcebreak'));
         }
       }
-      //
-      // Don't insert space right after an mo with linebreak="newline"
-      //
-      newline = !!(mo && mo.node.attributes.get('linebreak') === 'newline');
     }
     //
     // Move <defs> node (if any) to first line's svg and remove the original svg node

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -264,7 +264,7 @@ CommonOutputJax<
    * @param {number} h   The height of the SVG to create
    * @param {number} d   The depth of the SVG to create
    * @param {number} w   The width of the SVG to create
-   * @return [N, N]      The svg element and its initial g child
+   * @return {[N, N]}      The svg element and its initial g child
    */
   protected createSVG(h: number, d: number, w: number): [N, N] {
     const px = this.math.metrics.em / 1000;


### PR DESCRIPTION
This PR allows `mrow` nodes that were added by SRE to include in-line line breaks, so that TeX output will work as expected even after enrichment.  For example,

```
\(f(x+y+z+x+y+z+x+y+z+x+y+z+x+y+z+x+y+z)\)
```
should allow line breaks when it appears in a container with a small width.

We also fix some problems with SVG output when the top-level element is an `mstyle` or `semantics`, as in

```
\(\large x+y+z+x+y+z+x+y+z+x+y+z+x+y+z+x+y+z\)
```

When an `mstyle`, `semantics`, or `mrow` with `data-semantics-added` is encountered during in-line break processing, it is marked with the `inline-breaks` property, and that is used in CHTML output to add an attribute that is used to set `display: inline` in the CSS so that the breaks will be able to take effect (the default `inline-block` doesn't allow the breaks).  

The common in-line breaking code mishandled a potential breakpoint that has `linebreakstyle="after"`, and that has been fixed, here (by changes to the `markNext` variable).  The operator with `linebreakstyle="after"` doesn't need to be marked for a breakpoint (this lead to an empty `svg` node in the SVG output that was getting in the way of determining the spacing for the first svg in the next line).  That means we don't need the `newline` variable any longer in the SVG code that processes the breakpoints, as that was trying to compensate for the incorrect break for the `linebreakstyle="after"`. 

We also properly scale the SVG breakpoints, so the `\large` example above has the correct spacing.