### PR TITLE
Include default font configuration so that it will be loaded when input/chtml or input/svg is loaded

### DIFF
--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -34,9 +34,11 @@ const dir = global.MathJax.config.__dirname;   // set up by node-main.mjs or nod
  * Set up the initial configuration
  */
 combineDefaults(MathJax.config, 'loader', {
+  paths: {'mathjax-modern': 'mathjax-modern-font'},
   require: eval("(file) => import(file)"),   // use dynamic imports
   failed: (err) => {throw err}               // pass on error message to init()'s catch function
 });
+combineDefaults(MathJax.config, 'output', {font: 'mathjax-modern'});
 
 /*
  * Mark the preloaded components


### PR DESCRIPTION
This PR adds the default font to the default configuration for `node-main` so that when an output jax is loaded, it will load the default font automatically (rather than the "no-font" that is built into the `input/chtml` and `input/svg` components).  This allows you to do

``` js
require("mathjax-full").init({loader: {load: ['input/tex', 'output/svg']}}).then(...)
```

without having to include configuration for the font by hand.  You can still override the font by setting the `loader.paths` and `output.font` values in the argument to `init()` if you want to use a different font.