### PR TITLE
More updates to keyvalOptions, and add GetBrackets() option to match brackets.

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -346,15 +346,16 @@ export default class TexParser {
 
   /**
    * Get an optional LaTeX argument in brackets.
-   * @param {string} name Name of the current control sequence.
-   * @param {string} def? The default value for the optional argument.
+   * @param {string} _name Name of the current control sequence.
+   * @param {string?} def The default value for the optional argument.
+   * @param {boolean=} matchBrackets True if indernal brackets must match.
    * @return {string} The optional argument.
    */
-  public GetBrackets(_name: string, def?: string): string {
+  public GetBrackets(_name: string, def?: string, matchBrackets: boolean = false): string {
     if (this.GetNext() !== '[') {
       return def;
     }
-    let j = ++this.i, parens = 0;
+    let j = ++this.i, parens = 0, brackets = 0;
     while (this.i < this.string.length) {
       switch (this.string.charAt(this.i++)) {
       case '{':   parens++; break;
@@ -366,9 +367,13 @@ export default class TexParser {
                               'Extra close brace while looking for %1', '\']\'');
         }
         break;
+      case '[': if (parens === 0) brackets++; break;
       case ']':
         if (parens === 0) {
-          return this.string.slice(j, this.i - 1);
+          if (!matchBrackets || brackets === 0) {
+            return this.string.slice(j, this.i - 1);
+          }
+          brackets--;
         }
         break;
       }


### PR DESCRIPTION
This PR fixes more issues with `keyvalOptions()`, and provides an option to `GetBrackets()` to allow matching of brackets within the argument, as is done in LaTeX packages like siunitx.

One problem was that `keyvalOptions()` was removing trailing spaces when when it shouldn't.  For example, `keyvalOptiouns('x = { }')` should produce `{x: ' '}` with a space, not an empty string or `true`.  Also, `keyvalOptions('x = \\ ')` should return `{x: '\\ '}` with a trailing space, not `{x: '\\'}`.  Finally, `keyvalOptions('x = {}')` should produce `{x: ''}` not `{x: true}`.

The changes to `removeBraces()` are to handle the issue with trimming the result inappropriately.  The changes to `readValue()` fix the handling of empty braces and braces containing just spaces.  It turns out the the `stopCount` variable is not needed (everything is handled by the check for `start > braces` in the `default` branch of the `switch()` statement.

The change in new line 178 is to handle `\` at the end of the string, so as not to get `\undefined` as a result.

I changed `startCount` to `countBraces` because `startCount` sounds like it should be a number, while `countBraces` is a boolean.

I added a check for extra close braces, since `x = a}` would not throw an error before.

The logic for the `}` case is simplified, as we don't need `stopCount`, and the `start` is decremented in the `default` branch when a non-space character follows a brace.  In this case, `braces` will be smaller than `start`, and `start will be reset to the current unclosed brace count.

The other changes to readValue()` are to remove the `stopCount` variable that is no longer needed.

Since LaTeX3 packages match brackets within optional arguments (e.g., `\sample[a[b]c]{...}` would get `a[b]c` as the optional argument), the `GetBracket()` function now has a third argument that determines whether to match internal brackets in the optional argument.
