### PR TITLE
Don't insert <mi/> on right-aligned columns.  (mathjax/MathJax#3089)

### DIFF
--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -1393,7 +1393,9 @@ export class EqnArrayItem extends ArrayItem {
    */
   public EndEntry() {
     // @test Cubic Binomial
-    if (this.row.length) {
+    const calign = (this.arraydef.columnalign as string).split(/ /);
+    const align = this.row.length && calign.length ? calign[this.row.length % calign.length] : 'right';
+    if (align !== 'right') {
       ParseUtil.fixInitialMO(this.factory.configuration, this.nodes);
     }
     super.EndEntry();


### PR DESCRIPTION
This PR fixes a problem with the `align` and similar environments where if a second set of aligned columns are used, then initial minus signs (and other operators) will be treated as infix rather than prefix operators.  This is because the additional empty `mi` nodes are being inserted for all columns but the first one.  The fix proposed here is to not insert for right-justified columns (which will be the ones that start the second or later set of alignments).  We can't use the column number itself, since `align` repeats after two columns, while `eqnarray` repeats after 3.

Resolves issue mathjax/MathJax#3089.