### PR TITLE
Fix/explorer rules

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -383,7 +383,6 @@ export function setA11yOption(document: HTMLDOCUMENT, option: string, value: str
     break;
   case 'locale':
     document.options.sre.locale = value;
-    document.options.a11y.locale = value;
     break;
   default:
     document.options.a11y[option] = value;

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -382,7 +382,7 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
       sre: expandable({
         speech: 'none',                    // by default no speech is included
         locale: 'en',                      // switch the locale
-        domain: 'mathspeak',               // speech rules domain
+        domain: 'clearspeak',               // speech rules domain
         style: 'default',                  // speech rules style
         braille: 'nemeth',                 // TODO: Dummy switch for braille
       }),

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -91,6 +91,7 @@ export class MJContextMenu extends ContextMenu {
    */
   public unpost() {
     super.unpost();
+    this.mathItem.typesetRoot.blur();
     this.mathItem = null;
   }
 

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -91,7 +91,7 @@ export class MJContextMenu extends ContextMenu {
    */
   public unpost() {
     super.unpost();
-    this.mathItem.typesetRoot.blur();
+    this.mathItem?.typesetRoot?.blur();
     this.mathItem = null;
   }
 

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -146,7 +146,7 @@ export class Menu {
       speech: true,
       braille: true,
       brailleCode: 'nemeth',
-      speechRules: 'mathspeek-default'
+      speechRules: 'clearspeak-default'
     },
     jax: {
       CHTML: null,
@@ -507,11 +507,20 @@ export class Menu {
         this.a11yVar<boolean>('viewBraille'),
         this.a11yVar<boolean>('voicing'),
         this.a11yVar<string>('locale', locale => this.setLocale(locale)),
-        this.a11yVar<string>('speechRules', value => {
-          const [domain, style] = value.split('-');
-          this.document.options.sre.domain = domain;
-          this.document.options.sre.style = style;
-        }),
+        {
+          name: 'speechRules',
+          getter: () => {
+            return this.settings['speechRules'];
+          },
+          setter: (value: string) => {
+            const [domain, style] = value.split('-');
+            this.settings['speechRules'] = value;
+            this.document.options.sre.domain = domain;
+            this.document.options.sre.style = style;
+            this.rerender(STATE.COMPILED);
+            this.saveUserSettings();
+          }
+        },
         this.a11yVar<string> ('magnification'),
         this.a11yVar<string> ('magnify'),
         this.a11yVar<boolean>('treeColoring'),
@@ -840,7 +849,7 @@ export class Menu {
       options.linebreaks.inline = settings.breakInline;
       if (!settings.speechRules) {
         const sre = this.document.options.sre;
-        settings.speechRules = `${sre.domain || 'mathspeak'}-${sre.style || 'default'}`;
+        settings.speechRules = `${sre.domain || 'clearspeak'}-${sre.style || 'default'}`;
       }
     });
   }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -506,9 +506,7 @@ export class Menu {
         this.a11yVar<boolean>('subtitles'),
         this.a11yVar<boolean>('viewBraille'),
         this.a11yVar<boolean>('voicing'),
-        this.a11yVar<string>('locale', value => {
-          MathJax._.a11y.sre.Sre.setupEngine({locale: value as string});
-        }),
+        this.a11yVar<string>('locale', locale => this.setLocale(locale)),
         this.a11yVar<string>('speechRules', value => {
           const [domain, style] = value.split('-');
           this.document.options.sre.domain = domain;
@@ -979,6 +977,14 @@ export class Menu {
    */
   protected setBrailleCode(code: string) {
     this.document.options.sre.braille = code;
+    this.rerender(STATE.COMPILED);
+  }
+
+  /**
+   * @param {string} locale  The speech locale
+   */
+  protected setLocale(locale: string) {
+    this.document.options.sre.locale = locale;
     this.rerender(STATE.COMPILED);
   }
 


### PR DESCRIPTION
Reenables the change of rule sets and preferences for speech generation.
* Uses a standard variable definition for`speechRules`.
* Switches to clearspeak as default, thereby also fixing a type `mathspeek` that lead to incorrect speech computation.
* Fixes an error when the selection box is closed, as it is not attached to a `mathitem`.

Still two issues:
* I still need to make an SRE release. 
* Currently one can select rule sets that do not always exist for every locale. There are two solutions for this:
1. disactivating the menu items that should not be chosen, which would require quite a bit of refactoring of the current speech menu code,
2. on the other hand I always wanted to ensure that SRE produces reasonable output even with a non-existing rule set is chosen. I go with this solution for now.

