### PR TITLE
Refactors all `substr` to `substring` calls

### DIFF
--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -505,7 +505,7 @@ export class Collapse {
 
     const attributes = node.attributes.getAllAttributes();
     for (const name of Object.keys(attributes)) {
-      if (name.substr(0, 14) === 'data-semantic-') {
+      if (name.substring(0, 14) === 'data-semantic-') {
         mrow.attributes.set(name, attributes[name]);
         delete attributes[name];
       }

--- a/ts/components/latest.ts
+++ b/ts/components/latest.ts
@@ -174,7 +174,7 @@ function checkScript(script: HTMLScriptElement): ScriptData | null {
     const cdn = CDN.get(server);
     const url = cdn.base;
     const src = script.src;
-    if (src && src.substr(0, url.length) === url && src.match(/\/latest\.js(\?|$)/)) {
+    if (src && src.substring(0, url.length) === url && src.match(/\/latest\.js(\?|$)/)) {
       return scriptData(script, cdn);
     }
   }

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -113,7 +113,7 @@ export const PathFilters: {[name: string]: PathFilterFunction} = {
     let match;
     while ((match = data.name.match(/^\[([^\]]*)\]/))) {
       if (!CONFIG.paths.hasOwnProperty(match[1])) break;
-      data.name = CONFIG.paths[match[1]] + data.name.substr(match[0].length);
+      data.name = CONFIG.paths[match[1]] + data.name.substring(match[0].length);
     }
     return true;
   }

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -821,7 +821,7 @@ export abstract class AbstractMmlNode extends AbstractNode<MmlNode, MmlNodeClass
       const attributes = this.attributes;
       const bad = [];
       for (const name of attributes.getExplicitNames()) {
-        if (name.substr(0, 5) !== 'data-' && attributes.getDefault(name) === undefined &&
+        if (name.substring(0, 5) !== 'data-' && attributes.getDefault(name) === undefined &&
             !name.match(/^(?:class|style|id|(?:xlink:)?href)$/)) {
           // FIXME: provide a configurable checker for names that are OK
           bad.push(name);

--- a/ts/core/Tree/Visitor.ts
+++ b/ts/core/Tree/Visitor.ts
@@ -123,7 +123,7 @@ export abstract class AbstractVisitor<N extends VisitorNode<N>> implements Visit
    *  @return {string}  The name of the visitor method for the given node kind
    */
   protected static methodName(kind: string): string {
-    return 'visit' + (kind.charAt(0).toUpperCase() + kind.substr(1)).replace(/[^a-z0-9_]/ig, '_') + 'Node';
+    return 'visit' + (kind.charAt(0).toUpperCase() + kind.substring(1)).replace(/[^a-z0-9_]/ig, '_') + 'Node';
   }
 
   /**

--- a/ts/input/asciimath/FindAsciiMath.ts
+++ b/ts/input/asciimath/FindAsciiMath.ts
@@ -113,8 +113,9 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     let [ , display, pattern] = end;
     let i = pattern.lastIndex = start.index + start[0].length;
     let match = pattern.exec(text);
-    return (!match ? null : protoItem<N, T>(start[0], text.substr(i, match.index - i), match[0],
-                                            n, start.index, match.index + match[0].length, display));
+    return (!match ? null : protoItem<N, T>(
+      start[0], (match.index < i ? '' : text.substring(i, match.index)), match[0],
+      n, start.index, match.index + match[0].length, display));
   }
 
   /**

--- a/ts/input/mathml/FindMathML.ts
+++ b/ts/input/mathml/FindMathML.ts
@@ -91,8 +91,8 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
   protected findMathPrefixed(node: N, set: Set<N>) {
     let html = this.adaptor.root(this.adaptor.document);
     for (const attr of this.adaptor.allAttributes(html)) {
-      if (attr.name.substr(0, 6) === 'xmlns:' && attr.value === NAMESPACE) {
-        let prefix = attr.name.substr(6);
+      if (attr.name.substring(0, 6) === 'xmlns:' && attr.value === NAMESPACE) {
+        let prefix = attr.name.substring(6);
         for (const math of this.adaptor.tags(node, prefix + ':math')) {
           set.add(math);
         }

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -121,7 +121,7 @@ export class MathMLCompile<N, T, D> {
     let type = texClass && kind === 'mrow' ? 'TeXAtom' : kind;
     for (const name of this.filterClassList(adaptor.allClasses(node))) {
       if (name.match(/^MJX-TeXAtom-/) && kind === 'mrow') {
-        texClass = name.substr(12);
+        texClass = name.substring(12);
         type = 'TeXAtom';
       } else if (name === 'MJX-fixedlimits') {
         limits = true;
@@ -187,8 +187,8 @@ export class MathMLCompile<N, T, D> {
       if (value === null || name === 'xmlns') {
         continue;
       }
-      if (name.substr(0, 9) === 'data-mjx-') {
-        switch (name.substr(9)) {
+      if (name.substring(0, 9) === 'data-mjx-') {
+        switch (name.substring(9)) {
         case 'alternate':
           mml.setProperty('variantForm', true);
           break;
@@ -307,11 +307,11 @@ export class MathMLCompile<N, T, D> {
   protected checkClass(mml: MmlNode, node: N) {
     let classList = [];
     for (const name of this.filterClassList(this.adaptor.allClasses(node))) {
-      if (name.substr(0, 4) === 'MJX-') {
+      if (name.substring(0, 4) === 'MJX-') {
         if (name === 'MJX-variant') {
           mml.setProperty('variantForm', true);
-        } else if (name.substr(0, 11) !== 'MJX-TeXAtom') {
-          mml.attributes.set('mathvariant', this.fixCalligraphic(name.substr(3)));
+        } else if (name.substring(0, 11) !== 'MJX-TeXAtom') {
+          mml.attributes.set('mathvariant', this.fixCalligraphic(name.substring(3)));
         }
       } else {
         classList.push(name);

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -357,7 +357,7 @@ export class ColumnParser {
     if (String(n) !== num) {
       throw new TexError('ColArgNotNum', 'First argument to %1 column specifier must be a number', '*');
     }
-    state.template = new Array(n).fill(cols).join('') + state.template.substr(state.i);
+    state.template = new Array(n).fill(cols).join('') + state.template.substring(state.i);
     state.i = 0;
   }
 

--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -175,7 +175,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
     let match: RegExpExecArray, braces: number = 0;
     while ((match = pattern.exec(text))) {
       if ((match[1] || match[0]) === close && braces === 0) {
-        return protoItem<N, T>(start[0], text.substr(i, match.index - i), match[0],
+        return protoItem<N, T>(start[0], text.substring(i, match.index), match[0],
                                n, start.index, match.index + match[0].length, display);
       } else if (match[0] === '{') {
         braces++;

--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -209,7 +209,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
         let math = start[this.sub];
         let end = start.index + start[this.sub].length;
         if (math.length === 2) {
-          match = protoItem<N, T>('', math.substr(1), '', n, start.index, end);
+          match = protoItem<N, T>('', math.substring(1), '', n, start.index, end);
         } else {
           match = protoItem<N, T>('', math, '', n, start.index, end, false);
         }

--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -43,7 +43,7 @@ namespace ParseMethods {
     const def = ParseUtil.getFontDef(parser);
     const env = parser.stack.env;
     if (env.multiLetterIdentifiers && env.font !== '') {
-      c = parser.string.substr(parser.i - 1).match(env.multiLetterIdentifiers as any as RegExp)?.[0] || c;
+      c = parser.string.substring(parser.i - 1).match(env.multiLetterIdentifiers as any as RegExp)?.[0] || c;
       parser.i += c.length - 1;
       if (def.mathvariant === MATHVARIANT.NORMAL && env.noAutoOP && c.length > 1) {
         def.autoOP = false;

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -298,7 +298,7 @@ namespace ParseUtil {
           }
         } else if (c === '\\') {
           // @test Mbox Eqref, Mbox CR
-          if (match === '' && text.substr(i).match(/^(eq)?ref\s*\{/)) {
+          if (match === '' && text.substring(i).match(/^(eq)?ref\s*\{/)) {
             // @test Mbox Eqref
             let len = ((RegExp as any)['$&'] as string).length;
             if (k < i - 1) {
@@ -329,16 +329,16 @@ namespace ParseUtil {
             } else if (c.match(/[${}\\]/) && match === '')  {
               // @test Mbox CR
               i--;
-              text = text.substr(0, i - 1) + text.substr(i); // remove \ from \$, \{, \}, or \\
+              text = text.substring(0, i - 1) + text.substring(i); // remove \ from \$, \{, \}, or \\
             } else if (c === 'U') {
-              const arg = text.substr(i).match(/^\s*(?:([0-9A-F])|\{\s*([0-9A-F]+)\s*\})/);
+              const arg = text.substring(i).match(/^\s*(?:([0-9A-F])|\{\s*([0-9A-F]+)\s*\})/);
               if (!arg) {
                 throw new TexError('BadRawUnicode',
                                    'Argument to %1 must a hexadecimal number with 1 to 6 digits', '\\U');
               }
               //  Replace \U{...} with specified character
               const c = String.fromCodePoint(parseInt(arg[1] || arg[2], 16));
-              text = text.substr(0, i - 2) + c + text.substr(i + arg[0].length);
+              text = text.substring(0, i - 2) + c + text.substring(i + arg[0].length);
             }
           }
         }

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -53,7 +53,10 @@ export default class TexError {
       } else if (c === '{') {        // %{n} or %{plural:%n|...}
         c = parts[i].substring(1);
         if (c >= '0' && c <= '9') {  // %{n}
-          parts[i] = args[parseInt(parts[i].substr(1, parts[i].length - 2), 10) - 1];
+          parts[i] = args[parseInt(
+            // parts[i] = %{n}
+            parts[i].substring(1, parts[i].length - 1),
+            10) - 1];
           if (typeof parts[i] === 'number') {
             parts[i] = parts[i].toString();
           }

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -51,7 +51,7 @@ export default class TexError {
           parts[i] = parts[i].toString();
         }
       } else if (c === '{') {        // %{n} or %{plural:%n|...}
-        c = parts[i].substr(1);
+        c = parts[i].substring(1);
         if (c >= '0' && c <= '9') {  // %{n}
           parts[i] = args[parseInt(parts[i].substr(1, parts[i].length - 2), 10) - 1];
           if (typeof parts[i] === 'number') {

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -215,7 +215,7 @@ AmsMethods.HandleDeclareOp =  function (parser: TexParser, name: string) {
   let star = (parser.GetStar() ? '*' : '');
   let cs = ParseUtil.trimSpaces(parser.GetArgument(name));
   if (cs.charAt(0) === '\\') {
-    cs = cs.substr(1);
+    cs = cs.substring(1);
   }
   let op = parser.GetArgument(name);
   (parser.configuration.handlers.retrieve(NEW_OPS) as CommandMap).

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -1150,7 +1150,7 @@ export class ArrayItem extends BaseItem {
     // Check if there are extra entries at the end of a row to be added
     //
     if (term !== '&') {
-      found = !!entry.trim() || !!(n || term.substr(0, 4) !== '\\end');
+      found = !!entry.trim() || !!(n || term.substring(0, 4) !== '\\end');
       if (cextra[n + 1] && !cextra[n]) {
         end = (end || '') + '&';        // extra entries follow this one
         this.atEnd = true;

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -133,8 +133,8 @@ BaseMethods.Space = function(_parser: TexParser, _c: string) {};
 BaseMethods.Superscript = function(parser: TexParser, _c: string) {
   if (parser.GetNext().match(/\d/)) {
     // don't treat numbers as a unit
-    parser.string = parser.string.substr(0, parser.i + 1) +
-      ' ' + parser.string.substr(parser.i + 1);
+    parser.string = parser.string.substring(0, parser.i + 1) +
+      ' ' + parser.string.substring(parser.i + 1);
   }
   let primes: MmlNode;
   let base: MmlNode | void;
@@ -193,8 +193,8 @@ BaseMethods.Subscript = function(parser: TexParser, _c: string) {
   if (parser.GetNext().match(/\d/)) {
     // don't treat numbers as a unit
     parser.string =
-      parser.string.substr(0, parser.i + 1) + ' ' +
-      parser.string.substr(parser.i + 1);
+      parser.string.substring(0, parser.i + 1) + ' ' +
+      parser.string.substring(parser.i + 1);
   }
   let primes, base;
   const top = parser.stack.Top();
@@ -432,7 +432,7 @@ BaseMethods.Linebreak = function (parser: TexParser, _name: string, linebreak: s
  */
 BaseMethods.LeftRight = function(parser: TexParser, name: string) {
   // @test Fenced, Fenced3
-  const first = name.substr(1);
+  const first = name.substring(1);
   parser.Push(parser.itemFactory.create(first, parser.GetDelimiter(name), parser.stack.env.color));
 };
 
@@ -445,7 +445,7 @@ BaseMethods.LeftRight = function(parser: TexParser, name: string) {
 BaseMethods.NamedFn = function(parser: TexParser, name: string, id: string) {
   // @test Named Function
   if (!id) {
-    id = name.substr(1);
+    id = name.substring(1);
   }
   const mml = parser.create('token', 'mi', {texClass: TEXCLASS.OP}, id);
   parser.Push(parser.itemFactory.create('fn', mml));
@@ -461,7 +461,7 @@ BaseMethods.NamedFn = function(parser: TexParser, name: string, id: string) {
 BaseMethods.NamedOp = function(parser: TexParser, name: string, id: string) {
   // @test Limit
   if (!id) {
-    id = name.substr(1);
+    id = name.substring(1);
   }
   id = id.replace(/&thinsp;/, '\u2006');
   const mml = parser.create('token', 'mo', {
@@ -644,7 +644,7 @@ BaseMethods.MoveRoot = function(parser: TexParser, name: string, id: string) {
     throw new TexError('IntegerArg', 'The argument to %1 must be an integer', parser.currentCS);
   }
   n = (parseInt(n, 10) / 15) + 'em';
-  if (n.substr(0, 1) !== '-') {
+  if (n.substring(0, 1) !== '-') {
     n = '+' + n;
   }
   parser.stack.global[id] = n;
@@ -917,7 +917,7 @@ BaseMethods.MmlToken = function(parser: TexParser, name: string) {
       def[match[1]] = value;
       keep.push(match[1]);
     }
-    attr = attr.substr(match[0].length);
+    attr = attr.substring(match[0].length);
   }
   if (keep.length) {
     def['mjx-keep-attrs'] = keep.join(' ');
@@ -1020,7 +1020,7 @@ BaseMethods.RaiseLower = function(parser: TexParser, name: string) {
   if (h.charAt(0) === '-') {
     // @test Raise Negative, Lower Negative
     h = h.slice(1);
-    name = name.substr(1) === 'raise' ? '\\lower' : '\\raise';
+    name = name.substring(1) === 'raise' ? '\\lower' : '\\raise';
   }
   if (name === '\\lower') {
     // @test Raise, Raise Negative
@@ -1118,7 +1118,7 @@ BaseMethods.rule = function(parser: TexParser, name: string) {
     mml = parser.create('node', 'mpadded', [mml], {voffset: v});
     if (v.match(/^\-/)) {
       NodeUtil.setAttribute(mml, 'height', v);
-      NodeUtil.setAttribute(mml, 'depth', '+' + v.substr(1));
+      NodeUtil.setAttribute(mml, 'depth', '+' + v.substring(1));
     } else {
       NodeUtil.setAttribute(mml, 'height', '+' + v);
     }
@@ -1391,7 +1391,7 @@ BaseMethods.Entry = function(parser: TexParser, name: string) {
       //  (multi-letter names don't matter, as we will skip the rest of the
       //   characters in the main loop)
       //
-      const rest = str.substr(i);
+      const rest = str.substring(i);
       if (rest.match(/^((\\cr)[^a-zA-Z]|\\\\)/) || (end && rest.match(end))) {
         m = 0;
       } else {

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1409,7 +1409,8 @@ BaseMethods.Entry = function(parser: TexParser, name: string) {
   //  If not, process the second column as text and continue parsing from there,
   //    (otherwise process the second column as normal, since it is in \text{}
   //
-  const text = str.substr(parser.i, i - parser.i);
+  // i >= parser.i
+  const text = str.substring(parser.i, i);
   if (!text.match(/^\s*\\text[^a-zA-Z]/) || close !== text.replace(/\s+$/, '').length - 1) {
     const internal = ParseUtil.internalMath(parser, ParseUtil.trimSpaces(text), 0);
     parser.PushAll(internal);

--- a/ts/input/tex/cases/CasesConfiguration.ts
+++ b/ts/input/tex/cases/CasesConfiguration.ts
@@ -175,7 +175,8 @@ export const CasesMethods = {
     //
     //  Process the second column as text and continue parsing from there,
     //
-    const text = tex.substr(parser.i, i - parser.i).replace(/^\s*/, '');
+    // i >= parser.i
+    const text = tex.substring(parser.i, i).replace(/^\s*/, '');
     parser.PushAll(ParseUtil.internalMath(parser, text, 0));
     parser.i = i;
   }

--- a/ts/input/tex/extpfeil/ExtpfeilConfiguration.ts
+++ b/ts/input/tex/extpfeil/ExtpfeilConfiguration.ts
@@ -63,7 +63,7 @@ ExtpfeilMethods.NewExtArrow = function(parser: TexParser, name: string) {
       'Third argument to %1 must be a unicode character number',
       name);
   }
-  cs = cs.substr(1);
+  cs = cs.substring(1);
   let spaces = space.split(',');
   NewcommandUtil.addMacro(parser, cs, ExtpfeilMethods.xArrow,
                           [parseInt(chr), parseInt(spaces[0]), parseInt(spaces[1])]);

--- a/ts/input/tex/mathtools/MathtoolsMethods.ts
+++ b/ts/input/tex/mathtools/MathtoolsMethods.ts
@@ -346,7 +346,7 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
     //  Get the argument and the rest of the TeX string.
     //
     const arg = parser.GetArgument(name);
-    const rest = parser.string.substr(parser.i);
+    const rest = parser.string.substring(parser.i);
     //
     //  Put the argument back, followed by "&&", and a marker that we look for below.
     //
@@ -498,7 +498,7 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
       post = ParseUtil.substituteArgs(parser, args, post);
     }
     body = body.replace(/\\delimsize/g, delim);
-    parser.string = [pre, left, open, body, right, close, post, parser.string.substr(parser.i)]
+    parser.string = [pre, left, open, body, right, close, post, parser.string.substring(parser.i)]
       .reduce((s, part) => ParseUtil.addArgs(parser, s, part), '');
     parser.i = 0;
     ParseUtil.checkMaxMacros(parser);
@@ -585,7 +585,7 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
       parser.Push(parser.create('token', 'mo', {texClass: TEXCLASS.REL}, unicode));
     } else {
       tex = '\\mathrel{' + tex.replace(/:/g, '\\MTThinColon').replace(/-/g, '\\mathrel{-}') + '}';
-      parser.string = ParseUtil.addArgs(parser, tex, parser.string.substr(parser.i));
+      parser.string = ParseUtil.addArgs(parser, tex, parser.string.substring(parser.i));
       parser.i = 0;
     }
   },

--- a/ts/input/tex/mhchem/MhchemConfiguration.ts
+++ b/ts/input/tex/mhchem/MhchemConfiguration.ts
@@ -50,7 +50,7 @@ MhchemMethods.Machine = function(parser: TexParser, name: string, machine: 'tex'
   } catch (err) {
     throw new TexError(err[0], err[1]);
   }
-  parser.string = tex + parser.string.substr(parser.i);
+  parser.string = tex + parser.string.substring(parser.i);
   parser.i = 0;
 };
 

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -90,7 +90,7 @@ namespace NewcommandUtil {
                           '%1 must be followed by a control sequence', cmd);
     }
     let cs = ParseUtil.trimSpaces(parser.GetArgument(cmd));
-    return cs.substr(1);
+    return cs.substring(1);
   }
 
   /**
@@ -103,7 +103,7 @@ namespace NewcommandUtil {
     let cs = ParseUtil.trimSpaces(parser.GetArgument(name));
     if (cs.charAt(0) === '\\') {
       // @test Newcommand Simple
-      cs = cs.substr(1);
+      cs = cs.substring(1);
     }
     if (!cs.match(/^(.|[a-z]+)$/i)) {
       // @test Illegal CS

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -154,7 +154,8 @@ namespace NewcommandUtil {
         // @test Def ReDef, Def Let, Def Optional Brace
         if (i !== parser.i) {
           // @test Def Let, Def Optional Brace
-          params[n] = parser.string.substr(i, parser.i - i);
+          // parser.i >= i!
+          params[n] = parser.string.substring(i, parser.i);
         }
         c = parser.string.charAt(++parser.i);
         if (!c.match(/^[1-9]$/)) {
@@ -172,7 +173,8 @@ namespace NewcommandUtil {
         // @test Def Double Let, Def ReDef, Def Let
         if (i !== parser.i) {
           // @test Optional Brace Error
-          params[n] = parser.string.substr(i, parser.i - i);
+          // parser.i >= i!
+          params[n] = parser.string.substring(i, parser.i);
         }
         if (params.length > 0) {
           // @test Def Let, Def Optional Brace
@@ -222,13 +224,13 @@ namespace NewcommandUtil {
           i++;
           j -= 2;
         }
-        return parser.string.substr(i, j);
+        return j < 0 ? '' : parser.string.substring(i, i + j);
       } else if (c === '\\') {
         // @test Def Options CS
         parser.i++;
         j++;
         hasBraces = 0;
-        let match = parser.string.substr(parser.i).match(/[a-z]+|./i);
+        let match = parser.string.substring(parser.i).match(/[a-z]+|./i);
         if (match) {
           // @test Def Options CS
           parser.i += match[0].length;
@@ -256,7 +258,7 @@ namespace NewcommandUtil {
    */
   export function MatchParam(parser: TexParser, param: string): number {
     // @test Def Let, Def Optional Brace, Def Options CS
-    if (parser.string.substr(parser.i, param.length) !== param) {
+    if (parser.string.substring(parser.i, parser.i + param.length) !== param) {
       // @test Def Let, Def Options CS
       return 0;
     }

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -49,7 +49,7 @@ const MJCONFIG = MathJax.config;
 function RegisterExtension(jax: TeX<any, any, any>, name: string) {
   const require = jax.parseOptions.options.require;
   const required = jax.parseOptions.packageData.get('require').required as string[];
-  const extension = name.substr(require.prefix.length);
+  const extension = name.substring(require.prefix.length);
   if (required.indexOf(extension) < 0) {
     required.push(extension);
     //
@@ -96,7 +96,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
 function RegisterDependencies(jax: TeX<any, any, any>, names: string[] = []) {
   const prefix = jax.parseOptions.options.require.prefix;
   for (const name of names) {
-    if (name.substr(0, prefix.length) === prefix) {
+    if (name.substring(0, prefix.length) === prefix) {
       RegisterExtension(jax, name);
     }
   }
@@ -111,7 +111,7 @@ function RegisterDependencies(jax: TeX<any, any, any>, names: string[] = []) {
 export function RequireLoad(parser: TexParser, name: string) {
   const options = parser.options.require;
   const allow = options.allow;
-  const extension = (name.substr(0, 1) === '[' ? '' : options.prefix) + name;
+  const extension = (name.substring(0, 1) === '[' ? '' : options.prefix) + name;
   const allowed = (allow.hasOwnProperty(extension) ? allow[extension] :
                    allow.hasOwnProperty(name) ? allow[name] : options.defaultAllow);
   if (!allowed) {

--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -59,7 +59,7 @@ export const HtmlNodeMethods: Record<string, ParseMethod> = {
     if (i < 0) {
       throw new TexError('TokenNotFoundForCommand', 'Could not find %1 for %2', end, '<' + match[0]);
     }
-    const html = parser.string.substr(parser.i, i).trim();
+    const html = parser.string.substring(parser.i, parser.i + i).trim();
     parser.i += i + 11 + (match[1] ? 3 + match[1].length : 0);
     //
     // Parse the HTML and check that there is something there

--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -190,7 +190,7 @@ export const TextMacrosMethods = {
    * @param {string} name         The control sequence that called this function
    */
   SelfQuote(parser: TextParser, name: string) {
-    parser.text += name.substr(1);  // add in the quoted character
+    parser.text += name.substring(1);  // add in the quoted character
   },
 
   /**

--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -69,7 +69,8 @@ export const TextMacrosMethods = {
         //
         if (braces === 0 && open === c) {
           const config = parser.texParser.configuration;
-          const mml = (new TexParser(parser.string.substr(i, j - i), parser.stack.env, config)).mml();
+          // j > i!
+          const mml = (new TexParser(parser.string.substring(i, j), parser.stack.env, config)).mml();
           parser.PushMath(mml);
           return;
         }

--- a/ts/input/tex/unicode/UnicodeConfiguration.ts
+++ b/ts/input/tex/unicode/UnicodeConfiguration.ts
@@ -103,7 +103,7 @@ UnicodeMethods.RawUnicode = function (parser: TexParser, name: string) {
                        'Argument to %1 must a hexadecimal number with 1 to 6 digits', parser.currentCS);
   }
   const n = parseInt(hex, 16);
-  parser.string = String.fromCodePoint(n) + parser.string.substr(parser.i);
+  parser.string = String.fromCodePoint(n) + parser.string.substring(parser.i);
   parser.i = 0;
 }
 
@@ -117,7 +117,7 @@ UnicodeMethods.Char = function (parser: TexParser, _name: string) {
   let match;
   let next = parser.GetNext();
   let c = '';
-  const text = parser.string.substr(parser.i);
+  const text = parser.string.substring(parser.i);
   if (next === '\'') {
     match = text.match(/^'(?:([0-7]{1,7}) ?|(\\\S)|(.))/u);
     if (match) {

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -596,7 +596,7 @@ export function AddCSS(font: ChtmlCharMap, options: CharOptionsMap): ChtmlCharMa
     const data = options[n];
     if (data.c) {
       data.c = data.c.replace(/\\[0-9A-F]+/ig,
-                              (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
+                              (x) => String.fromCodePoint(parseInt(x.substring(1), 16)));
     }
     Object.assign(FontData.charOptions(font, n), data);
   }

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -457,7 +457,7 @@ CommonWrapper<
    * @return {string}   The className for the character
    */
   protected char(n: number): string {
-    return this.font.charSelector(n).substr(1);
+    return this.font.charSelector(n).substring(1);
   }
 
 }

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -233,7 +233,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
         const letter = options.f || (v === 'normal' ? '' : this.font.getVariant(v).letter);
         const font = options.ff || (letter ? `${this.font.cssFontPrefix}-${letter}` : '');
         let c = (options.c as string || String.fromCodePoint(n))
-          .replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substr(1), 16)));
+          .replace(/\\[0-9A-F]+/ig, (x) => String.fromCodePoint(parseInt(x.substring(1), 16)));
         content.push(this.html(part, {}, [
           this.html('mjx-c', font ? {class: font} : {}, [this.text(c)])
         ]));

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -446,7 +446,7 @@ export class Menu {
     this.settings.scale = jax.options.scale;
     this.defaultSettings = Object.assign({}, this.settings);
     this.settings.overflow =
-      jax.options.displayOverflow.substr(0, 1).toUpperCase() + jax.options.displayOverflow.substr(1).toLowerCase();
+      jax.options.displayOverflow.substring(0, 1).toUpperCase() + jax.options.displayOverflow.substring(1).toLowerCase();
     this.settings.breakInline = jax.options.linebreaks.inline;
   }
 

--- a/ts/ui/menu/MenuUtil.ts
+++ b/ts/ui/menu/MenuUtil.ts
@@ -2,7 +2,7 @@
  * True when platform is a Mac (so we can enable CMD menu item for zoom trigger)
  */
 export const isMac = (typeof window !== 'undefined' &&
-  window.navigator && window.navigator.platform.substr(0, 3) === 'Mac');
+  window.navigator && window.navigator.platform.substring(0, 3) === 'Mac');
 
 /**
  * @param {string} text   The text to be copied ot the clopboard

--- a/ts/ui/safe/safe.ts
+++ b/ts/ui/safe/safe.ts
@@ -248,7 +248,7 @@ export class Safe<N, T, D> {
   public mmlAttribute(id: string, value: string): string | null {
     if (id === 'class') return null;
     const method = this.filterAttributes.get(id);
-    const filter = (method || (id.substr(0, 5) === 'data-' ? this.filterAttributes.get('data-') : null));
+    const filter = (method || (id.substring(0, 5) === 'data-' ? this.filterAttributes.get('data-') : null));
     if (!filter) {
       return value;
     }


### PR DESCRIPTION
`substr` is deprecated and needs to be replaced by  `substring` (or `slice`). This PR replaces all occurences of `substr` in the `ts` code base with `substring` calls.  It uses the following approach:

* `substr(n)` $\to$ `substring(n)`
* `substr(0, n)` $\to$ `substring(0, n)`
* `substr(a, b)` $\to$ `substring(a, a + b)` if it is clear from context that $b >= 0$. Sometimes, I've added a comment for explanation.
*  `substr(a, b)` $\to$ `b < 0 ? '' : substring(a, a + b)` in all other cases.

