### PR TITLE
Fix font extension handling of extra variants, and handle those variants in enrichment.

### DIFF
--- a/ts/core/MmlTree/MmlVisitor.ts
+++ b/ts/core/MmlTree/MmlVisitor.ts
@@ -138,8 +138,12 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
       node.attributes.getAllAttributes()
     ) as PropertyList;
     const variants = CLASS.variants;
-    if (attributes.hasOwnProperty('mathvariant') && variants.hasOwnProperty(attributes.mathvariant as string)) {
-      attributes.mathvariant = variants[attributes.mathvariant as string];
+    if (attributes.hasOwnProperty('mathvariant')) {
+      if (variants.hasOwnProperty(attributes.mathvariant as string)) {
+        attributes.mathvariant = variants[attributes.mathvariant as string];
+      } else if (node.getProperty('ignore-variant')) {
+        delete attributes.mathvariant;
+      }
     }
     return attributes;
   }
@@ -154,7 +158,8 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
     const data = {} as PropertyList;
     const variant = node.attributes.getExplicit('mathvariant') as string;
     const variants = (this.constructor as typeof MmlVisitor).variants;
-    variant && variants.hasOwnProperty(variant) && this.setDataAttribute(data, 'variant', variant);
+    variant && (node.getProperty('ignore-variant') || variants.hasOwnProperty(variant)) &&
+      this.setDataAttribute(data, 'variant', variant);
     node.getProperty('variantForm') && this.setDataAttribute(data, 'alternate', '1');
     node.getProperty('pseudoscript') && this.setDataAttribute(data, 'pseudoscript', 'true');
     node.getProperty('autoOP') === false && this.setDataAttribute(data, 'auto-op', 'false');

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -525,7 +525,13 @@ export default class TexParser {
    * @return {MmlNode} The newly created node.
    */
   public create(kind: string, ...rest: any[]): MmlNode {
-    return this.configuration.nodeFactory.create(kind, ...rest);
+    const node = this.configuration.nodeFactory.create(kind, ...rest);
+    if (node.isToken && node.attributes.hasExplicit('mathvariant')) {
+      if ((node.attributes.get('mathvariant') as string).charAt(0) === '-') {
+        node.setProperty('ignore-variant', true);
+      }
+    }
+    return node;
   }
 
   /**

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -866,10 +866,10 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     defaultOptions(this.params, data.parameters || {});
     mergeOptions(this, 'sizeVariants', data.sizeVariants);
     mergeOptions(this, 'stretchVariants', data.stretchVariants);
-    this.defineCssFonts(mergeOptions({cssFonts: {}}, 'cssFonts', data.cssFonts).cssFonts);
-    this.createVariants(mergeOptions({variants: []}, 'variants', data.variants).variants);
+    this.defineCssFonts(mergeOptions({cssFonts: {}}, 'cssFonts', data.cssFonts));
+    this.createVariants(mergeOptions({variants: []}, 'variants', data.variants));
     if (data.delimiters) {
-      this.defineDelimiters(mergeOptions({delimiters: {}}, 'delimiters', data.delimiters).delimiters);
+      this.defineDelimiters(mergeOptions({delimiters: {}}, 'delimiters', data.delimiters));
       this.CLASS.adjustDelimiters(this.delimiters, Object.keys(data.delimiters),
                                   dynamicFont.sizeN, dynamicFont.stretchN);
     }

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -332,8 +332,8 @@ export interface FontExtensionData<C extends CharOptions, D extends DelimiterDat
 /**
  * Merge options into an object or array.
  */
-export function mergeOptions(dst: OptionList, src: OptionList) {
-  return (src ? defaultOptions([dst], [src])[0] : dst);
+export function mergeOptions(obj: OptionList, dst: string, src: OptionList) {
+  return (src ? defaultOptions(obj, {[dst]: src})[dst] : obj[dst]);
 }
 
 /****************************************************************************/
@@ -806,7 +806,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
       ['sizeVariants', 'defaultSizeVariants'],
       ['stretchVariants', 'defaultStretchVariants']
     ] as [keyof FontExtensionData<CharOptions, DelimiterData>, keyof typeof FontData][]) {
-      mergeOptions(this[dst] as OptionList, data[src] as OptionList);
+      mergeOptions(this, dst, data[src] as OptionList);
     }
     if (data.delimiters) {
       Object.assign(this.defaultDelimiters, data.delimiters);
@@ -843,7 +843,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @param {OptionList} options   The options to merge into the font options
    */
   public setOptions(options: OptionList) {
-    mergeOptions(this.options, options);
+    defaultOptions(this.options, options);
   }
 
   /**
@@ -864,12 +864,12 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
 
     defaultOptions(this.options, data.options || {});
     defaultOptions(this.params, data.parameters || {});
-    this.sizeVariants = mergeOptions(this.sizeVariants, data.sizeVariants);
-    this.stretchVariants = mergeOptions(this.stretchVariants, data.stretchVariants);
-    this.defineCssFonts(mergeOptions([], data.cssFonts));
-    this.createVariants(mergeOptions([], data.variants));
+    mergeOptions(this, 'sizeVariants', data.sizeVariants);
+    mergeOptions(this, 'stretchVariants', data.stretchVariants);
+    this.defineCssFonts(mergeOptions({cssFonts: {}}, 'cssFonts', data.cssFonts).cssFonts);
+    this.createVariants(mergeOptions({variants: []}, 'variants', data.variants).variants);
     if (data.delimiters) {
-      this.defineDelimiters(mergeOptions([], data.delimiters));
+      this.defineDelimiters(mergeOptions({delimiters: {}}, 'delimiters', data.delimiters).delimiters);
       this.CLASS.adjustDelimiters(this.delimiters, Object.keys(data.delimiters),
                                   dynamicFont.sizeN, dynamicFont.stretchN);
     }

--- a/ts/output/svg/FontData.ts
+++ b/ts/output/svg/FontData.ts
@@ -21,7 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {CharMap, CharOptions, CharDataArray, VariantData, DelimiterData, FontData} from '../common/FontData.js';
+import {OptionList} from '../../util/Options.js';
+import {CharMap, CharOptions, CharDataArray, VariantData, DelimiterData,
+        FontData, FontExtensionData, mergeOptions} from '../common/FontData.js';
 export * from '../common/FontData.js';
 
 export type CharStringMap = {[name: number]: string};
@@ -54,6 +56,15 @@ export interface SvgDelimiterData extends DelimiterData {
 }
 
 
+/**
+ * Includes the data needed for SVG font extensions
+ */
+export interface SvgFontExtensionData<C extends SvgCharOptions, D extends SvgDelimiterData>
+extends FontExtensionData<C, D> {
+  cacheIds: {[variant: string]: string}
+}
+
+
 /****************************************************************************/
 
 /**
@@ -79,6 +90,17 @@ export class SvgFontData extends FontData<SvgCharOptions, SvgVariantData, SvgDel
    */
   public static charOptions(font: SvgCharMap, n: number) {
     return super.charOptions(font, n) as SvgCharOptions;
+  }
+
+  /**
+   * @override
+   */
+  public static addExtension(
+    data: SvgFontExtensionData<SvgCharOptions, SvgDelimiterData>,
+    prefix: string = ''
+  ) {
+    super.addExtension(data, prefix);
+    mergeOptions(this, 'variantCacheIds', data.cacheIds);
   }
 
 }

