### PR TITLE
Make sure \operatorname stays an OP after enrichment. (mathjax/MathJax#3084)

### DIFF
--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -239,8 +239,7 @@ AmsMethods.HandleOperatorName = function(parser: TexParser, name: string) {
     ...parser.stack.env,
     font: TexConstant.Variant.NORMAL,
     multiLetterIdentifiers: parser.options.ams.operatornamePattern,
-    operatorLetters: true,
-    noAutoOP: true
+    operatorLetters: true
   }, parser.configuration).mml();
   //
   //  If we get something other than a single mi, wrap in a TeXAtom.


### PR DESCRIPTION
This PR makes sure that the result of `\operatorname{}` keeps TeX class OP after a round-trip through enrichment by removing the `noAutoOP` from its definition.  I'm not sure why it was there originally, but isn't needed.

Resolves issue mathjax/MathJax#3084.