### PR TITLE
Fix processing of \U{...}.

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -557,6 +557,7 @@ export const ParseUtil = {
               //  Replace \U{...} with specified character
               const c = String.fromCodePoint(parseInt(arg[1] || arg[2], 16));
               text = text.substring(0, i - 2) + c + text.substring(i + arg[0].length);
+              i = i - 2 + c.length;;
             }
           }
         }


### PR DESCRIPTION
This PR fixes the index being used when `\U{...}` has been found so that it is at the correct location to continue processing.  Without this, two occurrences of `\U` in a row will not process the second one.  E.g., `\text{\U{61}\U{62}}` would produce `a\U{62}` rather than `ab`.