### PR TITLE
`\sqrt` with index of radical exceeds two digits display incorrect

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -364,7 +364,6 @@ CommonWrapper<
    * @param {N} element  The element to be placed
    */
   public place(x: number, y: number, element: N = null) {
-    x += this.dx;
     if (!(x || y)) return;
     if (!element) {
       element = this.element;


### PR DESCRIPTION
When using the `sqrt` syntax but the `index of radical exceeds two digits`, the offset of expression is incorrect.

For example
```
aa\sqrt[33333]{a^{15}} + \sqrt[33333]{a^{15}}aa
```

<img width="700" alt="image" src="https://github.com/mathjax/MathJax-src/assets/1034290/0b0c1495-c7f1-4179-aa20-73521fd1c38b">

It is very easy to reproduce by using the [demo page](https://mathjax.github.io/MathJax-demos-web/input-tex2svg.html) provided by [MathJax-demos-web](https://github.com/mathjax/MathJax-demos-web)

The correct result should be displayed like the following image (the output is HTML, which means the issue is only on SVG)

<img width="692" alt="image" src="https://github.com/mathjax/MathJax-src/assets/1034290/da578933-688f-43e5-886f-35370441b55b">

After investigation, this is a bug caused by the following line. Seems like adding an extra `dx` value accidentally.

https://github.com/mathjax/MathJax-src/commit/5f6cc8a78092f6b7b0849deb0e57002a61e7953d#diff-21adda599dc0790184ec7dfa4cb615b263b9a91917f3386bc62d8730460548acR356
(Downgrading to v3.2.0 can fix this issue because the pr was not merged yet)

Remove this line, and the expression is displayed correctly.