### PR TITLE
Make tex font packages work with \require

### DIFF
--- a/components/mjs/input/tex/extension.js
+++ b/components/mjs/input/tex/extension.js
@@ -1,0 +1,20 @@
+import {combineDefaults} from '#js/components/global.js';
+
+export function fontExtension(id, name, pkg = `@mathjax/${name}`) {
+  if (MathJax.config?.loader) {
+    const FONTPATH = (typeof document === 'undefined' ? pkg :
+                      `https://cdn.jsdelivr.net/npm/${name}`);
+    const path = name.replace(/-font-extension$/, '-extension');
+    const extension = name.replace(/-font-extension$/, '');
+    combineDefaults(MathJax.config.loader, 'paths', {[path]: FONTPATH});
+    MathJax.config.loader[id] = {
+      checkReady() {
+        return MathJax.loader.load(
+          `[${path}]/${MathJax.config?.startup?.output || 'chtml'}`
+        ).then(() => {
+          MathJax.startup.document?.outputJax?.addExtension(extension);
+        });
+      }
+    };
+  }
+}

--- a/components/mjs/input/tex/extensions/bbm/bbm.js
+++ b/components/mjs/input/tex/extensions/bbm/bbm.js
@@ -1,17 +1,4 @@
 import './lib/bbm.js';
-import {MathJax, combineDefaults} from 'mathjax-full/js/components/global.js';
+import {fontExtension} from '../../extension.js';
 
-const FONTPATH = (typeof document === 'undefined' ?
-                   '@mathjax/mathjax-bbm-font-extension' :
-                   'https://cdn.jsdelivr.net/npm/mathjax-bbm-font-extension');
-
-if (MathJax.config?.loader) {
-  combineDefaults(MathJax.config.loader, 'paths', {
-    'mathjax-bbm-extension': FONTPATH
-  });
-  MathJax.config.loader['[tex]/bbm'] = {
-    checkReady() {
-      return MathJax.loader.load(`[mathjax-bbm-extension]/${MathJax.config?.startup?.output || 'chtml'}`);
-    }
-  };
-}
+fontExtension('[tex]/bbm', 'mathjax-bbm-font-extension');

--- a/components/mjs/input/tex/extensions/bboldx/bboldx.js
+++ b/components/mjs/input/tex/extensions/bboldx/bboldx.js
@@ -1,17 +1,4 @@
 import './lib/bboldx.js';
-import {MathJax, combineDefaults} from 'mathjax-full/js/components/global.js';
+import {fontExtension} from '../../extension.js';
 
-const FONTPATH = (typeof document === 'undefined' ?
-                   '@mathjax/mathjax-bboldx-font-extension' :
-                   'https://cdn.jsdelivr.net/npm/mathjax-bboldx-font-extension');
-
-if (MathJax.config?.loader) {
-  combineDefaults(MathJax.config.loader, 'paths', {
-    'mathjax-bboldx-extension': FONTPATH
-  });
-  MathJax.config.loader['[tex]/bboldx'] = {
-    checkReady() {
-      return MathJax.loader.load(`[mathjax-bboldx-extension]/${MathJax.config?.startup?.output || 'chtml'}`);
-    }
-  };
-}
+fontExtension('[tex]/bboldx', 'mathjax-bboldx-font-extension');

--- a/components/mjs/input/tex/extensions/dsfont/dsfont.js
+++ b/components/mjs/input/tex/extensions/dsfont/dsfont.js
@@ -1,17 +1,4 @@
 import './lib/dsfont.js';
-import {MathJax, combineDefaults} from 'mathjax-full/js/components/global.js';
+import {fontExtension} from '../../extension.js';
 
