### PR TITLE
Update handling of math accents to round-trip through SRE

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -124,6 +124,7 @@ export class MmlMo extends AbstractMmlTokenNode {
 
   /**
    * Regular expression matching characters that are marked as math accents
+   *  (property mathaccent = true)
    */
   protected static mathaccents = new RegExp([
     '^[',
@@ -135,11 +136,24 @@ export class MmlMo extends AbstractMmlTokenNode {
     '\u02D8\u0306',        // breve
     '\u02C7\u030C',        // check
     '\u005E\u0302\u02C6',  // hat
-    '\u2192\u20D7',        // vec
+    '\u20D0\u20D1',        // harpoons
+    '\u20D6\u20D7\u20E1',  // vec (backward, forward, double)
     '\u02D9\u0307',        // dot
     '\u02DA\u030A',        // mathring
     '\u20DB',              // dddot
     '\u20DC',              // ddddot
+    ']$'
+  ].join(''));
+
+  /**
+   * Regular expression matching characters that are marked as math accents
+   *   whose widths are to be respected (property mathaccent = false)
+   */
+  protected static mathaccentsWithWidth = new RegExp([
+    '^[',
+    '\u2015',              // overline and underline
+    '\u2190\u2192\u2194',  // arrows
+    '\u23DC\u23DD',        // over and under parens
     ']$'
   ].join(''));
 
@@ -470,10 +484,33 @@ export class MmlMo extends AbstractMmlTokenNode {
     const isUnder = !!(under && under.isEmbellished && under.coreMO() === this);
     const isOver = !!(over && over.isEmbellished && under.coreMO() === this);
     if (!isUnder && !isOver) return;
-    const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
-    if (mo.match(MATHACCENT)) {
-      this.setProperty('mathaccent', true);
+    if (this.isMathAccent(mo)) {
+      this.setProperty('mathaccent', true);   // math accent whose width is replaced by 0
+    } else if (this.isMathAccentWithWidth(mo)) {
+      this.setProperty('mathaccent', false);  // math accent whose width is normal
     }
+  }
+
+  /**
+   * Check a string for being a mathaccent
+   *
+   * @param {string} mo   The string to check
+   * @return {boolean}    True if the string should be a mathaccent
+   */
+  public isMathAccent(mo: string = this.getText()): boolean {
+    const MATHACCENT = (this.constructor as typeof MmlMo).mathaccents;
+    return !!mo.match(MATHACCENT);
+  }
+
+  /**
+   * Check a string for being a mathaccent with non-zero width
+   *
+   * @param {string} mo   The string to check
+   * @return {boolean}    True if the string should be a mathaccent
+   */
+  public isMathAccentWithWidth(mo: string = this.getText()): boolean {
+    const MATHACCENT = (this.constructor as typeof MmlMo).mathaccentsWithWidth;
+    return !!mo.match(MATHACCENT);
   }
 
 }

--- a/ts/core/MmlTree/MmlVisitor.ts
+++ b/ts/core/MmlTree/MmlVisitor.ts
@@ -22,6 +22,7 @@
  */
 
 import {MmlNode, TextNode, XMLNode, TEXCLASS, TEXCLASSNAMES} from './MmlNode.js';
+import {MmlMo} from './MmlNodes/mo.js';
 import {MmlMi} from './MmlNodes/mi.js';
 import {HtmlNode} from './MmlNodes/HtmlNode.js';
 import {MmlFactory} from './MmlFactory.js';
@@ -167,6 +168,13 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
     vbox && this.setDataAttribute(data, 'vbox', vbox);
     const scriptalign = node.getProperty('scriptalign') as string;
     scriptalign && this.setDataAttribute(data, 'script-align', scriptalign);
+    const accent = node.getProperty('mathaccent') as boolean;
+    if (accent !== undefined) {
+      if ((accent && !(node as MmlMo).isMathAccent()) ||
+          (!accent && !(node as MmlMo).isMathAccentWithWidth())) {
+        this.setDataAttribute(data, 'mathaccent', accent.toString());
+      }
+    }
     const texclass = node.getProperty('texClass') as number;
     if (texclass !== undefined) {
       let setclass = true;

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -201,7 +201,7 @@ export class MathMLCompile<N, T, D> {
           mml.setProperty('scriptlevel', 1);
           mml.setProperty('useHeight', false);
           break;
-        case 'accent':
+        case 'mathaccent':
           mml.setProperty('mathaccent', value === 'true');
           break;
         case 'auto-op':

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -793,7 +793,7 @@ export function CommonScriptbaseMixin<
       //  Determine if we are setting a mathaccent
       //
       this.isMathAccent = this.baseIsChar &&
-        (this.scriptChild && !!this.scriptChild.coreMO().node.getProperty('mathaccent')) as boolean;
+        (this.scriptChild && this.scriptChild.coreMO().node.getProperty('mathaccent') !== undefined);
       //
       // Check for overline/underline accents
       //


### PR DESCRIPTION
The `mathaccent` property is used to help produce accents that work more like TeX's accents, but it doesn't get serialized by `SerializeMmlVisitor` since the `mo` object itself sets this properly based on the accent being used (so that MathML will work like TeX without the need for extra data attributes).  So U+2192 (right arrow) get `mathaccent` set by default.  But macros like `\overrightarrow` set `mathaccent` to `false` to prevent them being treated like accents (since the TeX accents take up no horizontal space, whereas the right arrow can extend beyond its base and needs to take up space).  This setting of `false` is lost when we serialize the internal MathML for SRE and then parse it again.

This PR fixes that by having the `MmlVisitor` (the base class for `SerializedMmlVisitor`) check whether the value of `mathaccent` should be added as a data attribute so that it will be properly preserved, and change the data attribute name from `data-mjx-accent` to `data-mjx-mathaccent`.  We also add a list of characters that should have `mathaccent` set to `false` by default (so MathML will work like TeX without extra data attributes), and move the right arrow to this list.

In the past `\overrightarrow{x}\overleftarrow{x}` would have the wrong spacing (the arrows touch) because the right arrow was getting `mathaccent` set to `true` when the SRE output is parsed.  This PR should fix that.

This also affected things like `\overrightarrow{x}^2` where the 2 was too close to the base, since the arrow width was being treated as 0.  But if the right arrow is not considered a math accent, then the 2 (or other superscript) would be placed too high (in TeX the `\overrightarrow` acts like an accent for purposes of superscript placement).  Now that `mathaccent` is set to `false` explicitly, we use the presence of the `mathaccent` property to indicate the superscripts should be placed like math accents, while its value determines whether the width of the accent is set to 0 (`mathaccent=true`) or not (`mathaccent=false`).  One can check this by testing if the position of the 2 in `\overline{x}^2` is different from that in `{{}\overline{x}}^2`.

Resolves an issue from mathjax/MathJax#2226.