### PR TITLE
Remove incorrect frame from multline environment. (mathjax/MathJax#3083)

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -120,6 +120,7 @@ AmsMethods.Multline = function (parser: TexParser, begin: StackItem, numbered: b
   // @test Shove*, Multline
   ParseUtil.checkEqnEnv(parser);
   parser.Push(begin);
+  const padding = parser.options.ams['multlineIndent'];
   const item = parser.itemFactory.create('multline', numbered, parser.stack) as ArrayItem;
   item.arraydef = {
     displaystyle: true,
@@ -128,8 +129,7 @@ AmsMethods.Multline = function (parser: TexParser, begin: StackItem, numbered: b
     width: parser.options.ams['multlineWidth'],
     side: parser.options['tagSide'],
     minlabelspacing: parser.options['tagIndent'],
-    framespacing: parser.options.ams['multlineIndent'] + ' 0',
-    frame: '',   // Use frame spacing with no actual frame
+    'data-array-padding': `${padding} ${padding}`,
     'data-width-includes-label': true // take label space out of 100% width
   };
   return item;

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -268,7 +268,6 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     protected handleColumnSpacing() {
       const scale = (this.childNodes[0] ? 1 / this.childNodes[0].getBBox().rscale : 1);
       const spacing = this.getEmHalfSpacing([this.fSpace[0], this.fSpace[2]], this.cSpace, scale);
-      const frame = this.fframe;
       //
       //  For each row...
       //
@@ -288,10 +287,10 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
           //  default already set in the mtd styles
           //
           const styleNode = (cell ? cell.dom[0] : this.adaptor.childNodes(row.dom[0])[i] as N);
-          if ((i > 1 && lspace !== '0.4em') || (frame && i === 1)) {
+          if ((i > 1 && lspace !== '0.4em') || (lspace !== '0' && i === 1)) {
             this.adaptor.setStyle(styleNode, 'paddingLeft', lspace);
           }
-          if ((i < this.numCols && rspace !== '0.4em') || (frame && i === this.numCols)) {
+          if ((i < this.numCols && rspace !== '0.4em') || (rspace !== '0' && i === this.numCols)) {
             this.adaptor.setStyle(styleNode, 'paddingRight', rspace);
           }
         }


### PR DESCRIPTION
This PR fixes a problem with the `multline` environment where it was incorrectly getting a frame.  That was due to changes with how the `frame` attribute was being handled, and the fact that I had used an empty `frame` attribute to add the `framespacing` without a frame.  That was a misuse of the `frame` attribute, which I knew would come back to bite me, and now it did.

The fix is to change `multline` to use `data-array-padding` instead of `framespacing` for the spacing.  This also requires a fix in the CHTML output to properly handle that change as well.

Resolves issue mathjax/MathJax#3083.