### PR TITLE
Fix default option list to {}.  (mathjax/MathJax#3128)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -155,7 +155,7 @@ CommonOutputJax<
    * @override
    * @constructor
    */
-  constructor(options: OptionList = null) {
+  constructor(options: OptionList = {}) {
     super(options, ChtmlWrapperFactory as any, DefaultFont);
     this.font.adaptiveCSS(this.options.adaptiveCSS);
     this.wrapperUsage = new Usage<string>();

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -233,7 +233,7 @@ export abstract class CommonOutputJax<
    * @param {FC} defaultFont                       The default FontData constructor
    * @constructor
    */
-  constructor(options: OptionList = null,
+  constructor(options: OptionList = {},
               defaultFactory: typeof CommonWrapperFactory = null,
               defaultFont: FC = null) {
     const [fontClass, font] = (options.fontData instanceof FontData ?

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -140,7 +140,7 @@ CommonOutputJax<
    * @override
    * @constructor
    */
-  constructor(options: OptionList = null) {
+  constructor(options: OptionList = {}) {
     super(options, SvgWrapperFactory as any, DefaultFont);
     this.fontCache = new FontCache(this);
   }


### PR DESCRIPTION
This PR fixes a problem where the default options list was `null` rather than `{}`.  So, for example, `new SVG()` would produce an error.

Resolves issue mathjax/MathJax#3128.