### PR TITLE
Improve build tools for use with third-party extensions.  (mathjax/MathJax#3086)

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -79,7 +79,7 @@ const EXCLUDE = new Map((config.exclude || []).map(name => [name, true]));  // f
 const EXCLUDESUBDIRS = !!config.excludeSubdirs;                             // exclude subdirectories or not
 const JS = config.js || config.mathjax || mjPath;                           // path to the compiled .js files
 const LIB = config.lib || './lib';                                          // path to the lib directory to create
-const TS = config.ts || JS.replace(/[cm]js$/, 'ts');                        // path to the .ts files
+const TS = config.ts || path.join(JS, '..', 'ts');                          // path to the .ts files
 const GLOBAL = config.global || mjGlobal;                                   // path to the global.js file
 const VERSION = config.version || mjGlobal.replace(/global/, 'version');    // path to the version.js file
 const TYPE = config.type || getType();                                      // the module type

--- a/components/bin/pack
+++ b/components/bin/pack
@@ -104,6 +104,7 @@ async function webpackLib(dir) {
     if (!config) return;
     const jsdir = (config.js ? path.resolve(dir, config.js).replace(/js$/, target) : jsPath);
     const jsRE = fileRegExp(jsdir);
+    const jsRE2 = (config.js ? fileRegExp(path.resolve(dir, config.js)) : /^$/);
     const libRE = fileRegExp(path.resolve(jsdir, '..', 'components'));
 
     //
@@ -131,7 +132,8 @@ async function webpackLib(dir) {
             .replace(rootRE, '[mathjax]')
             .replace(fontRE, '[$1]/$2')
             .replace(jsRE,   '[js]')
-            .replace(libRE,  '[lib]');
+            .replace(jsRE2,  '[js]')
+            .replace(libRE,  '[build]');
         if (name.charAt(0) !== '.' && name.charAt(0) !== '[') {
           name = path.relative(dir, name);
         }

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -67,6 +67,7 @@ function fullPath(resource) {
 const PLUGINS = function (js, dir, target, font, jax, name) {
   //
   // Replace a11y/util and components/mjs/root with the webpack versions
+  //   and map mathjax-full/js to mathjax-full/${target}
   //
   const plugins = [
     new webpack.NormalModuleReplacementPlugin(
@@ -76,6 +77,12 @@ const PLUGINS = function (js, dir, target, font, jax, name) {
     new webpack.NormalModuleReplacementPlugin(
       /mjs\/components\/mjs\/root\.js/,
       '../../../components/root-pack.js'
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /mathjax-full\/js\//,
+      function (resource) {
+        resource.request = resource.request.replace(/mathjax-full\/js\//, `mathjax-full/${target}/`);
+      }
     )
   ];
 


### PR DESCRIPTION
This PR makes minor changes to the build tools so that they work better for third-party extensions.

The first change makes the build command have a better default for the `ts` directory (is it now next to the `js` directory, no matter what its name is).

The changes to `pack` produce better results for the file list when packing a file (the `[build]` files, which are the ones from the actual extension, will be at the top of the list, and the `[js]` will now be applied to file even if they are not in a mjs/cjs directory.

The change to `webpack.common.cjs` makes sure that *all* references to `mathjax-full/js` are remapped to the appropriate mjs/cjs version (without this, some were not getting caught, causing unwanted mathjax files to be included in the final packed file).

Resolves some issue raised in mathjax/MathJax#3086.