### PR TITLE
Fix problem with let using attributes of {} when they should be null

### DIFF
--- a/ts/input/tex/newcommand/NewcommandMethods.ts
+++ b/ts/input/tex/newcommand/NewcommandMethods.ts
@@ -133,13 +133,9 @@ NewcommandMethods.Let = function(parser: TexParser, name: string) {
       return;
     }
     macro = (map as sm.CharacterMap).lookup(name) as Token;
-    const newArgs = NewcommandUtil.disassembleToken(cs, macro);
-    const method = (p: TexParser, _cs: string, ...rest: any[]) => {
-      // @test Let Relet, Let Let, Let Circular Macro
-      const symb = NewcommandUtil.assembleToken(rest);
-      return map.parser(p, symb);
-    };
-    NewcommandUtil.addMacro(parser, cs, method, newArgs);
+    // @test Let Relet, Let Let, Let Circular Macro
+    const method = (p: TexParser) => map.parser(p, macro);
+    NewcommandUtil.addMacro(parser, cs, method, [cs, macro.char]);
     return;
   }
   // @test Let Brace Equal, Let Caret

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -34,48 +34,6 @@ import * as sm from '../TokenMap.js';
 namespace NewcommandUtil {
 
   /**
-   * Transforms the attributes of a token into the arguments of a macro. E.g.,
-   * Token('ell', 'l', {mathvariant: "italic"}) is turned into Macro arguments:
-   * ['ell', 'l', 'mathvariant', 'italic'].
-   *
-   * @param {string} name The command name for the token.
-   * @param {Token} token The token associated with name.
-   * @return {Args[]} Arguments for a macro.
-   */
-  export function disassembleToken(name: string, token: Token): Args[] {
-    let newArgs = [name, token.char] as Args[];
-    // @test Let Relet, Let Let, Let Circular Macro
-    if (token.attributes) {
-      // @test Let Relet
-      for (let key in token.attributes) {
-        newArgs.push(key);
-        newArgs.push(token.attributes[key] as Args);
-      }
-    }
-    return newArgs;
-  }
-
-
-  /**
-   * Assembles a token from a list of macro arguments. This is the inverse
-   * method of the one above.
-   *
-   * @param {Args[]} args The arguments of the macro.
-   * @return {Token} The Token generated from the arguments..
-   */
-  export function assembleToken(args: Args[]): Token {
-    // @test Let Relet, Let Let, Let Circular Macro
-    let name = args[0] as string;
-    let char = args[1] as string;
-    let attrs: Attributes = {};
-    for (let i = 2; i < args.length; i = i + 2) {
-      // @test Let Relet
-      attrs[args[i] as string] = args[i + 1];
-    }
-    return new Token(name, char, attrs);
-  }
-
-  /**
    * Get the next CS name or give an error.
    * @param {TexParser} parser The calling parser.
    * @param {string} cmd The string starting with a control sequence.


### PR DESCRIPTION
The current `disassembleToken()` and `assembleToken()` methods produce a new token whose attributes are `{}` when the original had `null` attributes.  This has implications for some tokens where the difference between these are important, as in the `mathchar7` function at

 https://github.com/mathjax/MathJax-src/blob/ae389ded62763bb176f797b6bfbb5a997c42dba1/ts/input/tex/ParseMethods.ts#L156-L165

where line 157 provides a default attribute list when `math.attributes` is `null` (but not if it is an empty object).

This leads to the loss of the default attributes when a new control sequence is `\let` equal to one that uses `mathchar7`, as in 

``` latex
\let\percent=\%
\percent\%
```

where the result of `\percent` will be in italics, while `\%` will not.

This PR resolves the issue by actually eliminating `disassembleToken()` and `assembleToken()` and just using the original token directly in the `method` at new line 137 (via the same closure that preserves `map`).