-const FONTPATH = (typeof document === 'undefined' ?
-                   '@mathjax/mathjax-dsfont-font-extension' :
-                   'https://cdn.jsdelivr.net/npm/mathjax-dsfont-font-extension');
-
-if (MathJax.config?.loader) {
-  combineDefaults(MathJax.config.loader, 'paths', {
-    'mathjax-dsfont-extension': FONTPATH
-  });
-  MathJax.config.loader['[tex]/dsfont'] = {
-    checkReady() {
-      return MathJax.loader.load(`[mathjax-dsfont-extension]/${MathJax.config?.startup?.output || 'chtml'}`);
-    }
-  };
-}
+fontExtension('[tex]/dsfont', 'mathjax-dsfont-font-extension');

--- a/ts/input/tex/bboldx/BboldxConfiguration.ts
+++ b/ts/input/tex/bboldx/BboldxConfiguration.ts
@@ -52,11 +52,13 @@ export const BboldxConfiguration = Configuration.create('bboldx', {
     bboldx: {
       bfbb: false,
       light: false
-    },
-    // add text macros by default to textmacros
-    textmacros: {
-      packages: {'[+]': ['text-bboldx']}
     }
-  }
+  },
+  config(_config, jax) {
+    const {textConf, parseOptions} = jax.parseOptions.packageData.get('textmacros');
+    parseOptions.options.textmacros.packages.push('text-bboldx');
+    textConf.add('text-bboldx', jax, {});
+  },
+  priority: 3   // load before base, since we override \mathbb
 });
 

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -165,6 +165,17 @@ CommonOutputJax<
   /**
    * @override
    */
+  public addExtension(name: string): string[] {
+    const css = super.addExtension(name);
+    if (css.length && this.options.adaptiveCSS && this.chtmlStyles) {
+      this.adaptor.insertRules(this.chtmlStyles, css);
+    }
+    return [];
+  }
+
+  /**
+   * @override
+   */
   public escaped(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
     this.setDocument(html);
     return this.html('span', {}, [this.text(math.math)]);

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -25,7 +25,7 @@ import {CharMap, CharOptions, CharDataArray, VariantData,
         DelimiterData, FontData, FontExtensionData, DIRECTION} from '../common/FontData.js';
 import {Usage} from './Usage.js';
 import {StringMap} from './Wrapper.js';
-import {StyleList, StyleData} from '../../util/StyleList.js';
+import {StyleList, StyleData, CssStyles} from '../../util/StyleList.js';
 import {em} from '../../util/lengths.js';
 
 export * from '../common/FontData.js';
@@ -186,6 +186,24 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
   ) {
     super.addExtension(data, prefix);
     data.fonts && this.addDynamicFontCss(this.defaultStyles, data.fonts, data.fontURL);
+  }
+
+  /**
+   * @override
+   */
+  public addExtension(
+    data: ChtmlFontExtensionData<ChtmlCharOptions, ChtmlDelimiterData>,
+    prefix: string = ''
+  ): string[] {
+    super.addExtension(data, prefix);
+    if (data.fonts && this.options.adaptiveCSS) {
+      const css = {};
+      const styles = new CssStyles();
+      (this.constructor as typeof ChtmlFontData).addDynamicFontCss(css, data.fonts, data.fontURL);
+      styles.addStyles(css);
+      return styles.getStyleRules();
+    }
+    return [];
   }
 
   /***********************************************************************/

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -196,14 +196,14 @@ export class ChtmlFontData extends FontData<ChtmlCharOptions, ChtmlVariantData, 
     prefix: string = ''
   ): string[] {
     super.addExtension(data, prefix);
-    if (data.fonts && this.options.adaptiveCSS) {
-      const css = {};
-      const styles = new CssStyles();
-      (this.constructor as typeof ChtmlFontData).addDynamicFontCss(css, data.fonts, data.fontURL);
-      styles.addStyles(css);
-      return styles.getStyleRules();
+    if (!data.fonts || !this.options.adaptiveCSS) {
+      return [];
     }
-    return [];
+    const css = {};
+    const styles = new CssStyles();
+    (this.constructor as typeof ChtmlFontData).addDynamicFontCss(css, data.fonts, data.fontURL);
+    styles.addStyles(css);
+    return styles.getStyleRules();
   }
 
   /***********************************************************************/

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -266,6 +266,17 @@ export abstract class CommonOutputJax<
     }
   }
 
