### PR TITLE
Prevent linebreaking from crashing on empty containers. (mathjax/MathJax#3232)

### DIFF
--- a/ts/output/common/LinebreakVisitor.ts
+++ b/ts/output/common/LinebreakVisitor.ts
@@ -402,6 +402,7 @@ export class LinebreakVisitor<
    * @override
    */
   public visitNode(wrapper: WW, i: number) {
+    if (!wrapper) return;
     this.state.depth++;
     if (wrapper.node.isEmbellished && !wrapper.node.isKind('mo')) {
       this.visitEmbellishedOperator(wrapper, i);
@@ -416,7 +417,7 @@ export class LinebreakVisitor<
    */
   public visitDefault(wrapper: WW, i: number) {
     const bbox = wrapper.getLineBBox(i);
-    if (wrapper.node.isToken || wrapper.node.linebreakContainer) {
+    if (wrapper.node.isToken || wrapper.node.linebreakContainer || !wrapper.childNodes?.[0]) {
       this.addWidth(bbox);
     } else {
       const [L, R] = this.getBorderLR(wrapper);


### PR DESCRIPTION
This PR fixes a problem in the LinebreakVisitor object where `malignmark` or `maligngroup` elements (which have no children) cause a "Math output error" due to an attempt to use `childNodes[0]` when that is null.

Resolves issue mathjax/MathJax#3232.