### PR TITLE
Add cssText() method to adaptor and handle dynamic rules in HTML output.

### DIFF
--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -69,8 +69,7 @@ export interface MinHTMLElement<N, T> {
   className: string;
   classList: DOMTokenList;
   style: OptionList;
-  sheet?: {insertRule: (rule: string, index?: number) => void};
-
+  sheet?: {insertRule: (rule: string, index?: number) => void, cssRules: Array<{cssText: string}>};
   childNodes: (N | T)[] | NodeList;
   firstChild: N | T | Node;
   lastChild: N | T | Node;
@@ -522,13 +521,23 @@ AbstractDOMAdaptor<N, T, D> implements MinHTMLAdaptor<N, T, D> {
    * @override
    */
   public insertRules(node: N, rules: string[]) {
-    for (const rule of rules.reverse()) {
+    for (const rule of rules) {
       try {
-        node.sheet.insertRule(rule, 0);
+        node.sheet.insertRule(rule, node.sheet.cssRules.length);
       } catch (e) {
         console.warn(`MathJax: can't insert css rule '${rule}': ${e.message}`);
       }
     }
+  }
+
+  /**
+   * @override
+   */
+  public cssText(node: N) {
+    if (this.kind(node) !== 'style') {
+      return '';
+    }
+    return Array.from(node.sheet.cssRules).map(rule => rule.cssText).join('\n');
   }
 
   /**

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -34,7 +34,6 @@ import {OptionList} from '../util/Options.js';
 
 /************************************************************/
 
-
 /**
  * Implements a lightweight DOMAdaptor on liteweight HTML elements
  */
@@ -549,7 +548,7 @@ export class LiteBase extends AbstractDOMAdaptor<LiteElement, LiteText, LiteDocu
    * @override
    */
   public insertRules(node: LiteElement, rules: string[]) {
-    node.children = [this.text(rules.join('\n\n') + '\n\n' + this.textContent(node))];
+    node.children = [this.text(this.textContent(node) + '\n\n' + rules.join('\n\n'))];
   }
 
   /*******************************************************************/

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -344,6 +344,12 @@ export interface DOMAdaptor<N, T, D> {
   insertRules(node: N, rules: string[]): void;
 
   /**
+   * @param {N} node        The stylesheet node whose rules are to be returned
+   * @return {string}       The string versions of the stylesheet rules
+   */
+  cssText(node: N): string;
+
+  /**
    * @param {N} node        The HTML node whose font size is to be determined
    * @return {number}       The font size (in pixels) of the node
    */
@@ -655,6 +661,13 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<N, T, D>
    * @override
    */
   public abstract insertRules(node: N, rules: string[]): void;
+
+  /**
+   * @override
+   */
+  public cssText(node: N) {
+    return (this.kind(node) === 'style' ? this.textContent(node) : '');
+  };
 
   /**
    * @override


### PR DESCRIPTION
It turns out that when a stylesheet has dynamically added rules (like the ones MathJax produced for CHTML output when `adaptiveCSS` is true), those rules are not returned by `innerHTML`, `outerHTML`, or `textContent`.  This makes it hard to obtain the CSS needed for HTML output in that case.

The PR adds a `cssText()` method to the adaptor class so that these rules will be included in the output.  This can be used in place of `innerHTML` or `textContent` to get the list of rules when `adaptiveCSS` is being used.