### PR TITLE
Make const enum into a regular object.  (mathjax/MathJax#3114)

### DIFF
--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -26,7 +26,7 @@ import {ChtmlWrapper, ChtmlWrapperClass, StringMap} from '../Wrapper.js';
 import {ChtmlWrapperFactory} from '../WrapperFactory.js';
 import {ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData,
         ChtmlFontData, ChtmlFontDataClass} from '../FontData.js';
-import {CommonMo, CommonMoClass, CommonMoMixin, DirectionVH} from '../../common/Wrappers/mo.js';
+import {CommonMo, CommonMoClass, CommonMoMixin} from '../../common/Wrappers/mo.js';
 import {MmlNode} from '../../../core/MmlTree/MmlNode.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 import {StyleList} from '../../../util/StyleList.js';
@@ -211,9 +211,8 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       //
       //  Make the main element and add it to the parent
       //
-      const dir = DirectionVH[delim.dir];
       const properties = {class: this.char(delim.c || c), style: styles};
-      const html = this.html('mjx-stretchy-' + dir, properties, content);
+      const html = this.html('mjx-stretchy-' + delim.dir, properties, content);
       const adaptor = this.adaptor;
       chtml[0] && adaptor.append(chtml[0], html);
       chtml[1] && adaptor.append(chtml[1], chtml[0] ? adaptor.clone(html) : html);

--- a/ts/output/common/Direction.ts
+++ b/ts/output/common/Direction.ts
@@ -21,6 +21,6 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-export const enum DIRECTION {None, Vertical, Horizontal}
+export const DIRECTION = {None: '', Vertical: 'v', Horizontal: 'h'}
 export const V = DIRECTION.Vertical;
 export const H = DIRECTION.Horizontal;

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -131,7 +131,7 @@ export type CssFontMap = {
  * Data needed for stretchy vertical and horizontal characters
  */
 export type DelimiterData = {
-  dir: DIRECTION;       // vertical or horizontal direction
+  dir: string;          // vertical or horizontal direction
   sizes?: number[];     // Array of fixed sizes for this character
   variants?: number[];  // The variants in which the different sizes can be found (if not the default)
   schar?: number[];     // The character number to use for each size (if different from the default)

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1040,10 +1040,10 @@ export class CommonWrapper<
   }
 
   /**
-   * @param {DIRECTION} direction  The direction to stretch this node
-   * @return {boolean}             Whether the node can stretch in that direction
+   * @param {string} direction  The direction to stretch this node
+   * @return {boolean}          Whether the node can stretch in that direction
    */
-  public canStretch(direction: DIRECTION): boolean {
+  public canStretch(direction: string): boolean {
     this.stretch = NOSTRETCH as DD;
     if (this.node.isEmbellished) {
       let core = this.core();

--- a/ts/output/common/Wrappers/mfrac.ts
+++ b/ts/output/common/Wrappers/mfrac.ts
@@ -348,7 +348,7 @@ export function CommonMfracMixin<
     /**
      * @override
      */
-    public canStretch(_direction: DIRECTION) {
+    public canStretch(_direction: string) {
       return false;
     }
 

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -34,15 +34,6 @@ import {DIRECTION, NOSTRETCH} from '../FontData.js';
 
 /*****************************************************************/
 /**
- * Convert direction to letter
- */
-export const DirectionVH: {[n: number]: string} = {
-  [DIRECTION.Vertical]: 'v',
-  [DIRECTION.Horizontal]: 'h'
-};
-
-/*****************************************************************/
-/**
  * The CommonMo interface
  *
  * @template N   The DOM node type
@@ -606,7 +597,7 @@ export function CommonMoMixin<
     /**
      * @override
      */
-    public canStretch(direction: DIRECTION) {
+    public canStretch(direction: string) {
       if (this.stretch.dir !== DIRECTION.None) {
         return this.stretch.dir === direction;
       }


### PR DESCRIPTION
This PR changes the `DIRECTION` enum into a regular object, like all other constants.  This was the only enum that we used, and it apparently is a problem when `--isolatedModules` is used.  This also means we don't need the `DirectionVH` object from `ts/common/Wrappers/mo.ts`.

Resolves issue mathjax/MathJax#3114.