### PR TITLE
Have \unicode check for illegal font name.  (mathjax/MathJax#3129)

### DIFF
--- a/ts/input/tex/unicode/UnicodeConfiguration.ts
+++ b/ts/input/tex/unicode/UnicodeConfiguration.ts
@@ -46,7 +46,7 @@ let UnicodeCache: {[key: number]: [number, number, string, number]} = {};
 UnicodeMethods.Unicode = function(parser: TexParser, name: string) {
   let HD = parser.GetBrackets(name);
   let HDsplit = null;
-  let font = null;
+  let font = '';
   if (HD) {
     if (HD.replace(/ /g, '').
         match(/^(\d+(\.\d*)?|\.\d+),(\d+(\.\d*)?|\.\d+)$/)) {
@@ -55,6 +55,9 @@ UnicodeMethods.Unicode = function(parser: TexParser, name: string) {
     } else {
       font = HD;
     }
+  }
+  if (font.match(/;/)) {
+    throw new TexError('BadFont', 'Font name for %1 can\'t contain semicolons',  parser.currentCS);
   }
   let n = ParseUtil.trimSpaces(parser.GetArgument(name)).replace(/^0x/, 'x');
   if (!n.match(/^(x[0-9A-Fa-f]+|[0-9]+)$/)) {


### PR DESCRIPTION
This PR adds a check that the font name doesn't include semicolons in the `\unicode` macro.  This prevents extra CSS from being inserted into the styles for the resulting output.

Resolves issue mathjax/MathJax#3129.