### PR TITLE
Introduces a speechgenerator pool

### DIFF
--- a/ts/a11y/SpeechUtil.ts
+++ b/ts/a11y/SpeechUtil.ts
@@ -220,6 +220,22 @@ export function setAria(node: MmlNode, locale: string) {
 }
 
 /**
+ * Updates Aria labels.
+ * @param {MmlNode} node The root node to search from.
+ */
+export function updateAria(node: HTMLElement, locale: string) {
+  let speech = node.getAttribute('data-semantic-speech');
+  if (speech) {
+    node.setAttribute('aria-label', buildSpeech(speech, locale)[0]);
+  }
+  for (let child of Array.from(node.childNodes)) {
+    if (child instanceof HTMLElement) {
+      updateAria(child, locale);
+    }
+  }
+}
+
+/**
  * Creates a honking sound.
  */
 export function honk() {

--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -468,6 +468,7 @@ export class Collapse {
    */
   public makeAction(node: MmlNode) {
     if (node.isKind('math')) {
+      // TODO: Move aria attributes from math to mrow?
       node = this.addMrow(node);
     }
     const factory = this.complexity.factory;
@@ -505,7 +506,9 @@ export class Collapse {
 
     const attributes = node.attributes.getAllAttributes();
     for (const name of Object.keys(attributes)) {
-      if (name.substring(0, 14) === 'data-semantic-') {
+      if (name.substring(0, 14) === 'data-semantic-' ||
+        name.substring(0, 5) === 'aria-' ||
+        name === 'role') {
         mrow.attributes.set(name, attributes[name]);
         delete attributes[name];
       }

--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -468,7 +468,6 @@ export class Collapse {
    */
   public makeAction(node: MmlNode) {
     if (node.isKind('math')) {
-      // TODO: Move aria attributes from math to mrow?
       node = this.addMrow(node);
     }
     const factory = this.complexity.factory;

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -101,11 +101,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
     protected refocus: boolean = false;
 
     /**
-     * Save explorer id during rerendering.
-     */
-    protected savedId: string = null;
-
-    /**
      * Add the explorer to the output for this math item
      *
      * @param {HTMLDocument} document   The MathDocument for the MathItem
@@ -116,10 +111,6 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
       if (!this.isEscaped && (document.options.enableExplorer || force)) {
         const node = this.typesetRoot;
         const mml = toMathML(this.root);
-        if (this.savedId) {
-          this.typesetRoot.setAttribute('sre-explorer-id', this.savedId);
-          this.savedId = null;
-        }
         if (!this.explorers) {
           this.explorers = new ExplorerPool();
         }
@@ -132,8 +123,8 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      * @override
      */
     public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
-      this.savedId = this.typesetRoot.getAttribute('sre-explorer-id');
-      this.refocus = (hasWindow ? window.document.activeElement === this.typesetRoot : false);
+      this.refocus = (hasWindow ?
+        window.document.activeElement === this.typesetRoot?.childNodes[0] : false);
       if (this.explorers) {
         this.explorers.reattach();
       }

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -123,7 +123,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      * @override
      */
     public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
-      let speech = this.explorers.speech();
+      let speech = this.explorers.speech;
       if (speech.attached && speech.active) {
         const focus = speech.semanticFocus();
         this.refocus = focus ? focus.id : null;
@@ -139,7 +139,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      */
     public updateDocument(document: ExplorerMathDocument) {
       super.updateDocument(document);
-      this.explorers.speech().restarted = this.refocus;
+      if (this.explorers?.speech) {
+        this.explorers.speech.restarted = this.refocus;
+      }
       this.refocus = null;
       if (this.explorers) {
         this.explorers.restart();

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -96,9 +96,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
     public explorers: ExplorerPool;
 
     /**
-     * True when a rerendered element should regain the focus
+     * Semantic id of the rerendered element that should regain the focus.
      */
-    protected refocus: boolean = false;
+    protected refocus: number = null;
 
     /**
      * Add the explorer to the output for this math item
@@ -123,8 +123,11 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      * @override
      */
     public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
-      this.refocus = (hasWindow ?
-        window.document.activeElement === this.typesetRoot?.childNodes[0] : false);
+      let speech = this.explorers.speech();
+      if (speech.attached && speech.active) {
+        const focus = speech.semanticFocus();
+        this.refocus = focus ? focus.id : null;
+      }
       if (this.explorers) {
         this.explorers.reattach();
       }
@@ -136,11 +139,11 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      */
     public updateDocument(document: ExplorerMathDocument) {
       super.updateDocument(document);
-      this.refocus && this.typesetRoot.focus();
+      this.explorers.speech().restarted = this.refocus;
+      this.refocus = null;
       if (this.explorers) {
         this.explorers.restart();
       }
-      this.refocus = false;
     }
 
   };

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -123,12 +123,12 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      * @override
      */
     public rerender(document: ExplorerMathDocument, start: number = STATE.RERENDER) {
-      let speech = this.explorers.speech;
-      if (speech.attached && speech.active) {
-        const focus = speech.semanticFocus();
-        this.refocus = focus ? focus.id : null;
-      }
       if (this.explorers) {
+        let speech = this.explorers.speech;
+        if (speech && speech.attached && speech.active) {
+          const focus = speech.semanticFocus();
+          this.refocus = focus ? focus.id : null;
+        }
         this.explorers.reattach();
       }
       super.rerender(document, start);

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -277,7 +277,7 @@ export class ExplorerPool {
       {color: 'red'}, {color: 'black'},
       {renderer: this.document.outputJax.name, browser: 'v3'}
     );
-    (this.speech().region as SpeechRegion).highlighter =
+    (this.speech.region as SpeechRegion).highlighter =
       this.secondaryHighlighter;
   }
 
@@ -303,7 +303,7 @@ export class ExplorerPool {
    *
    * @return {SpeechExplorer}
    */
-  public speech(): SpeechExplorer {
+  public get speech(): SpeechExplorer {
     return this.explorers['speech'] as SpeechExplorer;
   }
 

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -253,7 +253,9 @@ export class ExplorerPool {
    * Restarts explorers after a MathItem is rerendered.
    */
   public restart() {
-    this._restart.forEach(x => this.explorers[x].Start());
+    this._restart.forEach(x => {
+      this.explorers[x].Start(); 
+    });
     this._restart = [];
   }
 

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -26,7 +26,7 @@ import {LiveRegion, SpeechRegion, ToolTip, HoverRegion} from './Region.js';
 import type { ExplorerMathDocument, ExplorerMathItem } from '../explorer.js';
 
 import {Explorer} from './Explorer.js';
-import * as ke from './KeyExplorer.js';
+import {SpeechExplorer} from './KeyExplorer.js';
 import * as me from './MouseExplorer.js';
 import {TreeColorer, FlameColorer} from './TreeExplorer.js';
 
@@ -87,9 +87,9 @@ type ExplorerInit = (doc: ExplorerMathDocument, pool: ExplorerPool,
  */
 let allExplorers: {[options: string]: ExplorerInit} = {
   speech: (doc: ExplorerMathDocument, pool: ExplorerPool, node: HTMLElement, ...rest: any[]) => {
-    let explorer = ke.SpeechExplorer.create(
+    let explorer = SpeechExplorer.create(
       doc, pool, doc.explorerRegions.speechRegion, node,
-      doc.explorerRegions.brailleRegion, doc.explorerRegions.magnifier, rest[0], rest[1]) as ke.SpeechExplorer;
+      doc.explorerRegions.brailleRegion, doc.explorerRegions.magnifier, rest[0], rest[1]) as SpeechExplorer;
     explorer.sound = true;
     return explorer;
   },
@@ -213,7 +213,7 @@ export class ExplorerPool {
     let keyExplorers = [];
     for (let key of Object.keys(this.explorers)) {
       let explorer = this.explorers[key];
-      if (explorer instanceof ke.SpeechExplorer) {
+      if (explorer instanceof SpeechExplorer) {
         explorer.AddEvents();
         explorer.stoppable = false;
         keyExplorers.unshift(explorer);
@@ -277,7 +277,7 @@ export class ExplorerPool {
       {color: 'red'}, {color: 'black'},
       {renderer: this.document.outputJax.name, browser: 'v3'}
     );
-    ((this.explorers['speech'] as ke.SpeechExplorer).region as SpeechRegion).highlighter =
+    (this.speech().region as SpeechRegion).highlighter =
       this.secondaryHighlighter;
   }
 
@@ -295,6 +295,16 @@ export class ExplorerPool {
   public unhighlight() {
     this.secondaryHighlighter.unhighlight();
     this.highlighter.unhighlight();
+  }
+
+  /**
+   * Convenience method to return the speech explorer of the pool with the
+   * correct type.
+   *
+   * @return {SpeechExplorer}
+   */
+  public speech(): SpeechExplorer {
+    return this.explorers['speech'] as SpeechExplorer;
   }
 
   /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -262,7 +262,9 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   public summary(node: HTMLElement): HTMLElement {
     // const summary = this.item.speechGenerator.summary(node);
     // const speechGenerator = Sre.getSpeechGenerator('Summary');
-    // console.log(speechGenerator);
+    console.log(this.item.generatorPool.speechGenerator);
+    console.log(this.item.generatorPool.brailleGenerator);
+    console.log(this.item.generatorPool.summaryGenerator);
     // console.log(this.item);
     // console.log(this.item.inputData.originalMml);
     // console.log(speechGenerator.getSpeech(this.item.inputData.enrichedMml, this.item.inputData.enrichedMml));
@@ -270,21 +272,21 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   }
 
   public nextRuleSet(node: HTMLElement): HTMLElement {
-    this.item.speechGenerator.nextRules();
+    this.item.generatorPool.speechGenerator.nextRules();
     this.recomputeSpeech();
     this.refocus(node);
     return node;
   }
 
   public nextStyle(node: HTMLElement): HTMLElement {
-    this.item.speechGenerator.nextStyle(node.getAttribute('data-semantic-id'));
+    this.item.generatorPool.speechGenerator.nextStyle(node.getAttribute('data-semantic-id'));
     this.recomputeSpeech();
     this.refocus(node);
     return node;
   }
 
   private recomputeSpeech() {
-    const speech = this.item.speechGenerator.getSpeech(this.item.typesetRoot, this.item.typesetRoot);
+    const speech = this.item.generatorPool.speechGenerator.getSpeech(this.item.typesetRoot, this.item.typesetRoot);
     updateAria(this.item.typesetRoot, this.document.options.sre.locale);
     this.item.outputData.speech = buildSpeech(speech)[0];
     this.item.typesetRoot.setAttribute('aria-label', this.item.outputData.speech);
@@ -372,6 +374,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * @override
    */
   public Start() {
+    // this.item.generatorPool.update(this.document.options);
     if (this.node.hasAttribute('tabindex')) {
       this.node.removeAttribute('tabindex');
     }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { buildSpeech, updateAria, honk } from '../SpeechUtil.js';
+import { buildSpeech, updateAria, honk } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 // import { Walker } from './Walker.js';
@@ -260,8 +260,12 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   ]);
 
   public summary(node: HTMLElement): HTMLElement {
-    this.item.speechGenerator.summary(node);
-    const speechGenerator = Sre.getSpeechGenerator('Summary');
+    // const summary = this.item.speechGenerator.summary(node);
+    // const speechGenerator = Sre.getSpeechGenerator('Summary');
+    // console.log(speechGenerator);
+    // console.log(this.item);
+    // console.log(this.item.inputData.originalMml);
+    // console.log(speechGenerator.getSpeech(this.item.inputData.enrichedMml, this.item.inputData.enrichedMml));
     return node;
   }
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { buildSpeech, updateAria, honk } from '../speech/SpeechUtil.js';
+import { buildSpeech, setAria, honk } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 // import { Walker } from './Walker.js';
@@ -267,14 +267,14 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   }
 
   public nextRules(node: HTMLElement): HTMLElement {
-    this.item.generatorPool.speechGenerator.nextRules();
+    this.item.generatorPool.nextRules(node);
     this.recomputeSpeech();
     this.refocus(node);
     return node;
   }
 
   public nextStyle(node: HTMLElement): HTMLElement {
-    this.item.generatorPool.speechGenerator.nextStyle(node.getAttribute('data-semantic-id'));
+    this.item.generatorPool.nextStyle(node);
     this.recomputeSpeech();
     this.refocus(node);
     return node;
@@ -282,7 +282,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
 
   private recomputeSpeech() {
     const speech = this.item.generatorPool.speechGenerator.getSpeech(this.item.typesetRoot, this.item.typesetRoot);
-    updateAria(this.item.typesetRoot, this.document.options.sre.locale);
+    setAria(this.item.typesetRoot, this.document.options.sre.locale);
     this.item.outputData.speech = buildSpeech(speech)[0];
     this.item.typesetRoot.setAttribute('aria-label', this.item.outputData.speech);
     this.item.attachSpeech(this.document);
@@ -404,14 +404,8 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     force = false;
     if (!this.active && !force) return;
     this.pool.unhighlight();
-    // let nodes = this.walker.getFocus(true).getNodes();
-    // if (!nodes.length) {
-    //   this.walker.refocus();
-    //   nodes = this.walker.getFocus().getNodes();
-    // }
     this.pool.highlight([this.current]);
     this.region.node = this.node;
-    console.log(1);
     this.item.generatorPool.UpdateSpeech(
       this.current,
       this.region,

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -284,12 +284,26 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     ['x', this.summary.bind(this)],
   ]);
 
+  /**
+   * Computes the summary for this expression. This is temporary and will be
+   * replaced by the full speech on focus out.
+   *
+   * @param {HTMLElement} node The targeted node.
+   * @return {HTMLElement} The refocused targeted node.
+   */
   public summary(node: HTMLElement): HTMLElement {
     this.item.generatorPool.summary(node);
     this.refocus(node);
     return node;
   }
 
+  /**
+   * Cycles to next speech rule set if possible and recomputes the speech for
+   * the expression.
+   *
+   * @param {HTMLElement} node The targeted node.
+   * @return {HTMLElement} The refocused targeted node.
+   */
   public nextRules(node: HTMLElement): HTMLElement {
     this.item.generatorPool.nextRules(node);
     this.Speech();
@@ -297,6 +311,13 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     return node;
   }
 
+  /**
+   * Cycles to next speech style or preference if possible and recomputes the
+   * speech for the expression.
+   *
+   * @param {HTMLElement} node The targeted node.
+   * @return {HTMLElement} The refocused targeted node.
+   */
   public nextStyle(node: HTMLElement): HTMLElement {
     this.item.generatorPool.nextStyle(node);
     this.Speech();

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -31,8 +31,6 @@ import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 import { buildSpeech, setAria, honk } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
-// import { Walker } from './Walker.js';
-
 
 /**
  * Interface for keyboard explorers. Adds the necessary keyboard events.
@@ -363,10 +361,10 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * @override
    */
   public Start() {
+    if (!this.attached) return;
     if (this.node.hasAttribute('tabindex')) {
       this.node.removeAttribute('tabindex');
     }
-    if (!this.attached) return;
     if (this.active) return;
     let promise = SpeechExplorer.updatePromise();
     if (this.item.generatorPool.update(this.document.options)) {
@@ -399,41 +397,17 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   public Update(force: boolean = false) {
     // TODO (v4): This is a hack to avoid double voicing on initial startup!
     // Make that cleaner and remove force as it is not really used!
-    // let noUpdate = force;
     if (!this.active && !force) return;
     this.pool.unhighlight();
     this.pool.highlight([this.current]);
     this.region.node = this.node;
-    this.item.generatorPool.UpdateSpeech(
+    this.item.generatorPool.updateSpeech(
       this.current,
       this.region,
       this.brailleRegion
     );
     this.magnifyRegion.Update(this.current);
-    // let options = this.speechGenerator.getOptions();
-    // This is a necessary in case speech options have changed via keypress
-    // during walking.
-    // if (options.modality === 'speech') {
-    //   this.document.options.sre.domain = options.domain;
-    //   this.document.options.sre.style = options.style;
-    //   this.document.options.a11y.speechRules =
-    //     options.domain + '-' + options.style;
-    // }
-    // Ensure this autovoicing is retained later:
-    // SpeechExplorer.updatePromise = SpeechExplorer.updatePromise.then(async () => {
-    //   return Sre.sreReady()
-    //     .then(() => Sre.setupEngine({markup: options.markup,
-    //                                  modality: options.modality,
-    //                                  locale: options.locale}))
-    //     .then(() => {
-    //       if (!noUpdate) {
-    //         let speech = this.walker.speech();
-    //         this.region.Update(speech);
-    //       }
-    //     });
-    // });
   }
-
 
   /**
    * Computes the speech for the current expression.
@@ -445,7 +419,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     this.item.typesetRoot.setAttribute('aria-label', this.item.outputData.speech);
     this.item.attachSpeech(this.document);
   }
-
 
   /**
    * @override

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -254,24 +254,32 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     ['ArrowUp', (node: HTMLElement) => node.parentElement.closest(nav)],
     ['ArrowLeft', this.prevSibling.bind(this)],
     ['ArrowRight', this.nextSibling.bind(this)],
-    ['>', this.nextRuleSet.bind(this)],
+    ['>', this.nextRules.bind(this)],
     ['<', this.nextStyle.bind(this)],
     ['x', this.summary.bind(this)],
   ]);
 
   public summary(node: HTMLElement): HTMLElement {
-    // const summary = this.item.speechGenerator.summary(node);
-    // const speechGenerator = Sre.getSpeechGenerator('Summary');
-    console.log(this.item.generatorPool.speechGenerator);
-    console.log(this.item.generatorPool.brailleGenerator);
-    console.log(this.item.generatorPool.summaryGenerator);
-    // console.log(this.item);
-    // console.log(this.item.inputData.originalMml);
-    // console.log(speechGenerator.getSpeech(this.item.inputData.enrichedMml, this.item.inputData.enrichedMml));
+    const summary = this.item.generatorPool.summary(node);
+    console.log(summary);
+    console.log(buildLabel(
+        this.current.getAttribute('data-semantic-summary'),
+        this.current.getAttribute('data-semantic-prefix'),
+        this.current.getAttribute('data-semantic-postfix')
+      ));
+    console.log(this.region);
+    this.region.Update(
+      buildLabel(
+        this.current.getAttribute('data-semantic-summary'),
+        this.current.getAttribute('data-semantic-prefix'),
+        this.current.getAttribute('data-semantic-postfix')
+      ));
+    node.setAttribute('aria-label', buildSpeech(summary)[0]);
+    this.refocus(node);
     return node;
   }
 
-  public nextRuleSet(node: HTMLElement): HTMLElement {
+  public nextRules(node: HTMLElement): HTMLElement {
     this.item.generatorPool.speechGenerator.nextRules();
     this.recomputeSpeech();
     this.refocus(node);
@@ -416,13 +424,11 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     // }
     this.pool.highlight([this.current]);
     this.region.node = this.node;
-    this.region.Update(
-      buildLabel(
-        this.current.getAttribute('data-semantic-speech'),
-        this.current.getAttribute('data-semantic-prefix'),
-        this.current.getAttribute('data-semantic-postfix')
-      ));
-    this.brailleRegion.Update(this.current.getAttribute('aria-braillelabel'));
+    this.item.generatorPool.UpdateSpeech(
+      this.current,
+      this.region,
+      this.brailleRegion
+    );
     this.magnifyRegion.Update(this.current);
     // let options = this.speechGenerator.getOptions();
     // This is a necessary in case speech options have changed via keypress
@@ -597,7 +603,5 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     }
     super.Stop();
   }
-
-
 
 }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -179,6 +179,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     if (!this.move) {
       this.Stop();
     }
+    this.current.removeAttribute('tabindex');
     this.node.setAttribute('tabindex', '0');
   }
 
@@ -575,7 +576,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    */
   public Stop() {
     if (this.active) {
-      this.current.removeAttribute('tabindex');
       this.pool.unhighlight();
       this.magnifyRegion.Hide();
       this.region.Hide();

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -401,7 +401,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     // TODO (v4): This is a hack to avoid double voicing on initial startup!
     // Make that cleaner and remove force as it is not really used!
     // let noUpdate = force;
-    force = false;
     if (!this.active && !force) return;
     this.pool.unhighlight();
     this.pool.highlight([this.current]);

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -106,12 +106,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   private oldIndex: number = null;
 
   /**
-   * The attached Sre walker.
-   * @type {Walker}
-   */
-  public walker: Sre.walker;
-
-  /**
    * The currently focused elements.
    */
   protected current: HTMLElement = null;
@@ -202,7 +196,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     if (!this.move) {
       this.Stop();
     }
-    this.current.removeAttribute('tabindex');
+    this.current?.removeAttribute('tabindex');
     this.node.setAttribute('tabindex', '0');
   }
 
@@ -315,6 +309,10 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     node.focus();
   }
 
+  private static updatePromise() {
+    return Sre.sreReady();
+  }
+
   /**
    * @override
    */
@@ -345,32 +343,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   public NoMove() {
     honk();
   }
-
-  private static updatePromise() {
-    return Sre.sreReady();
-  }
-
-  /**
-   * The Sre speech generator associated with the walker.
-   * @type {SpeechGenerator}
-   */
-  public speechGenerator: Sre.speechGenerator;
-
-  /**
-   * The name of the option used to control when this is being shown
-   * @type {string}
-   */
-  public showRegion: string = 'subtitles';
-
-  // private init: boolean = false;
-
-  /**
-   * Flag in case the start method is triggered before the walker is fully
-   * initialised. I.e., we have to wait for Sre. Then region is re-shown if
-   * necessary, as otherwise it leads to incorrect stacking.
-   * @type {boolean}
-   */
-  // private restarted: boolean = false;
 
   /**
    * @constructor
@@ -553,26 +525,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   }
 
   /**
-   * Retrieves the speech options to sync with document options.
-   * @return {{[key: string]: string}} The options settings for the speech
-   *     generator.
-   */
-  protected getOptions(): {[key: string]: string} {
-    let options = this.speechGenerator.getOptions();
-    let sreOptions = this.document.options.sre;
-    if (options.modality === 'speech' &&
-      (options.locale !== sreOptions.locale ||
-        options.domain !== sreOptions.domain ||
-        options.style !== sreOptions.style)) {
-      options.domain = sreOptions.domain;
-      options.style = sreOptions.style;
-      options.locale = sreOptions.locale;
-      this.walker.update(options);
-    }
-    return options;
-  }
-
-  /**
    * @override
    */
   public Stop() {
@@ -583,6 +535,17 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       this.brailleRegion.Hide();
     }
     super.Stop();
+  }
+
+  /**
+   * @return The semantic node that is currently focused.
+   */
+  public semanticFocus() {
+    const node = this.current || this.node;
+    const id = node.getAttribute('data-semantic-id');
+    const stree = this.item.generatorPool.speechGenerator.getRebuilt().stree;
+    const snode = stree.root.querySelectorAll((x) => x.id.toString() === id)[0];
+    return snode || stree.root;
   }
 
 }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { buildLabel, buildSpeech, updateAria, honk } from '../speech/SpeechUtil.js';
+import { buildSpeech, updateAria, honk } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 // import { Walker } from './Walker.js';
@@ -180,6 +180,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * @override
    */
   public FocusOut(_event: FocusEvent) {
+    this.item.generatorPool.CleanUp(this.current);
     if (!this.move) {
       this.Stop();
     }
@@ -260,21 +261,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   ]);
 
   public summary(node: HTMLElement): HTMLElement {
-    const summary = this.item.generatorPool.summary(node);
-    console.log(summary);
-    console.log(buildLabel(
-        this.current.getAttribute('data-semantic-summary'),
-        this.current.getAttribute('data-semantic-prefix'),
-        this.current.getAttribute('data-semantic-postfix')
-      ));
-    console.log(this.region);
-    this.region.Update(
-      buildLabel(
-        this.current.getAttribute('data-semantic-summary'),
-        this.current.getAttribute('data-semantic-prefix'),
-        this.current.getAttribute('data-semantic-postfix')
-      ));
-    node.setAttribute('aria-label', buildSpeech(summary)[0]);
+    this.item.generatorPool.summary(node);
     this.refocus(node);
     return node;
   }
@@ -424,6 +411,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     // }
     this.pool.highlight([this.current]);
     this.region.node = this.node;
+    console.log(1);
     this.item.generatorPool.UpdateSpeech(
       this.current,
       this.region,

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -167,7 +167,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       this.mousedown = false;
       return;
     }
-    this.current = this.current || this.node.querySelector('[role="tree"]');
+    this.current = this.current || this.node.querySelector('[role="treeitem"]');
     this.Start();
     event.preventDefault();
   }
@@ -257,18 +257,20 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     this.item.speechGenerator.summary(node);
     const speechGenerator = Sre.getSpeechGenerator('Summary');
     console.log(speechGenerator.getSpeech(node, node));
+    return node;
   }
 
   public nextRuleSet(node: HTMLElement): HTMLElement {
     this.item.speechGenerator.nextRules();
     this.recomputeSpeech();
+    this.refocus(node);
     return node;
   }
 
   public nextStyle(node: HTMLElement): HTMLElement {
-    console.log(node);
     this.item.speechGenerator.nextStyle(node.getAttribute('data-semantic-id'));
     this.recomputeSpeech();
+    this.refocus(node);
     return node;
   }
 
@@ -280,6 +282,10 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     this.item.attachSpeech(this.document);
   }
 
+  private refocus(node: HTMLElement) {
+    node.blur();
+    node.focus();
+  }
 
   /**
    * @override

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -140,6 +140,10 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
 
   public Click(e: MouseEvent) {
     const clicked = (e.target as HTMLElement).closest(nav) as HTMLElement;
+    if (!this.node.contains(clicked)) {
+      // In case the mjx-container is in a div, we get the click, although it is outside.
+      this.mousedown = false;
+    }
     if (this.node.contains(clicked)) {
       const prev = this.node.querySelector(prevNav);
       if (prev) {
@@ -258,7 +262,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   public summary(node: HTMLElement): HTMLElement {
     this.item.speechGenerator.summary(node);
     const speechGenerator = Sre.getSpeechGenerator('Summary');
-    console.log(speechGenerator.getSpeech(node, node));
     return node;
   }
 
@@ -485,7 +488,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       }
       if (!this.active) {
         if (!this.current) {
-          this.current = this.node.querySelector('[role="tree"]');
+          this.current = this.node.querySelector('[role="treeitem"]');
         }
         this.Start();
         this.stopEvent(event);

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { buildSpeech, updateAria, honk } from '../speech/SpeechUtil.js';
+import { buildLabel, buildSpeech, updateAria, honk } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 // import { Walker } from './Walker.js';
@@ -416,7 +416,12 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     // }
     this.pool.highlight([this.current]);
     this.region.node = this.node;
-    this.region.Update(this.current.getAttribute('aria-label'));
+    this.region.Update(
+      buildLabel(
+        this.current.getAttribute('data-semantic-speech'),
+        this.current.getAttribute('data-semantic-prefix'),
+        this.current.getAttribute('data-semantic-postfix')
+      ));
     this.brailleRegion.Update(this.current.getAttribute('aria-braillelabel'));
     this.magnifyRegion.Update(this.current);
     // let options = this.speechGenerator.getOptions();

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -179,6 +179,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     if (!this.move) {
       this.Stop();
     }
+    this.node.setAttribute('tabindex', '0');
   }
 
   /**
@@ -455,7 +456,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     const code = event.key;
     // this.walker.modifier = event.shiftKey;
     if (code === 'Tab') {
-      this.tabout = true;
       this.Stop()
       return;
     }
@@ -580,13 +580,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       this.magnifyRegion.Hide();
       this.region.Hide();
       this.brailleRegion.Hide();
-      // Not pretty, but currently the only solution I found.  The issue: if we
-      // shift-tab backwards then settingthe tabindex immediately catches the
-      // focus and we can't leave the expression.
-      setTimeout(
-        () => this.node.setAttribute('tabindex', '0'),
-        50
-      );
     }
     super.Stop();
   }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -337,13 +337,14 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     return node;
   }
 
+  /**
+   * Refocuses the active elements, mainly to alert screenreaders of changes.
+   *
+   * @param {HTMLElement} node The node to refocus on.
+   */
   private refocus(node: HTMLElement) {
     node.blur();
     node.focus();
-  }
-
-  private static updatePromise() {
-    return Sre.sreReady();
   }
 
   /**
@@ -417,7 +418,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       // the root node by default.
       this.current = this.node.childNodes[0] as HTMLElement;
     }
-    let promise = SpeechExplorer.updatePromise();
+    let promise = Sre.sreReady();
     if (this.generators.update(this.document.options)) {
       promise = promise.then(
         () => this.Speech()

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { buildSpeech, setAria, honk } from '../speech/SpeechUtil.js';
+import { honk } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 
@@ -451,7 +451,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     this.pool.unhighlight();
     this.pool.highlight([this.current]);
     this.region.node = this.node;
-    this.generators.updateSpeech(
+    this.generators.updateRegions(
       this.current,
       this.region,
       this.brailleRegion
@@ -463,11 +463,8 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * Computes the speech for the current expression.
    */
   public Speech() {
-    const speech = this.generators.speechGenerator.getSpeech(this.item.typesetRoot, this.item.typesetRoot);
-    setAria(this.item.typesetRoot, this.document.options.sre.locale);
-    this.item.outputData.speech = buildSpeech(speech)[0];
-    this.item.typesetRoot.setAttribute('aria-label', this.item.outputData.speech);
-    this.item.attachSpeech(this.document);
+    this.item.outputData.speech =
+      this.generators.updateSpeech(this.item.typesetRoot);
   }
 
   /**
@@ -589,7 +586,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     const node = this.current || this.node;
     const id = node.getAttribute('data-semantic-id');
     const stree = this.generators.speechGenerator.getRebuilt().stree;
-    const snode = stree.root.querySelectorAll((x) => x.id.toString() === id)[0];
+    const snode = stree.root.querySelectorAll((x: any) => x.id.toString() === id)[0];
     return snode || stree.root;
   }
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -416,7 +416,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     // }
     this.pool.highlight([this.current]);
     this.region.node = this.node;
-    this.region.Update(this.current.getAttribute('data-semantic-speech'));
+    this.region.Update(this.current.getAttribute('aria-label'));
     this.brailleRegion.Update(this.current.getAttribute('aria-braillelabel'));
     this.magnifyRegion.Update(this.current);
     // let options = this.speechGenerator.getOptions();

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -460,7 +460,6 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     const code = event.key;
     // this.walker.modifier = event.shiftKey;
     if (code === 'Tab') {
-      this.Stop()
       return;
     }
     if (code === ' ') {

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -363,6 +363,9 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * @override
    */
   public Start() {
+    if (this.node.hasAttribute('tabindex')) {
+      this.node.removeAttribute('tabindex');
+    }
     if (!this.attached) return;
     if (this.active) return;
     this.current.setAttribute('tabindex', '0');
@@ -452,7 +455,11 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     const code = event.key;
     // this.walker.modifier = event.shiftKey;
     if (code === 'Tab') {
+      this.tabout = true;
       this.Stop()
+      return;
+    }
+    if (code === ' ') {
       return;
     }
     if (code === 'Control') {
@@ -573,6 +580,13 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       this.magnifyRegion.Hide();
       this.region.Hide();
       this.brailleRegion.Hide();
+      // Not pretty, but currently the only solution I found.  The issue: if we
+      // shift-tab backwards then settingthe tabindex immediately catches the
+      // focus and we can't leave the expression.
+      setTimeout(
+        () => this.node.setAttribute('tabindex', '0'),
+        50
+      );
     }
     super.Stop();
   }

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -26,7 +26,7 @@
 import {MathDocument} from '../../core/MathDocument.js';
 import {CssStyles} from '../../util/StyleList.js';
 import {Sre} from '../sre.js';
-import {SsmlElement, buildSpeech} from '../SpeechUtil.js';
+import {SsmlElement, buildSpeech} from '../speech/SpeechUtil.js';
 
 export type A11yDocument = MathDocument<HTMLElement, Text, Document>;
 

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -21,7 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {mathjax} from '../mathjax.js';
+// import {mathjax} from '../mathjax.js';
 import {Handler} from '../core/Handler.js';
 import {MathDocument, AbstractMathDocument, MathDocumentConstructor} from '../core/MathDocument.js';
 import {MathItem, AbstractMathItem, STATE, newState} from '../core/MathItem.js';

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -386,9 +386,7 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
      * Attach speech from a MathItem to a node
      */
     public attachSpeech() {
-      console.log(5);
       if (!this.processed.isSet('attach-speech')) {
-        console.log(6);
         for (const math of this.math) {
           (math as EnrichedMathItem<N, T, D>).attachSpeech(this);
         }

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -31,7 +31,7 @@ import {MathML} from '../input/mathml.js';
 import {SerializedMmlVisitor} from '../core/MmlTree/SerializedMmlVisitor.js';
 import {OptionList, expandable} from '../util/Options.js';
 import {Sre} from './sre.js';
-import { buildSpeech, setAria } from './SpeechUtil.js';
+import { buildSpeech, setAria } from './speech/SpeechUtil.js';
 
 /*==========================================================================*/
 
@@ -192,6 +192,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
         // TODO: Sort out the loading of the locales better
         if (document.options.enableSpeech) {
+          console.log(document.options.sre.locale);
           if (document.options.sre.locale !== currentLocale) {
             currentLocale = document.options.sre.locale;
             // TODO: Sort out the loading of the locales better

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -107,7 +107,7 @@ export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
   /**
    * The speech generators for this math item.
    */
-  generatorPool: GeneratorPool<N>;
+  generatorPool: GeneratorPool;
 
   /**
    * @param {MathDocument} document  The document where enrichment is occurring
@@ -145,8 +145,11 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
     /**
      * @override
      */
-    public generatorPool = new GeneratorPool<N>();
+    public generatorPool = new GeneratorPool();
 
+    /**
+     *  The MathML adaptor.
+     */
     public toMathML = toMathML;
 
     /**
@@ -179,7 +182,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       if (this.state() >= STATE.ENRICHED) return;
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
         this.generatorPool.init(document.options);
-        this.generatorPool.setAttribute = document.adaptor.setAttribute;
+        // this.generatorPool.setAttribute = document.adaptor.setAttribute;
         const math = new document.options.MathItem('', MmlJax);
         try {
           let mml;
@@ -248,7 +251,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       if (!speech || !braille ||
         document.options.enableSpeech || document.options.enableBraille) {
         [newSpeech, newBraille] = this.generatorPool.computeSpeech(
-          this.typesetRoot, this.toMathML(this.root, this));
+          this.typesetRoot as Element, this.toMathML(this.root, this));
       }
       speech = speech || newSpeech;
       braille = braille || newBraille;

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -176,21 +176,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
     public enrich(document: MathDocument<N, T, D>, force: boolean = false) {
       if (this.state() >= STATE.ENRICHED) return;
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
-        // TODO: Sort out the loading of the locales better
         this.generatorPool.init(document.options);
-          // if (document.options.sre.locale !== currentLocale) {
-          //   currentLocale = document.options.sre.locale;
-          //   // TODO: Sort out the loading of the locales better
-          //   mathjax.retryAfter(
-          //     Sre.setupEngine({locale: document.options.sre.locale})
-          //       .then(() => Sre.sreReady()));
-          // }
-          // if (document.options.sre.braille !== currentBraille) {
-          //   currentBraille = document.options.sre.braille;
-          //   mathjax.retryAfter(
-          //     Sre.setupEngine({locale: document.options.sre.braille})
-          //       .then(() => Sre.sreReady()));
-          // }
         const math = new document.options.MathItem('', MmlJax);
         try {
           let mml;
@@ -201,6 +187,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
           }
           Sre.setupEngine(document.options.sre);
           const enriched = Sre.toEnriched(mml);
+          this.generatorPool.node = enriched;
           if (document.options.enableSpeech) {
             this.outputData.speech = buildSpeech(
               this.generatorPool.speechGenerator.getSpeech(enriched, enriched),

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -393,7 +393,7 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
         locale: 'en',                      // switch the locale
         domain: 'mathspeak',               // speech rules domain
         style: 'default',                  // speech rules style
-        braille: 'euro',                   // TODO: Dummy switch for braille
+        braille: 'nemeth',                 // TODO: Dummy switch for braille
       }),
     };
 

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -185,7 +185,6 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
           } else {
             mml = this.adjustSelections();
           }
-          Sre.setupEngine(document.options.sre);
           const enriched = Sre.toEnriched(mml);
           this.generatorPool.element = enriched;
           if (document.options.enableSpeech) {

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -193,7 +193,8 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
               this.generatorPool.speechGenerator.getSpeech(enriched, enriched),
               document.options.sre.locale,
               document.options.sre.rate)[0];
-            this.outputData.braille = this.generatorPool.brailleGenerator.getSpeech(enriched, enriched);
+            this.outputData.braille =
+              this.generatorPool.brailleGenerator.getSpeech(enriched, enriched);
           }
           this.inputData.enrichedMml = math.math = this.serializeMml(enriched);
           math.display = this.display;

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -145,7 +145,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
     /**
      * @override
      */
-    public generatorPool = new GeneratorPool();
+    public generatorPool = new GeneratorPool(this.root);
 
     /**
      * @param {any} node  The node to be serialized
@@ -187,7 +187,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
           }
           Sre.setupEngine(document.options.sre);
           const enriched = Sre.toEnriched(mml);
-          this.generatorPool.node = enriched;
+          this.generatorPool.element = enriched;
           if (document.options.enableSpeech) {
             this.outputData.speech = buildSpeech(
               this.generatorPool.speechGenerator.getSpeech(enriched, enriched),
@@ -341,7 +341,7 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
     public static OPTIONS: OptionList = {
       ...BaseDocument.OPTIONS,
       enableEnrichment: true,
-      enableSpeech: true,
+      enableSpeech: false,
       enrichError: (doc: EnrichedMathDocument<N, T, D>,
                     math: EnrichedMathItem<N, T, D>,
                     err: Error) => doc.enrichError(doc, math, err),
@@ -386,7 +386,9 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
      * Attach speech from a MathItem to a node
      */
     public attachSpeech() {
+      console.log(5);
       if (!this.processed.isSet('attach-speech')) {
+        console.log(6);
         for (const math of this.math) {
           (math as EnrichedMathItem<N, T, D>).attachSpeech(this);
         }

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -106,7 +106,7 @@ export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
   /**
    * The speech generators for this math item.
    */
-  generatorPool: GeneratorPool;
+  generatorPool: GeneratorPool<N, T, D>;
 
   /**
    * @param {MathDocument} document  The document where enrichment is occurring
@@ -144,7 +144,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
     /**
      * @override
      */
-    public generatorPool = new GeneratorPool();
+    public generatorPool = new GeneratorPool<N, T, D>();
 
     /**
      *  The MathML adaptor.
@@ -180,7 +180,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
     public enrich(document: MathDocument<N, T, D>, force: boolean = false) {
       if (this.state() >= STATE.ENRICHED) return;
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
-        this.generatorPool.init(document.options);
+        this.generatorPool.init(document.options, document.adaptor);
         const math = new document.options.MathItem('', MmlJax);
         try {
           let mml;
@@ -249,7 +249,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       if (!speech || !braille ||
         document.options.enableSpeech || document.options.enableBraille) {
         [newSpeech, newBraille] = this.generatorPool.computeSpeech(
-          this.typesetRoot as Element, this.toMathML(this.root, this));
+          this.typesetRoot, this.toMathML(this.root, this));
       }
       speech = speech || newSpeech;
       braille = braille || newBraille;

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -21,7 +21,6 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-// import {mathjax} from '../mathjax.js';
 import {Handler} from '../core/Handler.js';
 import {MathDocument, AbstractMathDocument, MathDocumentConstructor} from '../core/MathDocument.js';
 import {MathItem, AbstractMathItem, STATE, newState} from '../core/MathItem.js';
@@ -182,7 +181,6 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       if (this.state() >= STATE.ENRICHED) return;
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
         this.generatorPool.init(document.options);
-        // this.generatorPool.setAttribute = document.adaptor.setAttribute;
         const math = new document.options.MathItem('', MmlJax);
         try {
           let mml;
@@ -360,7 +358,7 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
     public static OPTIONS: OptionList = {
       ...BaseDocument.OPTIONS,
       enableEnrichment: true,
-      enableSpeech: false,
+      enableSpeech: true,
       enrichError: (doc: EnrichedMathDocument<N, T, D>,
                     math: EnrichedMathItem<N, T, D>,
                     err: Error) => doc.enrichError(doc, math, err),

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -145,6 +145,10 @@ export class GeneratorPool {
   // Summary computations are very fast, and we recompute in case the rule sets
   // have changed and there is a different summary.
   public summary(node: Element) {
+    if (this.lastSummary) {
+      this.CleanUp(node);
+      return this.lastSpeech;
+    }
     this.lastSpeech = this.summaryGenerator.getSpeech(node, this.element)
     return this.lastSpeech;
   }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -1,0 +1,97 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2009-2023 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {mathjax} from '../../mathjax.js';
+import {Sre} from '../sre.js';
+import {OptionList} from '../../util/Options.js';
+// import { MathItem } from '../../core/MathItem.js';
+
+/**
+ * @fileoverview Speech generator collections for enrichment and explorers.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+export class GeneratorPool {
+
+  /**
+   * The speech generator for a math item.
+   */
+  public speechGenerator = Sre.getSpeechGenerator('Tree');
+
+  /**
+   * The braille generator for a math item.
+   */
+  public brailleGenerator = Sre.getSpeechGenerator('Tree');
+
+  /**
+   * The summary generator for a math item.
+   */
+  public summaryGenerator = Sre.getSpeechGenerator('Summary');
+
+  /**
+   *  The current speech setting for Sre
+   */
+  private currentLocale = 'none';
+  private currentBraille = 'none';
+
+  public setOptions(options: OptionList) {
+    this.speechGenerator.setOptions(Object.assign(
+      {}, options.sre, {
+        modality: 'speech',
+        markup: 'ssml',
+        automark: true,
+      }));
+    this.summaryGenerator.setOptions(Object.assign(
+      {}, options.sre, {
+        modality: 'summary',
+        markup: 'ssml',
+        automark: true,
+      }));
+    this.brailleGenerator.setOptions({
+      locale: options.sre.braille,
+      domain: 'default',
+      style: 'default',
+      modality: 'braille',
+      markup: 'none',
+    });
+  }
+
+  public init(options: OptionList) {
+    this.setOptions(options);
+    if (this.update(options)) {
+      mathjax.retryAfter(Sre.sreReady());
+    }
+  }
+
+  public update(options: OptionList) {
+    let update = false;
+    if (options.sre.locale !== this.currentLocale) {
+      this.currentLocale = options.sre.locale;
+      update = true;
+      // TODO: Sort out the loading of the locales better
+      Sre.setupEngine({locale: options.sre.locale})
+    }
+    if (options.sre.braille !== this.currentBraille) {
+      this.currentBraille = options.sre.braille;
+      update = true;
+      Sre.setupEngine({locale: options.sre.braille})
+    }
+    return update;
+  }
+
+}

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -29,12 +29,9 @@ import { getLabel, setAria, buildSpeech } from '../speech/SpeechUtil.js';
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-export class GeneratorPool<N> {
+export class GeneratorPool {
 
   private _element: Element;
-  public setAttribute:
-  (node: N, attr: string, value: string|number) => void;
-
 
   set element(element: Element) {
     this._element = element;
@@ -48,8 +45,6 @@ export class GeneratorPool<N> {
   get element() {
     return this._element;
   }
-
-  public constructor() { }
 
   /**
    * The speech generator for a math item.
@@ -163,7 +158,7 @@ export class GeneratorPool<N> {
     return this.lastSpeech;
   }
 
-  public computeSpeech(node: N, mml: string): [string, string] {
+  public computeSpeech(node: Element, mml: string): [string, string] {
     this.element = Sre.parseDOM(mml);
     let speech = this.speechGenerator.getSpeech(node as Element, this.element);
     let braille = this.brailleGenerator.getSpeech(node as Element, this.element);

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -19,9 +19,8 @@ import {mathjax} from '../../mathjax.js';
 import {Sre} from '../sre.js';
 import {OptionList} from '../../util/Options.js';
 import {LiveRegion} from '../explorer/Region.js';
-import { getLabel, setAria, buildSpeech } from '../speech/SpeechUtil.js';
-// import { MmlNode } from '../../core/MmlTree/MmlNode.js';
-// import { DOMAdaptor } from '../../core/DOMAdaptor.js';
+import { buildLabel, buildSpeech } from '../speech/SpeechUtil.js';
+import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 
 /**
  * @fileoverview Speech generator collections for enrichment and explorers.
@@ -29,7 +28,7 @@ import { getLabel, setAria, buildSpeech } from '../speech/SpeechUtil.js';
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-export class GeneratorPool {
+export class GeneratorPool<N, T, D> {
 
   private _element: Element;
 
@@ -45,6 +44,11 @@ export class GeneratorPool {
   get element() {
     return this._element;
   }
+
+  /**
+   * The adaptor to work with typeset nodes.
+   */
+  public adaptor: DOMAdaptor<N, T, D> = null;
 
   /**
    * The speech generator for a math item.
@@ -68,6 +72,12 @@ export class GeneratorPool {
   private currentBraille = 'none';
   private _options: OptionList = {};
 
+  /**
+   * Option setter that takes care of setting up SRE and assembling the options
+   * for the speech generators.
+   * 
+   * @param {OptionList} options The option list.
+   */
   public set options(options: OptionList) {
     this._options = options;
     Sre.setupEngine(options.sre);
@@ -104,8 +114,9 @@ export class GeneratorPool {
    *
    * @param {OptionList} options A list of options.
    */
-  public init(options: OptionList) {
+  public init(options: OptionList, adaptor: DOMAdaptor<N, T, D>) {
     if (this._init) return;
+    this.adaptor = adaptor;
     this.options = options;
     this._init = true;
     if (this._update(options)) {
@@ -139,68 +150,204 @@ export class GeneratorPool {
     return update;
   }
 
-  public CleanUp(node: Element) {
-    if (this.lastSummary) {
-      // TODO: Remember the speech.
-      node.setAttribute('aria-label', buildSpeech(getLabel(node))[0]);
-    }
-    this.lastSummary = false;
-  }
-  
-  // Summary computations are very fast, and we recompute in case the rule sets
-  // have changed and there is a different summary.
-  public summary(node: Element) {
-    if (this.lastSummary) {
-      this.CleanUp(node);
-      return this.lastSpeech;
-    }
-    this.lastSpeech = this.summaryGenerator.getSpeech(node, this.element)
-    return this.lastSpeech;
-  }
-
-  public computeSpeech(node: Element, mml: string): [string, string] {
+  /**
+   * Compute speech using the original MathML element as reference.
+   *
+   * @param {N} node The typeset node.
+   * @param {string} mml The serialized mml node.
+   * @return {[string, string]} Speech and Braille expression pair.
+   */
+  public computeSpeech(node: N, mml: string): [string, string] {
     this.element = Sre.parseDOM(mml);
-    let speech = this.speechGenerator.getSpeech(node as Element, this.element);
-    let braille = this.brailleGenerator.getSpeech(node as Element, this.element);
+    const xml = this.prepareXml(node);
+    const speech = this.speechGenerator.getSpeech(xml, this.element);
+    const braille = this.brailleGenerator.getSpeech(xml, this.element);
     if (this.options.enableSpeech || this.options.enableBraille) {
-      setAria(node as Element, this.options.sre.locale);
+      this.setAria(node, xml, this.options.sre.locale);
     }
     return [speech, braille];
   }
 
+  /**
+   * Computes the summary for the current node. Summary computations are very
+   * fast, and we recompute in case the rule sets have changed and there is a
+   * different summary.
+   * 
+   * @param {N} node The typeset node.
+   */
+  public summary(node: N) {
+    if (this.lastSummary) {
+      this.CleanUp(node);
+      return this.lastSpeech;
+    }
+    const xml = this.prepareXml(node);
+    this.lastSpeech = this.summaryGenerator.getSpeech(xml, this.element)
+    return this.lastSpeech;
+  }
+
+  /**
+   * Cleans up after an explorer move by replacing the aria-label with the
+   * original speech again.
+   *
+   * @param {N} node 
+   */
+  public CleanUp(node: N) {
+    if (this.lastSummary) {
+      // TODO: Remember the speech.
+      this.adaptor.setAttribute(node, 'aria-label', buildSpeech(this.getLabel(node))[0]);
+    }
+    this.lastSummary = false;
+  }
+  
+  /**
+   * Remembers the last speech element after a summary computation.
+   */
   private lastSpeech = '';
+
+  /**
+   * Remembers that the last speech computation was a summary.
+   */
   private lastSummary = false;
 
   /**
    * Updates the given speech regions, possibly reinstanting previously saved
    * speech.
    *
-   * @param {Element} node 
-   * @param {LiveRegion} speechRegion 
-   * @param {LiveRegion} brailleRegion 
+   * @param {N} node The typeset node
+   * @param {LiveRegion} speechRegion The speech region.
+   * @param {LiveRegion} brailleRegion The braille region. 
    */
-  public updateSpeech(
-    node: Element,
+  public updateRegions(
+    node: N,
     speechRegion: LiveRegion,
     brailleRegion: LiveRegion
   ) {
-    let speech = getLabel(node, this.lastSpeech);
+    let speech = this.getLabel(node, this.lastSpeech);
     speechRegion.Update(speech);
     // TODO: See if we can reuse the speech from the speech region.
-    node.setAttribute('aria-label', buildSpeech(speech)[0]);
+    this.adaptor.setAttribute(node, 'aria-label', buildSpeech(speech)[0]);
     if (this.lastSpeech) {
       this.lastSummary = true;
     }
     this.lastSpeech = '';
-    brailleRegion.Update(node.getAttribute('aria-braillelabel'));
+    brailleRegion.Update(
+      this.adaptor.getAttribute(node, 'aria-braillelabel'));
   }
 
-  public nextRules(_node: Element) {
+  /**
+   * Updates the speech in the give node.
+   *
+   * @param {N} node The typeset node.
+   */
+  public updateSpeech(node: N) {
+    const xml = this.prepareXml(node);
+    const speech = this.speechGenerator.getSpeech(xml, this.element);
+    this.setAria(node, xml, this.options.sre.locale);
+    const label = buildSpeech(speech)[0];
+    this.adaptor.setAttribute(node, 'aria-label', label);
+    return label;
+  }
+
+  /**
+   * Cycles rule sets for the speech generator.
+   *
+   * @param {N} _node The typeset node.
+   */
+  public nextRules(_node: N) {
     this.speechGenerator.nextRules();
+    this.updateSummaryGenerator();
   }
 
-  public nextStyle(node: Element) {
-    this.speechGenerator.nextStyle(node.getAttribute('data-semantic-id'));
+  /**
+   * Cycles style or preference settings for the speech generator.
+   *
+   * @param {N} node The typeset node.
+   */
+  public nextStyle(node: N) {
+    this.speechGenerator.nextStyle(
+      this.adaptor.getAttribute(node, 'data-semantic-id'));
+    this.updateSummaryGenerator();
+  }
+
+  /**
+   * Copies domain and style option from speech to summary generator. This is
+   * necessary after when either option is changed on the fly.
+   */
+  private updateSummaryGenerator() {
+    const options = this.speechGenerator.getOptions();
+    this.summaryGenerator.setOption('domain', options['domain']);
+    this.summaryGenerator.setOption('style', options['style']);
+  }
+
+  /**
+   * Makes a node amenable for SRE computations by reparsing.
+   *
+   * @param {N} node The node.
+   */
+  private prepareXml(node: N) {
+    return Sre.parseDOM(this.adaptor.serializeXML(node));
+  }
+
+  /**
+   * Speech, labels and aria
+   */
+
+  /**
+   * Computes the speech label from the node combining prefixes and postfixes.
+   *  
+   * @param {N} node The typeset node.
+   * @param {string=} center Core speech. Defaults to `data-semantic-speech`.
+   * @param {string=} sep The speech separator. Defaults to space.
+   */
+  public getLabel(node: N,
+                  center: string = '',
+                  sep: string = ' ') {
+    return buildLabel(
+      center || this.adaptor.getAttribute(node, 'data-semantic-speech'),
+      this.adaptor.getAttribute(node, 'data-semantic-prefix'),
+      // TODO: check if we need this or if it is automatic by the screen readers.
+      this.adaptor.getAttribute(node, 'data-semantic-postfix'),
+      sep
+    );
+  }
+
+  private copyAttributes(xml: Element, node: N, attr: string) {
+    const value = xml.getAttribute(attr);
+    if (value !== undefined && value !== null) {
+      this.adaptor.setAttribute(node, attr, value);
+    }
+  }
+
+  private attrList: string[] = [
+    'data-semantic-prefix',
+    'data-semantic-postfix',
+    'data-semantic-speech',
+    'data-semantic-braille',
+  ]
+  
+  /**
+   * Retrieve and sets aria and braille labels recursively.
+   * @param {MmlNode} node The root node to search from.
+   */
+  public setAria(node: N, xml: Element, locale: string) {
+    this.attrList.forEach(attr => this.copyAttributes(xml, node, attr));
+    const speech = this.getLabel(node);
+    if (speech) {
+      this.adaptor.setAttribute(node, 'aria-label', buildSpeech(speech, locale)[0]);
+    }
+    const braille = this.adaptor.getAttribute(node, 'data-semantic-braille');
+    if (braille) {
+      this.adaptor.setAttribute(node, 'aria-braillelabel', braille);
+    }
+    const xmlChildren = Array.from(xml.childNodes);
+    Array.from(this.adaptor.childNodes(node)).forEach(
+      (child, index) => {
+        if (this.adaptor.kind(child) !== '#text' &&
+          this.adaptor.kind(child) !== '#comment') {
+          this.setAria(child as N, xmlChildren[index] as Element, locale);
+        }
+      }
+    );
   }
 
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -69,6 +69,7 @@ export class GeneratorPool {
 
   public set options(options: OptionList) {
     this._options = options;
+    Sre.setupEngine(options.sre);
     this.speechGenerator.setOptions(Object.assign(
       {}, options?.sre || {}, {
         modality: 'speech',
@@ -94,6 +95,8 @@ export class GeneratorPool {
     return this._options;
   }
 
+  private _init = false;
+
   /**
    * Init method for speech generation. Runs a retry until locales have been
    * loaded.
@@ -101,7 +104,9 @@ export class GeneratorPool {
    * @param {OptionList} options A list of options.
    */
   public init(options: OptionList) {
+    if (this._init) return;
     this.options = options;
+    this._init = true;
     if (this._update(options)) {
       mathjax.retryAfter(Sre.sreReady());
     }
@@ -113,9 +118,9 @@ export class GeneratorPool {
    *
    * @param {OptionList} options A list of options.
    */
-  public async update(options: OptionList) {
+  public update(options: OptionList) {
     this.options = options;
-    return this._update(options) ? Sre.sreReady() : Promise.resolve();
+    return this._update(options);
   }
 
   private _update(options: OptionList) {

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -21,11 +21,11 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import { SpeechExplorer } from './explorer/KeyExplorer.js';
-import { ExplorerMathItem } from './explorer.js';
-import {MJContextMenu} from '../ui/menu/MJContextMenu.js';
-import {SubMenu, Submenu} from '../ui/menu/mj-context-menu.js';
-import {Sre} from './sre.js';
+import { SpeechExplorer } from '../explorer/KeyExplorer.js';
+import { ExplorerMathItem } from '../explorer.js';
+import {MJContextMenu} from '../../ui/menu/MJContextMenu.js';
+import {SubMenu, Submenu} from '../../ui/menu/mj-context-menu.js';
+import {Sre} from '../sre.js';
 
 /**
  * Values for the ClearSpeak preference variables.

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -21,7 +21,6 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import { SpeechExplorer } from '../explorer/KeyExplorer.js';
 import { ExplorerMathItem } from '../explorer.js';
 import {MJContextMenu} from '../../ui/menu/MJContextMenu.js';
 import {SubMenu, Submenu} from '../../ui/menu/mj-context-menu.js';
@@ -170,12 +169,14 @@ export function clearspeakMenu(menu: MJContextMenu, sub: Submenu) {
   let locale = menu.pool.lookup('locale').getValue() as string;
   const box = csSelectionBox(menu, locale);
   let items: Object[] = [];
-  const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.explorers?.speech as SpeechExplorer;
-  const semantic = explorer.semanticFocus();
+  const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.speech();
+  const semantic = explorer?.semanticFocus();
   const previous = Sre.clearspeakPreferences.currentPreference();
-  const smart = Sre.clearspeakPreferences.relevantPreferences(semantic);
   items = items.concat(basePreferences(previous));
-  items = items.concat(smartPreferences(previous, smart, locale));
+  if (semantic) {
+    const smart = Sre.clearspeakPreferences.relevantPreferences(semantic);
+    items = items.concat(smartPreferences(previous, smart, locale));
+  }
   if (box) {
     items.splice(2, 0, box);
   }

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -169,7 +169,7 @@ export function clearspeakMenu(menu: MJContextMenu, sub: Submenu) {
   let locale = menu.pool.lookup('locale').getValue() as string;
   const box = csSelectionBox(menu, locale);
   let items: Object[] = [];
-  const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.speech();
+  const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.speech;
   const semantic = explorer?.semanticFocus();
   const previous = Sre.clearspeakPreferences.currentPreference();
   items = items.concat(basePreferences(previous));

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -170,17 +170,12 @@ export function clearspeakMenu(menu: MJContextMenu, sub: Submenu) {
   let locale = menu.pool.lookup('locale').getValue() as string;
   const box = csSelectionBox(menu, locale);
   let items: Object[] = [];
-  let explorer = (menu.mathItem as ExplorerMathItem)?.
-    explorers?.explorers?.speech as SpeechExplorer;
-  if (explorer?.walker) {
-    let semantic = explorer.walker.getFocus()?.getSemanticPrimary();
-    if (semantic) {
-      const previous = Sre.clearspeakPreferences.currentPreference();
-      const smart = Sre.clearspeakPreferences.relevantPreferences(semantic);
-      items = items.concat(basePreferences(previous));
-      items = items.concat(smartPreferences(previous, smart, locale));
-    }
-  }
+  const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.explorers?.speech as SpeechExplorer;
+  const semantic = explorer.semanticFocus();
+  const previous = Sre.clearspeakPreferences.currentPreference();
+  const smart = Sre.clearspeakPreferences.relevantPreferences(semantic);
+  items = items.concat(basePreferences(previous));
+  items = items.concat(smartPreferences(previous, smart, locale));
   if (box) {
     items.splice(2, 0, box);
   }

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -157,6 +157,13 @@ function extractProsody(attr: string) {
   return [match[1], match[2]];
 }
 
+
+/**
+ *
+ * Speech, labels and aria
+ *
+ */
+
 /**
  * Computes the aria-label from the node.
  * @param {MmlNode} node The Math element.
@@ -222,6 +229,7 @@ export function setAria(node: MmlNode, locale: string) {
   const attributes = node.attributes;
   if (!attributes) return;
   const speech = getLabel(node);
+  console.log(speech);
   if (speech) {
     attributes.set('aria-label', buildSpeech(speech, locale)[0]);
   }
@@ -238,8 +246,8 @@ export function setAria(node: MmlNode, locale: string) {
  * Updates Aria labels.
  * @param {MmlNode} node The root node to search from.
  */
-export function updateAria(node: HTMLElement, locale: string) {
-  let speech = node.getAttribute('data-semantic-speech');
+export function updateAria(node: HTMLElement, locale: string) { 
+ let speech = node.getAttribute('data-semantic-speech');
   if (speech) {
     node.setAttribute('aria-label', buildSpeech(speech, locale)[0]);
   }

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -164,17 +164,32 @@ function extractProsody(attr: string) {
  */
 function getLabel(node: MmlNode, sep: string = ' ') {
   const attributes = node.attributes;
-  const speech = attributes.getExplicit('data-semantic-speech') as string;
+  return buildLabel(
+    attributes.getExplicit('data-semantic-speech') as string,
+    attributes.getExplicit('data-semantic-prefix') as string,
+    // TODO: check if we need this or if it is automatic by the screen readers.
+    attributes.getExplicit('data-semantic-postfix') as string,
+    sep
+  );
+}
+
+/**
+ * Builds a speech label from input components.
+ *
+ * @param speech The speech string.
+ * @param prefix The prefix expression.
+ * @param postfix The postfix expression.
+ * @param sep The separator string. Defaults to space.
+ */
+export function buildLabel(
+  speech: string, prefix: string, postfix: string, sep: string = ' ') {
   if (!speech) {
     return '';
   }
   const label = [speech];
-  const prefix = attributes.getExplicit('data-semantic-prefix') as string;
   if (prefix) {
     label.unshift(prefix);
   }
-  // TODO: check if we need this or if it is automatic by the screen readers.
-  const postfix = attributes.getExplicit('data-semantic-postfix') as string;
   if (postfix) {
     label.push(postfix);
   }

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -164,18 +164,25 @@ function extractProsody(attr: string) {
  *
  */
 
+function getAttribute(node: MmlNode | Element, attr: string): string {
+  return (node instanceof Element) ?
+    node.getAttribute(attr) :
+    node.attributes.getExplicit(attr) as string;
+}
+
 /**
  * Computes the aria-label from the node.
  * @param {MmlNode} node The Math element.
  * @param {string=} sep The speech separator. Defaults to space.
  */
-function getLabel(node: MmlNode, sep: string = ' ') {
-  const attributes = node.attributes;
+export function getLabel(node: MmlNode | Element,
+                  center: string = 'data-semantic-speech',
+                  sep: string = ' ') {
   return buildLabel(
-    attributes.getExplicit('data-semantic-speech') as string,
-    attributes.getExplicit('data-semantic-prefix') as string,
+    getAttribute(node, center),
+    getAttribute(node, 'data-semantic-prefix'),
     // TODO: check if we need this or if it is automatic by the screen readers.
-    attributes.getExplicit('data-semantic-postfix') as string,
+    getAttribute(node, 'data-semantic-postfix'),
     sep
   );
 }
@@ -229,11 +236,10 @@ export function setAria(node: MmlNode, locale: string) {
   const attributes = node.attributes;
   if (!attributes) return;
   const speech = getLabel(node);
-  console.log(speech);
   if (speech) {
     attributes.set('aria-label', buildSpeech(speech, locale)[0]);
   }
-  const braille = node.attributes.getExplicit('data-semantic-braille') as string;
+  const braille = getAttribute(node, 'data-semantic-braille');
   if (braille) {
     attributes.set('aria-braillelabel', braille);
   }
@@ -247,7 +253,7 @@ export function setAria(node: MmlNode, locale: string) {
  * @param {MmlNode} node The root node to search from.
  */
 export function updateAria(node: HTMLElement, locale: string) { 
- let speech = node.getAttribute('data-semantic-speech');
+  let speech = node.getAttribute('data-semantic-speech');
   if (speech) {
     node.setAttribute('aria-label', buildSpeech(speech, locale)[0]);
   }

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -21,8 +21,8 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import {MmlNode} from '../core/MmlTree/MmlNode.js';
-import Sre from './sre.js';
+import {MmlNode} from '../../core/MmlTree/MmlNode.js';
+import Sre from '../sre.js';
 
 const ProsodyKeys = [ 'pitch', 'rate', 'volume' ];
 

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -158,27 +158,8 @@ function extractProsody(attr: string) {
 
 
 /**
- *
  * Speech, labels and aria
- *
  */
-
-/**
- * Computes the aria-label from the node.
- * @param {MmlNode} node The Math element.
- * @param {string=} sep The speech separator. Defaults to space.
- */
-export function getLabel(node: Element,
-                  center: string = '',
-                  sep: string = ' ') {
-  return buildLabel(
-    center || node.getAttribute('data-semantic-speech'),
-    node.getAttribute('data-semantic-prefix'),
-    // TODO: check if we need this or if it is automatic by the screen readers.
-    node.getAttribute('data-semantic-postfix'),
-    sep
-  );
-}
 
 /**
  * Builds a speech label from input components.
@@ -219,26 +200,6 @@ export function buildSpeech(speech: string, locale: string = 'en',
     ` xml:lang="${locale}">` +
     `<prosody rate="${rate}%">${speech}`+
     '</prosody></speak>');
-}
-
-/**
- * Retrieve and sets aria and braille labels recursively.
- * @param {MmlNode} node The root node to search from.
- */
-export function setAria(node: Element, locale: string) {
-  const speech = getLabel(node);
-  if (speech) {
-    node.setAttribute('aria-label', buildSpeech(speech, locale)[0]);
-  }
-  const braille = node.getAttribute('data-semantic-braille');
-  if (braille) {
-    node.setAttribute('aria-braillelabel', braille);
-  }
-  for (let child of Array.from(node.childNodes)) {
-    if (child instanceof Element) {
-      setAria(child, locale);
-    }
-  }
 }
 
 /**

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -21,7 +21,6 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import {MmlNode} from '../../core/MmlTree/MmlNode.js';
 import Sre from '../sre.js';
 
 const ProsodyKeys = [ 'pitch', 'rate', 'volume' ];
@@ -164,31 +163,19 @@ function extractProsody(attr: string) {
  *
  */
 
-function getAttribute(node: MmlNode | Element, attr: string): string {
-  return (node instanceof Element) ?
-    node.getAttribute(attr) :
-    node.attributes.getExplicit(attr) as string;
-}
-
-function setAttribute(node: MmlNode | Element, attr: string, value: string) {
-  return (node instanceof Element) ?
-    node.setAttribute(attr, value) :
-    node.attributes.set(attr, value);
-}
-
 /**
  * Computes the aria-label from the node.
  * @param {MmlNode} node The Math element.
  * @param {string=} sep The speech separator. Defaults to space.
  */
-export function getLabel(node: MmlNode | Element,
+export function getLabel(node: Element,
                   center: string = '',
                   sep: string = ' ') {
   return buildLabel(
-    center || getAttribute(node, 'data-semantic-speech'),
-    getAttribute(node, 'data-semantic-prefix'),
+    center || node.getAttribute('data-semantic-speech'),
+    node.getAttribute('data-semantic-prefix'),
     // TODO: check if we need this or if it is automatic by the screen readers.
-    getAttribute(node, 'data-semantic-postfix'),
+    node.getAttribute('data-semantic-postfix'),
     sep
   );
 }
@@ -238,18 +225,17 @@ export function buildSpeech(speech: string, locale: string = 'en',
  * Retrieve and sets aria and braille labels recursively.
  * @param {MmlNode} node The root node to search from.
  */
-export function setAria(node: MmlNode | Element, locale: string) {
+export function setAria(node: Element, locale: string) {
   const speech = getLabel(node);
   if (speech) {
-    setAttribute(node, 'aria-label', buildSpeech(speech, locale)[0]);
+    node.setAttribute('aria-label', buildSpeech(speech, locale)[0]);
   }
-  const braille = getAttribute(node, 'data-semantic-braille');
+  const braille = node.getAttribute('data-semantic-braille');
   if (braille) {
-    setAttribute(node, 'aria-braillelabel', braille);
+    node.setAttribute('aria-braillelabel', braille);
   }
-  let children = node.childNodes as (MmlNode | Element)[];
-  for (let child of children) {
-    if (child instanceof Element || child.attributes) {
+  for (let child of Array.from(node.childNodes)) {
+    if (child instanceof Element) {
       setAria(child, locale);
     }
   }

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -23,8 +23,6 @@
  */
 
 import * as Api from '#sre/common/system.js';
-import {Walker} from '#sre/walker/walker.js';
-import * as WalkerFactory from '#sre/walker/walker_factory.js';
 import * as SpeechGeneratorFactory from '#sre/speech_generator/speech_generator_factory.js';
 import { Engine } from '#sre/common/engine.js';
 import {ClearspeakPreferences} from '#sre/speech_rules/clearspeak_preferences.js';
@@ -40,9 +38,6 @@ export namespace Sre {
   export type highlighter = Highlighter;
 
   export type speechGenerator = SpeechGenerator;
-
-  export type walker = Walker;
-
 
   export const locales = Variables.LOCALES;
 
@@ -63,8 +58,6 @@ export namespace Sre {
   export const updateHighlighter = HighlighterFactory.update;
 
   export const getSpeechGenerator = SpeechGeneratorFactory.generator;
-
-  export const getWalker = WalkerFactory.walker;
 
   export const parseDOM = parseInput;
 

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -26,7 +26,7 @@ import * as Api from '#sre/common/system.js';
 import {Walker} from '#sre/walker/walker.js';
 import * as WalkerFactory from '#sre/walker/walker_factory.js';
 import * as SpeechGeneratorFactory from '#sre/speech_generator/speech_generator_factory.js';
-import Engine from '#sre/common/engine.js';
+import { Engine } from '#sre/common/engine.js';
 import {ClearspeakPreferences} from '#sre/speech_rules/clearspeak_preferences.js';
 import {Highlighter} from '#sre/highlighter/highlighter.js';
 import * as HighlighterFactory from '#sre/highlighter/highlighter_factory.js';

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -492,7 +492,7 @@ export class Menu {
         this.a11yVar<string>('locale', value => {
           MathJax._.a11y.sre.Sre.setupEngine({locale: value as string});
         }),
-        this.a11yVar<string> ('speechRules', value => {
+        this.a11yVar<string>('speechRules', value => {
           const [domain, style] = value.split('-');
           this.document.options.sre.domain = domain;
           this.document.options.sre.style = style;

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -32,7 +32,7 @@ import {AssistiveMmlMathDocument, AssistiveMmlMathItem} from '../../a11y/assisti
 import {expandable} from '../../util/Options.js';
 
 import {Menu} from './Menu.js';
-import '../../a11y/SpeechMenu.js';
+import '../../a11y/speech/SpeechMenu.js';
 
 /*==========================================================================*/
 


### PR DESCRIPTION
PR introduces a `GeneratorPool` data structure that 
* coordinates the computation of speech. 
* takes care of async locale loading.

This makes the speech computation considerably cleaner. In particular there is no longer speech computation in the semantic enrichment method. Speech can be computed if the `speech="deep"` option is set. 
All Speech is now computed in the `attachSpeech` method, where originally only the `aria-label` was set. 

Since the `attachSpeech` state is called after rerender, this also takes care of computing speech for the collapsed elements etc. 

Another side effect is that we no longer use the walkers provided by SRE, which makes syncing a lot easier. At the moment only the walking and summary functionality is ported. The rest will be ported in a subsequent PR. 

**Note:** Currently only works with SRE branch `new_explorer_changes`. I'll try to merge that asap.

