### PR TITLE
Prevent setting a propery that has a getter.  (mathjax/MathJax#3098)

### DIFF
--- a/ts/components/global.ts
+++ b/ts/components/global.ts
@@ -78,18 +78,21 @@ export function isObject(x: any): boolean {
  * Combine user-produced configuration with existing defaults.  Values
  * from src will replace those in dst.
  *
- * @param {any} dst      The destination config object (to be merged into)
- * @param {any} src      The source configuration object (to replace defaul values in dst}
- * @return {any}         The resulting (modified) config object
+ * @param {any} dst         The destination config object (to be merged into)
+ * @param {any} src         The source configuration object (to replace defaul values in dst}
+ * @param {boolean} check   True when combining into MathJax._ to avoid setting getter properties
+ * @return {any}            The resulting (modified) config object
  */
-export function combineConfig(dst: any, src: any): any {
+export function combineConfig(dst: any, src: any, check: boolean = false): any {
   for (const id of Object.keys(src)) {
-    if (id === '__esModule') continue;
+    if (id === '__esModule' || dst[id] === src[id]) continue;
     if (isObject(dst[id]) && isObject(src[id]) &&
         !(src[id] instanceof Promise) /* needed for IE polyfill */) {
-      combineConfig(dst[id], src[id]);
-    } else if (src[id] !== null && src[id] !== undefined && dst[id] !== src[id]) {
-      dst[id] = src[id];
+      combineConfig(dst[id], src[id], check || id === '_');
+    } else if (src[id] !== null && src[id] !== undefined) {
+      if (!check || !Object.getOwnPropertyDescriptor(dst, id)?.get) {
+        dst[id] = src[id];
+      }
     }
   }
   return dst;

--- a/ts/components/global.ts
+++ b/ts/components/global.ts
@@ -79,20 +79,22 @@ export function isObject(x: any): boolean {
  * from src will replace those in dst.
  *
  * @param {any} dst         The destination config object (to be merged into)
- * @param {any} src         The source configuration object (to replace defaul values in dst}
- * @param {boolean} check   True when combining into MathJax._ to avoid setting getter properties
+ * @param {any} src         The source configuration object (to replace default values in dst}
+ * @param {boolean} check   True when combining into MathJax._ to avoid setting a property with a getter
  * @return {any}            The resulting (modified) config object
  */
 export function combineConfig(dst: any, src: any, check: boolean = false): any {
   for (const id of Object.keys(src)) {
-    if (id === '__esModule' || dst[id] === src[id]) continue;
-    if (isObject(dst[id]) && isObject(src[id]) &&
-        !(src[id] instanceof Promise) /* needed for IE polyfill */) {
+    if (id === '__esModule' ||
+        dst[id] === src[id] ||
+        src[id] === null ||
+        src[id] === undefined) {
+      continue;
+    }
+    if (isObject(dst[id]) && isObject(src[id])) {
       combineConfig(dst[id], src[id], check || id === '_');
-    } else if (src[id] !== null && src[id] !== undefined) {
-      if (!check || !Object.getOwnPropertyDescriptor(dst, id)?.get) {
-        dst[id] = src[id];
-      }
+    } else if (!check || !Object.getOwnPropertyDescriptor(dst, id)?.get) {
+      dst[id] = src[id];
     }
   }
   return dst;
@@ -105,7 +107,7 @@ export function combineConfig(dst: any, src: any, check: boolean = false): any {
  *
  * @param {any} dst      The destination config object (to be merged into)
  * @param {string} name  The id of the configuration block to modify (created if doesn't exist)
- * @param {any} src      The source configuration object (to replace defaul values in dst}
+ * @param {any} src      The source configuration object (to replace default values in dst}
  * @return {any}         The resulting (modified) config object
  */
 export function combineDefaults(dst: any, name: string, src: any): any {


### PR DESCRIPTION
This PR resolves a problem that occurs when `combineConfig()` or `combineWithMathJax()` are used to merge an object into the `MathJax._` object and the item to be set is already set and has a getter.  This occurs due to the way exports are handled in ESM modules, where the exports are in an object each with a getter (so that they can't be modified, as imports are supposed to be immutable).  That didn't seem to be the case for the CJS components we used to use.  As a consequence, changing the renderer now causes an error since both the CHTML and SVG components include the common output code, and both set the properties of `MathJax._.output.common`, which are all getters.  This produces errors.

Resolves the console error issue from mathjax/MathJax#3098.