### PR TITLE
Fixes incorrect lifecycle script for test

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "use-cjs": "echo '{\n  \"extends\": \"./tsconfig/cjs.json\"\n}' > tsconfig.json",
     "use-mjs": "echo '{\n  \"extends\": \"./tsconfig/mjs.json\"\n}' > tsconfig.json",
     "=============================================================================== aliases": "",
-    "test": "cd jest && pnpm test",
+    "test": "cd testsuite && pnpm test",
     "clean": "pnpm -s clean:mod cjs && pnpm -s cjs:bundle:clean && pnpm -s clean:mod mjs && pnpm -s clean:dir bundle",
     "compile-cjs": "pnpm -s cjs:compile",
     "compile-mjs": "pnpm -s mjs:compile",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "use-cjs": "echo '{\n  \"extends\": \"./tsconfig/cjs.json\"\n}' > tsconfig.json",
     "use-mjs": "echo '{\n  \"extends\": \"./tsconfig/mjs.json\"\n}' > tsconfig.json",
     "=============================================================================== aliases": "",
-    "test": "cd testsuite && pnpm test",
+    "test": "cd testsuite && pnpm -s test --"
     "clean": "pnpm -s clean:mod cjs && pnpm -s cjs:bundle:clean && pnpm -s clean:mod mjs && pnpm -s clean:dir bundle",
     "compile-cjs": "pnpm -s cjs:compile",
     "compile-mjs": "pnpm -s mjs:compile",


### PR DESCRIPTION
Fixes an oversight from PR #1100, that retains the `jest` directory name in the `test` lifecycle script.