### PR TITLE
Fix make-cjs-components script to work without mjs files being built first

### DIFF
--- a/components/bin/link-full
+++ b/components/bin/link-full
@@ -3,6 +3,7 @@ const path = require('path');
 
 const dir = path.join(__dirname, '..', '..');
 
-if (fs.existsSync(path.join(dir, 'node_modules'))) {
+if (fs.existsSync(path.join(dir, 'node_modules')) &&
+   !fs.existsSync(path.join(dir, 'node_modules', 'mathjax-full'))) {
   fs.symlinkSync(dir, path.join(dir, 'node_modules', 'mathjax-full'));
 }

--- a/components/mjs/fullpath.cjs
+++ b/components/mjs/fullpath.cjs
@@ -1,0 +1,41 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2023 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Gets the fully resolved path from a webpack request object using the
+ * correct package.json file to map pseudo-packages to the mjs/cjs directories.
+ * When this file is in the components/cjs directory, it will use the
+ * package.json in that directory, which maps them to the mathjax-full/cjs files.
+ * When in the components/mjs directory, the main package.json file will be used.
+ */
+
+let path = require('path');
+
+/**
+ * @param {object} resource  The module resource object from webpack
+ * @return {string}  The full path to the module
+ */
+function fullPath(resource) {
+  const file = resource.request ?
+        (resource.request.charAt(0) === '.' ?
+         path.resolve(resource.path, resource.request) :
+         resource.request) :
+        resource.path;
+  return file.charAt(0) === '/' ? file : require.resolve(file);
+}
+
+module.exports.fullPath = fullPath;

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -38,19 +38,6 @@ function quoteRE(string) {
   return string.replace(/([\\.{}[\]()?*^$])/g, '\\$1');
 }
 
-/**
- * @param {object} resource  The module resource object from webpack
- * Wreturn {string}  The full path to the module
- */
-function fullPath(resource) {
-  const file = resource.request ?
-        (resource.request.charAt(0) === '.' ?
-         path.resolve(resource.path, resource.request) :
-         resource.request) :
-        resource.path;
-  return file.charAt(0) === '/' ? file : require.resolve(file);
-}
-
 /****************************************************************/
 
 /**
@@ -149,6 +136,12 @@ const RESOLVE = function (js, dir, target, libs) {
         .map(lib => (lib.charAt(0) === '.' ?
                      [jsRE, path.join(dir, lib) + path.sep] :
                      [mjRE, path.join(root, lib) + path.sep]));
+
+  //
+  // Function to get full paths using the proper package.json file get the
+  // pseudo-package includes to be correct.
+  //
+  const {fullPath} = require(`./${target}/fullpath.cjs`);
 
   //
   // Function to replace imported files by ones in the specified component lib directories.


### PR DESCRIPTION
This PR resolves the problem where the webpacking failed when building the cjs bundle without having first build the mjs files.  It was due to the `webpack.common.cjs` file using `require.resolve()` command to get full path names; since `webpack.common.cjs` is in the `components` directory, it was using the main `package.json` file, and so the pseudo-packages like `#js` were resolving to the `mathjax-full/mjs` direcrtory rather than the `mathjax-full/cjs` directory.

This resolves the problem by moving the `fullPath()` function to a separate `fullpath.cjs` file in the `components/mjs` and `components/cjs` directories, so that the cjs file will use the `components/cjs/package.json` mappings instead.

It also adds a test to the `link:full` script to only make the link if it is not already there, so it is safe to run the script more than once.