### PR TITLE
Add xmlns for global cache svg element.  (mathjax/MathJax-demos-node#58)

### DIFF
--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -198,7 +198,11 @@ CommonOutputJax<
    */
   public pageElements(html: MathDocument<N, T, D>) {
     if (this.options.fontCache === 'global' && !this.findCache(html)) {
-      return this.svg('svg', {id: SVG.FONTCACHEID, style: {display: 'none'}}, [this.fontCache.getCache()]);
+      return this.svg('svg', {
+        xmlns: SVGNS,
+        id: SVG.FONTCACHEID,
+        style: {display: 'none'}
+      }, [this.fontCache.getCache()]);
     }
     return null as N;
   }


### PR DESCRIPTION
This PR adds the `xmlns` attribute to the `svg` element used for the global font cache.  This is needed in XHTML output for the links to the global definitions to work properly.

Resolves issue mathjax/MathJax-demos-node#58.