### PR TITLE
Make stretchy paried delimiters not be class INNER.  (mathjax/MathJax#3183)

### DIFF
--- a/ts/input/tex/mathtools/MathtoolsMethods.ts
+++ b/ts/input/tex/mathtools/MathtoolsMethods.ts
@@ -486,7 +486,8 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
                    pre: string = '',  post: string = '') {
     const star = parser.GetStar();
     const size = (star ? '' : parser.GetBrackets(name));
-    const [left, right] = (star ? ['\\left', '\\right'] : size ? [size + 'l' , size + 'r'] : ['', '']);
+    const [left, right, after] = (star ? ['\\mathopen{\\left', '\\right', '}\\mathclose{}'] :
+                                 size ? [size + 'l' , size + 'r', ''] : ['', '', '']);
     const delim = (star ? '\\middle' : size || '');
     if (n) {
       const args: string[] = [];
@@ -498,7 +499,7 @@ export const MathtoolsMethods: Record<string, ParseMethod> = {
       post = ParseUtil.substituteArgs(parser, args, post);
     }
     body = body.replace(/\\delimsize/g, delim);
-    parser.string = [pre, left, open, body, right, close, post, parser.string.substring(parser.i)]
+    parser.string = [pre, left, open, body, right, close, after, post, parser.string.substring(parser.i)]
       .reduce((s, part) => ParseUtil.addArgs(parser, s, part), '');
     parser.i = 0;
     ParseUtil.checkMaxMacros(parser);


### PR DESCRIPTION
This PR fixes an issue with the `mathtools` package's paired delimiter implementation.  The used to have the default class of  `INNER`, but now they have class `OPEN` and are followed by an empty item of class `CLOSE`, so the stretchy delimiters now act like regular open and close delimiters, but are stretchy.

Resolves issue mathjax/MathJax#3183.