### PR TITLE
Update check for spacelike mml nodes to be more sensible.  (mathjax/MathJax#3098)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/ts/core/MmlTree/MmlNodes/mspace.ts
@@ -77,10 +77,12 @@ export class MmlMspace extends AbstractMmlTokenNode {
   }
 
   /**
+   * Only make mspace be space-like if it doesn't have certain attributes
+   *
    * @override
    */
   public get isSpacelike() {
-    return true;
+    return this.attributes.getExplicit('linebreak') === undefined && this.canBreak;
   }
 
   /**

--- a/ts/core/MmlTree/MmlNodes/mtext.ts
+++ b/ts/core/MmlTree/MmlNodes/mtext.ts
@@ -51,11 +51,18 @@ export class MmlMtext extends AbstractMmlTokenNode {
   }
 
   /**
-   * <mtext> is always space-like according to the spec
+   * <mtext> is always space-like according to the spec,
+   * but we make it so only if it contains only spaces and
+   * doesn't have certain attributes
+   *
    * @override
    */
   public get isSpacelike() {
-    return true;
+    const attributes = this.attributes;
+    const spaces = !!this.getText().match(/^\s*$/);
+    return spaces && (attributes.getExplicit('mathbackground') === undefined &&
+                      attributes.getExplicit('background') === undefined &&
+                      attributes.getExplicit('style') === undefined);
   }
 
 }


### PR DESCRIPTION
This PR adjusts the way that `mspace` and `mtext` nodes are treated as spacelike.  The spec says they are always spacelike, but that causes all kinds of problems, like making `{\text{a}=\text{b}}` being treated as an embellished operator.  This interferes with line-breaking, for example, since a break at the equal sign will be moved to outside the text elements, which is not what is usually wanted.  Similarly, 

``` xml
<math>
  <mtext>a</mtext>
  <mspace linebreak="newline">
  <mo>=</mo>
  <mtext>b</mtex>
</math>
```

is also an embellished operator, and so treated as a single unit.

This PR makes `mtext` be spacelike only if it consists only of spaces, and doesn't have styles or background colors. Similarly, `mspace` will not be spacelike if it has an explicit `linebreak` attribute (or if it is not breakable due to other attributes).  This is not according to the spec, but makes more sense, particularly for how we use `mtext` and `mspace` in translating TeX to MathML.