### PR TITLE
Add missing commands to textmacros package

### DIFF
--- a/ts/input/tex/textmacros/TextMacrosMappings.ts
+++ b/ts/input/tex/textmacros/TextMacrosMappings.ts
@@ -114,6 +114,9 @@ new CommandMap('text-macros', {
   dagger:       ['Insert', '\u2020'],
   ddagger:      ['Insert', '\u2021'],
   S:            ['Insert', '\u00A7'],
+  AA:           ['Insert', '\u212B'],
+  ldots:        ['Insert', '\u2026'],
+  vdots:        ['Insert', '\u22EE'],
 
   ',':          ['Spacer', MATHSPACE.thinmathspace],
   ':':          ['Spacer', MATHSPACE.mediummathspace],


### PR DESCRIPTION
Adds Angstrom, vdots and ldots macros. Those work in LaTeX text mode, e.g., in `\hbox`, but not yet in MathJax.
