### PR TITLE
Adds the dsfont package.

### DIFF
--- a/components/mjs/input/tex/extensions/dsfont/config.json
+++ b/components/mjs/input/tex/extensions/dsfont/config.json
@@ -1,0 +1,14 @@
+{
+  "build": {
+    "id": "[tex]//dsfont",
+    "component": "input/tex/extensions//dsfont",
+    "targets": ["input/tex//dsfont"]
+  },
+  "webpack": {
+    "name": "input/tex/extensions/dsfont",
+    "libs": [
+      "components/src/input/tex-base/lib",
+      "components/src/core/lib"
+    ]
+  }
+}

--- a/components/mjs/input/tex/extensions/dsfont/dsfont.js
+++ b/components/mjs/input/tex/extensions/dsfont/dsfont.js
@@ -1,0 +1,17 @@
+import './lib/dsfont.js';
+import {MathJax, combineDefaults} from 'mathjax-full/js/components/global.js';
+
+const FONTPATH = (typeof document === 'undefined' ?
+                   '@mathjax/mathjax-dsfont-font-extension' :
+                   'https://cdn.jsdelivr.net/npm/mathjax-dsfont-font-extension');
+
+if (MathJax.config?.loader) {
+  combineDefaults(MathJax.config.loader, 'paths', {
+    'mathjax-dsfont-extension': FONTPATH
+  });
+  MathJax.config.loader['[tex]/dsfont'] = {
+    checkReady() {
+      return MathJax.loader.load(`[mathjax-dsfont-extension]/${MathJax.config?.startup?.output || 'chtml'}`);
+    }
+  };
+}

--- a/ts/input/tex/dsfont/DsfontConfiguration.ts
+++ b/ts/input/tex/dsfont/DsfontConfiguration.ts
@@ -1,0 +1,57 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2017-2023 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/**
+ * @fileoverview The dsfont package.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+import {Configuration} from '../Configuration.js';
+import {CommandMap} from '../TokenMap.js';
+import BaseMethods from '../base/BaseMethods.js';
+import TexParser from '../TexParser.js';
+
+/**
+ * The methods that implement the dsfont package.
+ */
+
+new CommandMap('dsfont', {
+  mathds: 'ChooseFont',
+}, {
+  ChooseFont: function (parser: TexParser, name: string) {
+    BaseMethods.MathFont(
+      parser, name,
+      parser.options.dsfont.sans ? '-ds-ss' : '-ds-rm');
+  }
+});
+
+//
+//  Define the package configuration, including switch for sans serif.
+//
+export const DsfontConfiguration = Configuration.create('dsfont', {
+  handler: {
+    macro: ['dsfont'],
+  },
+  options: {
+    dsfont: {
+      sans: false
+    }
+  }
+});
+


### PR DESCRIPTION
Implements the [`dsfont` package](https://ctan.org/pkg/doublestroke)

Requires the `dsfont` from https://github.com/mathjax/MathJax-fonts/pull/2