### PR TITLE
Update version to beta.3

### DIFF
--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -58,6 +58,8 @@ if (path.basename(dir) === 'node-main') {
     return REQUIRE(name.charAt(0) === '.' ? path.resolve(ROOT, name) :
                    name.charAt(0) === '[' ? Package.resolvePath(name) : name);
   };
+} else {
+  CONFIG.paths.mathjax = dir;
 }
 
 /*

--- a/components/root-pack.js
+++ b/components/root-pack.js
@@ -1,0 +1,4 @@
+//
+//  Do what __dirname does in webpack
+//
+export const esRoot = () => '/';

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -66,12 +66,16 @@ function fullPath(resource) {
  */
 const PLUGINS = function (js, dir, target, font, jax, name) {
   //
-  // Replace a11y/util with the webpack version
+  // Replace a11y/util and components/mjs/root with the webpack versions
   //
   const plugins = [
     new webpack.NormalModuleReplacementPlugin(
       /components\/[cm]js\/a11y\/util\.js/,
       './util-pack.js'
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /mjs\/components\/mjs\/root\.js/,
+      '../../../components/root-pack.js'
     )
   ];
 
@@ -185,7 +189,7 @@ const RESOLVE = function (js, dir, target, libs) {
   // The resolve object to use
   //
   return {
-    plugins: [new ResolveReplacementPlugin()],
+    plugins: [new ResolveReplacementPlugin()]
   };
 }
 
@@ -197,10 +201,12 @@ const RESOLVE = function (js, dir, target, libs) {
  * @param {{
  *          name: string,     // The name of the component to create
  *          js: string,       // The path to the compiled .js files (default is mathjax js directory)
+ *          target: string,   // 'mjs' or 'cjs' (defaults to 'mjs')
+ *          bundle: string,   // name of sub-directory where packed files go (defaults to 'bundle')
  *          libs: string[],   // Array of paths to component lib directories to link against
  *          dir: string,      // The directory of the component being built
  *          dist: string,     // The path to the directory where the component .js file will be placed
- *                                (defaults to es5 or es6 in the same directory as the js directory)
+ *                                (defaults to the bundle directory in the same directory as the js directory)
  *          font: boolean,    // false to replace default font with no font
  *          jax: string,      // the jax whose default font should be redirected
  *        }}  options

--- a/components/webpack.config.cjs
+++ b/components/webpack.config.cjs
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/components/webpack.config.mjs
+++ b/components/webpack.config.mjs
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,23 @@
 {
   "name": "mathjax-full",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mathjax-full",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "mathjax-modern-font": "^4.0.0-beta.1",
+        "mathjax-modern-font": "^4.0.0-beta.3",
         "mhchemparser": "^4.2.1",
-        "mj-context-menu": "^0.8.1",
+        "mj-context-menu": "^0.9.1",
         "speech-rule-engine": "^4.1.0-beta.7"
       },
       "devDependencies": {
         "copyfiles": "^2.4.1",
         "diff": "^5.1.0",
-        "mj-context-menu": "^0.9.1",
         "rimraf": "^5.0.1",
         "tape": "^5.6.3",
         "terser-webpack-plugin": "^5.3.9",
@@ -1919,9 +1918,9 @@
       }
     },
     "node_modules/mathjax-modern-font": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-4.0.0-beta.1.tgz",
-      "integrity": "sha512-ItwLZ6i2bEQGO6W0yVUAQwlhZ+kBvs9ipkamBttfKbhiRTkTyiOzK6/X/3TK8nFH3brheYQE7Wj3RVemkzBSdQ=="
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/mathjax-modern-font/-/mathjax-modern-font-4.0.0-beta.3.tgz",
+      "integrity": "sha512-rUD7Hxu2yKCogWg0PVx5l4iMn2mOjcD4/vseIU+u2RxFkRfEDvfCphdBiQv27O8wnYEbdhjmn9+v4cDeDowDWg=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -1988,8 +1987,7 @@
     "node_modules/mj-context-menu": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.9.1.tgz",
-      "integrity": "sha512-ECPcVXZFRfeYOxb1MWGzctAtnQcZ6nRucE3orfkKX7t/KE2mlXO2K/bq4BcCGOuhdz3Wg2BZDy2S8ECK73/iIw==",
-      "dev": true
+      "integrity": "sha512-ECPcVXZFRfeYOxb1MWGzctAtnQcZ6nRucE3orfkKX7t/KE2mlXO2K/bq4BcCGOuhdz3Wg2BZDy2S8ECK73/iIw=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjax-full",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "description": "Beautiful and accessible math in all browsers. MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all browsers and in server-side node applications. This package includes the source code as well as the packaged components.",
   "keywords": [
     "MathJax",
@@ -134,7 +134,7 @@
     "webpack-cli": "^5.1.1"
   },
   "dependencies": {
-    "mathjax-modern-font": "^4.0.0-beta.1",
+    "mathjax-modern-font": "^4.0.0-beta.3",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
     "speech-rule-engine": "^4.1.0-beta.7"

--- a/ts/components/cjs/root.ts
+++ b/ts/components/cjs/root.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ts/components/mjs/root.ts
+++ b/ts/components/mjs/root.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ts/components/version.ts
+++ b/ts/components/version.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2022-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,4 +22,4 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-export const VERSION = '4.0.0-beta.1';
+export const VERSION = '4.0.0-beta.3';

--- a/ts/input/mathml/mml3/cjs/xsltFilename.ts
+++ b/ts/input/mathml/mml3/cjs/xsltFilename.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ts/input/mathml/mml3/mjs/xsltFilename.ts
+++ b/ts/input/mathml/mml3/mjs/xsltFilename.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ts/output/svg/Wrappers/zero.ts
+++ b/ts/output/svg/Wrappers/zero.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ts/ui/menu/mj-context-menu.ts
+++ b/ts/ui/menu/mj-context-menu.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ts/util/asyncLoad/esm.ts
+++ b/ts/util/asyncLoad/esm.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2023-2023 The MathJax Consortium
+ *  Copyright (c) 2023 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR includes several changes needed for version 4.0.0-beta.3.  These fixes include:

* Using the correct root path for webpacked node-main.js (for when you use `require("mathjax")` or `import "mathjax"` or the same for `mathjax-full`.
* Replacing `mjs/root.js` in the webpacked combined configuration files with a new `components/root-pack.mjs` that does the same thing as `__dirname` does in CommonJS webpacking (it replaces it with the directory `/`).  This is not ideal, but it prevents the inclusion of the directory name where the webpacked file was created (e.g., `/home/travis/mathjax/MathJax-src/...`).  The v3 versions had a broken default directory in node as well, so this is no worse than in the past.
* Fixing some comments (in particular some copyright dates that should not have been ranges).
