### PR TITLE
Refactor/explorer depth

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { honk } from '../speech/SpeechUtil.js';
+import { honk, InPlace } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 
@@ -312,6 +312,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   public depth(node: HTMLElement): HTMLElement {
     this.generators.depth(node, !!this.actionable(node));
     this.refocus(node);
+    this.generators.lastMove = InPlace.DEPTH;
     return node;
   }
 
@@ -337,6 +338,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   public summary(node: HTMLElement): HTMLElement {
     this.generators.summary(node);
     this.refocus(node);
+    this.generators.lastMove = InPlace.SUMMARY;
     return node;
   }
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -295,6 +295,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     ['<', this.nextStyle.bind(this)],
     ['x', this.summary.bind(this)],
     ['-', this.expand.bind(this)],
+    ['d', this.depth.bind(this)],
   ]);
 
   /**
@@ -306,6 +307,12 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
   private actionable(node: HTMLElement): HTMLElement {
     const parent = node?.parentNode as HTMLElement;
     return parent && this.highlighter.isMactionNode(parent) ? parent : null;
+  }
+
+  public depth(node: HTMLElement): HTMLElement {
+    this.generators.depth(node, !!this.actionable(node));
+    this.refocus(node);
+    return node;
   }
 
   /**

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -378,4 +378,19 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
+  public depth(node: N, actionable: boolean) {
+    if (this.lastSummary) {
+      this.CleanUp(node);
+      return this.lastSpeech;
+    }
+    let postfix = this.summaryGenerator.getExpandable(
+      actionable ?
+        (this.adaptor.childNodes(node).length === 0 ? -1 : 1)
+        : 0);
+    const depth = this.summaryGenerator.getLevel(
+      this.adaptor.getAttribute(node, 'aria-level'));
+    this.lastSpeech = `${depth} ${postfix}`;
+    return this.lastSpeech;
+  }
+
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -19,7 +19,7 @@ import {mathjax} from '../../mathjax.js';
 import {Sre} from '../sre.js';
 import {OptionList} from '../../util/Options.js';
 import {LiveRegion} from '../explorer/Region.js';
-import { buildLabel, buildSpeech } from '../speech/SpeechUtil.js';
+import { buildLabel, buildSpeech, InPlace } from '../speech/SpeechUtil.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 
 /**
@@ -177,7 +177,7 @@ export class GeneratorPool<N, T, D> {
    * @param {N} node The typeset node.
    */
   public summary(node: N) {
-    if (this.lastSummary) {
+    if (this.lastMove === InPlace.SUMMARY) {
       this.CleanUp(node);
       return this.lastSpeech;
     }
@@ -193,11 +193,11 @@ export class GeneratorPool<N, T, D> {
    * @param {N} node
    */
   public CleanUp(node: N) {
-    if (this.lastSummary) {
+    if (this.lastMove) {
       // TODO: Remember the speech.
       this.adaptor.setAttribute(node, 'aria-label', buildSpeech(this.getLabel(node))[0]);
     }
-    this.lastSummary = false;
+    this.lastMove = InPlace.NONE;
   }
 
   /**
@@ -206,9 +206,24 @@ export class GeneratorPool<N, T, D> {
   private lastSpeech = '';
 
   /**
-   * Remembers that the last speech computation was a summary.
+   * Remembers whether the last speech computation was in-place, i.e., a summary
+   * or depth computation.
    */
-  private lastSummary = false;
+  private lastMove_ = InPlace.NONE;
+
+  /**
+   * Getter for last move.
+   */
+  public get lastMove() {
+    return this.lastMove_;
+  }
+
+  /**
+   * Setter for last move.
+   */
+  public set lastMove(move: InPlace) {
+    this.lastMove_ = this.lastSpeech ? move : InPlace.NONE;
+  }
 
   /**
    * Updates the given speech regions, possibly reinstanting previously saved
@@ -225,11 +240,7 @@ export class GeneratorPool<N, T, D> {
   ) {
     let speech = this.getLabel(node, this.lastSpeech);
     speechRegion.Update(speech);
-    // TODO: See if we can reuse the speech from the speech region.
     this.adaptor.setAttribute(node, 'aria-label', buildSpeech(speech)[0]);
-    if (this.lastSpeech) {
-      this.lastSummary = true;
-    }
     this.lastSpeech = '';
     brailleRegion.Update(
       this.adaptor.getAttribute(node, 'aria-braillelabel'));
@@ -379,7 +390,7 @@ export class GeneratorPool<N, T, D> {
   }
 
   public depth(node: N, actionable: boolean) {
-    if (this.lastSummary) {
+    if (this.lastMove === InPlace.DEPTH) {
       this.CleanUp(node);
       return this.lastSpeech;
     }

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -213,3 +213,13 @@ export function honk() {
   os.start(ac.currentTime);
   os.stop(ac.currentTime + .05);
 }
+
+/**
+ * In place speech computations.
+ */
+export enum InPlace {
+  NONE,
+  DEPTH,
+  SUMMARY
+}
+


### PR DESCRIPTION
The PR
* adds depth message output to the explorer
* generalises the handling of `InPlace` moves

`InPlace` moves are those, that generate a different speech output without actually walking in the DOM, like summary or depth. They need to be copied into the `aria-label`, the node needs to be refocused to alert a screen reader and they need to be cleaned up on the next move (ie., the original speech needs to be copied back into the `aria-label`).

This needs some changes in SRE that I still need to push.
