### PR TITLE
Move \divsymbol to physics package and add \divisionsymbol. (mathjax/MathJax#3173)

### DIFF
--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -222,7 +222,6 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   bullet:       '\u2219',
   wr:           '\u2240',
   div:          '\u00F7',
-  divsymbol:    '\u00F7',
   odot:         ['\u2299', {largeop: false}],
   oslash:       ['\u2298', {largeop: false}],
   otimes:       ['\u2297', {largeop: false}],

--- a/ts/input/tex/physics/PhysicsMappings.ts
+++ b/ts/input/tex/physics/PhysicsMappings.ts
@@ -65,7 +65,10 @@ new CharacterMap('Physics-vector-mo', ParseMethods.mathchar0mo, {
   cross:         '\u00D7',
   cp:            '\u00D7',
   // This is auxiliary!
-  gradientnabla: ['\u2207', {mathvariant: TexConstant.Variant.BOLD}]
+  gradientnabla: ['\u2207', {mathvariant: TexConstant.Variant.BOLD}],
+  // Replacements for original latex \div (physics2, and physics versions)
+  divsymbol:     '\u00F7',
+  divisionsymbol: '\u00F7'
 });
 
 new CharacterMap('Physics-vector-mi', ParseMethods.mathchar0mi, {


### PR DESCRIPTION
This PR moves the `\divsymbol` mapping from the `base` package to the `physics` package, where it comes from in actual LaTeX, and adds `\divisionsymbol` as well.  It looks like the LaTeX `physics` package uses `\divisionsymbol`, while `physics2` uses `\divsymbol`.

Resolves issue mathjax/MathJax#3173.