### PR TITLE
Allow unknown characters to use operator table to determine class and node type.  (mathjax/MathJax#3203)

### DIFF
--- a/ts/core/MmlTree/OperatorDictionary.ts
+++ b/ts/core/MmlTree/OperatorDictionary.ts
@@ -140,6 +140,10 @@ export const RANGES: RangeDef[] = [
  * @return {RangeDef}     The range containing that character, or null
  */
 export function getRange(text: string): RangeDef {
+  const def = OPTABLE.infix[text] || OPTABLE.prefix[text] || OPTABLE.postfix[text];
+  if (def) {
+    return [0, 0, def[2], 'mo'];
+  }
   const n = text.codePointAt(0);
   for (const range of RANGES) {
     if (n <= range[1]) {


### PR DESCRIPTION
MathJax's handling of characters that aren't mapped to special functions (like `^` and `_`), or that match the variable or number patterns, is controlled by the `RANGES` and `OPTABLE` in the `OperatorDictionary.ts` file.  When an unmapped character is encountered, the `RANGES` array is searched for a block in which the unknown character is found, and that gives the TeX class and MathML node type to use for the character.

These blocks are just a rough breakdown of the unicode ranges into groups that should be treated similarly, but it is not perfect, and some characters are mischaracterized by it.  Two such are U+00D7 (×) and U+00F7 (÷), which are found in a block of Latin letters, which MathJax marks as TeX class ORD using an `mi` node.  These two *should* be treated as operators, but they have not been singled out from among the Latin letters, so get the wrong MathML node type.

One solution would be to make the `RANGES` table more granular, but another is to note that U+00D7 and U+00F7 are present in the operator dictionary, so Mathjax could use that to find the TeX class and wrap it in an `mo`.  The latter is implemented here.  That means that any character that is in the operator dictionary will be put into an `mo` automatically, rather than use the `RANGES` table.  That makes it easier to customize the operators recognized by MathJax without having to adjust the `RANGES` table.

Resolves issue mathjax/MathJax#3203.