### PR TITLE
Update LiteParser's serializeXML.  (mathjax/MathJax-demos-node#58)

### DIFF
--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -91,6 +91,12 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     script: true
   };
 
+  public static XMLNS: {[name: string]: string} = {
+    svg:  'http://www.w3.org/2000/svg',
+    math: 'http://www.w3.org/1998/Math/MathML',
+    html: 'http://www.w3.org/1999/xhtml'
+  };
+
   /**
    * @override
    */
@@ -365,8 +371,18 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
    */
   protected allAttributes(adaptor: LiteAdaptor, node: LiteElement, xml: boolean): AttributeData[] {
     let attributes = adaptor.allAttributes(node);
+    //
+    // If we aren't in XML mode, just use the attributes given
+    //
+    if (!xml) {
+      return attributes;
+    }
+    //
+    // Check that we know the namespace for the kind of node
+    //
     const kind = adaptor.kind(node);
-    if (!xml || (kind !== 'svg' && kind !== 'math' && kind !== 'html')) {
+    const xmlns = (this.constructor as typeof LiteParser).XMLNS;
+    if (!xmlns.hasOwnProperty(kind)) {
       return attributes;
     }
     //
@@ -380,14 +396,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     //
     // Add one of it is missing
     //
-    attributes.push({
-      name: 'xmlns',
-      value: ({
-        svg:  'http://www.w3.org/2000/svg',
-        math: 'http://www.w3.org/1998/Math/MathML',
-        html: 'http://www.w3.org/1999/xhtml'
-      })[kind]
-    });
+    attributes.push({name: 'xmlns', value: xmlns[kind]});
     return attributes;
   }
 


### PR DESCRIPTION
This PR fixes two problems with the LiteDOM `serializeXML()` method.  It protects `<` and `>` in attributes, which is not needed for HTML, but is for XHTML, and it adds namespaces for `html`, `svg`, and `math` elements, if they don't already have one.

Resolves an issue from mathjax/MathJax-demos-node#58.