### PR TITLE
Fix bug with \text{} in textmacros package. (mathjax/MathJax#3082)

### DIFF
--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -98,7 +98,7 @@ export class TextParser extends TexParser {
    */
   protected copyLists() {
     const parseOptions = this.texParser.configuration;
-    for (const [name, list] of Object.keys(this.configuration.nodeLists)) {
+    for (const [name, list] of Object.entries(this.configuration.nodeLists)) {
       for (const node of list) {
         parseOptions.addNode(name, node);
       }


### PR DESCRIPTION
This PR fixes a problem introduced by a last minute change in respond to PR review where I didn't change `keys()` to `entries()` as I should have, and apparently failed to test the result.  Argh!

Resolves issue mathjax/MathJax#3082.