### PR TITLE
Don't descend into items that aren't broken when looking for the linebreak node.  (mathjax/MathJax#3135)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -625,7 +625,10 @@ export class CommonWrapper<
    * @return {[WW, WW]}        The embellished mo node and its core mo
    */
   public getBreakNode(bbox: LineBBox): [WW, WW] {
-    const [i, j] = bbox.start || [0, 0];
+    if (!bbox.start) {
+      return [this, null] as any as [WW, WW];
+    }
+    const [i, j] = bbox.start;
     if (this.node.isEmbellished) {
       return [this, this.coreMO()] as any as [WW, WW];
     }


### PR DESCRIPTION
This PR fixes a problem with the size of SVG elements for in-lin math when in-line line-breaking is enabled.  It fixes the determination of the node where the line breaking occurs by not descending into unbroken nodes.  The `bbox.start` was not being properly tested, so it would descending into a fraction, for example, and stop at its numerator, giving the wrong scaling factor when the `height` and `width` of the resulting SVG was set.

Resolves issue mathjax/MathJax#3135.