### PR TITLE
Fix handling of unknown characters in SVG output. (mathjax/MathJax#3224)

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -489,21 +489,25 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     }
     const C = n.toString(16).toUpperCase();
     const [ , , w, data] = this.getVariantChar(variant, n);
+    if (data.unknown) {
+      this.utext += String.fromCodePoint(n);
+      return (buffer ? 0 : this.addUtext(x, y, parent, variant));
+    }
+    const dx = this.addUtext(x, y, parent, variant);
     if ('p' in data) {
-      x += this.addUtext(x, y, parent, variant);
+      x += dx;
       const path = (data.p ? 'M' + data.p + 'Z' : '');
       this.place(x, y, this.adaptor.append(parent, this.charNode(variant, C, path)) as N);
-    } else if ('c' in data) {
-      x += this.addUtext(x, y, parent, variant);
+      return w + dx;
+    }
+    if ('c' in data) {
       const g = this.adaptor.append(parent, this.svg('g', {'data-c': C})) as N;
-      this.place(x, y, g);
+      this.place(x + dx, y, g);
       x = 0;
       for (const n of this.unicodeChars(data.c, variant)) {
         x += this.placeChar(n, x, y, g, variant);
       }
-    } else if (data.unknown) {
-      this.utext += String.fromCodePoint(n);
-      return (buffer ? 0 : this.addUtext(x, y, parent, variant));
+      return x + dx;
     }
     return w;
   }


### PR DESCRIPTION
This PR fixes an issue with the handling of the width of characters that are not in the MathJax fonts in SVG mode that could lead to overlapping characters.  The SVG wrapper's `toSVG()` code has been reordered to make this work properly.  The handling of unknown characters has been moved to the top, and `if-then-else` has been broken into separate `if-then` with returns, with the width of previous unknown characters being taken properly into account (which was what wasn't being done).

This only affects text that is all in the same MathML node, so you can test using `\text{aaa 中文 bbbb}` for the `unknown` and `p` sections of the code.  To get a `c` test, you need to use the `mathjax-tex` font with `\text{aaa\U{220C}bbb}`.

Resolves issue mathjax/MathJax#3224.