### PR TITLE
Fix spacing before \vcenter, \vtop, \vbox.  (mathjax/MathJax#3085)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mpadded.ts
+++ b/ts/core/MmlTree/MmlNodes/mpadded.ts
@@ -64,6 +64,7 @@ export class MmlMpadded extends AbstractMmlLayoutNode {
     if (!this.getProperty('vbox')) {
       return super.setTeXclass(prev);
     }
+    this.getPrevClass(prev);
     this.texClass = TEXCLASS.ORD;
     this.childNodes[0].setTeXclass(null);
     return this;


### PR DESCRIPTION
This PR fixes the spacing before `\vcenter`, `\vtop`, and `\vbox` macros.  The problem was that the previous element's class wasn't being properly recorded, so nob spacing was being computed for it (the TeX spacing is based on the TeX classes of adjacent pairs of nodes).

Resolves issue mathjax/MathJax#3085