### PR TITLE
Update MathJax contextual menus for assistive tools

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -39,7 +39,7 @@ const EXPORTPATTERN =
       /(^export(?:\s+default)?(?:\s+abstract)?\s+(?:[^ {*}]+\s+(?:enum\s+)?[a-zA-Z0-9_.$]+|\{.* as .*\}))/m;
 
 const EXPORT_IGNORE = ['type', 'interface'];
-const EXPORT_PROCESS = ['let', 'const', 'var', 'function', 'class', 'namespace', 'as'];
+const EXPORT_PROCESS = ['let', 'const', 'var', 'function', 'class', 'namespace', 'enum', 'as'];
 
 /**
  * The module type to use ('cjs' or 'mjs')
@@ -159,7 +159,7 @@ function processParts(parts) {
   for (let i = 1; i < parts.length; i += 2) {
     const words = parts[i].split(/\s+/);
     const n = words.length;
-    const type = (words[n - 2] === 'enum' ? words[n - 3] : words[n - 2]);
+    const type = (words[n - 2] === 'enum' && n > 3 ? words[n - 3] : words[n - 2]);
     const name = words[n - 1].replace(/\}$/, '');
 
     if (words[1] === 'default' || type === 'default') {

--- a/components/mjs/a11y/explorer/config.json
+++ b/components/mjs/a11y/explorer/config.json
@@ -6,7 +6,6 @@
   "webpack": {
     "name": "a11y/explorer",
     "libs": [
-      "components/src/ui/menu/lib",
       "components/src/a11y/semantic-enrich/lib",
       "components/src/a11y/sre/lib",
       "components/src/input/mml/lib",

--- a/components/mjs/a11y/explorer/explorer.js
+++ b/components/mjs/a11y/explorer/explorer.js
@@ -1,17 +1,7 @@
 import './lib/explorer.js';
 
-import {combineDefaults} from '#js/components/global.js';
 import {ExplorerHandler} from '#js/a11y/explorer.js';
 
 if (MathJax.startup && typeof window !== 'undefined') {
-  if (MathJax.config.options && MathJax.config.options.enableExplorer !== false) {
-    combineDefaults(MathJax.config, 'options', {
-      menuOptions: {
-        settings: {
-          explorer: true
-        }
-      }
-    });
-  }
   MathJax.startup.extendHandler(handler => ExplorerHandler(handler));
 }

--- a/components/mjs/a11y/semantic-enrich/config.json
+++ b/components/mjs/a11y/semantic-enrich/config.json
@@ -1,7 +1,11 @@
 {
   "build": {
     "component": "a11y/semantic-enrich",
-    "targets": ["a11y/semantic-enrich.ts"]
+    "targets": [
+      "a11y/semantic-enrich.ts",
+      "a11y/speech/SpeechUtil.ts",
+      "a11y/speech/GeneratorPool.ts"
+    ]
   },
   "webpack": {
     "name": "a11y/semantic-enrich",

--- a/components/mjs/dependencies.js
+++ b/components/mjs/dependencies.js
@@ -18,7 +18,7 @@
 export const dependencies = {
   'a11y/semantic-enrich': ['input/mml', 'a11y/sre'],
   'a11y/complexity': ['a11y/semantic-enrich'],
-  'a11y/explorer': ['a11y/semantic-enrich', 'ui/menu'],
+  'a11y/explorer': ['a11y/semantic-enrich'],
   '[mml]/mml3': ['input/mml'],
   '[tex]/all-packages': ['input/tex-base'],
   '[tex]/action': ['input/tex-base', '[tex]/newcommand'],

--- a/components/mjs/ui/menu/config.json
+++ b/components/mjs/ui/menu/config.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "component": "ui/menu",
-    "targets": ["ui/menu"],
+    "targets": ["ui/menu", "a11y/speech/SpeechMenu.ts"],
     "excludeSubdirs": true
   },
   "webpack": {

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -203,7 +203,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
         align: 'top',                      // placement of magnified expression
         backgroundColor: 'Blue',           // color for background of selected sub-expression
         backgroundOpacity: 20,             // opacity for background of selected sub-expression
-        braille: false,                    // switch on Braille output
+        braille: true,                     // switch on Braille output
         flame: false,                      // color collapsible sub-expressions
         foregroundColor: 'Black',          // color to use for text of selected sub-expression
         foregroundOpacity: 100,            // opacity for text of selected sub-expression
@@ -219,7 +219,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
         speech: true,                      // switch on speech output
         subtitles: true,                   // show speech as a subtitle
         treeColoring: false,               // tree color expression
-        viewBraille: false,                // display Braille output as subtitles
+        viewBraille: true,                 // display Braille output as subtitles
         voicing: false,                    // switch on speech output
       }
     };
@@ -257,7 +257,6 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
      * @return {ExplorerMathDocument}   The MathDocument (so calls can be chained)
      */
     public explorable(): ExplorerMathDocument {
-      this.options.enableSpeech = true;
       if (!this.processed.isSet('explorer')) {
         if (this.options.enableExplorer) {
           if (!this.explorerRegions) {
@@ -320,18 +319,13 @@ export function setA11yOptions(document: HTMLDOCUMENT, options: {[key: string]: 
   for (let key in options) {
     if (document.options.a11y[key] !== undefined) {
       setA11yOption(document, key, options[key]);
-      if (key === 'locale') {
-        document.options.sre[key] = options[key];
-      }
-      continue;
-    }
-    if (sreOptions[key] !== undefined) {
+    } else if (sreOptions[key] !== undefined) {
       document.options.sre[key] = options[key];
     }
   }
   // Reinit explorers
   for (let item of document.math) {
-    (item as ExplorerMathItem).explorers.attach();
+    (item as ExplorerMathItem)?.explorers?.attach();
   }
 }
 
@@ -386,6 +380,10 @@ export function setA11yOption(document: HTMLDOCUMENT, option: string, value: str
       document.options.a11y.flame = true;
       break;
     }
+    break;
+  case 'locale':
+    document.options.sre.locale = value;
+    document.options.a11y.locale = value;
     break;
   default:
     document.options.a11y[option] = value;

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -211,6 +211,7 @@ export class ExplorerPool {
   public attach() {
     this.attached = [];
     let keyExplorers = [];
+    const a11y = this.document.options.a11y;
     for (let key of Object.keys(this.explorers)) {
       let explorer = this.explorers[key];
       if (explorer instanceof SpeechExplorer) {
@@ -218,7 +219,7 @@ export class ExplorerPool {
         explorer.stoppable = false;
         keyExplorers.unshift(explorer);
       }
-      if (this.document.options.a11y[key]) {
+      if (a11y[key] || (key === 'speech' && (a11y.braille || a11y.keyMagnifier))) {
         explorer.Attach();
         this.attached.push(key);
       } else {

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -486,11 +486,11 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     this.current.setAttribute('tabindex', '0');
     this.current.focus();
     super.Start();
-    if (this.document.options.a11y.subtitles) {
+    if (this.document.options.a11y.subtitles && this.document.options.enableSpeech) {
       promise.then(
         () => this.region.Show(this.node, this.highlighter));
     }
-    if (this.document.options.a11y.viewBraille) {
+    if (this.document.options.a11y.viewBraille && this.document.options.enableBraille) {
       promise.then(
         () => this.brailleRegion.Show(this.node, this.highlighter));
     }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -178,6 +178,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       const prev = this.node.querySelector(prevNav);
       if (prev) {
         prev.removeAttribute('tabindex');
+        this.FocusOut(null);
       }
       this.current = clicked;
       if (!this.triggerLinkMouse()) {
@@ -477,8 +478,9 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
       // the root node by default.
       this.current = this.node.childNodes[0] as HTMLElement;
     }
+    const options = this.document.options;
     let promise = Sre.sreReady();
-    if (this.generators.update(this.document.options)) {
+    if (this.generators.update(options)) {
       promise = promise.then(
         () => this.Speech()
       );
@@ -486,15 +488,15 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
     this.current.setAttribute('tabindex', '0');
     this.current.focus();
     super.Start();
-    if (this.document.options.a11y.subtitles && this.document.options.enableSpeech) {
+    if (options.a11y.subtitles && options.a11y.speech && options.enableSpeech) {
       promise.then(
         () => this.region.Show(this.node, this.highlighter));
     }
-    if (this.document.options.a11y.viewBraille && this.document.options.enableBraille) {
+    if (options.a11y.viewBraille && options.a11y.braille && options.enableBraille) {
       promise.then(
         () => this.brailleRegion.Show(this.node, this.highlighter));
     }
-    if (this.document.options.a11y.keyMagnifier) {
+    if (options.a11y.keyMagnifier) {
       this.magnifyRegion.Show(this.node, this.highlighter);
     }
     this.Update();

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -169,23 +169,25 @@ export function clearspeakMenu(menu: MJContextMenu, sub: Submenu) {
   let locale = menu.pool.lookup('locale').getValue() as string;
   const box = csSelectionBox(menu, locale);
   let items: Object[] = [];
-  const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.speech;
-  const semantic = explorer?.semanticFocus();
-  const previous = Sre.clearspeakPreferences.currentPreference();
-  items = items.concat(basePreferences(previous));
-  if (semantic) {
-    const smart = Sre.clearspeakPreferences.relevantPreferences(semantic);
-    items = items.concat(smartPreferences(previous, smart, locale));
-  }
-  if (box) {
-    items.splice(2, 0, box);
+  if (menu.settings.speech) {
+    const explorer = (menu.mathItem as ExplorerMathItem)?.explorers?.speech;
+    const semantic = explorer?.semanticFocus();
+    const previous = Sre.clearspeakPreferences.currentPreference();
+    items = items.concat(basePreferences(previous));
+    if (semantic) {
+      const smart = Sre.clearspeakPreferences.relevantPreferences(semantic);
+      items = items.concat(smartPreferences(previous, smart, locale));
+    }
+    if (box) {
+      items.splice(2, 0, box);
+    }
   }
   return menu.factory.get('subMenu')(menu.factory, {
     items: items,
     id: 'Clearspeak'
   }, sub);
 }
-MJContextMenu.DynamicSubmenus.set('Clearspeak', clearspeakMenu);
+MJContextMenu.DynamicSubmenus.set('Clearspeak', [clearspeakMenu, 'speech']);
 
 let LOCALE_MENU: SubMenu = null;
 /**
@@ -209,4 +211,4 @@ export function localeMenu(menu: MJContextMenu, sub: Submenu) {
     items: radios, id: 'Language'}, sub);
   return LOCALE_MENU;
 }
-MJContextMenu.DynamicSubmenus.set('A11yLanguage', localeMenu);
+MJContextMenu.DynamicSubmenus.set('A11yLanguage', [localeMenu, 'speech']);

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -145,7 +145,8 @@ export class Menu {
       assistiveMml: false,
       speech: true,
       braille: true,
-      brailleCode: 'nemeth'
+      brailleCode: 'nemeth',
+      speechRules: 'mathspeek-default'
     },
     jax: {
       CHTML: null,
@@ -595,8 +596,6 @@ export class Menu {
           this.checkbox('Subtitles', 'Show Subtitles', 'subtitles'),
           this.checkbox('Auto Voicing', 'Auto Voicing', 'voicing'),
           this.rule(),
-          this.submenu('A11yLanguage', 'Language'),
-          this.rule(),
           this.label('Rules', 'Rules:'),
           this.submenu('Mathspeak', 'Mathspeak', this.radioGroup('speechRules', [
             ['mathspeak-default', 'Verbose'],
@@ -610,6 +609,8 @@ export class Menu {
             ['chromevox-default', 'Standard'],
             ['chromevox-alternative', 'Alternative']
           ])),
+          this.rule(),
+          this.submenu('A11yLanguage', 'Language')
         ]),
         this.submenu('Braille', '\xA0 \xA0 Braille', [
           this.checkbox('Generate', 'Generate', 'braille'),

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -43,7 +43,6 @@ import * as MenuUtil from './MenuUtil.js';
 
 import {Info, Parser, Rule, CssStyles, Submenu} from './mj-context-menu.js';
 
-
 /*==========================================================================*/
 
 /**
@@ -78,20 +77,21 @@ export interface MenuSettings {
   breakInline: boolean;
   autocollapse: boolean;
   collapsible: boolean;
+  enrich: boolean;
   inTabOrder: boolean;
   assistiveMml: boolean;
   // A11y settings
   backgroundColor: string;
   backgroundOpacity: string;
   braille: boolean;
-  explorer: boolean;
+  brailleCode: string;
   foregroundColor: string;
   foregroundOpacity: string;
   highlight: string;
-  locale: string;
   infoPrefix: boolean;
   infoRole: boolean;
   infoType: boolean;
+  locale: string;
   magnification: string;
   magnify: string;
   speech: boolean;
@@ -140,9 +140,12 @@ export class Menu {
       breakInline: true,
       autocollapse: false,
       collapsible: false,
+      enrich: true,
       inTabOrder: true,
       assistiveMml: false,
-      explorer: false
+      speech: true,
+      braille: true,
+      brailleCode: 'nemeth'
     },
     jax: {
       CHTML: null,
@@ -298,14 +301,15 @@ export class Menu {
         ' as MathML or in its original format, to the clipboard',
         ' (in browsers that support that).</p>',
         '<p><b>Math Settings:</b> These give you control over features of MathJax,',
-        ' such the size of the mathematics, and the mechanism used',
-        ' to display equations.</p>',
+        ' such the size of the mathematics, the mechanism used to display equations,',
+        ' how to handle equations that are too wide, and the language to use for',
+        ' MathJax\'s menus and error messages (not yet implemented in v4).',
+        '</p>',
         '<p><b>Accessibility</b>: MathJax can work with screen',
         ' readers to make mathematics accessible to the visually impaired.',
-        ' Turn on the explorer to enable generation of speech strings',
-        ' and the ability to investigate expressions interactively.</p>',
-        '<p><b>Language</b>: This menu lets you select the language used by MathJax',
-        ' for its menus and warning messages. (Not yet implemented in version 3.)</p>',
+        ' Turn on speech or braille generation to enable creation of speech strings',
+        ' and the ability to investigate expressions interactively.  You can control',
+        ' the style of the explorer in its menu.</p>',
         '</div>',
         '<p><b>Math Zoom</b>: If you are having difficulty reading an',
         ' equation, MathJax can enlarge it to help you see it better, or',
@@ -388,6 +392,20 @@ export class Menu {
   );
 
   /**
+   * The "Show As Speech Text" info box
+   */
+  protected brailleText = new SelectableInfo(
+    'MathJax Braille Code',
+    () => {
+      if (!this.menu.mathItem) return '';
+      return '<div style="font-size:125%; margin:0">'
+        + this.formatSource(this.menu.mathItem.outputData.braille)
+        + '</div>';
+    },
+    ''
+  );
+
+  /**
    * The "Show As Error Message" info box
    */
   protected errorMessage = new SelectableInfo(
@@ -442,13 +460,11 @@ export class Menu {
     const jax = this.document.outputJax;
     this.jax[jax.name] = jax;
     this.settings.renderer = jax.name;
-    if (MathJax._.a11y && MathJax._.a11y.explorer) {
-      Object.assign(this.settings, this.document.options.a11y);
-    }
     this.settings.scale = jax.options.scale;
     this.defaultSettings = Object.assign({}, this.settings);
     this.settings.overflow =
-      jax.options.displayOverflow.substring(0, 1).toUpperCase() + jax.options.displayOverflow.substring(1).toLowerCase();
+      jax.options.displayOverflow.substring(0, 1).toUpperCase() +
+      jax.options.displayOverflow.substring(1).toLowerCase();
     this.settings.breakInline = jax.options.linebreaks.inline;
   }
 
@@ -478,15 +494,15 @@ export class Menu {
         this.variable<boolean>('ctrl'),
         this.variable<boolean>('shift'),
         this.variable<string> ('scale', scale => this.setScale(scale)),
-        this.variable<boolean>('explorer', explore => this.setExplorer(explore)),
+        this.a11yVar<boolean>('speech', speech => this.setSpeech(speech)),
+        this.a11yVar<boolean>('braille', braille => this.setBraille(braille)),
+        this.variable<string>('brailleCode', code => this.setBrailleCode(code)),
         this.a11yVar<string> ('highlight'),
         this.a11yVar<string> ('backgroundColor'),
         this.a11yVar<string> ('backgroundOpacity'),
         this.a11yVar<string> ('foregroundColor'),
         this.a11yVar<string> ('foregroundOpacity'),
-        this.a11yVar<boolean>('speech'),
         this.a11yVar<boolean>('subtitles'),
-        this.a11yVar<boolean>('braille'),
         this.a11yVar<boolean>('viewBraille'),
         this.a11yVar<boolean>('voicing'),
         this.a11yVar<string>('locale', value => {
@@ -505,6 +521,7 @@ export class Menu {
         this.a11yVar<boolean>('infoPrefix'),
         this.variable<boolean>('autocollapse'),
         this.variable<boolean>('collapsible', collapse => this.setCollapsible(collapse)),
+        this.variable<boolean>('enrich', enrich => this.setEnrichment(enrich)),
         this.variable<boolean>('inTabOrder', tab => this.setTabOrder(tab)),
         this.variable<boolean>('assistiveMml', mml => this.setAssistiveMml(mml))
       ],
@@ -514,6 +531,7 @@ export class Menu {
           this.command('Original', 'Original Form', () => this.originalText.post()),
           this.rule(),
           this.command('Speech', 'Speech Text', () => this.speechText.post(), {disabled: true}),
+          this.command('Braille', 'Braille Code', () => this.brailleText.post(), {disabled: true}),
           this.command('SVG', 'SVG Image', () => this.postSvgImage(), {disabled: true}),
           this.submenu('ShowAnnotation', 'Annotation'),
           this.rule(),
@@ -524,6 +542,7 @@ export class Menu {
           this.command('Original', 'Original Form', () => this.copyOriginal()),
           this.rule(),
           this.command('Speech', 'Speech Text', () => this.copySpeechText(), {disabled: true}),
+          this.command('Braille', 'Braille Code', () => this.copyBrailleText(), {disabled: true}),
           this.command('SVG', 'SVG Image', () => this.copySvgImage(), {disabled: true}),
           this.submenu('CopyAnnotation', 'Annotation'),
           this.rule(),
@@ -546,6 +565,7 @@ export class Menu {
             this.checkbox('texHints', 'TeX hints', 'texHints'),
             this.checkbox('semantics', 'Original as annotation', 'semantics')
           ]),
+          this.submenu('Language', 'Language'),
           this.rule(),
           this.submenu('ZoomTrigger', 'Zoom Trigger', [
             this.command('ZoomNow', 'Zoom Once Now', () => this.zoom(null, '', this.menu.mathItem)),
@@ -568,30 +588,37 @@ export class Menu {
           this.rule(),
           this.command('Reset', 'Reset to defaults', () => this.resetDefaults())
         ]),
-        this.submenu('Accessibility', 'Accessibility', [
-          this.checkbox('Activate', 'Activate', 'explorer'),
-          this.submenu('Speech', 'Speech', [
-            this.checkbox('Speech', 'Speech Output', 'speech'),
-            this.checkbox('Subtitles', 'Speech Subtitles', 'subtitles'),
-            this.checkbox('Auto Voicing', 'Auto Voicing', 'voicing'),
-            this.checkbox('Braille', 'Braille Output', 'braille'),
-            this.checkbox('View Braille', 'Braille Subtitles', 'viewBraille'),
-            this.rule(),
-            this.submenu('A11yLanguage', 'Language'),
-            this.rule(),
-            this.submenu('Mathspeak', 'Mathspeak Rules', this.radioGroup('speechRules', [
-              ['mathspeak-default', 'Verbose'],
-              ['mathspeak-brief', 'Brief'],
-              ['mathspeak-sbrief', 'Superbrief']
-            ])),
-            this.submenu('Clearspeak', 'Clearspeak Rules', this.radioGroup('speechRules', [
-              ['clearspeak-default', 'Auto']
-            ])),
-            this.submenu('ChromeVox', 'ChromeVox Rules', this.radioGroup('speechRules', [
-              ['chromevox-default', 'Standard'],
-              ['chromevox-alternative', 'Alternative']
-            ]))
-          ]),
+        this.rule(),
+        this.label('Accessibility', '\xA0\xA0 Accessibility:'),
+        this.submenu('Speech', '\xA0 \xA0 Speech', [
+          this.checkbox('Generate', 'Generate', 'speech'),
+          this.checkbox('Subtitles', 'Show Subtitles', 'subtitles'),
+          this.checkbox('Auto Voicing', 'Auto Voicing', 'voicing'),
+          this.rule(),
+          this.submenu('A11yLanguage', 'Language'),
+          this.rule(),
+          this.label('Rules', 'Rules:'),
+          this.submenu('Mathspeak', 'Mathspeak', this.radioGroup('speechRules', [
+            ['mathspeak-default', 'Verbose'],
+            ['mathspeak-brief', 'Brief'],
+            ['mathspeak-sbrief', 'Superbrief']
+          ])),
+          this.submenu('Clearspeak', 'Clearspeak', this.radioGroup('speechRules', [
+            ['clearspeak-default', 'Auto']
+          ])),
+          this.submenu('ChromeVox', 'ChromeVox', this.radioGroup('speechRules', [
+            ['chromevox-default', 'Standard'],
+            ['chromevox-alternative', 'Alternative']
+          ])),
+        ]),
+        this.submenu('Braille', '\xA0 \xA0 Braille', [
+          this.checkbox('Generate', 'Generate', 'braille'),
+          this.checkbox('Subtitles', 'Show Subtitles', 'viewBraille'),
+          this.rule(),
+          this.label('Code', 'Code Format:'),
+          this.radioGroup('brailleCode', [['nemeth', 'Nemeth'], ['ueb', 'UEB'], ['euro', 'Euro']])
+        ]),
+        this.submenu('Explorer', '\xA0 \xA0 Explorer', [
           this.submenu('Highlight', 'Highlight', [
             this.submenu('Background', 'Background', this.radioGroup('backgroundColor', [
               ['Blue'], ['Red'], ['Green'], ['Yellow'], ['Cyan'], ['Magenta'], ['White'], ['Black']
@@ -627,23 +654,47 @@ export class Menu {
             this.checkbox('Type', 'Type', 'infoType'),
             this.checkbox('Role', 'Role', 'infoRole'),
             this.checkbox('Prefix', 'Prefix', 'infoPrefix')
-          ], true),
-          this.rule(),
+          ], true)
+        ]),
+        this.submenu('Options', '\xA0 \xA0 Options', [
+          this.checkbox('Enrich', 'Enriched Math', 'enrich'),
           this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
           this.checkbox('AutoCollapse', 'Auto Collapse', 'autocollapse', {disabled: true}),
           this.rule(),
           this.checkbox('InTabOrder', 'Include in Tab Order', 'inTabOrder'),
           this.checkbox('AssistiveMml', 'Include Hidden MathML', 'assistiveMml')
         ]),
-        this.submenu('Language', 'Language'),
         this.rule(),
         this.command('About', 'About MathJax', () => this.about.post()),
         this.command('Help', 'MathJax Help', () => this.help.post())
       ]
     }) as MJContextMenu;
     const menu = this.menu;
+    menu.settings = this.settings;
     menu.findID('Settings', 'Overflow', 'Elide').disable();
+    menu.findID('Braille', 'ueb').hide();
     menu.setJax(this.jax);
+    this.attachDialogMenus(menu);
+    this.checkLoadableItems();
+    this.enableAccessibilityItems('Speech', this.settings.speech);
+    this.enableAccessibilityItems('Braille', this.settings.braille);
+    this.setAccessibilityMenus();
+    const cache: [string, string][] = [];
+    MJContextMenu.DynamicSubmenus.set(
+      'ShowAnnotation',
+      [AnnotationMenu.showAnnotations(
+        this.annotationBox, this.options.annotationTypes, cache), '']);
+    MJContextMenu.DynamicSubmenus.set(
+      'CopyAnnotation',
+      [AnnotationMenu.copyAnnotations(cache), '']);
+    CssStyles.addInfoStyles(this.document.document as any);
+    CssStyles.addMenuStyles(this.document.document as any);
+  }
+
+  /**
+   * @param {MJContextMenu} menu   The menu to attach
+   */
+  protected attachDialogMenus(menu: MJContextMenu) {
     this.about.attachMenu(menu);
     this.help.attachMenu(menu);
     this.originalText.attachMenu(menu);
@@ -651,20 +702,9 @@ export class Menu {
     this.originalText.attachMenu(menu);
     this.svgImage.attachMenu(menu);
     this.speechText.attachMenu(menu);
+    this.brailleText.attachMenu(menu);
     this.errorMessage.attachMenu(menu);
     this.zoomBox.attachMenu(menu);
-    this.checkLoadableItems();
-    this.enableExplorerItems(this.settings.explorer);
-    const cache: [string, string][] = [];
-    MJContextMenu.DynamicSubmenus.set(
-      'ShowAnnotation',
-      AnnotationMenu.showAnnotations(
-        this.annotationBox, this.options.annotationTypes, cache));
-    MJContextMenu.DynamicSubmenus.set(
-      'CopyAnnotation',
-      AnnotationMenu.copyAnnotations(cache));
-    CssStyles.addInfoStyles(this.document.document as any);
-    CssStyles.addMenuStyles(this.document.document as any);
   }
 
   /**
@@ -675,13 +715,11 @@ export class Menu {
    */
   protected checkLoadableItems() {
     if (MathJax && MathJax._ && MathJax.loader && MathJax.startup) {
-      if (this.settings.collapsible && (!MathJax._.a11y || !MathJax._.a11y.complexity)) {
-        this.loadA11y('complexity');
-      }
-      if (this.settings.explorer && (!MathJax._.a11y || !MathJax._.a11y.explorer)) {
+      if ((this.settings.enrich || this.settings.collapsible || this.settings.speech || this.settings.braille) &&
+          (!MathJax._?.a11y?.['semantic-enrich'])) {
         this.loadA11y('explorer');
       }
-      if (this.settings.assistiveMml && (!MathJax._.a11y || !MathJax._.a11y['assistive-mml'])) {
+      if (this.settings.assistiveMml && !MathJax._?.a11y?.['assistive-mml']) {
         this.loadA11y('assistive-mml');
       }
     } else {
@@ -691,22 +729,26 @@ export class Menu {
           menu.findID('Settings', 'Renderer', name).disable();
         }
       }
-      menu.findID('Accessibility', 'Activate').disable();
-      menu.findID('Accessibility', 'AutoCollapse').disable();
-      menu.findID('Accessibility', 'Collapsible').disable();
+      menu.findID('Speech').disable();
+      menu.findID('Braille').disable();
+      menu.findID('Explorer').disable();
+      menu.findID('Options', 'AutoCollapse').disable();
+      menu.findID('Options', 'Collapsible').disable();
+      menu.findID('Options', 'Enrich').disable();
+      menu.findID('Options', 'AssistiveMml').disable();
     }
   }
 
   /**
-   * Enable/disable the Explorer submenu items
+   * Enable/disable an assistive submenu's items
    *
    * @param {boolean} enable  True to enable, false to disable
    */
-  protected enableExplorerItems(enable: boolean) {
-    const menu = (this.menu.findID('Accessibility', 'Activate') as Submenu).menu;
+  protected enableAccessibilityItems(name: string, enable: boolean) {
+    const menu = (this.menu.findID(name) as Submenu).submenu;
     for (const item of menu.items.slice(1)) {
-      if (item instanceof Rule) break;
-      enable ? item.enable() : item.disable();
+      if (item instanceof Rule) continue;
+      enable && (!(item instanceof Submenu) || item.submenu.items.length) ? item.enable() : item.disable();
     }
 
   }
@@ -753,7 +795,7 @@ export class Menu {
    * @param {{[key: string]: any}} options The options.
    */
   protected setA11y(options: {[key: string]: any}) {
-    if (MathJax._.a11y && MathJax._.a11y.explorer) {
+    if (MathJax._?.a11y?.explorer) {
       MathJax._.a11y.explorer_ts.setA11yOptions(this.document, options);
     }
   }
@@ -764,7 +806,7 @@ export class Menu {
    * @return {any}            The value of the option
    */
   protected getA11y(option: string): any {
-    if (MathJax._.a11y && MathJax._.a11y.explorer) {
+    if (MathJax._?.a11y?.explorer) {
       if (this.document.options.a11y[option] !== undefined) {
         return this.document.options.a11y[option];
       }
@@ -780,16 +822,27 @@ export class Menu {
    */
   protected applySettings() {
     this.setTabOrder(this.settings.inTabOrder);
-    this.document.options.enableAssistiveMml = this.settings.assistiveMml;
+    const options = this.document.options;
+    options.enableAssistiveMml = this.settings.assistiveMml;
+    options.enableSpeech = this.settings.speech;
+    options.enableBraille = this.settings.braille;
+    options.enableExplorer = this.settings.enrich;
     const renderer = this.settings.renderer.replace(/[^a-zA-Z0-9]/g, '') || 'CHTML';
-    const promise = (renderer !== this.defaultSettings.renderer ?
-                     this.setRenderer(renderer, false) :
-                     Promise.resolve());
+    const promise = (Menu._loadingPromise || Promise.resolve()).then(
+      () => (renderer !== this.defaultSettings.renderer ?
+             this.setRenderer(renderer, false) :
+             Promise.resolve())
+    );
     promise.then(() => {
-      this.document.options.enableExplorer = this.settings.explorer;
-      this.document.outputJax.options.scale = parseFloat(this.settings.scale);
-      this.document.outputJax.options.displayOverflow = this.settings.overflow.toLowerCase();
-      this.document.outputJax.options.linebreaks.inline = this.settings.breakInline;
+      const settings = this.settings;
+      const options = this.document.outputJax.options;
+      options.scale = parseFloat(settings.scale);
+      options.displayOverflow = settings.overflow.toLowerCase();
+      options.linebreaks.inline = settings.breakInline;
+      if (!settings.speechRules) {
+        const sre = this.document.options.sre;
+        settings.speechRules = `${sre.domain || 'mathspeak'}-${sre.style || 'default'}`;
+      }
     });
   }
 
@@ -874,7 +927,7 @@ export class Menu {
    */
   protected setAssistiveMml(mml: boolean) {
     this.document.options.enableAssistiveMml = mml;
-    if (!mml || (MathJax._.a11y && MathJax._.a11y['assistive-mml'])) {
+    if (!mml || MathJax._?.a11y?.['assistive-mml']) {
       this.rerender();
     } else {
       this.loadA11y('assistive-mml');
@@ -882,13 +935,60 @@ export class Menu {
   }
 
   /**
-   * @param {boolean} explore   True to enable the explorer, false to not
+   * Enable/disable assistive menus based on enrichment setting
    */
-  protected setExplorer(explore: boolean) {
-    this.enableExplorerItems(explore);
-    this.document.options.enableExplorer = explore;
-    if (!explore || (MathJax._.a11y && MathJax._.a11y.explorer)) {
-      this.rerender(this.settings.collapsible ? STATE.RERENDER : STATE.COMPILED);
+  protected setAccessibilityMenus() {
+    const enable = this.settings.enrich;
+    const method = (enable ? 'enable' : 'disable');
+    ['Speech', 'Braille', 'Explorer'].forEach(id => this.menu.findID(id)[method]());
+    if (!enable) {
+      this.settings.collapsible = false;
+      this.document.options.enableCollapsible = false;
+    }
+  }
+
+  /**
+   * @param {boolean} speech   True to enable speech, false to not
+   */
+  protected setSpeech(speech: boolean) {
+    this.enableAccessibilityItems('Speech', speech);
+    this.document.options.enableSpeech = speech;
+    if (!speech || MathJax._?.a11y?.['semantic-enrich']) {
+      this.rerender(STATE.COMPILED);
+    } else {
+      this.loadA11y('explorer');
+    }
+  }
+
+  /**
+   * @param {boolean} braille   True to enable braille, false to not
+   */
+  protected setBraille(braille: boolean) {
+    this.enableAccessibilityItems('Braille', braille);
+    this.document.options.enableBraille = braille;
+    if (!braille || MathJax._?.a11y?.['semantic-enrich']) {
+      this.rerender(STATE.COMPILED);
+    } else {
+      this.loadA11y('explorer');
+    }
+  }
+
+  /**
+   * @param {string} code  The Braille code format (nemeth or euro)
+   */
+  protected setBrailleCode(code: string) {
+    this.document.options.sre.braille = code;
+    this.rerender(STATE.COMPILED);
+  }
+
+  /**
+   * @param {boolean} enrich   True to enable enriched math, false to not
+   */
+  protected setEnrichment(enrich: boolean) {
+    this.document.options.enableEnrichment = this.document.options.enableExplorer = enrich;
+    this.setAccessibilityMenus();
+    if (!enrich || MathJax._?.a11y?.['semantic-enrich']) {
+      this.rerender(STATE.COMPILED);
     } else {
       this.loadA11y('explorer');
     }
@@ -899,10 +999,17 @@ export class Menu {
    */
   protected setCollapsible(collapse: boolean) {
     this.document.options.enableComplexity = collapse;
-    if (!collapse || (MathJax._.a11y && MathJax._.a11y.complexity)) {
+    if (collapse && !this.settings.enrich) {
+      this.settings.enrich = true;
+      this.setEnrichment(true);
+    }
+    if (!collapse || MathJax._?.a11y?.complexity) {
       this.rerender(STATE.COMPILED);
     } else {
       this.loadA11y('complexity');
+      if (!MathJax._?.a11y?.explorer) {
+        this.loadA11y('explorer');
+      }
     }
   }
 
@@ -1015,6 +1122,7 @@ export class Menu {
       const document = this.document;
       this.document = startup.document = startup.getDocument();
       this.document.menu = this;
+      this.setA11y(this.settings);
       this.document.outputJax.reset();
       this.transferMathList(document);
       this.document.processed = document.processed;
@@ -1026,7 +1134,6 @@ export class Menu {
       }
     });
   }
-
 
   /**
    * @param {MenuMathDocument} document  The original document whose list is to be transferred
@@ -1088,7 +1195,7 @@ export class Menu {
    * @param {boolean} breaks      True if there are inline breaks
    * @returns {Promise<string>}   A promise returning the serialized SVG
    */
-  protected typesetSVG(math: HTMLMATHITEM, cache: string, breaks: boolean): Promise<string> {
+  protected async typesetSVG(math: HTMLMATHITEM, cache: string, breaks: boolean): Promise<string> {
     const jax = this.jax.SVG as SVG<HTMLElement, Text, Document>;
     const div = jax.html('div');
     if (cache === 'global') {
@@ -1111,7 +1218,7 @@ export class Menu {
       math.root = root;
       jax.options.fontCache = cache;
       return this.formatSvg(jax.adaptor.innerHTML(div));
-    })
+    });
   }
 
   /**
@@ -1221,6 +1328,13 @@ export class Menu {
   }
 
   /**
+   * Copy the speech text to the clipboard
+   */
+  protected copyBrailleText() {
+    MenuUtil.copyToClipboard(this.menu.mathItem.outputData.braille);
+  }
+
+  /**
    * Copy the error message to the clipboard
    */
   protected copyErrorMessage() {
@@ -1285,9 +1399,7 @@ export class Menu {
       getter: () => this.getA11y(name),
       setter: (value: T) => {
         (this.settings as any)[name] = value;
-        let options: {[key: string]: any} = {};
-        options[name] = value;
-        this.setA11y(options);
+        this.setA11y({[name]: value});
         action && action(value);
         this.saveUserSettings();
       }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -658,7 +658,7 @@ export class Menu {
           ], true)
         ]),
         this.submenu('Options', '\xA0 \xA0 Options', [
-          this.checkbox('Enrich', 'Enriched Math', 'enrich'),
+          this.checkbox('Enrich', 'Semantic Enrichment', 'enrich'),
           this.checkbox('Collapsible', 'Collapsible Math', 'collapsible'),
           this.checkbox('AutoCollapse', 'Auto Collapse', 'autocollapse', {disabled: true}),
           this.rule(),

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -172,6 +172,8 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       //
       enableEnrichment: true,
       enableComplexity: true,
+      enableSpeech: true,
+      enableBraille: true,
       enableExplorer: true,
       enrichSpeech: 'none',
       enrichError: (_doc: MenuMathDocument, _math: MenuMathItem, err: Error) =>
@@ -203,11 +205,20 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
     constructor(...args: any[]) {
       super(...args);
       this.menu = new this.options.MenuClass(this, this.options.menuOptions);
+
       const ProcessBits = (this.constructor as typeof BaseDocument).ProcessBits;
       if (!ProcessBits.has('context-menu')) {
         ProcessBits.allocate('context-menu');
       }
       this.options.MathItem = MenuMathItemMixin<A11yMathItemConstructor>(this.options.MathItem);
+
+      const settings = this.menu.settings;
+      const options = this.options;
+      const enrich = options.enableEnrichment = settings.enrich;
+      options.enableSpeech = settings.speech && enrich;
+      options.enableBraille = settings.braille && enrich;
+      options.enableComplexity = settings.collapsible && enrich;
+      options.enableExplorer = enrich;
     }
 
     /**
@@ -234,14 +245,10 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       if (this.menu.isLoading) {
         mathjax.retryAfter(this.menu.loadingPromise.catch((err) => console.log(err)));
       }
-      const settings = this.menu.settings;
-      if (settings.collapsible) {
-        this.options.enableComplexity = true;
+      if (this.options.enableComplexity) {
         this.menu.checkComponent('a11y/complexity');
       }
-      if (settings.explorer) {
-        this.options.enableEnrichment = true;
-        this.options.enableExplorer = true;
+      if (this.options.enableExplorer) {
         this.menu.checkComponent('a11y/explorer');
       }
       return this;


### PR DESCRIPTION
This PR implements the new menu structure that we discussed over the last few developer meetings.

While updating the menus, we also normalize how the settings are handled, so that the `enableSpeech`, `enableBraille`, `enableEnrichment` and `enableExplorer` document options control whether those actions are taken, and are controlled automatically by the menu settings.  When enrichment is enabled, the accessibility submenus are made active (and the `enable...` options are set to true).  This allows the explorer to run, and whatever settings are present in the `Speech`, `Braille`, and `Explorer` menus to take effect.  Those submenus control the `a11y` settings of the document's options (and the `menuOptions.settings` section, which is what initializes the `a11y` values when the menu code is loaded, and are what are stored in the menu's `localStorage` cache).

All of this means that, for example, for speech to be added, both the document's `enableSpeech` and `a11y.speech` options must be true, and for the subtitles to be shown, the `a11y.substitles` option must also be true.  Similarly for the Braille settings.  This generated the changes to `KeyExplorer.ts` for example.

The `setA11yOptions()` function in `explorer.ts` is simplified by moving the handling of `locale` to the `setA11yOption()` function where all the other special keys are processed.

The `ExplorerPool.ts` file is modified to attach explorers when speech isn't enabled but one of Braille or magnification is (there were not separate explorer keys for these, as the speech explorer handles all three).

In `semantic-enrich.ts`, we add code to remove enrichment if the state drops below the enrichment state, and we add an error function to process enrichment errors that can be overriden by the user.

The `MJContextMenu` is modified to:
* Add a `Braille Code` item to the `Show As` and `Copy to Clipboard` submenus (enabled when Braille generation is active).
* Modify the `DynamicSubmenus` code to allow enabling of a non-empty menu to be controlled by a menu setting (so that, for example, the `language` submenu does not get enabled when speech is not being generated). 
* The `findID()` method has been rewritten to not use `find()`, which descends into submenus too soon for `findID()`.

The `SpeechMenu.ts` file uses the new `DynamicSubmenus` parameter to handle the language and clearspeak submenus.

The `MenuHandler` adds the `enableSpeech` and `enableBraille` options, and handles the transfer of the menu settings to the various `enable...` options.  Note that `enableExplorer ` and `enableEnrichment` are initially the same, since enrichment is all that is needed for the explorer at this point.

Finally, the `Menu.ts` file has significant changes to implement the new menu structure and loading of the needed components when the settings change.  The `explorer` menu setting has been removed, since there is no longer an explicit menu setting for it (instead, it is controlled by enrichment setting).

It may be useful to turn off white-space difference when looking at the changes.

Note that you will need to use the `lab-menu-update` branch in the `MathJax-dev` repository to get the needed changes to the lab in order for the lab to work with this branch.