+  /**
+   * Add a registered font extension to the output jax's font.
+   *
+   * @param {string} name   The name of the extension to add to this output jax's font
+   * @return {string[]}     New CSS rules needed for the font
+   */
+  public addExtension(name: string): string[] {
+    const font = this.font.CLASS.dynamicExtensions.get(name);
+    return this.font.addExtension(font.data);
+  }
+
 
   /*****************************************************************/
 

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -293,6 +293,7 @@ export type DynamicFont = {
   files: DynamicFileList;
   sizeN: number;
   stretchN: number;
+  data: FontExtensionData<any, any>
 };
 
 /**
@@ -623,7 +624,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   /**
    * The font extension dynamic data
    */
-  protected static dynamicExtensions: DynamicFontMap = new Map();
+  public static dynamicExtensions: DynamicFontMap = new Map();
 
   /**
    * The font options
@@ -792,7 +793,8 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
       prefix: prefix,
       files: this.defineDynamicFiles(data.ranges, data.name),
       sizeN: this.defaultSizeVariants.length,
-      stretchN: this.defaultStretchVariants.length
+      stretchN: this.defaultStretchVariants.length,
+      data: data
     };
     this.dynamicExtensions.set(data.name, extension);
     for (const [src, dst] of [
@@ -853,14 +855,16 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    *
    * @param {FontExtensionData} data    The data for the font extension to merge into this font.
    * @param {string} prefix             The [prefix] to add to all component names
+   * @return {string[]}                 The new CSS rules needed for this extension
    */
-  public addExtension(data: FontExtensionData<C, D>, prefix: string = '') {
+  public addExtension(data: FontExtensionData<C, D>, prefix: string = ''): string[] {
     const dynamicFont = {
       name: data.name,
       prefix: prefix,
       files: this.CLASS.defineDynamicFiles(data.ranges, prefix),
       sizeN: this.sizeVariants.length,
-      stretchN: this.stretchVariants.length
+      stretchN: this.stretchVariants.length,
+      data: data
     };
     this.CLASS.dynamicExtensions.set(data.name, dynamicFont);
 
@@ -885,6 +889,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     if (data.ranges) {
       this.defineDynamicCharacters(dynamicFont.files);
     }
+    return [];
   }
 
   /**


### PR DESCRIPTION
This PR makes the changes needed to the font extension infrastructure to allow a TeX font package to be loaded via `\require` (e.g., `\require{dsfont}`) and have it load the needed font.

The `components/mjs/input/tex/extension.js` file exports a function that does the work of loading and adding a font extension, simplifying the `dsfont`, `bbm` and `bboldx` component files.  This sets up the needed path for the extension, and the load hook that loads the font extension and adds it into the output jax when it is loaded.

To do this, the common output jax gets a new `addExtension()` function that looks up the font extension and adds it to the current font for that output jax.  The chtml output jax overrides this so that it can add the needed CSS rules to load the fonts needed for the extension, if any.  These come from a modified `addExtension()` in the `ChtmlFontData` object, which produces the needed `@fontface` rules and passes them back so that the output jax's `addExtension()` can insert the rules into the chtml stylesheet.

The common FontData object now saves the complete `FontExtensionData` object so that it can be used in the common output jax's `addExtension()` to add the extension to its existing font.

Finally, the `bboldx` extension is modified to configure the `textmacros` packages in its `config()` method rather than via its `options` setting.  This is because when you use `\require{bboldx}`, this forces the `textmacros` package to be loaded and configured before `bboldx` is, and so the `textmacros` packages have already been processed before `bboldx` adds its package.  So this allows `bboldx` to adds the package after the fact.  You need to merge the `textcomp-textmacros` branch in order for this to work, since it includes changes to `textmacros` that are needed for the `config()` method to work (the `textConf` object).

I'm sorry to be adding yet another PR for beta.5, but since we are including the font extensions, it is probably best to have them work with `\require`.