### PR TITLE
Propery handle placement of scripts on \vcenter, \vbox, and \vtop (mathjax/MathJax#3091)

### DIFF
--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -462,12 +462,13 @@ export function CommonScriptbaseMixin<
      */
     public getBaseCore(): WW {
       let core = this.getSemanticBase() || this.childNodes[0];
+      let node = core?.node;
       while (core &&
              ((core.childNodes.length === 1 &&
-               (core.node.isKind('mrow') || core.node.isKind('TeXAtom') ||
-                core.node.isKind('mstyle') || core.node.isKind('mpadded') ||
-                core.node.isKind('mphantom') || core.node.isKind('semantics'))) ||
-              (core.node.isKind('munderover') &&
+               (node.isKind('mrow') || node.isKind('TeXAtom') ||
+                node.isKind('mstyle') || (node.isKind('mpadded') && !node.getProperty('vbox')) ||
+                node.isKind('mphantom') || node.isKind('semantics'))) ||
+              (node.isKind('munderover') &&
                (core as any as CommonMunderover<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>).isMathAccent))) {
         this.setBaseAccentsFor(core);
         core = core.childNodes[0];


### PR DESCRIPTION
This PR fixes a problem where super- and subscripts were not placed properly on the results of `\vcenter`, `\vbox`, and `\vtop` elements.  These are implemented using `mpadded` nodes with `data-vertical-align` attributes and a `vbox` property to mark them as vboxes.  The problem is that the `getBaseCore()` method should stop at an `mpadded` element being used as a vbox, but was continuing down into it incorrectly if there was only one child element.  The fix is to stop when the `mpadded` has the `vbox` property.

Resolves issue mathjax/MathJax#3091.