### PR TITLE
Fixes issue with wrapped script bases.

### DIFF
--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -472,6 +472,7 @@ export function CommonScriptbaseMixin<
                (core as any as CommonMunderover<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>).isMathAccent))) {
         this.setBaseAccentsFor(core);
         core = core.childNodes[0];
+        node = core?.node;
       }
       if (!core) {
         this.baseHasAccentOver = this.baseHasAccentUnder = false;


### PR DESCRIPTION
This is a fix for the issue that rendering of script elements with an base element that is wrapped in a `TexAtom` fails.
E.g., ${\bf a}^b$ fails, while $a^b$ works. But he latter only by accident.
 
The problem is in the `getBaseCore` method, where we loop into the base element. However, the loop works effectively on the node and not the wrapper, thus we have to reset both `core` and `node`, otherwise we end up with the innermost text node and an error in the `baseCharZero` method.