### PR TITLE
Clear process bits for findMath and attach-speech, and remove safe bit that isn't needed.

### DIFF
--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -393,6 +393,9 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
       if (state < STATE.ENRICHED) {
         this.processed.clear('enriched');
       }
+      if (state < STATE.ATTACHSPEECH) {
+        this.processed.clear('attach-speech');
+      }
       return this;
     }
 

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -909,6 +909,9 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     if (state < STATE.COMPILED) {
       this.processed.clear('compile');
     }
+    if (state < STATE.FINDMATH) {
+      this.processed.clear('findMath');
+    }
     return this;
   }
 

--- a/ts/ui/safe/SafeHandler.ts
+++ b/ts/ui/safe/SafeHandler.ts
@@ -86,10 +86,6 @@ export function SafeMathDocumentMixin<N, T, D, B extends MathDocumentConstructor
     constructor(...args: any[]) {
       super(...args);
       this.safe = new this.options.SafeClass(this, this.options.safeOptions);
-      const ProcessBits = (this.constructor as typeof BaseDocument).ProcessBits;
-      if (!ProcessBits.has('safe')) {
-        ProcessBits.allocate('safe');
-      }
       for (const jax of this.inputJax) {
         if (jax.name.match(/MathML/)) {
           (jax as any).mathml.filterAttribute = this.safe.mmlAttribute.bind(this.safe);


### PR DESCRIPTION
When the document state is reset, the process bits should be reset for the actions that are for higher states.  This wasn't happening for the `attach-speech` bit in the `semantic-enrich` extension.  I did a check to make sure all the other bits are bing properly handled, and the `findMath` bit was not being recent properly, either.  Also, a `safe` bit was being allocated that was never used.  This PR fixes these three problems.

Resolve issues raised in a [user's forum post](https://groups.google.com/g/mathjax-users/c/7vrAnA7SMz0).