### PR TITLE
Don't include extra linebreak positions after an explicit break.

### DIFF
--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -260,7 +260,7 @@ CommonWrapper<
    */
   protected handleSpace() {
     const adaptor = this.adaptor;
-    const breakable = !!this.node.getProperty('breakable');
+    const breakable = !!this.node.getProperty('breakable') && !this.node.getProperty('newline');
     const n = this.dom.length - 1;
     for (const data of [[this.getLineBBox(0).L, 'space',  'marginLeft', 0],
                         [this.getLineBBox(n).R, 'rspace', 'marginRight', n]]) {

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -395,12 +395,14 @@ export abstract class CommonOutputJax<
   public markInlineBreaks(node: MmlNode) {
     if (!node) return;
     const forcebreak = this.forceInlineBreaks;
+    let postbreak = false;
     let marked = false;
     let markNext = '';
     for (const child of node.childNodes) {
       if (markNext) {
         marked = this.markInlineBreak(marked, forcebreak, markNext, node, child);
         markNext = '';
+        postbreak = false;
       } else if (child.isEmbellished) {
         if (child === node.childNodes[0]) {
           continue;
@@ -413,29 +415,36 @@ export abstract class CommonOutputJax<
              (texClass === TEXCLASS.ORD && mo.hasSpacingAttributes()) ||
              linebreak !== 'auto') && linebreak !== 'nobreak') {
           if (linebreakstyle === 'before') {
-            marked = this.markInlineBreak(marked, forcebreak, linebreak, node, child, mo);
+            if (!postbreak || linebreak !== 'auto') {
+              marked = this.markInlineBreak(marked, forcebreak, linebreak, node, child, mo);
+            }
           } else {
             markNext = linebreak;
           }
         }
+        postbreak = (linebreak === 'newline' && linebreakstyle === 'after');
       } else if (child.isKind('mspace')) {
         const linebreak = child.attributes.get('linebreak') as string;
         if (linebreak !== 'nobreak') {
           marked = this.markInlineBreak(marked, forcebreak, linebreak, node, child);
         }
-      } else if ((child.isKind('mstyle') && !child.attributes.get('style') &&
-                  !child.attributes.getExplicit('mathbackground')) || child.isKind('semantics')) {
-        this.markInlineBreaks(child.childNodes[0]);
-        if (child.getProperty('process-breaks')) {
-          child.setProperty('inline-breaks', true);
-          child.childNodes[0].setProperty('inline-breaks', true);
-          node.parent.setProperty('process-breaks', 'true');
-        }
-      } else if (child.isKind('mrow') && child.attributes.get('data-semantic-added')) {
-        this.markInlineBreaks(child);
-        if (child.getProperty('process-breaks')) {
-          child.setProperty('inline-breaks', true);
-          node.parent.setProperty('process-breaks', 'true');
+        postbreak = (linebreak === 'newline');
+      } else {
+        postbreak = false;
+        if ((child.isKind('mstyle') && !child.attributes.get('style') &&
+             !child.attributes.getExplicit('mathbackground')) || child.isKind('semantics')) {
+          this.markInlineBreaks(child.childNodes[0]);
+          if (child.getProperty('process-breaks')) {
+            child.setProperty('inline-breaks', true);
+            child.childNodes[0].setProperty('inline-breaks', true);
+            node.parent.setProperty('process-breaks', 'true');
+          }
+        } else if (child.isKind('mrow') && child.attributes.get('data-semantic-added')) {
+          this.markInlineBreaks(child);
+          if (child.getProperty('process-breaks')) {
+            child.setProperty('inline-breaks', true);
+            node.parent.setProperty('process-breaks', 'true');
+          }
         }
       }
     }
@@ -462,6 +471,9 @@ export abstract class CommonOutputJax<
       //
       child.removeProperty('forcebreak');
       mo?.removeProperty('forcebreak');
+      if (linebreak === 'newline') {
+        child.setProperty('newline', true);
+      }
     }
     if (!marked) {
       node.setProperty('process-breaks', true);


### PR DESCRIPTION
This PR fixes a problem with CHTML output where in-line expressions with explicit line breaks could end up with extra vertical space at the explicit break if the part after it starts with an operator and is too wide for the container.  To do with, we mark the nodes with explicit linebreaks, and if we are just after an explicit line break, we don't mark an operator as breakable (preventing an extra line break from occurring right after an explicit one).  In the CHTML output, we don't insert breakpoints before explicit linebreaks (preventing an extra line break from occurring before that).

A test case is to use 

``` html
<div style="width:5em; border: 1px solid black">
\(a + \text{bbbbbbbbbbbbbbbbb} \\ = \text{cccccccccccccccc} + d\)
</div>
```

to see that there are no extra blank lines in CHTML output.