### PR TITLE
Fix regression from #1069 (mathjax/MathJax#3233, mathjax/MathJax#3234)

### DIFF
--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -208,8 +208,11 @@ export class PrimeItem extends BaseItem {
    */
   public checkItem(item: StackItem): CheckType {
     let [top0, top1] = this.Peek(2);
-    const isSup = NodeUtil.isType(top0, 'msubsup') && !NodeUtil.getChildAt(top0, (top0 as MmlMsubsup).sup);
-    const isOver = NodeUtil.isType(top0, 'munderover') && !NodeUtil.getChildAt(top0, (top0 as MmlMunderover).over);
+    const isSup = NodeUtil.isType(top0, 'msubsup') &&
+      !NodeUtil.getChildAt(top0, (top0 as MmlMsubsup).sup);
+    const isOver = NodeUtil.isType(top0, 'munderover') &&
+      !NodeUtil.getChildAt(top0, (top0 as MmlMunderover).over) &&
+      !NodeUtil.getProperty(top0, 'subsupOK');
     if (!isSup && !isOver) {
       // @test Prime, Double Prime
       const node = this.create('node', top0.getProperty('movesupsub') ? 'mover' : 'msup', [top0, top1]);

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -510,13 +510,13 @@ new sm.CommandMap('macros', {
   tan:                'NamedFn',
   tanh:               'NamedFn',
 
-  limits:            ['Limits', 1],
-  nolimits:          ['Limits', 0],
+  limits:            ['Limits', true],
+  nolimits:          ['Limits', false],
 
   overline:            ['UnderOver', '2015'],
   underline:           ['UnderOver', '2015'],
-  overbrace:           ['UnderOver', '23DE', 1],
-  underbrace:          ['UnderOver', '23DF', 1],
+  overbrace:           ['UnderOver', '23DE', true],
+  underbrace:          ['UnderOver', '23DF', true],
   overparen:           ['UnderOver', '23DC'],
   underparen:          ['UnderOver', '23DD'],
   overrightarrow:      ['UnderOver', '2192'],

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -258,7 +258,8 @@ BaseMethods.Prime = function(parser: TexParser, c: string) {
   if ((NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
        NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) ||
       (NodeUtil.isType(base, 'munderover') && !NodeUtil.isType(base, 'mover') &&
-       NodeUtil.getChildAt(base, (base as MmlMunderover).over))) {
+       NodeUtil.getChildAt(base, (base as MmlMunderover).over) &&
+       !NodeUtil.getProperty(base, 'subsupOK'))) {
     // @test Double Prime Error
     throw new TexError('DoubleExponentPrime',
                         'Prime causes double exponent: use braces to clarify');
@@ -481,9 +482,9 @@ BaseMethods.NamedOp = function(parser: TexParser, name: string, id: string) {
  * Handle a limits command for math operators.
  * @param {TexParser} parser The calling parser.
  * @param {string} name The macro name.
- * @param {string} limits The limits arguments.
+ * @param {boolean} limits True for \limits, false for \nolimits.
  */
-BaseMethods.Limits = function(parser: TexParser, _name: string, limits: string) {
+BaseMethods.Limits = function(parser: TexParser, _name: string, limits: boolean) {
   // @test Limits
   let op = parser.stack.Prev(true);
   // Get the texclass for the core operator.


### PR DESCRIPTION
This PR fixes a regression introduced in #1069 in which primes are misplaced for `\underline{x}` and give an error about double superscripts for `\overline{x}` and similar macros.  This was du to not taking the `subsupOK` property in account for these `munder` and `mover` constructs.  We add those checks here.

Also, this fixes some non-critical number/boolean issues in the base mappings and macros.  It works the way it is, but the types are wrong, so we straighten that out here.

Resolves issue mathjax/MathJax#3233 and mathjax/MathJax#3234.