### PR TITLE
Fix error on empty vec. (mathjax/MathJax#3195)

### DIFF
--- a/ts/input/asciimath/mathjax2/legacy/jax/input/AsciiMath/jax.js
+++ b/ts/input/asciimath/mathjax2/legacy/jax/input/AsciiMath/jax.js
@@ -917,7 +917,7 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
 		(result[0].nodeName=="mrow" && result[0].childNodes.length==1
 			&& result[0].firstChild.firstChild.nodeValue !== null
 			&& result[0].firstChild.firstChild.nodeValue.length==1) ||
-		(result[0].firstChild.nodeValue !== null
+		(result[0].firstChild && result[0].firstChild.nodeValue !== null
 			&& result[0].firstChild.nodeValue.length==1) )) {
 			accnode.setAttribute("stretchy",false);
         }


### PR DESCRIPTION
This PR resolves https://github.com/mathjax/MathJax/issues/3195

Applied https://github.com/asciimath/asciimathml/commit/36b3cb0a1bac755b4f66a0b49e2e7c9e85cf55bb.