### PR TITLE
Filter aria-owns attributes from SRE

### DIFF
--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -111,7 +111,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
     }
     if (this.options.filterSRE) {
       const keys = Object.keys(list).filter(
-        id => id.match(/^(?:data-semantic-.*?|role|aria-(?:level|posinset|setsize))$/)
+        id => id.match(/^(?:data-semantic-.*?|role|aria-(?:level|posinset|setsize|owns))$/)
       );
       for (const key of keys) {
         delete list[key];


### PR DESCRIPTION
This is a small PR to remove the `aria-owns` attributes from SRE when SRE attributes are being filtered from the MathML output in the "Show Math As" menu.