### PR TITLE
Fix issues with line breaks and spacing in SVG output. (mathjax/MathJax#3166)

### DIFF
--- a/ts/output/common/LineBBox.ts
+++ b/ts/output/common/LineBBox.ts
@@ -99,7 +99,7 @@ export class LineBBox extends BBox {
    */
   public append(cbox: LineBBox) {
     if (this.isFirst) {
-      cbox.originalL = cbox.L;
+      cbox.originalL += cbox.L;
       cbox.L = 0;  // remove spacing after an operator with a linebreak after it
     }
     if (cbox.indentData) {

--- a/ts/output/common/Wrappers/mspace.ts
+++ b/ts/output/common/Wrappers/mspace.ts
@@ -201,7 +201,8 @@ export function CommonMspaceMixin<
       const bbox = LineBBox.from(BBox.zero(), leading);
       if (i === 1) {
         bbox.getIndentData(this.node);
-        bbox.isFirst = true;
+        bbox.w = this.getBBox().w;
+        bbox.isFirst = (bbox.w === 0);
       }
       return bbox;
     }

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -397,12 +397,12 @@ CommonOutputJax<
       if (forced && mo.node.attributes.get('linebreakstyle') === 'after') {
         const k = mml.parent.node.childIndex(mml.node) + 1;
         const next = mml.parent.childNodes[k];
-        const dimen = (next ? next.getLineBBox(0).originalL : 0) * scale;
+        const dimen = (next ? next.getLineBBox(0).originalL * scale : 0);
         if (dimen) {
           this.addInlineBreak(nsvg, dimen, forced);
         }
       } else if (forced || i) {
-        const dimen = (mml && i ? mml.getLineBBox(0).originalL : 0) * scale;
+        const dimen = (mml && i ? mml.getLineBBox(0).originalL * scale : 0);
         if (dimen || !forced) {
           this.addInlineBreak(nsvg, dimen, forced || !!mml.node.getProperty('forcebreak'));
         }


### PR DESCRIPTION
This issue fixes several issues with in-line line breaking in SVG mode that arise when extra spacing is placed around operators, as is done by `\implies`, or `A\;+\;B`, for example.  When in-line breaks are allowed, SVG output will lose the spacing around the operator (both the extra spacing as well as the normal operator spacing).

Both issues are cause primarily by the `computeLineBBox()` function for the SVG `mspace` wrapper.  The size of the space was lost because the width was not being added to the `LineBBox`, and the operator spacing was lost because the `isFirst` property was assuming that the mspace had no width (i.e., was used for line-breaking only).

I also moved `* scale` inside a conditional since there is no need to multiply 0 by the scale.

The `LineBBox.append()` is modified to make sure that `originalL` is not lost if it has already been set earlier on.

Resolves issue mathjax/MathJax#3166.