### PR TITLE
Remove errant mjx-linestrut from SVG output. (mathjax/MathJax#3087)

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -120,8 +120,6 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    */
   public toEmbellishedSVG(parents: N[]): boolean {
     if (parents.length <= 1 || !this.node.isEmbellished) return false;
-    const adaptor = this.adaptor;
-    parents.forEach(dom => adaptor.append(dom, this.html('mjx-linestrut')));
     const style = this.coreMO().embellishedBreakStyle;
     //
     // At the end of the first line or beginning of the second,


### PR DESCRIPTION
This PR removes the code that adds `mjx-linestrut` node to embellished operators in SVG output for in-line math with line-breaks allowed.  It seems to have been left over when copying the CHTML output `toEmbellishedCHTML()` to make the SVG version.

Resolves issue mathjax/MathJax#3087.