### PR TITLE
Feature/better honking

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -294,7 +294,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     ['>', this.nextRules.bind(this)],
     ['<', this.nextStyle.bind(this)],
     ['x', this.summary.bind(this)],
-    ['-', this.expand.bind(this)],
+    ['Enter', this.expand.bind(this)],
     ['d', this.depth.bind(this)],
   ]);
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -330,9 +330,11 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    */
   public expand(node: HTMLElement) {
     const expandable = this.actionable(node);
-    if (expandable) {
-      expandable.dispatchEvent(new Event('click'));
+    if (!expandable) {
+      return null;
     }
+    expandable.dispatchEvent(new Event('click'));
+    return node;
   }
 
   /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -327,8 +327,9 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * Expands or collapses the currently focused node.
    *
    * @param {HTMLElement} node The focused node.
+   * @return {HTMLElement} The node if action was successful. O/w null.
    */
-  public expand(node: HTMLElement) {
+  public expand(node: HTMLElement): HTMLElement {
     const expandable = this.actionable(node);
     if (!expandable) {
       return null;

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -83,7 +83,7 @@ export class enrichVisitor<N, T, D> extends SerializedMmlVisitor {
       // Add maction id and make sure selection is the next attribute
       //
       attributes = ` data-maction-id="${id}" selection="${node.attributes.get('selection')}"`
-        + attributes.replace(/ selection="\d+"/, '');
+        + attributes.replace(/ selection="\d+"/, '').replace(/ data-maction-id="\d+"/, '');
     }
     return space + '<maction' + attributes + '>'
                  + (children.match(/\S/) ? nl + children + endspace : '')


### PR DESCRIPTION
One more PR. Fixes error in expressions that already contain an `maction` (i.e., not one introduced by `collapsible` option), where `visitMactionNode` can introduce a second duplicate `data-maction-id` attribute. This breaks XML parsing. Previously this was not an issue as we used HTML parsing, but now we are using SRE's XML parsing. 

Also some improvements to expansion/collapse/action:
* Only honks when no action can be taken on a node.
* Uses the `Enter` key for action as this is what the aria tree pattern expects for triggering actions.