### PR TITLE
Improve performance by detaching speech computation

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -24,11 +24,12 @@
 
 
 import {A11yDocument, HoverRegion, SpeechRegion, LiveRegion} from './Region.js';
+import {STATE} from '../../core/MathItem.js';
 import type { ExplorerMathItem } from '../explorer.js';
 import {Explorer, AbstractExplorer} from './Explorer.js';
 import {ExplorerPool} from './ExplorerPool.js';
 import {MmlNode} from '../../core/MmlTree/MmlNode.js';
-import { honk, InPlace } from '../speech/SpeechUtil.js';
+import { honk, InPlace, Timing } from '../speech/SpeechUtil.js';
 import {Sre} from '../sre.js';
 
 
@@ -446,6 +447,11 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
    * @override
    */
   public Start() {
+    // In case the speech is not attached yet, we restart the explorer after a
+    // fashion.
+    if (this.item.state() < STATE.ATTACHSPEECH) {
+      setTimeout(() => this.Start(), Timing.INITIAL);
+    };
     if (!this.attached) return;
     if (this.node.hasAttribute('tabindex')) {
       this.node.removeAttribute('tabindex');

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -223,3 +223,12 @@ export enum InPlace {
   SUMMARY
 }
 
+/**
+ * Some timing constants for asynchronous speech computation.
+ */
+export const Timing = {
+  THRESHOLD: 250,
+  INITIAL: 100,
+  INTERMEDIATE: 10
+};
+


### PR DESCRIPTION
Detaches the speech computation by starting it after the typeset elements are inserted:
* Introduces a set of timeouts that allow us to 
    * to initially delay the computation by 100ms
    * loop through mathitems for ~250ms before breaking 
    * for 10ms to allow other processes to come in.
* Similarly the explorer restarts in case the speech is not yet attached
