### PR TITLE
Fix keyvalueOptions to process braces and backslahses better

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -109,16 +109,19 @@ function muReplace([value, unit, length]: [string, string, number]): [string, st
  * Implementation of the keyval function from https://www.ctan.org/pkg/keyval
  * @param {string} text The optional parameter string for a package or
  *     command.
+ * @param {boolean?} l3keys If true, use l3key-style parsing (only remove one set of braces)
  * @return {EnvList} Set of options as key/value pairs.
  */
-function readKeyval(text: string): EnvList {
+function readKeyval(text: string, l3keys: boolean = false): EnvList {
   let options: EnvList = {};
   let rest = text;
   let end, key, val;
+  let dropBrace = true;
   while (rest) {
-    [key, end, rest] = readValue(rest, ['=', ',']);
+    [key, end, rest] = readValue(rest, ['=', ','], l3keys, dropBrace);
+    dropBrace = false;
     if (end === '=') {
-      [val, end, rest] = readValue(rest, [',']);
+      [val, end, rest] = readValue(rest, [','], l3keys);
       val = (val === 'false' || val === 'true') ?
         JSON.parse(val) : val;
       options[key] = val;
@@ -150,10 +153,13 @@ function removeBraces(text: string, count: number): string {
  * string is exhausted.
  * @param {string} text The string to process.
  * @param {string[]} end List of possible end characters.
+ * @param {boolean?} l3keys If true, use l3key-style parsing (only remove one set of braces)
+ * @param {boolean?} dropBrace True if the outermost braces should be dropped
  * @return {[string, string, string]} The collected value, the actual end
  *     character, and the rest of the string still to parse.
  */
-function readValue(text: string, end: string[]): [string, string, string] {
+function readValue(text: string, end: string[],
+                   l3keys: boolean = false, dropBrace: boolean = false): [string, string, string] {
   let length = text.length;
   let braces = 0;
   let value = '';
@@ -165,6 +171,10 @@ function readValue(text: string, end: string[]): [string, string, string] {
   while (index < length) {
     let c = text[index++];
     switch (c) {
+      case '\\':               // Handle control sequences (in particular, \{ and \})
+        value += c + text[index++];
+        startCount = stopCount = false;
+        continue;
       case ' ':                // Ignore spaces.
         break;
       case '{':
@@ -172,9 +182,6 @@ function readValue(text: string, end: string[]): [string, string, string] {
           start++;
         } else {
           stopCount = false;
-          if (start > braces) {   // Some start left braces have been closed.
-            start = braces;
-          }
         }
         braces++;
         break;
@@ -192,7 +199,10 @@ function readValue(text: string, end: string[]): [string, string, string] {
         if (!braces && end.indexOf(c) !== -1) {   // End character reached.
           return [stopCount ? 'true' :            // If Stop count is true we
             // have balanced braces, only.
-            removeBraces(value, start), c, text.slice(index)];
+            removeBraces(value, l3keys ? Math.min(1, start) : start), c, text.slice(index)];
+        }
+        if (start > braces) {   // Some start left braces have been closed.
+          start = braces;
         }
         startCount = false;
         stopCount = false;
@@ -203,7 +213,8 @@ function readValue(text: string, end: string[]): [string, string, string] {
     throw new TexError('ExtraOpenMissingClose',
                        'Extra open brace or missing close brace');
   }
-  return [stopCount ? 'true' : removeBraces(value, start), '', text.slice(index)];
+  return (dropBrace && !stopCount && start) ? ['', '', removeBraces(value, 1)] :
+    [stopCount ? 'true' : removeBraces(value, l3keys ? Math.min(1, start) : start), '', text.slice(index)];
 }
 
 export const ParseUtil = {
@@ -770,12 +781,14 @@ export const ParseUtil = {
    *     given only allowed arguments are returned.
    * @param {boolean?} error If true, raises an exception if not allowed options
    *     are found.
+   * @param {boolean?} l3keys If true, use l3key-style parsing (only remove one set of braces)
    * @return {EnvList} The attribute list.
    */
   keyvalOptions: function(attrib: string,
                           allowed: {[key: string]: number} = null,
-                          error: boolean = false): EnvList {
-    let def: EnvList = readKeyval(attrib);
+                          error: boolean = false,
+                          l3keys: boolean = false): EnvList {
+    let def: EnvList = readKeyval(attrib, l3keys);
     if (allowed) {
       for (let key of Object.keys(def)) {
         if (!allowed.hasOwnProperty(key)) {


### PR DESCRIPTION
This PR fixes several issues with the `keyvalueOptions()` utility's handling of braces and control sequences, and adds an extra parameter that controls whether it should do LaTeX3-style processing, or traditional processing.  

The current implementation doesn't handle some control sequences properly, in particular, `\{`, so,

``` js
keyvalueOptions('x = \\{');
```

with throw an error about a missing closing brace or extra open brace.  This PR fixes that issue with the addition of `case '\\'` in the `readValue()` function.

The current implementation doesn't always handle braces properly.  For example

``` js
keyvalueOptions('a = {{x}y}');
```

returns `{ a: "x}" }` rather than `{ a: "{x}y"}`.  This is due to thinking that there are two outer sets of braces to be removed, rather than only one (`start` isn't decremented where it should be, so the `if (start > brace) { start = brace }`  is moved to a location that takes care of that.

Finally, the current implementation doesn't remove an outer set of braces for the entire string, as it should.  That is,

``` js
keyvalueOptions('{x = y}');
```

returns `{ "x = y": true }` rather than `{ x: "y" }`, as expected.  This is corrected via the `dropBraces` flag that allows one level of bracing to be removed.

In addition to these changes, we add a flag to `keyvalueOptions()` that determines whether the LaTeX3 rules are to be used, or the traditional LaTeX2 rules, for parsing the key-value pairs.  The difference is that traditional parsing removes any number of outermost braces, while LaTeX3 only removes one.  So

``` js
keyvalueOptions('x = {{y}}');
```

would return `{ x: "y" }` using traditional rules, while

``` js
keyvalueOptions('x = {{y}}', null, false, true);
```

would return `{ x: "{y}" }` using LaTeX3 rules (the final `true` parameter controls this).

LaTeX3 key-value parsing has the ability to check types of arguments and report errors, but that has not been implemented here.  It might be worth doing so in the future.