### PR TITLE
Proper handling of typesetPromise in defaultPageReady. (mathjax/MathJax#3130)

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -301,7 +301,7 @@ export namespace Startup {
     return (CONFIG.loadAllFontFiles && (output as COMMONJAX).font ?
             (output as COMMONJAX).font.loadDynamicFiles() : Promise.resolve())
       .then(CONFIG.typeset && MathJax.typesetPromise ?
-            typesetPromise(CONFIG.elements) :
+            () => typesetPromise(CONFIG.elements) :
             Promise.resolve());
   }
 


### PR DESCRIPTION
This PR fixes a problem with `defaultPageReady()` where the typesetting could be done at the wrong time.  With this PR, it should be performed when the `then()` is triggered, whereas before it was done when the `defaultPageReady()` call was made (OOPS!).

Resolves issue mathjax/MathJax#3130.