### PR TITLE
Make sure math item have their metrics set before lazy typesetting.  (mathjax/MathJax#3167)

### DIFF
--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -604,6 +604,9 @@ B extends MathDocumentConstructor<HTMLDocument<N, T, D>>>(
         if (math.lazyCompile) {
           math.state(STATE.COMPILED - 1);
           state = STATE.COMPILED;
+        } else if (!math.metrics.hasOwnProperty('em')) {
+          math.state(STATE.METRICS - 1);
+          state = STATE.METRICS;
         } else {
           math.state(STATE.TYPESET - 1);
         }


### PR DESCRIPTION
This PR resolves a problem when the lazy typesetter is used with the assistive MathML extension and the initial typesetting is disabled with SVG output.  In that case, any math that is showing initially will get a bad `viewBox` for their `svg` element due to the fact that the metrics for the surrounding font haven't been computed.  We fix this by checking whether the metrics are available and setting the state to before the measuring of metrics in that case.

Resolves issue mathjax/MathJax#3167.