### PR TITLE
Fix regression from #1069 (mathjax/MathJax#3233, mathjax/MathJax#3234)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -154,6 +154,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     '\u2015',              // overline and underline
     '\u2190\u2192\u2194',  // arrows
     '\u23DC\u23DD',        // over and under parens
+    '\u23DE\u23DF',        // over and under braces
     ']$'
   ].join(''));
 

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -208,8 +208,11 @@ export class PrimeItem extends BaseItem {
    */
   public checkItem(item: StackItem): CheckType {
     let [top0, top1] = this.Peek(2);
-    const isSup = NodeUtil.isType(top0, 'msubsup') && !NodeUtil.getChildAt(top0, (top0 as MmlMsubsup).sup);
-    const isOver = NodeUtil.isType(top0, 'munderover') && !NodeUtil.getChildAt(top0, (top0 as MmlMunderover).over);
+    const isSup = NodeUtil.isType(top0, 'msubsup') &&
+      !NodeUtil.getChildAt(top0, (top0 as MmlMsubsup).sup);
+    const isOver = NodeUtil.isType(top0, 'munderover') &&
+      !NodeUtil.getChildAt(top0, (top0 as MmlMunderover).over) &&
+      !NodeUtil.getProperty(top0, 'subsupOK');
     if (!isSup && !isOver) {
       // @test Prime, Double Prime
       const node = this.create('node', top0.getProperty('movesupsub') ? 'mover' : 'msup', [top0, top1]);

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -510,13 +510,13 @@ new sm.CommandMap('macros', {
   tan:                'NamedFn',
   tanh:               'NamedFn',
 
-  limits:            ['Limits', 1],
-  nolimits:          ['Limits', 0],
+  limits:            ['Limits', true],
+  nolimits:          ['Limits', false],
 
   overline:            ['UnderOver', '2015'],
   underline:           ['UnderOver', '2015'],
-  overbrace:           ['UnderOver', '23DE', 1],
-  underbrace:          ['UnderOver', '23DF', 1],
+  overbrace:           ['UnderOver', '23DE', true],
+  underbrace:          ['UnderOver', '23DF', true],
   overparen:           ['UnderOver', '23DC'],
   underparen:          ['UnderOver', '23DD'],
   overrightarrow:      ['UnderOver', '2192'],
@@ -650,10 +650,10 @@ new sm.CommandMap('macros', {
   breve:             ['Accent', '02D8'],  // or 0306
   check:             ['Accent', '02C7'],  // or 030C
   hat:               ['Accent', '005E'],  // or 0302 or 02C6
-  vec:               ['Accent', '2192'],  // or 20D7
+  vec:               ['Accent', '2192', false],  // or 20D7
   dot:               ['Accent', '02D9'],  // or 0307
-  widetilde:         ['Accent', '007E', 1], // or 0303 or 02DC
-  widehat:           ['Accent', '005E', 1], // or 0302 or 02C6
+  widetilde:         ['Accent', '007E', true], // or 0303 or 02DC
+  widehat:           ['Accent', '005E', true], // or 0302 or 02C6
 
   matrix:             'Matrix',
   array:              'Matrix',

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -282,9 +282,10 @@ const BaseMethods: {[key: string]: ParseMethod} = {
       base = parser.create('token', 'mi');
     }
     if ((NodeUtil.isType(base, 'msubsup') && !NodeUtil.isType(base, 'msup') &&
-      NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) ||
-      (NodeUtil.isType(base, 'munderover') && !NodeUtil.isType(base, 'mover') &&
-        NodeUtil.getChildAt(base, (base as MmlMunderover).over))) {
+         NodeUtil.getChildAt(base, (base as MmlMsubsup).sup)) ||
+        (NodeUtil.isType(base, 'munderover') && !NodeUtil.isType(base, 'mover') &&
+         NodeUtil.getChildAt(base, (base as MmlMunderover).over) &&
+         !NodeUtil.getProperty(base, 'subsupOK'))) {
       // @test Double Prime Error
       throw new TexError('DoubleExponentPrime',
                          'Prime causes double exponent: use braces to clarify');
@@ -496,10 +497,10 @@ const BaseMethods: {[key: string]: ParseMethod} = {
   /**
    * Handle a limits command for math operators.
    * @param {TexParser} parser The calling parser.
-   * @param {string} name The macro name.
-   * @param {string} limits The limits arguments.
+   * @param {string} _name The macro name.
+   * @param {boolean} limits True for \limits, false for \nolimits.
    */
-  Limits(parser: TexParser, _name: string, limits: string) {
+  Limits(parser: TexParser, _name: string, limits: boolean) {
     // @test Limits
     let op = parser.stack.Prev(true);
     // Get the texclass for the core operator.
@@ -645,13 +646,17 @@ const BaseMethods: {[key: string]: ParseMethod} = {
    * @param {TexParser} parser The calling parser.
    * @param {string} name The macro name.
    * @param {string} accent The accent.
-   * @param {boolean} stretchy True if accent is stretchy.
+   * @param {boolean} stretchy True if accent is stretchy, false if mathaccent should be false.
    */
   Accent(parser: TexParser, name: string, accent: string, stretchy: boolean) {
     // @test Vector
     const c = parser.ParseArg(name);
     // @test Vector Font
-    const def = {...ParseUtil.getFontDef(parser), accent: true, mathaccent: true};
+    const def = {
+        ...ParseUtil.getFontDef(parser),
+      accent: true,
+      mathaccent: stretchy === undefined ? true : stretchy
+    };
     const entity = NodeUtil.createEntity(accent);
     const moNode = parser.create('token', 'mo', def, entity);
     const mml = moNode;


### PR DESCRIPTION
This PR fixes a regression introduced in #1069 in which primes are misplaced for `\underline{x}` and give an error about double superscripts for `\overline{x}` and similar macros.  This was du to not taking the `subsupOK` property in account for these `munder` and `mover` constructs.  We add those checks here.

Also, this fixes some non-critical number/boolean issues in the base mappings and macros.  It works the way it is, but the types are wrong, so we straighten that out here.

Resolves issue mathjax/MathJax#3233 and mathjax/MathJax#3234.