### PR TITLE
Fix typo in MathJax Help Modal

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -309,7 +309,7 @@ export class Menu {
         '</div>',
         '<p><b>Math Zoom</b>: If you are having difficulty reading an',
         ' equation, MathJax can enlarge it to help you see it better, or',
-        ' you can scall all the math on the page to make it larger.',
+        ' you can scale all the math on the page to make it larger.',
         ' Turn these features on in the <b>Math Settings</b> menu.</p>',
         '<p><b>Preferences</b>: MathJax uses your browser\'s localStorage database',
         ' to save the preferences set via this menu locally in your browser.  These',


### PR DESCRIPTION
I just stumbled on this typo (mathjax/MathJax#3140) and thought that as it is so simple to fix I should submit it in a pull request. The change is: 

```diff
-...you can scall all the math...
+...you can scale all the math...
```