### PR TITLE
Better measuring of text that is in a native font rather than MathJax fonts

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -286,8 +286,7 @@ CommonOutputJax<
     //    and call to getBBox().w in TextNode.ts)
     //
     if (width !== null) {
-      const metrics = this.math.metrics;
-      styles.width = Math.round(width * metrics.em * metrics.scale * rscale) + 'px';
+      styles.width = this.fixed(width * this.math.metrics.scale * rscale) + 'em';
     }
     //
     return this.html('mjx-utext', {variant: variant, style: styles}, [this.text(text)]);
@@ -308,11 +307,16 @@ CommonOutputJax<
     //
     adaptor.setStyle(text, 'font-family', adaptor.getStyle(text, 'font-family').replace(/MJXZERO, /g, ''));
     //
-    const style = {position: 'absolute', 'white-space': 'nowrap'};
+    const em = this.math.metrics.em;
+    const style = {
+      position: 'absolute', top: 0, left: 0,
+      'white-space': 'nowrap',
+      'font-size': this.fixed(em, 3) + 'px'
+    };
     const node = this.html('mjx-measure-text', {style}, [text]);
     adaptor.append(adaptor.parent(this.math.start.node), this.container);
     adaptor.append(this.container, node);
-    let w = adaptor.nodeSize(text, this.math.metrics.em)[0] / this.math.metrics.scale;
+    let w = adaptor.nodeSize(text, em)[0];
     adaptor.remove(this.container);
     adaptor.remove(node);
     return {w: w, h: .75, d: .2};

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -488,7 +488,7 @@ CommonOutputJax<
     const ex = this.fixed(this.font.params.x_height * 1000, 1);
     const svg = this.svg('svg', {
       position: 'absolute', visibility: 'hidden',
-      width: '1ex', height: '1ex',
+      width: '1ex', height: '1ex', top: 0, left: 0,
       viewBox: [0, 0, ex, ex].join(' ')
     }, [text]);
     adaptor.append(adaptor.body(adaptor.document), svg);


### PR DESCRIPTION
This PR fixes a problem with determining the width of text that is in a system font rather than in the MathJax fonts.  These come from `\text{}` then `mtextInheritFont` is true, or from error messages (when `merrorInheritFont` is true, which it is by default), or from characters that aren't in the MathJax fonts, like Chinese characters, or when a `font-family` is specified in a `\style{}` command or MathML `style` attribute.

You can't test this in the lab, as the issue only occurs when the math is typeset outside the DOM via `MathJax.tex2chtml()` or one of the other conversion functions, and then inserted into a container with a `font-size` that is other than 100%.