### PR TITLE
Make textcomp package register with textmacros automatically.

### DIFF
--- a/ts/input/tex/textcomp/TextcompConfiguration.ts
+++ b/ts/input/tex/textcomp/TextcompConfiguration.ts
@@ -25,10 +25,19 @@
 import {Configuration} from '../Configuration.js';
 import './TextcompMappings.js';
 
+Configuration.create('text-textcomp', {
+  parser: 'text',
+  handler: {macro: ['textcomp-macros']}
+});
 
 export const TextcompConfiguration = Configuration.create(
   'textcomp', {
-    handler: {macro: ['textcomp-macros']}
+    handler: {macro: ['textcomp-macros']},
+    config(_config, jax) {
+      const {textConf, parseOptions} = jax.parseOptions.packageData.get('textmacros');
+      parseOptions.options.textmacros.packages.push('text-textcomp');
+      textConf.add('text-textcomp', jax, {});
+    }
   }
 );
 

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -39,6 +39,7 @@ import './TextMacrosMappings.js';
  */
 export const TextBaseConfiguration = Configuration.create('text-base', {
   parser: 'text',
+  priority: 1,
   handler: {
     character: ['command', 'text-special'],
     macro: ['text-macros']
@@ -96,6 +97,7 @@ function internalMath(parser: TexParser, text: string, level?: number | string, 
 //  The textmacros package configuration
 //
 export const TextMacrosConfiguration = Configuration.create('textmacros', {
+  priority: 1,
   /**
    * @param {ParserConfiguration} config   The configuration object we are being configured within
    * @param {TeX<any,any,any>} jax         The TeX input jax in which we are running
@@ -120,7 +122,7 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
     //   and replace the internalMath function with our own.
     //
     parseOptions.packageData = jax.parseOptions.packageData;
-    parseOptions.packageData.set('textmacros', {parseOptions, jax, texParser: null});
+    parseOptions.packageData.set('textmacros', {textConf, parseOptions, jax, texParser: null});
     parseOptions.options.internalMath = internalMath;
   },
   preprocessors: [(data: {data: ParseOptions}) => {


### PR DESCRIPTION
This PR causes the `textcomp` package to add itself to the `textmacros` packages automatically.  In order to allow it to work with `\require{textcomp}` (and to work better with the Lab), we do this through the `config()` function of the configuration rather than setting it via `options`.  This is because when `\require{textcomp}` is processed, its dependecies are loaded and added to the configuration first, then `textcomp` is added.  Because `textmacros` is a dependency, it will be added and configured *before* `textcomp` adds to the `textmacros.packages` if it is placed in the `options.textmacros.packages` configuration option.  Here, using `config()`, we know that `textmacros` will already be configured, so we can add to the `textConf` configuration directly.

It may be possible to have `\require` collect the `config()` methods from the dependencies and run them *after* all the initialization is done, but I didn't want to make that big a change here.  This should the job for now.