### PR TITLE
Allow tex packages that load font extensions to work better with \require and renderer changes.

### DIFF
--- a/components/mjs/input/tex/extension.js
+++ b/components/mjs/input/tex/extension.js
@@ -1,24 +1,16 @@
 import {combineDefaults} from '#js/components/global.js';
 
 export function fontExtension(id, name, pkg = `@mathjax/${name}`) {
-  if (MathJax.config?.loader) {
-    const FONTPATH = (typeof document === 'undefined' ? pkg :
-                      `https://cdn.jsdelivr.net/npm/${name}`);
+  if (MathJax.loader) {
+    const FONTPATH = (typeof document === 'undefined' ? pkg : `https://cdn.jsdelivr.net/npm/${name}`);
     const path = name.replace(/-font-extension$/, '-extension');
     const extension = name.replace(/-font-extension$/, '');
+    const jax = (MathJax.config?.startup?.output || 'chtml');
     combineDefaults(MathJax.config.loader, 'paths', {[path]: FONTPATH});
-    combineDefaults(MathJax.config.loader, 'dependencies', {
-      [`[${path}]/chtml`]: ['output/chtml'],
-      [`[${path}]/svg`]: ['output/svg']
+    combineDefaults(MathJax.config.loader, 'dependencies', {[`[${path}]/${jax}`]: [`output/${jax}`]});
+    MathJax.loader.addPackageData(id, {
+      extraLoads: [`[${path}]/${jax}`],
+      rendererExtensions: [path]
     });
-    MathJax.config.loader[id] = {
-      checkReady() {
-        return MathJax.loader.load(
-          `[${path}]/${MathJax.config?.startup?.output || 'chtml'}`
-        ).then(() => {
-          MathJax.startup.document?.outputJax?.addExtension(extension);
-        });
-      }
-    };
   }
 }

--- a/components/mjs/output/chtml/config.json
+++ b/components/mjs/output/chtml/config.json
@@ -5,10 +5,6 @@
       "output/chtml.ts",
       "output/chtml",
       "output/common"
-    ],
-    "exclude": [
-      "output/chtml/ts5",
-      "output/chtml/ts6"
     ]
   },
   "webpack": {

--- a/components/mjs/output/chtml/nofont.js
+++ b/components/mjs/output/chtml/nofont.js
@@ -4,3 +4,5 @@ export class DefaultFont extends ChtmlFontData {};
 export const fontName = 'nofont';
 
 DefaultFont.OPTIONS = {fontURL: '.'};
+
+export const Font = {fontName, DefaultFont};

--- a/components/mjs/output/svg/config.json
+++ b/components/mjs/output/svg/config.json
@@ -5,10 +5,6 @@
       "output/svg.ts",
       "output/svg",
       "output/common"
-    ],
-    "exclude": [
-      "output/svg/ts5",
-      "output/svg/ts6"
     ]
   },
   "webpack": {

--- a/components/mjs/output/svg/nofont.js
+++ b/components/mjs/output/svg/nofont.js
@@ -2,3 +2,5 @@ import {SvgFontData} from '#js/output/svg/FontData.js';
 
 export class DefaultFont extends SvgFontData {};
 export const fontName = 'nofont';
+
+export const Font = {fontName, DefaultFont};

--- a/components/mjs/output/util.js
+++ b/components/mjs/output/util.js
@@ -31,13 +31,14 @@ export const OutputUtil = {
 
       if (name !== defaultFont) {
 
-        combineDefaults(MathJax.config.loader, `output/${jax}`, {
-          checkReady() {
-            return MathJax.loader.load(`${font}/${jax}`).catch(err => console.log(err));
-          }
-        });
+        MathJax.loader.addPackageData(`output/${jax}`, {extraLoads: [`${font}/${jax}`]});
 
       } else {
+
+        const extraLoads = MathJax.config.loader[`${font}/${jax}`]?.extraLoads;
+        if (extraLoads) {
+          MathJax.loader.addPackageData(`output/${jax}`, {extraLoads});
+        }
 
         combineWithMathJax({_: {
           output: {
@@ -78,14 +79,12 @@ export const OutputUtil = {
 
   loadFont(startup, jax, font, preload) {
     if (!MathJax.loader) {
-      return Promise.resolve();
+      return startup;
     }
     if (preload) {
       MathJax.loader.preLoad(`[${font}]/${jax}`);
     }
-    const check = MathJax.config.loader[`output/${jax}`];
-    const start = (check && check.checkReady ? check.checkReady().then(startup) : startup());
-    return start.catch(err => console.log(err));
+    return Package.loadPromise(`output/${jax}`).then(startup);
   }
 
 };

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -25,7 +25,7 @@
 
 import {MathJax as MJGlobal, MathJaxObject as MJObject, MathJaxLibrary,
         MathJaxConfig as MJConfig, combineWithMathJax, combineDefaults} from './global.js';
-import {Package, PackageError, PackageReady, PackageFailed} from './package.js';
+import {Package, PackageError, PackageReady, PackageFailed, PackageConfig} from './package.js';
 import {FunctionList} from '../util/FunctionList.js';
 import {mjxRoot} from '#root/root.js';
 
@@ -73,7 +73,9 @@ export interface MathJaxObject extends MJObject {
     getRoot: () => string;                            // Find the root URL for the MathJax files
     checkVersion: (name: string, version: string) => boolean;   // Check the version of an extension
     saveVersion: (name: string) => void;              // Set the version for a combined component
-    pathFilters: FunctionList;                        // the filters to use for looking for package paths
+    pathFilters: FunctionList;                        // The filters to use for looking for package paths
+    addExtraLoads: (name: string, ...extra: string[]) => void;  // Add packages to be loaded after a given one
+    addPackageData: (name: string, data: PackageConfig) => void;  // Add more package data for a package
   };
   startup?: any;
 }
@@ -196,6 +198,30 @@ export namespace Loader {
         extension.provides(CONFIG.provides[name]);
       }
       extension.loaded();
+    }
+  }
+
+  /**
+   * Insert options into a package configuration
+   *
+   * @param {string} name         The package whose configuration is being augmented
+   * @param {PackageConfig} data  The extra configuraiton information to add
+   */
+  export function addPackageData(name: string, data: PackageConfig) {
+    let config = CONFIG[name];
+    if (!config) {
+      config = CONFIG[name] = {};
+    }
+    for (const [key, value] of Object.entries(data)) {
+      if (Array.isArray(value)) {
+        if (!config[key]) {
+          config[key] = [];
+        }
+        const set = new Set([...config[key], ...value]);
+        config[key] = [...set];
+      } else {
+        config[key] = value;
+      }
     }
   }
 

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -74,7 +74,6 @@ export interface MathJaxObject extends MJObject {
     checkVersion: (name: string, version: string) => boolean;   // Check the version of an extension
     saveVersion: (name: string) => void;              // Set the version for a combined component
     pathFilters: FunctionList;                        // The filters to use for looking for package paths
-    addExtraLoads: (name: string, ...extra: string[]) => void;  // Add packages to be loaded after a given one
     addPackageData: (name: string, data: PackageConfig) => void;  // Add more package data for a package
   };
   startup?: any;

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -29,11 +29,12 @@ import {ParseMethod} from '../Types.js';
 import TexError from '../TexError.js';
 import {TeX} from '../../tex.js';
 
-import {MathJax} from '../../../components/global.js';
+import {MathJax} from '../../../components/startup.js';
 import {Package} from '../../../components/package.js';
 import {Loader, CONFIG as LOADERCONFIG} from '../../../components/loader.js';
 import {mathjax} from '../../../mathjax.js';
 import {expandable} from '../../../util/Options.js';
+import {MenuMathDocument} from '../../../ui/menu/MenuHandler.js';
 
 /**
  * The MathJax configuration block (for looking up user-defined package options)
@@ -147,11 +148,12 @@ export function RequireLoad(parser: TexParser, name: string) {
   if (!allowed) {
     throw new TexError('BadRequire', 'Extension "%1" is not allowed to be loaded', extension);
   }
-  if (Package.packages.has(extension)) {
-    RegisterExtension(parser.configuration.packageData.get('require').jax, extension);
-  } else {
+  if (!Package.packages.has(extension)) {
     mathjax.retryAfter(Loader.load(extension));
   }
+  const require = LOADERCONFIG[extension]?.rendererExtensions;
+  (MathJax.startup.document as MenuMathDocument)?.menu?.addRequiredExtensions?.(require);
+  RegisterExtension(parser.configuration.packageData.get('require').jax, extension);
 }
 
 /**

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -31,7 +31,7 @@ import {MathItem} from '../core/MathItem.js';
 import {ChtmlWrapper, ChtmlWrapperClass} from './chtml/Wrapper.js';
 import {ChtmlWrapperFactory} from './chtml/WrapperFactory.js';
 import {ChtmlCharOptions, ChtmlVariantData, ChtmlDelimiterData,
-        ChtmlFontData, ChtmlFontDataClass} from './chtml/FontData.js';
+        ChtmlFontData, ChtmlFontDataClass, FontExtensionData} from './chtml/FontData.js';
 import {Usage} from './chtml/Usage.js';
 import * as LENGTHS from '../util/lengths.js';
 import {unicodeChars} from '../util/string.js';
@@ -165,8 +165,11 @@ CommonOutputJax<
   /**
    * @override
    */
-  public addExtension(name: string): string[] {
-    const css = super.addExtension(name);
+  public addExtension(
+    font: FontExtensionData<ChtmlCharOptions, ChtmlDelimiterData>,
+    prefix: string = ''
+  ): string[] {
+    const css = super.addExtension(font, prefix);
     if (css.length && this.options.adaptiveCSS && this.chtmlStyles) {
       this.adaptor.insertRules(this.chtmlStyles, css);
     }

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -26,7 +26,8 @@ import {MathDocument} from '../core/MathDocument.js';
 import {MathItem, Metrics, STATE} from '../core/MathItem.js';
 import {MmlNode, TEXCLASS} from '../core/MmlTree/MmlNode.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
-import {FontData, FontDataClass, CharOptions, VariantData, DelimiterData, CssFontData} from './common/FontData.js';
+import {FontData, FontDataClass, CharOptions, VariantData, DelimiterData,
+        CssFontData, FontExtensionData} from './common/FontData.js';
 import {OptionList, separateOptions} from '../util/Options.js';
 import {CommonWrapper, CommonWrapperClass} from './common/Wrapper.js';
 import {CommonWrapperFactory} from './common/WrapperFactory.js';
@@ -269,12 +270,12 @@ export abstract class CommonOutputJax<
   /**
    * Add a registered font extension to the output jax's font.
    *
-   * @param {string} name   The name of the extension to add to this output jax's font
-   * @return {string[]}     New CSS rules needed for the font
+   * @param {FontExtensionData} font   The name of the extension to add to this output jax's font
+   * @param {string} prefix            The prefix for dynamically loaded files for this extension
+   * @return {string[]}                New CSS rules needed for the font
    */
-  public addExtension(name: string): string[] {
-    const font = this.font.CLASS.dynamicExtensions.get(name);
-    return this.font.addExtension(font.data);
+  public addExtension(font: FontExtensionData<CC, DD>, prefix: string = ''): string[] {
+    return this.font.addExtension(font, prefix);
   }
 
 

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -293,7 +293,6 @@ export type DynamicFont = {
   files: DynamicFileList;
   sizeN: number;
   stretchN: number;
-  data: FontExtensionData<any, any>
 };
 
 /**
@@ -790,11 +789,10 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
   public static addExtension(data: FontExtensionData<CharOptions, DelimiterData>, prefix: string = '') {
     const extension = {
       name: data.name,
-      prefix: prefix,
+      prefix: prefix || `[${data.name}-extension]/${this.JAX.toLowerCase()}/dynamic`,
       files: this.defineDynamicFiles(data.ranges, data.name),
       sizeN: this.defaultSizeVariants.length,
-      stretchN: this.defaultStretchVariants.length,
-      data: data
+      stretchN: this.defaultStretchVariants.length
     };
     this.dynamicExtensions.set(data.name, extension);
     for (const [src, dst] of [
@@ -858,13 +856,13 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    * @return {string[]}                 The new CSS rules needed for this extension
    */
   public addExtension(data: FontExtensionData<C, D>, prefix: string = ''): string[] {
+    const jax = (this.constructor as typeof FontData<C, V, D>).JAX.toLowerCase();
     const dynamicFont = {
       name: data.name,
-      prefix: prefix,
+      prefix: prefix || `[${data.name}-extension]/${jax}/dynamic`,
       files: this.CLASS.defineDynamicFiles(data.ranges, prefix),
       sizeN: this.sizeVariants.length,
-      stretchN: this.stretchVariants.length,
-      data: data
+      stretchN: this.stretchVariants.length
     };
     this.CLASS.dynamicExtensions.set(data.name, dynamicFont);
 


### PR DESCRIPTION
This PR is for beta.6.

The addition of the new TeX packages that load various double-struck fonts has broken the previous separation of input and output jax.  There are some assumptions that relied on this separation, so these new TeX packages complicate things somewhat.  In particular, switching renderers when one of these packages has been loaded via `\require` would not necessarily retain the font in the new renderer.  Furthermore, because of the way the extensions hooked into the renderer changes, leading a second font extension would interfere with the loading of the first one when a renderer change occurred.

The component packages for these extensions tried to set things up overcome some of these complications, but were not completely successful.  So this PR includes changes to properly handle switching renderers and fonts, both in regular pages and in the v4-lab.  In addition, it implements generic font extensions that are not tied to a particular base font, so that the extensions like `mathjax-dsfont` can be applied to any font.

One of the important changes is to move the code that adds an extension to a font from the TeX component file (where it currently is) into the font extension's component file instead.  So all the code controlling the extension being added to a font is now in the extension itself, rather than in the TeX package.  The TeX package file now simply has to set up the loading of the extension and that is it.  This is done via the changes to the `components/mjs/input/tex/extension.js` file.

To facilitate this, and to overcome the problem with multiple font extensions, the loader has been extended to include a new function `addPackageData()` that can be used to update the loader package information (like the `checkReady()` function), and that data can now include a list of additional packages to load after the initial one is loaded.  So we can now set up several font extensions to be loaded when the output jax is changed, for example.

There is also an array of extensions that need to be installed when the renderer changes that is set when one of the font extensions is loaded by `\require` (in case the new renderer has already been loaded, and so the file-based hooks will not be triggered).  This is referenced by the changes in the `\require` macro, which sets a corresponding array in the document's `Menu` object, and that is used by the menu code to install the needed extensions when the output jax changes.

Because of the `extraLoads` array, the `Package` object gets a new method `loadPromise()` that returns a promise that is resolved when all the extra files are loaded, and the `checkReady()` method (if any) resolves.  This is also used in the `components/mjs/output/util.js` file to make sure these files are loaded when a new output jax component is loaded.

Some other cleanup is also performed.  The `addExtension()` functions in the common and chtml output jax files now have the optional `prefix` argument that the `FontData` version has (though it is not currently used), and the instance versions of these functions now take a `FontExtensionData` object rather than an extension name, so that we don't have to store that data in the dynamic extension data.  (Since these `addExtension()` calls have been moved to the font extension components themselves, and those have access to the font data, that means we don't need to keep that data in the saved dynamic extension object any longer).  The dynamic extension data now uses a default value for the `prefix`, rather than requiring it to be set in the font extension component, as in the past.

Finally, some of the config files have been updated to remove `exclude` arrays that are no longer needed.

This branch requires changes in the font components, as well as the font tools, and also the v4-lab.  You will need to check out the `generic-extensions` branches in the font-tools and fonts repositories, then compile the font-tools, and rebuild the extension fonts (all three).  Then check out the `lab-extension-update` in the MathJax-dev repository.  Finally, link the newly built fonts into MathJax-dev's `node_modules` directory next to the other fonts.