### PR TITLE
Fix \require to properly handle retries in dependencies.  (mathjax/MathJax#3170)

### DIFF
--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -41,7 +41,7 @@ import {expandable} from '../../../util/Options.js';
 const MJCONFIG = MathJax.config;
 
 /**
- * Add an extension to the configuration, and configure its user options
+ * Load any dependencies for an extension, and add the extension to the input jax.
  *
  * @param {TeX} jax       The TeX jax whose configuration is to be modified
  * @param {string} name   The name of the extension being added (e.g., '[tex]/amscd')

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -53,36 +53,57 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
   if (required.indexOf(extension) < 0) {
     required.push(extension);
     //
-    //  Register any dependencies that were loaded to handle this one
+    //  Register any dependencies that were loaded to handle this one,
+    //  and save the retry promise, if any, for when the dependencies need
+    //  to restart the expression (due to preprocessors, see below).
     //
-    RegisterDependencies(jax, LOADERCONFIG.dependencies[name]);
+    let retry = RegisterDependencies(jax, LOADERCONFIG.dependencies[name]);
     //
-    //  If the required file loaded an extension...
+    // If we need to restart the expression due to the dependencies,
+    //   Wait for the dependencies to load, process this extension, then retry,
+    // Otherwise, process the extension now.
     //
-    const handler = ConfigurationHandler.get(extension);
-    if (handler) {
-      //
-      //  Check if there are user-supplied options
-      //    (place them in a block for the extension, if needed)
-      //
-      let options = MJCONFIG[name] || {};
-      if (handler.options && Object.keys(handler.options).length === 1 && handler.options[extension]) {
-        options = {[extension]: options};
-      }
-      //
-      //  Register the extension with the jax's configuration
-      //
-      (jax as any).configuration.add(extension, jax, options);
-      //
-      // If there are preprocessors, restart so that they run
-      // (we don't have access to the document or MathItem needed to call
-      //  the preprocessors from here)
-      //
-      const configured = jax.parseOptions.packageData.get('require').configured;
-      if (handler.preprocessors.length && !configured.has(extension)) {
-        configured.set(extension, true);
-        mathjax.retryAfter(Promise.resolve());
-      }
+    if (retry) {
+      mathjax.retryAfter(retry.then(() => ProcessExtension(jax, name, extension)));
+    } else {
+      ProcessExtension(jax, name, extension);
+    }
+  }
+}
+
+/**
+ * Add an extension to the configuration, and configure its user options
+ *
+ * @param {TeX} jax       The TeX jax whose configuration is to be modified
+ * @param {string} name   The name of the extension being added (e.g., '[tex]/amscd')
+ */
+function ProcessExtension(jax: TeX<any, any, any>, name: string, extension: string) {
+  //
+  //  If the required file loaded an extension...
+  //
+  const handler = ConfigurationHandler.get(extension);
+  if (handler) {
+    //
+    //  Check if there are user-supplied options
+    //    (place them in a block for the extension, if needed)
+    //
+    let options = MJCONFIG[name] || {};
+    if (handler.options && Object.keys(handler.options).length === 1 && handler.options[extension]) {
+      options = {[extension]: options};
+    }
+    //
+    //  Register the extension with the jax's configuration
+    //
+    (jax as any).configuration.add(extension, jax, options);
+    //
+    //  If there are preprocessors, restart the typesetting so that they run
+    //  (we don't have access to the document or MathItem needed to call
+    //   the preprocessors from here)
+    //
+    const configured = jax.parseOptions.packageData.get('require').configured;
+    if (handler.preprocessors.length && !configured.has(extension)) {
+      configured.set(extension, true);
+      mathjax.retryAfter(Promise.resolve());
     }
   }
 }
@@ -92,14 +113,23 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
  *
  * @param {TeX} jax          The jax whose configuration is being modified
  * @param {string[]} names   The names of the dependencies to register
+ * @return {Promise<any>}    A promise resolved when all dependency's retries
+ *                             are complete (or null if no retries)
  */
-function RegisterDependencies(jax: TeX<any, any, any>, names: string[] = []) {
+function RegisterDependencies(jax: TeX<any, any, any>, names: string[] = []): Promise<any> {
   const prefix = jax.parseOptions.options.require.prefix;
+  const retries = [];
   for (const name of names) {
     if (name.substring(0, prefix.length) === prefix) {
-      RegisterExtension(jax, name);
+      try {
+        RegisterExtension(jax, name);
+      } catch (err) {
+        if (!err.retry) throw err;
+        retries.push(err.retry);
+      }
     }
   }
+  return (retries.length ? Promise.all(retries) : null);
 }
 
 /**


### PR DESCRIPTION
When `\require{}` is used to load an extension, then if the extension has preprocessors, that means the the expression needs to be re-typeset so that the preprocessors will be run.  This is handled by calling `mathjax.retryAfter()` during the `RegisterExtension()` function.

If the extension has other extensions as dependencies, then they may also cause re-typesetting if they have preprocessors.  That means the `RegisterDependencies()` function may throw a `retry` error, which stops the processing of the dependencies, and prevents the remainder of the `RegisterExtension()` function from completing.

This occurs, for example, when `\require{textcomp}` is processed, as `textcomp` depends on `textmacros`, and the latter has preprocessors, so `retryAfter()` is called when the `textmacros` dependency is registered.  That means the `RegisterExtension()` for the `textcomp` will be interrupted at the `RegisterDependencies()` call, and the rest won't be processed.  Because `textcomp` has already been pushed onto the `required` array, the retype setting will not run the main code for `RegisterExtension`, and `textcomp` won't be properly added to the configuration.  That means that the macros won't be defined, leading to unexpected errors reporting undefined macros.

This PR resolves the problem by trapping the `retry` errors in the `RegisterDependencies()` function and returning either `null` if there were none, or a promise that resolves when all the dependencies are loaded.  The `RegisterExtension` function then either waits for these those promises and adds the main extension, restarting the typesetting after that, or if there are no dependency promises, it adds the extension immediately and continues processing the expression.  To make that easier, the main part of `RegisterExtension` has been broken out into a new `ProcessExtension()` function that can be called in either situation.

Resolves issue mathjax/MathJax#3170.