### PR TITLE
Use superscript for scriptChild in msubsup.  (mathjax/MathJax#3097)

### DIFF
--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -415,6 +415,13 @@ export function CommonMsubsupMixin<
     /**
      * @override
      */
+    public get scriptChild(): WW {
+      return this.supChild;
+    }
+
+    /**
+     * @override
+     */
     public getUVQ(
       subbox: BBox = this.subChild.getOuterBBox(),
       supbox: BBox = this.supChild.getOuterBBox()
@@ -426,6 +433,8 @@ export function CommonMsubsupMixin<
       const t = 3 * tex.rule_thickness;
       const subscriptshift = this.length2em(this.node.attributes.get('subscriptshift'), tex.sub2);
       const drop = this.baseCharZero(bbox.d * this.baseScale + tex.sub_drop * subbox.rscale);
+      const supd = supbox.d * supbox.rscale;
+      const subh = subbox.h * subbox.rscale;
       //
       // u and v are the veritcal shifts of the scripts, initially set to minimum values and then adjusted
       //
@@ -433,16 +442,17 @@ export function CommonMsubsupMixin<
       //
       // q is the space currently between the super- and subscripts.
       // If it is less than 3 rule thicknesses,
-      //   increase the subscript offset to make the space 3 rule thicknesses
+      //   Increase the subscript offset to make the space 3 rule thicknesses
       //   If the bottom of the superscript is below 4/5 of the x-height
       //     raise both the super- and subscripts by the difference
       //     (make the bottom of the superscript be at 4/5 the x-height, and the
-      //      subscript 3 rule thickness below that).
+      //      subscript 3 rule thickness below that),
+      //     provided we don't move up past the original subscript position.
       //
-      let q = (u - supbox.d * supbox.rscale) - (subbox.h * subbox.rscale - v);
+      let q = (u - supd) - (subh - v);
       if (q < t) {
         v += t - q;
-        const p = (4 / 5) * tex.x_height - (u - supbox.d * supbox.rscale);
+        const p = (4 / 5) * tex.x_height - (u - supd);
         if (p > 0) {
           u += p;
           v -= p;
@@ -454,7 +464,7 @@ export function CommonMsubsupMixin<
       //
       u = Math.max(this.length2em(this.node.attributes.get('superscriptshift'), u), u);
       v = Math.max(this.length2em(this.node.attributes.get('subscriptshift'), v), v);
-      q = (u - supbox.d * supbox.rscale) - (subbox.h * subbox.rscale - v);
+      q = (u - supd) - (subh - v);
       this.UVQ = [u, -v, q];
       return this.UVQ;
     }


### PR DESCRIPTION
This PR fixes a problem with the placement of `msubsup` scripts when when the depth of either script is large.  The problem was due to the `getU()` method using `this.scriptChild`, where `sciptChild` was always set to `childNodes[1]`; for `msubsup` nodes, it should be `childNodes[2]`, the superscript.  The solution is to override `scriptChild` in the `CommonMsubsupMixin` wrapper.  (I also cached the superscript depth and subscript height values that are used in several places).

The issue would show up if the superscript has large depth, as in 

```
$$\int_0^{\Rule{3pt}{0pt}{20pt}}$$
```

which produces

<img width="46" alt="bad-int" src="https://github.com/mathjax/MathJax-src/assets/432782/e29414c8-ca7a-49b2-8c21-efc3c1ec6998">

or if the subscript has large depth, as in

```
$$x_{\Rule{3pt}{0pt}{20pt}}^2$$
```

which produces

<img width="32" alt="bad-x" src="https://github.com/mathjax/MathJax-src/assets/432782/f1bbb66e-1c0d-4cf9-996f-aa47c8eb4fe9">

With this PR, both produce the proper results:

<img width="121" alt="good" src="https://github.com/mathjax/MathJax-src/assets/432782/e8717d0d-737c-4d7c-8932-f02405ba7b4b">

Resolves issue mathjax/MathJax#3097.