--- a/ts/output/svg/FontData.ts
+++ b/ts/output/svg/FontData.ts
@@ -21,7 +21,6 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {OptionList} from '../../util/Options.js';
 import {CharMap, CharOptions, CharDataArray, VariantData, DelimiterData,
         FontData, FontExtensionData, mergeOptions} from '../common/FontData.js';
 export * from '../common/FontData.js';


### PR DESCRIPTION
This PR fixes several problems with font extensions that define new font variants, and allows non-standard variants to round-trip through SRE without causing verification errors (now that we are checking `mathvariant` values in `MmlNode`).

Currently, the `ignore-variant` property is used to determine whether a node's non-standard `mathvariant` should produce an error message when used in MathML input, and non-standard variants can be specified using the `data-mjx-variant` attribute.  The presence of that attribute sets the `ignore-variant` properly when a MathML element is created by the MathML input jax, and the serialization of the node via `MmlVisitor` and its subclasses would add the `data-mjx-variant` attribute when `ignore-variant` is set.

 In this PR, the `MmlVisitor` is modified to remove the `mathvariant` when `ignore-variant` is set (and `data-mjx-variant` is added as before), since the variant is non-standard and should not be included in actual serialized MathML.

In the past, when a non-standard variant is needed in TeX output, the `ignore-variant` property would need to be added by hand.  If the parser's `stack.env.font` is a non-standard variant, this was not being done, and so if a non-standard variant is needed in a font extension (as with the IEEE Euler fonts), this would lead to an error during parsing of the MathML generated during SRE enrichment.  To fix this, the `TexParser` is modified to set the `ignore-variant` when any token node is created with a non-standard `mathvariant`. 

The `mergeOptions()` function in the common `FontData.ts`, which is used to merge font-extension information into an existing font, was not working properly, so this PR fixes how the merge is handled: it now modifies a named property of the font instance rather than using arrays, which never worked, and I don't know what I was thinking, as that makes no sense.  The uses of `mergeOptions` are updated accordingly.

Finally, the SVG version of `FontData.ts` is modified to add a `cacheIds` property to the data for font extensions in SVG fonts, as these are needed to name the font caches for any new variants that the extension adds.

All this will allow a custom IEEE Euler font extension that stores the needed characters in separate variants, like in their v2 extension.