### PR TITLE
Add ability to not show latex attributes, and reorganize settings menu

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -62,7 +62,8 @@ const XMLDECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>';
  * The various values that are stored in the menu
  */
 export interface MenuSettings {
-  filterSRE: boolean;
+  showSRE: boolean;
+  showTex: boolean;
   texHints: boolean;
   semantics: boolean;
   zoom: string;
@@ -123,7 +124,8 @@ export class Menu {
    */
   public static OPTIONS: OptionList = {
     settings: {
-      filterSRE: true,
+      showSRE: false,
+      showTex: false,
       texHints: true,
       semantics: false,
       zoom: 'NoZoom',
@@ -462,7 +464,8 @@ export class Menu {
       type: 'contextMenu',
       id: 'MathJax_Menu',
       pool: [
-        this.variable<boolean>('filterSRE'),
+        this.variable<boolean>('showSRE'),
+        this.variable<boolean>('showTex'),
         this.variable<boolean>('texHints'),
         this.variable<boolean>('semantics'),
         this.variable<string> ('zoom'),
@@ -537,6 +540,13 @@ export class Menu {
             this.checkbox('BreakInline', 'Allow In-line Breaks', 'breakInline'),
           ]),
           this.rule(),
+          this.submenu('MathmlIncludes', 'MathML Includes', [
+            this.checkbox('showSRE', 'Semantic attributes', 'showSRE'),
+            this.checkbox('showTex', 'LaTeX attributes', 'showTex'),
+            this.checkbox('texHints', 'TeX hints', 'texHints'),
+            this.checkbox('semantics', 'Original as annotation', 'semantics')
+          ]),
+          this.rule(),
           this.submenu('ZoomTrigger', 'Zoom Trigger', [
             this.command('ZoomNow', 'Zoom Once Now', () => this.zoom(null, '', this.menu.mathItem)),
             this.rule(),
@@ -555,10 +565,6 @@ export class Menu {
           ])),
           this.rule(),
           this.command('Scale', 'Scale All Math...', () => this.scaleAllMath()),
-          this.rule(),
-          this.checkbox('filterSRE', 'Filter semantic annotations', 'filterSRE'),
-          this.checkbox('texHints', 'Add TeX hints to MathML', 'texHints'),
-          this.checkbox('semantics', 'Add original as annotation', 'semantics'),
           this.rule(),
           this.command('Reset', 'Reset to defaults', () => this.resetDefaults())
         ]),
@@ -1047,12 +1053,12 @@ export class Menu {
    * @returns {string}            The serialized version of the internal MathML
    */
   protected toMML(math: HTMLMATHITEM): string {
-    const mml = this.MmlVisitor.visitTree(math.root, math, {
+    return this.MmlVisitor.visitTree(math.root, math, {
+      filterSRE: !this.settings.showSRE,
+      filterTex: !this.settings.showTex,
       texHints: this.settings.texHints,
       semantics: (this.settings.semantics && math.inputJax.name !== 'MathML')
     });
-    return (!this.settings.filterSRE ?  mml :
-            mml.replace(/ (?:data-semantic-.*?|role|aria-(?:level|posinset|setsize))=".*?"/g, ''));
   }
 
   /**

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -106,7 +106,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
   protected getAttributeList(node: MmlNode): PropertyList {
     const list = super.getAttributeList(node);
     if (this.options.filterTex) {
-      delete list['data-latex'], list['data-latexItem'];
+      delete list['data-latex'], list['data-latex-item'];
     }
     if (this.options.filterSRE) {
       const keys = Object.keys(list).filter(

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -106,7 +106,8 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
   protected getAttributeList(node: MmlNode): PropertyList {
     const list = super.getAttributeList(node);
     if (this.options.filterTex) {
-      delete list['data-latex'], list['data-latex-item'];
+      delete list['data-latex'];
+      delete list['data-latex-item'];
     }
     if (this.options.filterSRE) {
       const keys = Object.keys(list).filter(

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -23,6 +23,7 @@
 
 import {MathItem} from '../../core/MathItem.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import {PropertyList} from '../../core/Tree/Node.js';
 import {SerializedMmlVisitor} from '../../core/MmlTree/SerializedMmlVisitor.js';
 import {OptionList, userOptions} from '../../util/Options.js';
 
@@ -41,6 +42,8 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
    * The options controlling the serialization
    */
   public options: OptionList = {
+    filterSRE: true,          // True means remove data-semantic, role, and aria attributes
+    filterTex: true,          // True means remove data-latex and data-latexItem attributes
     texHints: true,           // True means include classes for TeXAtom elements
     semantics: false,         // True means include original form as annotation in a semantics element
   };
@@ -97,4 +100,22 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
                  + space + '</math>';
   }
 
+  /**
+   * @override
+   */
+  protected getAttributeList(node: MmlNode): PropertyList {
+    const list = super.getAttributeList(node);
+    if (this.options.filterTex) {
+      delete list['data-latex'], list['data-latexItem'];
+    }
+    if (this.options.filterSRE) {
+      const keys = Object.keys(list).filter(
+        id => id.match(/^(?:data-semantic-.*?|role|aria-(?:level|posinset|setsize))$/)
+      );
+      for (const key of keys) {
+        delete list[key];
+      }
+    }
+    return list;
+  }
 }


### PR DESCRIPTION
This PR adds a menu option to remove the `data-latex` and `data-latexItem` attributes from the "Show Math As MathML" menu item, as these can get quite long, making it hard to see the MathML structure.  We also reorganize the Math Settings submenu to push the MathML filters into an additional submenu level.  Finally, we move the filtering of the SRE attributes into the `MmlVisitor` so the attributes are never added, rather than using a string replacement after the fact.