### PR TITLE
Correct width for unknown fonts in scaled text in CHTML (mathjax/MathJax#3194)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -291,7 +291,7 @@ CommonOutputJax<
     //    and call to getBBox().w in TextNode.ts)
     //
     if (width !== null) {
-      styles.width = this.fixed(width * this.math.metrics.scale * rscale) + 'em';
+      styles.width = this.fixed(width * this.math.metrics.scale) + 'em';
     }
     //
     return this.html('mjx-utext', {variant: variant, style: styles}, [this.text(text)]);


### PR DESCRIPTION
This PR fixes a problem with the width of text that is taken from a non-MathJax font when it is in a context where it is scaled in CHTML output.  For example, when `mtextInteritFont` is true,

``` latex
x_{\bbox[red]{\text{xxxxxxx}}}
```

will have an incorrectly sized red background in CHTML.  Other examples are

``` latex
\Large \bbox[red]{\text{xxxxx}}
```

``` latex
\textstyle \frac{1}{\bbox[red]{\text{xxxxx}}}
```

``` latex
\sqrt{\scriptstyle\bbox[red]{\text{xxxxx}}}
```

Resolves issue at the bottom of mathjax/MathJax#3194.