### PR TITLE
Fix incorrect flagging of nested environments. (mathjax/MathJax#3070)

### DIFF
--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1714,7 +1714,6 @@ BaseMethods.Equation = function (
 ) {
   parser.configuration.mathItem.display = display;
   parser.stack.env.display = display;
-  parser.Push(begin);
   ParseUtil.checkEqnEnv(parser);
   parser.Push(begin);
   return parser.itemFactory.create('equation', numbered).


### PR DESCRIPTION
This PR fixes an incorrect error message about nested environments whenever the `equation`, `displaymath`, or `math` environments are used.  There were two calls to `parser.Push(begin)` in

https://github.com/mathjax/MathJax-src/blob/49db078a876cce1f2157c9c58fb98bb145a09068/ts/input/tex/base/BaseMethods.ts#L1709-L1722

but the first was supposed to have been removed:

https://github.com/mathjax/MathJax-src/commit/7bb5fbd541c88234eae9092e0f075f3eadf2219b#diff-8b54d4a07ba56e1e6678245687ace65d468dd87cb4c8770a11b261c94d0231a0

Not sure how it got restored (maybe a bad merge or merge conflict resolution).  In any case, the first one needs to be removed, as it forces the "Erroneous nesting" message to be produced whenever `\begin{equation}...\end{equation}` is used (and also affects the `displaymath` and `math` environments).

Resolve issue mathjax/MathJax#3070.