### PR TITLE
Fix and catch speech computation errors, add missing braille option

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,6 @@
     "mathjax-modern-font": "^4.0.0-beta.4",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "^4.1.0-beta.7"
+    "speech-rule-engine": "^4.1.0-beta.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^0.9.1
     version: 0.9.1
   speech-rule-engine:
-    specifier: ^4.1.0-beta.7
-    version: 4.1.0-beta.7
+    specifier: ^4.1.0-beta.8
+    version: 4.1.0-beta.8
 
 devDependencies:
   copyfiles:
@@ -567,15 +567,15 @@ packages:
       delayed-stream: 1.0.0
     dev: true
 
-  /commander@10.0.0:
-    resolution: {integrity: sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==}
-    engines: {node: '>=14'}
-    dev: false
-
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
     dev: true
+
+  /commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+    dev: false
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1696,12 +1696,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /speech-rule-engine@4.1.0-beta.7:
-    resolution: {integrity: sha512-e9QntjrfSKDa/w0baCXsoPQRPD9uY0r7q86Jr8ud/5zElzdG0Beiz4mc38kFb/E53c4RuYyZKSKyug8e5cVrpQ==}
+  /speech-rule-engine@4.1.0-beta.8:
+    resolution: {integrity: sha512-XG/BnvfH3alVKS1pOpu1JkGyTlqFZGNmTFE3e47gQrCyL3oM2vT0XhNjBNrV3yEr4kjcV8vKRN/7h0nh3BO1jA==}
     hasBin: true
     dependencies:
       '@xmldom/xmldom': 0.9.0-beta.8
-      commander: 10.0.0
+      commander: 11.1.0
       wicked-good-xpath: 1.3.0
     dev: false
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -309,6 +309,13 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     return parent && this.highlighter.isMactionNode(parent) ? parent : null;
   }
 
+  /**
+   * Computes the nesting depth announcement for the currently focused sub
+   * expression.
+   *
+   * @param {HTMLElement} node The current node.
+   * @return {HTMLElement} The refocused node.
+   */
   public depth(node: HTMLElement): HTMLElement {
     this.generators.depth(node, !!this.actionable(node));
     this.refocus(node);

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -244,10 +244,8 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
      */
     public attachSpeech(document: MathDocument<N, T, D>) {
       if (this.state() >= STATE.ATTACHSPEECH) return;
-      if (this.isEscaped || !document.options.enableEnrichment) {
-        this.state(STATE.ATTACHSPEECH);
-        return;
-      }
+      this.state(STATE.ATTACHSPEECH);
+      if (this.isEscaped || !document.options.enableEnrichment) return;
       let [speech, braille] = this.existingSpeech();
       let [newSpeech, newBraille] = ['', ''];
       if ((!speech && document.options.enableSpeech) ||
@@ -262,10 +260,7 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       }
       speech = speech || newSpeech;
       braille = braille || newBraille;
-      if (!speech && !braille) {
-        this.state(STATE.ATTACHSPEECH);
-        return;
-      }
+      if (!speech && !braille) return;
       const adaptor = document.adaptor;
       const node = this.typesetRoot;
       if (speech) {
@@ -279,7 +274,6 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       }
       this.outputData.speech = speech;
       this.outputData.braille = braille;
-      this.state(STATE.ATTACHSPEECH);
     }
 
   };

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -250,8 +250,8 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       }
       let [speech, braille] = this.existingSpeech();
       let [newSpeech, newBraille] = ['', ''];
-      if (!speech || !braille ||
-        document.options.enableSpeech || document.options.enableBraille) {
+      if ((!speech && document.options.enableSpeech) ||
+        (!braille && document.options.enableBraille)) {
         try {
           [newSpeech, newBraille] = this.generatorPool.computeSpeech(
             this.typesetRoot, this.toMathML(this.root, this));
@@ -280,29 +280,6 @@ export function EnrichedMathItemMixin<N, T, D, B extends Constructor<AbstractMat
       this.outputData.speech = speech;
       this.outputData.braille = braille;
       this.state(STATE.ATTACHSPEECH);
-    }
-
-    /**
-     * Retrieves the actual speech element that should be used as aria label.
-     * @param {MmlNode} node The root node to search from.
-     * @return {string} The speech content.
-     */
-    protected getSpeech(node: MmlNode): string {
-      const attributes = node.attributes;
-      if (!attributes) return '';
-      const speech = attributes.getExplicit('data-semantic-speech') as string;
-      // TODO (explorer) For tree role move all speech etc. to container
-      // element.
-      if (!attributes.hasExplicit('data-semantic-parent') && speech) {
-        return speech;
-      }
-      for (let child of node.childNodes) {
-        let value = this.getSpeech(child);
-        if (value) {
-          return value;
-        }
-      }
-      return '';
     }
 
   };
@@ -414,8 +391,10 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
      */
     public attachSpeech() {
       if (!this.processed.isSet('attach-speech')) {
-        for (const math of this.math) {
-          (math as EnrichedMathItem<N, T, D>).attachSpeech(this);
+        if (this.options.enableSpeech || this.options.enableBraille) {
+          for (const math of this.math) {
+            (math as EnrichedMathItem<N, T, D>).attachSpeech(this);
+          }
         }
         this.processed.set('attach-speech');
       }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -394,7 +394,7 @@ export class GeneratorPool<N, T, D> {
       this.CleanUp(node);
       return this.lastSpeech;
     }
-    let postfix = this.summaryGenerator.getExpandable(
+    let postfix = this.summaryGenerator.getActionable(
       actionable ?
         (this.adaptor.childNodes(node).length === 0 ? -1 : 1)
         : 0);


### PR DESCRIPTION
PR contains some corrections.

* Builds the correct speech string from the SSML also for the `mjx-container` element's `aria-label`.
* No speech is computed when `enableEnrichment` is set to `false`. Also catches error on speech computation when `enableEnrichment` is `true` but the element is actually not enriched. I think this currently only happens in the lab or when an enrichment error is caught.
* Adds missing `enableBraille` option.