### PR TITLE
Add ability to do typechecking and conversion on the values of key-value options

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -842,10 +842,10 @@ export const ParseUtil = {
    * @param {boolean?} l3keys If true, use l3key-style parsing (only remove one set of braces)
    * @return {EnvList} The attribute list.
    */
-  keyvalOptions: function(attrib: string,
-                          allowed: {[key: string]: number | KeyValueType<any>} = null,
-                          error: boolean = false,
-                          l3keys: boolean = false): EnvList {
+  keyvalOptions(attrib: string,
+                allowed: {[key: string]: number | KeyValueType<any>} = null,
+                error: boolean = false,
+                l3keys: boolean = false): EnvList {
     let def: EnvList = readKeyval(attrib, l3keys);
     if (allowed) {
       for (let key of Object.keys(def)) {


### PR DESCRIPTION
This PR adds optional type checking and conversion to the `keyvalueOptions()` function.  Currently, the `allowed` argument gives an object that says what keys are allowed (ones with non-zero values in that object).  Here, we extend the use of the `allowed` object to provide data for type checking and converting the values of the given keys.

This is done through a new `KeyValueType` object that has `validate()` and `convert()` methods (and a name, for potential error reporting).  There is a `KeyValueTypeDefinition()` function that makes creating these objects easier, and a `KeyValueTypes` object that holds predefined definitions for the standard types (boolean, number, string) and some variations (integer, dimen, and `oneof()` that gives a collection of valid option for the string).  These seem to be a good base set of definitions, but you can create your own custom types with more detailed checker and converter, as needed.

We aren't currently using this feature now, but it would be useful in the siunitx extension that I am reviewing for PCC now.

A similar idea may also be useful for making the option checking more robust in the future (in `util/Options.ts`), where we only do key name checking, but not type checking currently.