### PR TITLE
Set TeX class OP for multi-letter mo elements, as in v2.  (mathjax/MathJax#3095)

### DIFF
--- a/ts/core/MmlTree/OperatorDictionary.ts
+++ b/ts/core/MmlTree/OperatorDictionary.ts
@@ -136,10 +136,10 @@ export const RANGES: RangeDef[] = [
 /**
  * Get the Unicode range for the first character of a string
  *
- * @param {string} text      The character to check
- * @return {RangeDef|null}   The range containing that character, or null
+ * @param {string} text   The character to check
+ * @return {RangeDef}     The range containing that character, or null
  */
-export function getRange(text: string): RangeDef | null {
+export function getRange(text: string): RangeDef {
   const n = text.codePointAt(0);
   for (const range of RANGES) {
     if (n <= range[1]) {
@@ -149,7 +149,7 @@ export function getRange(text: string): RangeDef | null {
       break;
     }
   }
-  return null;
+  return [0, 0, TEXCLASS.REL, 'mo'];
 }
 
 /**

--- a/ts/input/tex/base/BaseConfiguration.ts
+++ b/ts/input/tex/base/BaseConfiguration.ts
@@ -58,11 +58,11 @@ export function Other(parser: TexParser, char: string) {
     {mathvariant: parser.stack.env['font']} : {};
   const remap = (MapHandler.getMap('remap') as CharacterMap).lookup(char);
   const range = getRange(char);
-  const type = (range ? range[3] : 'mo');
+  const type = range[3]
   // @test Other
   // @test Other Remap
   let mo = parser.create('token', type, def, (remap ? remap.char : char));
-  const variant = (range?.[4] ||
+  const variant = (range[4] ||
                    (ParseUtil.isLatinOrGreekChar(char) ? parser.configuration.mathStyle(char, true) : ''));
   if (variant) {
     mo.attributes.set('mathvariant', variant);


### PR DESCRIPTION
In version 2, an `mo` with multiple letters, like `<mo>Hom</mo>`, would be given the TeX class of OP when it doesn't appear explicitly in the operator table.  This was lost in the v3 translation, and this PR reinstates that.  In addition, it refactors the code that does the checking, since it is used in two places (the `get texClass()` getter, and the `checkOperatorTable()` initialization routine.  It also adjusts the `getRange()` function in the `OperatorTable.ts` to always return a value.

The pattern used to identify a multi-letter operator is a property of the `MmlMo` object, so that it can be adjusted during initialization, if desired.

Resolves issue mathjax/MathJax#3095.