### PR TITLE
Use XML serialization not HTML serialization for SVG images. (mathjax/MathJax#3226)

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1207,7 +1207,7 @@ export class Menu {
         adaptor.getAttribute(math.typesetRoot, 'jax') === 'SVG') {
       for (const child of adaptor.childNodes(math.typesetRoot)) {
         if (adaptor.kind(child) === 'svg') {
-          return Promise.resolve(this.formatSvg(adaptor.outerHTML(child as HTMLElement)));
+          return Promise.resolve(this.formatSvg(adaptor.serializeXML(child as HTMLElement)));
         }
       }
     }


### PR DESCRIPTION
This PR changes the serialization of SVG elements to use XML rather than HTML rules (so that the xml in the `data-semantic-speech` attribute is properly quoted).

Resolves issue mathjax/MathJax#3226.