### PR TITLE
Handle primes in munderover as in msubsup.  (mathjax/MathJax#3202)

### DIFF
--- a/ts/core/MmlTree/OperatorDictionary.ts
+++ b/ts/core/MmlTree/OperatorDictionary.ts
@@ -321,13 +321,13 @@ export const OPTABLE: {[form: string]: OperatorList} = {
     '\u201E': MO.ACCENT,     // double low-9 quotation mark
     '\u201F': MO.ACCENT,     // double high-reversed-9 quotation mark
     '\u2032': MO.ORD,        // prime
-    '\u2033': MO.ACCENT,     // double prime
-    '\u2034': MO.ACCENT,     // triple prime
-    '\u2035': MO.ACCENT,     // reversed prime
-    '\u2036': MO.ACCENT,     // reversed double prime
-    '\u2037': MO.ACCENT,     // reversed triple prime
+    '\u2033': MO.ORD,        // double prime
+    '\u2034': MO.ORD,        // triple prime
+    '\u2035': MO.ORD,        // reversed prime
+    '\u2036': MO.ORD,        // reversed double prime
+    '\u2037': MO.ORD,        // reversed triple prime
     '\u203E': MO.WIDEACCENT, // overline
-    '\u2057': MO.ACCENT,     // quadruple prime
+    '\u2057': MO.ORD,        // quadruple prime
     '\u20DB': MO.ACCENT,     // combining three dots above
     '\u20DC': MO.ACCENT,     // combining four dots above
     '\u2309': MO.CLOSE,      // right ceiling

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -29,6 +29,7 @@ import {entities} from '../../../util/Entities.js';
 import {MmlNode, TextNode, TEXCLASS} from '../../../core/MmlTree/MmlNode.js';
 import {MmlMo} from '../../../core/MmlTree/MmlNodes/mo.js';
 import {MmlMsubsup} from '../../../core/MmlTree/MmlNodes/msubsup.js';
+import {MmlMunderover} from '../../../core/MmlTree/MmlNodes/munderover.js';
 import TexParser from '../TexParser.js';
 import TexError from '../TexError.js';
 import {ParseUtil} from '../ParseUtil.js';
@@ -194,12 +195,15 @@ export class PrimeItem extends BaseItem {
    */
   public checkItem(item: StackItem): CheckType {
     let [top0, top1] = this.Peek(2);
-    if (!NodeUtil.isType(top0, 'msubsup') || NodeUtil.isType(top0, 'msup')) {
+    const isSup = NodeUtil.isType(top0, 'msubsup') && !NodeUtil.getChildAt(top0, (top0 as MmlMsubsup).sup);
+    const isOver = NodeUtil.isType(top0, 'munderover') && !NodeUtil.getChildAt(top0, (top0 as MmlMunderover).over);
+    if (!isSup && !isOver) {
       // @test Prime, Double Prime
-      const node = this.create('node', 'msup', [top0, top1]);
+      const node = this.create('node', top0.getProperty('movesupsub') ? 'mover' : 'msup', [top0, top1]);
       return [[node, item], true];
     }
-    NodeUtil.setChild(top0, (top0 as MmlMsubsup).sup, top1);
+    const pos = isSup ? (top0 as MmlMsubsup).sup : (top0 as MmlMunderover).over;
+    NodeUtil.setChild(top0, pos, top1);
     return [[top0, item], true];
   }
 }

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -254,8 +254,10 @@ BaseMethods.Prime = function(parser: TexParser, c: string) {
     // @test PrimeSup, PrePrime, Prime on Sup
     base = parser.create('token', 'mi');
   }
-  if (NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
-      NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) {
+  if ((NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
+       NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) ||
+      (NodeUtil.isType(base, 'munderover') && !NodeUtil.isType(base, 'mover') &&
+       NodeUtil.getChildAt(base, (base as MmlMunderover).over))) {
     // @test Double Prime Error
     throw new TexError('DoubleExponentPrime',
                         'Prime causes double exponent: use braces to clarify');


### PR DESCRIPTION
This PR resolves the issues raised in mathjax/MathJax#3202, namely that primes are not placed properly on operators.  E.g., `\sum_n'` should act like `\sum_n^\prime` but doesn't.  The reason is that the `PrimeItem` and `BaseMethods.Prime` function don't treat `munderover` the same as `msubsup`, so this PR fixes that.

This also fixes the problem with `\int\limits'` not working like `\int\limits^\prime`.

It also fixes the problem with `\sum''` and larger numbers of primes not using the proper size in display mode.

Resolves issue mathjax/MathJax#3202.