### PR TITLE
Add Text.splitText() method to linkedom.  (mathjax/MathJax#3134)

### DIFF
--- a/ts/adaptors/linkedomAdaptor.ts
+++ b/ts/adaptors/linkedomAdaptor.ts
@@ -66,6 +66,22 @@ export class LinkedomAdaptor extends NodeMixin<HTMLElement, Text, Document, HTML
  */
 export function linkedomAdaptor(parseHTML: any, options: OptionList = null): LinkedomAdaptor {
   const window = parseHTML('<html></html>');
-  window.HTMLCollection = class {};  // add fake class for missing HTMLCollecton
+  //
+  // Add fake class for missing HTMLCollection
+  //
+  window.HTMLCollection = class {};
+  //
+  // Add missing splitText() method
+  //
+  window.Text.prototype.splitText = function (offset: number) {
+    const text = this.data;
+    if (offset > text.length) {
+      throw Error('Index Size Error');
+    }
+    const newNode = window.document.createTextNode(text.substring(offset));
+    this.parentNode.insertBefore(newNode, this.nextSibling);
+    this.data = text.substring(0, offset);
+    return newNode;
+  };
   return new LinkedomAdaptor(window, options);
 }


### PR DESCRIPTION
This PR adds the missing `splitText()` method to the linkedom `Text` object, which we need since it is used to split the text around TeX and AsciiMath delimiters so that the math can be removed and replaced by the typeset math.