### PR TITLE
Update handling of braket bars so that the enclosing braket can be more accurately found. (mathjax/MathJax#3164)

### DIFF
--- a/ts/input/tex/Stack.ts
+++ b/ts/input/tex/Stack.ts
@@ -127,7 +127,7 @@ export default class Stack {
 
 
   /**
-   * Lookup the nth elements on the stack without removing them.
+   * Look up the nth elements on the stack without removing them.
    * @param {number=} n Position of element that should be returned. Default 1.
    * @return {StackItem} Nth item on the stack.
    */
@@ -137,7 +137,7 @@ export default class Stack {
 
 
   /**
-   * Lookup the topmost element on the stack, returning the Mml node in that
+   * Look up the topmost element on the stack, returning the Mml node in that
    * item. Optionally pops the Mml node from that stack item.
    * @param {boolean=} noPop Pop top item if true.
    * @return {MmlNode} The Mml node in the topmost stack item.
@@ -145,6 +145,14 @@ export default class Stack {
   public Prev(noPop?: boolean): MmlNode | void {
     const top = this.Top();
     return noPop ? top.First : top.Pop();
+  }
+
+  /**
+   * Look up the current number of stack items.
+   * @return {number}  The number of items on the stack.
+   */
+  public get height(): number {
+    return this.stack.length;
   }
 
 

--- a/ts/input/tex/braket/BraketConfiguration.ts
+++ b/ts/input/tex/braket/BraketConfiguration.ts
@@ -35,7 +35,8 @@ export const BraketConfiguration = Configuration.create(
     },
     items: {
       [BraketItem.prototype.kind]: BraketItem,
-    }
+    },
+    priority: 3   // must come before base configuration
   }
 );
 


### PR DESCRIPTION
This PR fixes a problem where the `BraketMethods.Bar()` function doesn't find the enclosing `braket` item properly when there are certain types of enclosing elements (like style or color changes).

To do this, we add a function to the `Stack` object to get its current height (the number of elements on the stack), and save that in the `braket` item's `env` object, which will be available in the parser stack's `env` object.  Then the `BraketMethods.Bar()` function can use `parser.stack.env.braketItem` to find the matching `braket` item without having to look through the stack items to find it.  (The current approach doesn't work if there are intervening items other than an `over` item).

We also set the `braket` package priority so that it is searched before the `base` package, guaranteeing that the `braket` function for `|` is used rather than the `base` one.

Finally, we fix a few comments along the way.

Resolves issue mathjax/MathJax#3164.