### PR TITLE
Handle pnpm node_module paths better in [node] prefix in messages

### DIFF
--- a/components/bin/pack
+++ b/components/bin/pack
@@ -40,10 +40,11 @@ const bundle = (process.argv[3] || 'bundle');
 
 /**
  * @param {string} name    The file name to turn into a Regular expression
+ * @param {string} tail    Additional regexp to include after the file path
  * @return {RegExp}        The regular expression for the name,
  */
-function fileRegExp(name) {
-  return new RegExp(name.replace(/([\\.{}[\]()?*^$])/g, '\\$1'), 'g');
+function fileRegExp(name, tail = '') {
+  return new RegExp(name.replace(/([\\.{}[\]()?*^$])/g, '\\$1') + tail, 'g');
 }
 
 /**
@@ -63,7 +64,7 @@ const mjPath = path.dirname(compPath);
 const jsPath = path.join(__dirname, '..', '..', target);
 const compRE = fileRegExp(compPath);
 const rootRE = fileRegExp(path.dirname(jsPath));
-const nodeRE = fileRegExp(nodePath);
+const nodeRE = fileRegExp(nodePath, '(?:/\\.pnpm/.*?/node_modules)?');
 const fontRE = new RegExp('^.*\\/(mathjax-[^\/-]*)(?:-font)?\/(build|[cm]js)');
 
 /**


### PR DESCRIPTION
This is a small PR to improve the output from the `components/bin/pack` command for reporting files included from the `node_modules` directory.  Since `pnpm` uses symbolic links, the filenames reported are not as concise as they could be.  This alters the regex pattern used for the `[node]` prefix to collapse `.pnpm` links for shorter file names.