### PR TITLE
Fix bussproofs

### DIFF
--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -232,7 +232,9 @@ export function CommonMrowMixin<
     constructor(factory: WF, node: MmlNode, parent: WW = null) {
       super(factory, node, parent);
       const self = this as any as WW;
-      this.isStack = (this.parent.node.isInferred || this.parent.breakTop(self, self) !== self);
+      this.isStack = (!this.parent ||
+        this.parent.node.isInferred ||
+        this.parent.breakTop(self, self) !== self);
       this.stretchChildren();
       for (const child of this.childNodes) {
         if (child.bbox.pwidth) {
@@ -306,6 +308,7 @@ export function CommonMrowMixin<
      * Adjust bbox vertical alignment. (E.g., for \vbox, \vcenter.)
      */
     protected vboxAdjust(bbox: BBox) {
+      if (!this.parent) return;
       const n = this.breakCount;
       const valign = this.parent.node.attributes.get('data-vertical-align');
       if (n && valign === 'bottom') {


### PR DESCRIPTION
This is a fix for the bussproofs issue that occurs during abstract bounding box computation. The problem here is that some of the `mrow` elements introduced for measuring width will not have a parent. So I introduced two guards for methods that throw errors otherwise.

I assume setting `isStack` to `true` is reasonable, as for the time being, we don't really want line breaking in proof tree expressions.

