### PR TITLE
Add tests for all ts/util files and update some utils to fix issues found from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ coverage
 /mjs
 /bundle
 /bundle-cjs
-
+/testsuite/js

--- a/testsuite/jest.config.ts
+++ b/testsuite/jest.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
   collectCoverage: true,
   coverageDirectory: "coverage",
   coverageProvider: "v8",
+  coveragePathIgnorePatterns: ["node_modules", "testsuite", "mjs/util/entities"],
   testEnvironment: "node",
   verbose: true,
   preset: tsjest,

--- a/testsuite/lib/AsyncLoad.child.cjs
+++ b/testsuite/lib/AsyncLoad.child.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  loaded: true
+};

--- a/testsuite/lib/AsyncLoad.child.mjs
+++ b/testsuite/lib/AsyncLoad.child.mjs
@@ -1,0 +1,1 @@
+export const loaded = true;

--- a/testsuite/src/dirname.ts
+++ b/testsuite/src/dirname.ts
@@ -1,0 +1,6 @@
+declare var __dirname: string;
+
+export function setDirname(name: string) {
+  __dirname = name;
+}
+

--- a/testsuite/tests/util/AsyncLoad.test.ts
+++ b/testsuite/tests/util/AsyncLoad.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from '@jest/globals';
+import {asyncLoad} from '#js/util/AsyncLoad.js';
+import {mathjax} from '#js/mathjax.js';
+
+describe('asyncLoad()', () => {
+
+  test('asyncLoad()', async () => {
+    //
+    // Throws error if not set in mathjax
+    //
+    expect(asyncLoad('x.js').then(() => false).catch(() => true)).resolves.toBe(true);
+
+    //
+    // mathjax.asyncLoad returns value
+    //
+    mathjax.asyncLoad = (_name: string) => 'success';
+    await expect(asyncLoad('x.js')).resolves.toBe('success');
+
+    //
+    // mathjax.asyncLoad throws error
+    //
+    mathjax.asyncLoad = (_name: string) => {throw 'fail'};
+    await expect(asyncLoad('x.js')).rejects.toBe('fail');
+
+    //
+    // mathjax.asyncLoad returns promise
+    //
+    mathjax.asyncLoad = (_name: string) => Promise.resolve().then(() => 'success');
+    await expect(asyncLoad('x.js')).resolves.toBe('success');
+
+    //
+    // mathjax.asyncLoad returns promise that rejects
+    //
+    mathjax.asyncLoad = (_name: string) => Promise.reject().catch(() => {throw 'fail'});
+    await expect(asyncLoad('x.js')).rejects.toBe('fail');
+
+  });
+
+});

--- a/testsuite/tests/util/BBox.test.ts
+++ b/testsuite/tests/util/BBox.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from '@jest/globals';
+import {BBox} from '#js/util/BBox.js';
+import {BIGDIMEN} from '#js/util/lengths.js';
+
+describe('BBox object', () => {
+
+  test('BBox creation', () => {
+    expect(BBox.zero()).toEqual(expect.objectContaining({w: 0, h: 0, d: 0}));
+    expect(BBox.empty()).toEqual(expect.objectContaining({w: 0, h: -BIGDIMEN, d: -BIGDIMEN}));
+    expect(new BBox({w: 1, h: 2, d: 0})).toEqual({
+      w: 1, h: 2, d: 0,
+      L: 0, R: 0,
+      ic: 0, oc: 0, sk: 0, dx: 0,
+      scale: 1, rscale: 1,
+      pwidth: ''
+    });
+    expect(new BBox({w: 1})).toEqual(expect.objectContaining({w: 1, h: -BIGDIMEN, d: -BIGDIMEN}));
+  });
+
+  test('empty()', () => {
+    expect(BBox.zero().empty()).toEqual(expect.objectContaining({w: 0, h: -BIGDIMEN, d: -BIGDIMEN}));
+  });
+
+  test('clean()', () => {
+    const bbox = BBox.empty();
+    bbox.w = -BIGDIMEN;
+    bbox.clean();
+    expect(bbox).toEqual(expect.objectContaining({w: 0, h: 0, d: 0}));
+  });
+
+  test('rescale()', () => {
+    const bbox = new BBox({w: 1, h: 2, d: 3});
+    bbox.rescale(2);
+    expect(bbox).toEqual(expect.objectContaining({w: 2, h: 4, d: 6}));
+    bbox.rescale(0);
+    expect(bbox).toEqual(BBox.zero());
+  });
+
+  test('copy()', () => {
+    const bbox = Object.assign(new BBox({w: 1, h: 2, d: 3}), {
+      L: 4, R: 5,
+      ic: 6, oc: 7, sk: 8, dx: 9,
+      scale: 10, rscale: 11,
+      pwidth: '10%'
+    });
+    const copy = bbox.copy();
+    expect(copy).toEqual(bbox);
+    expect(copy).not.toBe(bbox);
+  });
+
+  test('updateFrom()', () => {
+    const bbox1 = Object.assign(new BBox({w: 1, h: 2, d: 3}), {
+      L: 4, R: 5,
+      ic: 6, oc: 7, sk: 8, dx: 9,
+      scale: 10, rscale: 11,
+      pwidth: ''
+    });
+    bbox1.updateFrom(BBox.empty());
+    expect(bbox1).toEqual({
+      w: 0, h: -BIGDIMEN, d: -BIGDIMEN,
+      L: 4, R: 5,
+      ic: 6, oc: 7, sk: 8, dx: 9,
+      scale: 10, rscale: 11,
+      pwidth: ''
+    });
+    bbox1.pwidth = '100%';
+    const bbox2 = BBox.zero();
+    bbox2.updateFrom(bbox1);
+    expect(bbox2).toEqual({
+      w: 0, h: -BIGDIMEN, d: -BIGDIMEN,
+      L: 0, R: 0,
+      ic: 0, oc: 0, sk: 0, dx: 0,
+      scale: 1, rscale: 1,
+      pwidth: '100%'
+    });
+  });
+
+  test('combine()', () => {
+    let bbox = BBox.empty();
+    const cbox = new BBox({w: 1, h: 2, d: 3});
+    bbox.combine(cbox);
+    expect(bbox).toEqual(expect.objectContaining({w: 1, h: 2, d: 3}));
+
+    //
+    //  Check that a scaled bbox is placed properly
+    //
+    cbox.rscale = 2;
+    bbox.combine(cbox);
+    expect(bbox).toEqual(expect.objectContaining({w: 2, h: 4, d: 6}));
+
+    //
+    //  Check x and y positioning
+    //
+    bbox = BBox.empty();
+    cbox.L = 2;
+    cbox.R = 1;
+    cbox.rscale = .5;
+    bbox.combine(cbox, 1, 2);
+    expect(bbox).toEqual(expect.objectContaining({w: 3, h: 3, d: -.5}));
+
+    //
+    //  Check box that doesn't change current bbox
+    //
+    cbox.rscale = .01;
+    bbox.combine(cbox, 1, 1);
+    expect(bbox).toEqual(expect.objectContaining({w: 3, h: 3, d: -.5}));
+  });
+
+  test('append()', () => {
+    let bbox = BBox.empty();
+    const cbox = new BBox({w: 1, h: 2, d: 3});
+    bbox.append(cbox);
+    expect(bbox).toEqual(expect.objectContaining({w: 1, h: 2, d: 3}));
+
+    //
+    //  Check that a scaled bbox is placed properly
+    //
+    cbox.rscale = 2;
+    bbox.append(cbox);
+    expect(bbox).toEqual(expect.objectContaining({w: 3, h: 4, d: 6}));
+
+    //
+    //  Check that h and d don't change
+    //
+    cbox.rscale = 1;
+    bbox.append(cbox);
+    expect(bbox).toEqual(expect.objectContaining({w: 4, h: 4, d: 6}));
+  });
+
+});

--- a/testsuite/tests/util/BitField.test.ts
+++ b/testsuite/tests/util/BitField.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from '@jest/globals';
+import {BitField, BitFieldClass} from '#js/util/BitField.js';
+
+const MAXBIT = (BitField as any).MAXBIT;
+
+const bitClass = BitFieldClass('a', 'b');
+bitClass.allocate('c');
+
+describe('BitField object', () => {
+
+  test('Allocating bits', () => {
+    expect(bitClass.has('a')).toBe(true);
+    expect(bitClass.has('b')).toBe(true);
+    expect(bitClass.has('c')).toBe(true);
+    expect(() => bitClass.allocate('a')).toThrow('Bit already allocated for a');
+    for (let i = 1 << 3; i !== MAXBIT; i = i << 1) {
+      bitClass.allocate('x' + i);
+    }
+    expect(() => bitClass.allocate('y')).toThrow('Maximum number of bits already allocated');
+  });
+
+  test('set/clear/isSet/reset', () => {
+    const bits = new bitClass();
+    //
+    //  Bit is initially false
+    //
+    expect(bits.isSet('a')).toBe(false);
+    expect(bits.isSet('b')).toBe(false);
+    //
+    //  Check that it sets
+    //
+    bits.set('a');
+    expect(bits.isSet('a')).toBe(true);
+    expect(bits.isSet('b')).toBe(false);
+    //
+    //  Check that setting again is still set
+    //
+    bits.set('a')
+    expect(bits.isSet('a')).toBe(true);
+    //
+    //  Check that it clears
+    //
+    bits.clear('a');
+    expect(bits.isSet('a')).toBe(false);
+    //
+    //  Check that it stays clear
+    //
+    bits.clear('a');
+    expect(bits.isSet('a')).toBe(false);
+    //
+    //  Check that reset clears all bits
+    //
+    bits.set('a');
+    bits.set('b');
+    expect(bits.isSet('a')).toBe(true);
+    expect(bits.isSet('b')).toBe(true);
+    bits.reset();
+    expect(bits.isSet('a')).toBe(false);
+    expect(bits.isSet('b')).toBe(false);
+    //
+    //  Invalid name throws error
+    //
+    expect(() => bits.isSet('A')).toThrow('Unknown bit-field name: A');
+  });
+
+});

--- a/testsuite/tests/util/Entities.test.ts
+++ b/testsuite/tests/util/Entities.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from '@jest/globals';
+import * as Entities from '#js/util/Entities.js';
+import {handleRetriesFor} from '#js/util/Retries.js';
+import '#js/util/asyncLoad/esm.js';
+
+describe('Entities translation', () => {
+
+  test('translate()', async () => {
+    expect(Entities.translate('&#97;')).toBe('a');
+    expect(Entities.translate('&#x61;')).toBe('a');
+    expect(Entities.translate('&amp;')).toBe('&');
+    await expect(handleRetriesFor(() => Entities.translate('&xyz;'))).resolves.toBe('&xyz;');     // no such entity
+    await expect(handleRetriesFor(() => Entities.translate('&approx;'))).resolves.toBe('\u2248'); // load a.js
+    await expect(handleRetriesFor(() => Entities.translate('&Bscr;'))).resolves.toBe('\u212C');   // load scr.js
+    Entities.remove('approx');
+    expect(Entities.translate('&approx;')).toBe('&approx;');      // undefined entities remain unchanged
+    Entities.options.loadMissingEntities = false;
+    expect(Entities.translate('&bigwedge;')).toBe('&bigwedge;');  // don't load b.js
+  });
+
+});

--- a/testsuite/tests/util/FunctionList.test.ts
+++ b/testsuite/tests/util/FunctionList.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect } from '@jest/globals';
+import {FunctionList} from '#js/util/FunctionList.js';
+
+//
+//  Set up a function list with 6 functions that captures output
+//
+function LIST(): [FunctionList, string[]] {
+  const output = [] as string[];
+  const list = new FunctionList();
+  for (const i of [5, 0, 2, 1, 6, 3, 4]) {list.add(FN(i, output), i)}
+  return [list, output];
+}
+
+//
+//  A function that buffers the value of its parameters plus i
+//    unless the parameter is false or fail, which do special actions,
+//    or if the second is 'p', when we return a promise with a delay.
+//
+function FN(i: number, output: string[] = []) {
+  return function (x?: string, y?: string) {
+    if (x === 'false' && i === 3) return false;
+    if (x === 'fail' && i === 3) throw new Error('fail');
+    output.push(x === undefined ? String(i) : y == null ? x + i : x + y + i);
+    if (x === 'delay' && i === 3) {
+      return new Promise<void>((ok, fail) => {
+        setTimeout(() => {y === 'fail' ? fail('Failed!') : ok()}, 10);
+      });
+    }
+    return true;
+  };
+}
+
+describe('FunctionList functionality', () => {
+  test('Empty list is empty array', () => {
+    expect(Array.from(new FunctionList())).toEqual([]);
+  });
+
+  test('Adding one item', () => {
+    const list = new FunctionList();
+    const fn = FN(0);
+    const item = list.add(fn);
+    expect(Array.from(list)).toEqual([{item: item, priority: 5}]);
+    expect(item).toBe(fn);
+  });
+
+  test('Removing one item', () => {
+    const list = new FunctionList();
+    const fn = list.add(FN(0));
+    const item = list.remove(fn);
+    expect(Array.from(list)).toEqual([]);
+    expect(item).toBe(list);
+  });
+
+  test('Executing list', () => {
+    const output = [] as string[];
+    const list = new FunctionList();
+    list.add(FN(0, output));
+    expect(list.execute()).toBe(true);
+    expect(output).toEqual(["0"]);
+  });
+
+  test('Sorting of list', () => {
+    const [list, output] = LIST();
+    expect(list.execute()).toBe(true);
+    expect(output).toEqual(['0', '1', '2', '3', '4', '5', '6']);
+  });
+
+  test('Passing one parameter', () => {
+    const [list, output] = LIST();
+    expect(list.execute('x')).toBe(true);
+    expect(output).toEqual(['x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6']);
+  });
+
+  test('Passing multiple parameters', () => {
+    const [list, output] = LIST();
+    expect(list.execute('x', 'y')).toBe(true);
+    expect(output).toEqual(['xy0', 'xy1', 'xy2', 'xy3', 'xy4', 'xy5', 'xy6']);
+  });
+
+  test('Function returning false', () => {
+    const [list, output] = LIST();
+    expect(list.execute('false')).toBe(false);
+    expect(output).toEqual(['false0', 'false1', 'false2']);
+  });
+
+  test('asyncExecute() returns promise', () => {
+    const list = new FunctionList();
+    expect(list.asyncExecute() instanceof Promise).toBe(true);
+  });
+
+  test('asyncExecute() runs', () => {
+    const [list, output] = LIST();
+    list.asyncExecute().then((result: boolean) => {
+      expect(result).toBe(true);
+      expect(output).toEqual(['0', '1', '2', '3', '4', '5', '6']);
+    });
+  });
+
+  test('Passing parameter to asyncExecute()', () => {
+    const [list, output] = LIST();
+    list.asyncExecute('x').then((result: boolean) => {
+      expect(result).toBe(true);
+      expect(output).toEqual(['x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6']);
+    });
+  });
+
+  test('Passing multiple parameters to asyncExecute()', () => {
+    const [list, output] = LIST();
+    list.asyncExecute('x', 'y').then((result: boolean) => {
+      expect(result).toBe(true);
+      expect(output).toEqual(['xy0', 'xy1', 'xy2', 'xy3', 'xy4', 'xy5', 'xy6']);
+    });
+  });
+
+  test('Function returning false in asyncExecute()', () => {
+    const [list, output] = LIST();
+    list.asyncExecute('false').then((result: boolean) => {
+      expect(result).toBe(false);
+      expect(output).toEqual(['false0', 'false1', 'false2']);
+    });
+  });
+
+  test('Function error in asyncExecute()', () => {
+    const [list, output] = LIST();
+    expect.assertions(2);
+    list.asyncExecute('fail').catch((err: Error) => {
+      expect(output).toEqual(['fail0', 'fail1', 'fail2']);
+      expect(err.message).toBe("fail");
+    });
+  });
+
+  test('Delay in asyncExecute()', () => {
+    const [list, output] = LIST();
+    list.asyncExecute('delay', '').then((result: boolean) => {
+      expect(result).toBe(true);
+      expect(output).toEqual(['delay0', 'delay1', 'delay2', 'delay3', 'delay4', 'delay5', 'delay6']);
+    });
+  });
+
+  test('Failed promise in asyncExecute()', () => {
+    const [list, output] = LIST();
+    list.asyncExecute('delay', 'fail').catch((result: string) => {
+      expect(output).toEqual(['delayfail0', 'delayfail1', 'delayfail2', 'delayfail3']);
+      expect(result).toBe("Failed!");
+    });
+  });
+
+});

--- a/testsuite/tests/util/LinkedList.test.ts
+++ b/testsuite/tests/util/LinkedList.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from '@jest/globals';
+import {LinkedList} from '#js/util/LinkedList.js';
+
+function inReverse(a: number, b: number) {return a > b}
+
+describe('LinkedList functionality', () => {
+  test('Empty list is empty array', () => {
+    const list = new LinkedList();
+    expect(Array.from(list)).toEqual([]);
+  });
+
+  test('Adding one item', () => {
+    const list = new LinkedList();
+    const item = list.push('x');
+    expect(Array.from(list)).toEqual(['x']);
+    expect(item).toBe(list);
+  });
+
+  test('Removing an item from list of 1 item', () => {
+    const list = new LinkedList('x');
+    const item = list.pop();
+    expect(Array.from(list)).toEqual([]);
+    expect(item).toBe('x');
+  });
+
+  test('Removing from empty list', () => {
+    const list = new LinkedList();
+    const item1 = list.pop();
+    expect(Array.from(list)).toEqual([]);
+    expect(item1).toBe(null);
+    const item2 = list.shift();
+    expect(Array.from(list)).toEqual([]);
+    expect(item2).toBe(null);
+  });
+
+  test('Removing items', () => {
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove())).toEqual([1, 2, 3, 4]); // remove nothing
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(1))).toEqual([2, 3, 4]); // at start
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(4))).toEqual([1, 2, 3]); // at end
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(2))).toEqual([1, 3, 4]); // in midle
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(1, 3, 4))).toEqual([2]); // multiple items removed
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(6))).toEqual([1, 2, 3, 4]); // item not in list
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(2, 6))).toEqual([1, 3, 4]); // some items not in list
+    expect(Array.from(new LinkedList(1, 2, 3, 4).remove(1, 2, 3, 4))).toEqual([]); // all items removed
+  });
+
+  test('Adding nothing', () => {
+    expect(Array.from(new LinkedList().push())).toEqual([]);
+    expect(Array.from(new LinkedList().unshift())).toEqual([]);
+    expect(Array.from(new LinkedList(1, 2).push())).toEqual([1, 2]);
+    expect(Array.from(new LinkedList(1, 2).unshift())).toEqual([1, 2]);
+  });
+
+  test('unshift to empty array', () => {
+    const list = new LinkedList();
+    expect(Array.from(list.unshift('x'))).toEqual(['x']);
+    const item = list.shift();
+    expect(Array.from(list)).toEqual([]);
+    expect(item).toBe('x');
+  });
+
+  test('Pushing several items', () => {
+    const list = new LinkedList();
+    list.push(2, 3, 4);
+    expect(Array.from(list)).toEqual([2, 3, 4]);
+    list.push(5, 6);
+    expect(Array.from(list)).toEqual([2, 3, 4, 5, 6]);
+    const item = list.unshift(0, 1);
+    expect(Array.from(list)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(item).toBe(list);
+  });
+
+  test('Iterator', () => {
+    const list = new LinkedList(0, 1, 2, 3, 4, 5, 6);
+    let j = 0;
+    for (const item of list) {
+      if (item === j) j++; else break;
+    }
+    expect(j).toBe(7);
+  });
+
+  test('Reversed iterator', () => {
+    const list = new LinkedList(0, 1, 2, 3, 4, 5, 6);
+    let j = 6;
+    for (const item of list.reversed()) {
+      if (item === j) j--; else break;
+    }
+    expect(j).toBe(-1);
+  });
+
+  test('Removing items by shift', () => {
+    const list = new LinkedList(0, 1, 2, 3);
+    expect(list.shift()).toBe(0);
+    expect(Array.from(list)).toEqual([1, 2, 3]);
+    expect(list.pop()).toBe(3);
+    expect(Array.from(list)).toEqual([1, 2]);
+  });
+
+  test('Clearing of list', () => {
+    const list = new LinkedList(1, 2, 3);
+    expect(Array.from(list.clear())).toEqual([]);
+    expect(list.clear()).toBe(list); // clear() returns list
+  });
+
+  test('Sorting of list', () => {
+    const list = new LinkedList();
+    expect(list.sort()).toBe(list); // sort() returns list
+    expect(Array.from(list.sort())).toEqual([]); // empty list
+    expect(Array.from(new LinkedList(5, 1, 3, 6, 4, 0, 2).sort())).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(Array.from(new LinkedList(5, 1, 3, 6, 4, 0, 2).sort(inReverse))).toEqual([6, 5, 4, 3, 2, 1, 0]);
+  });
+
+  test('Inserting item in sorted list', () => {
+    const list = new LinkedList();
+    expect(list.insert(3)).toBe(list); // insert() returns list
+    expect(Array.from(new LinkedList().insert(3))).toEqual([3]); // with empty list
+    expect(Array.from(new LinkedList(5, 3, 4, 1).sort().insert(0))).toEqual([0, 1, 3, 4, 5]); // at start
+    expect(Array.from(new LinkedList(5, 3, 4, 1).sort().insert(6))).toEqual([1, 3, 4, 5, 6]); // at end
+    expect(Array.from(new LinkedList(5, 3, 4, 1).sort().insert(2))).toEqual([1, 2, 3, 4, 5]); // in middle
+  });
+
+  test('Inserting with sort function', () => {
+    expect(Array.from(new LinkedList().insert(3, inReverse))).toEqual([3]);  // with empty list
+    expect(Array.from(new LinkedList(3, 2, 1).insert(4, inReverse))).toEqual([4, 3, 2, 1]); // at start
+    expect(Array.from(new LinkedList(3, 2, 1).insert(0, inReverse))).toEqual([3, 2, 1, 0]); // at end
+    expect(Array.from(new LinkedList(4, 3, 1).insert(2, inReverse))).toEqual([4, 3, 2, 1]); // in middle
+  });
+
+  test('Merging of lists', () => {
+    const list = new LinkedList(1, 3);
+    expect(list.merge(new LinkedList(2, 4))).toBe(list);  // merge() return list
+    expect(Array.from(new LinkedList().merge(new LinkedList()))).toEqual([]); // with two empty lists
+    expect(Array.from(new LinkedList().merge(new LinkedList(1, 3, 5)))).toEqual([1, 3, 5]); // with 1st list empty
+    expect(Array.from(new LinkedList(1, 3, 5).merge(new LinkedList()))).toEqual([1, 3, 5]); // with 2nd list empty
+    expect(Array.from(new LinkedList(1, 3, 4, 7, 8, 9).merge(new LinkedList(2, 5, 6, 10, 11))))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]); // intermized lists
+    expect(Array.from(new LinkedList(1, 3, 4).merge(new LinkedList(1, 2, 4, 5))))
+      .toEqual([1, 1, 2, 3, 4, 4, 5]); // merge with repeats
+    expect(Array.from(new LinkedList(1, 2, 3, 4).merge(new LinkedList(5, 6, 7, 8))))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8]); // at end
+    expect(Array.from(new LinkedList(5, 6, 7, 8).merge(new LinkedList(1, 2, 3, 4))))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8]); // at start
+    expect(Array.from(new LinkedList(1, 2, 7, 8).merge(new LinkedList(3, 4, 5, 6))))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8]); // in the middle
+    expect(Array.from(new LinkedList(9, 8, 7, 4, 3, 1).merge(new LinkedList(11, 10, 6, 5, 2, 0), inReverse)))
+      .toEqual([11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]); // with sort function
+  });
+
+});

--- a/testsuite/tests/util/Options.test.ts
+++ b/testsuite/tests/util/Options.test.ts
@@ -1,0 +1,340 @@
+import { describe, test, expect } from '@jest/globals';
+import * as Options from '#js/util/Options.js';
+
+const SYMB = Symbol('symbol');
+const OPTIONS = Options.OPTIONS
+const optionError = OPTIONS.optionError;
+
+describe('Options utility', () => {
+
+  test('keys()', () => {
+    expect(Options.keys({a: 1, [Symbol.iterator]: 2})).toEqual(['a', Symbol.iterator]);
+    expect(Options.keys(null)).toEqual([]);
+    expect(Options.keys({})).toEqual([]);
+  });
+
+  test('copy()', () => {
+    //
+    // Copy() copies deeply
+    //
+    const orig: any = {
+      a: 1,
+      b: {x: 'x'},
+      c: {y: 'y'},
+      d: [1, {z: 'z'}, {w: 'w'}],
+      e: [1],
+      [SYMB]: 1
+    };
+    let copy = Options.copy(orig);
+    expect(copy).toEqual(orig);
+
+    //
+    //  Changing original doesn't change copy
+    //
+    orig.a = 2;
+    orig.b.x = 'xx';
+    orig.c = {yy: 'yy'};
+    orig.d[0] = 2;
+    orig.d[1].z = 'zz';
+    orig.d[2] = {ww: 'ww'};
+    orig.e = [2];
+    orig.f = 2;
+    orig[SYMB] = 2;
+    expect(copy).toEqual({
+      a: 1,
+      b: {x: 'x'},
+      c: {y: 'y'},
+      d: [1, {z: 'z'}, {w: 'w'}],
+      e: [1],
+      [SYMB]: 1
+    });
+
+    //
+    //  Copy() copies symbols
+    //
+    expect((copy as any)[SYMB]).toBe(1);
+
+    //
+    //  Copy() copies getter and setter
+    //
+    copy = Options.copy({
+      _a: 1,
+      get a() {return this._a},
+      set a(x) {this._a = x}
+    });
+    expect(copy.a).toBe(1);
+    copy.a = 2;
+    expect(copy._a).toBe(2);
+
+    //
+    //  Copy() handle empty objects
+    //
+    expect(Options.copy({})).toEqual({});
+  });
+
+  test('insert()', () => {
+    let warnings = [] as string[];
+    OPTIONS.optionError = (_msg: string, key: string) => {warnings.push(key)};
+
+    const options = {a: 1, b: {x: 'x', y: [0]}, c: [1, 2, 3]};
+    let copy = Options.insert({}, options, false);
+    expect(copy).toEqual(options);
+    expect(warnings).toEqual([]);
+
+    //
+    //  Error on unknown keys
+    //
+    copy = Options.insert({}, options);
+    expect(copy).toEqual({});
+    expect(warnings).toEqual(['a', 'b', 'c']);  // invalid keys
+    warnings = [];
+    copy = Options.insert({a: 2, b: {}, c: [4]}, options, true);
+    expect(copy).toEqual({a: 1, b: {}, c: [1, 2, 3]});
+    expect(warnings).toEqual(['x', 'y']);  // invalid keys
+    warnings = [];
+    copy = Options.insert({}, {[SYMB]: 1});
+    expect(copy).toEqual({});
+    expect(warnings).toEqual(['Symbol(symbol)']);
+    warnings = [];
+
+    //
+    //  insert() adds to objects and replaces other values
+    //
+    copy = Options.insert({a: 2, b: {}, c: [4]}, options, false);
+    expect(copy).toEqual(options);
+
+    //
+    //  insert() merges objects
+    //
+    copy = Options.insert({a: {}, b: 2}, {a: {x: 'x'}}, false);
+    expect(copy).toEqual({a: {x: 'x'}, b: 2});
+
+    //
+    //  insert() merges into functions
+    //
+    copy = Options.insert({a: function () {}}, {a: {x: 'x'}}, false);
+    expect(copy.a.x).toBe('x');
+
+    //
+    //  insert() changes object type
+    //
+    copy = Options.insert({a: {x: 'x'}}, {a: 1}, false);
+    expect(copy).toEqual({a: 1});
+
+    //
+    //  insert() replaces arrays
+    //
+    copy = Options.insert({a: [1, 2]}, {a: [3, 4]}, false);
+    expect(copy).toEqual({a: [3, 4]});
+
+    //
+    //  insert() appends to arrays with APPEND key
+    //
+    copy = Options.insert({a: [1, 2]}, {a: {[Options.APPEND]:[3, 4]}}, false);
+    expect(copy).toEqual({a: [1, 2, 3, 4]});
+
+    //
+    //  insert() removes from arrays with REMOVE key
+    //
+    copy = Options.insert({a: [1, 2, 3, 4]}, {a: {[Options.REMOVE]:[1, 3]}}, false);
+    expect(copy).toEqual({a: [2, 4]});
+
+    //
+    //  insert() adds and removes from arrays
+    //
+    copy = Options.insert({a: [1, 2, 3, 4]}, {a: {[Options.REMOVE]:[1, 3], [Options.APPEND]: [3, 5]}}, false);
+    expect(copy).toEqual({a: [2, 4, 3, 5]});
+
+    //
+    //  insert() handles empty objects
+    //
+    copy = Options.insert({a: 1}, {});
+    expect(copy).toEqual({a: 1});
+    expect(warnings).toEqual([]);
+
+    OPTIONS.optionError = optionError;
+  });
+
+  test('expandable()', () => {
+    let warnings = [] as string[];
+    OPTIONS.optionError = (_msg: string, key: string) => {warnings.push(key)};
+
+    //
+    //  No error for unknonw keys in expandables
+    //
+    const options = {a: Options.expandable({x: 1})};
+    let copy = Options.userOptions(options, {a: {y: 2}});
+    expect(copy).toEqual({a: {x: 1, y: 2}});
+    expect(warnings).toEqual([]);
+
+    OPTIONS.optionError = optionError;
+
+    //
+    //  Expandable copies as expandable
+    //
+    copy = Options.copy(Options.expandable({x: 1}));
+    expect(copy instanceof Options.Expandable).toBe(true);
+    expect(copy).toEqual({x:1});
+  });
+
+  test('defaultOptions()', () => {
+    let warnings = 0;
+    OPTIONS.optionError = () => {warnings++};
+
+    const copy = Options.defaultOptions({}, {a: 1}, {b: 2});
+    expect(copy).toEqual({a: 1, b: 2});
+    expect(warnings).toBe(0);
+
+    OPTIONS.optionError = optionError;
+  });
+
+  test('userOptions()', () => {
+    let warnings = [] as string[];
+    OPTIONS.optionError = (_msg: string, key: string) => {warnings.push(key)};
+
+    //
+    // userOptions() warns about invalid options
+    //
+    let copy = Options.userOptions({}, {a: 1}, {b: 2});
+    expect(copy).toEqual({});
+    expect(warnings).toEqual(['a', 'b']);
+    warnings = [];
+
+    //
+    // userOptions() warns about invalid secondary options
+    //
+    copy = Options.userOptions({a: 'x'}, {a: 1}, {b: 2});
+    expect(copy).toEqual({a: 1});
+    expect(warnings).toEqual(['b']);
+    warnings = [];
+
+    //
+    // userOptions() merges multiple options
+    //
+    copy = Options.userOptions({a: 'x', b: 'y'}, {a: 1}, {b: 2});
+    expect(copy).toEqual({a: 1, b: 2});
+    expect(warnings).toEqual([]);
+
+    OPTIONS.optionError = optionError;
+  });
+
+  test('selectOptions()', () => {
+    //
+    //  selectOptions() finds existing keys and skips others
+    //
+    const options = {a: 1, b: 2, c: 3, d: 4};
+    let copy = Options.selectOptions(options, 'a', 'c', 'x', 'y');
+    expect(copy).toEqual({a: 1, c: 3});
+
+    //
+    //  selectOptions() handles empty list
+    //
+    copy = Options.selectOptions({}, 'x', 'y');
+    expect(copy).toEqual({});
+
+    //
+    //  selectOptions() handles empty list of keys
+    //
+    copy = Options.selectOptions(options);
+    expect(copy).toEqual({});
+  });
+
+  test('selectOptionsFromKeys()', () => {
+    //
+    //  selectOptionsFromKeys() finds existing keys and skips others
+    //
+    const options = {a: 1, b: 2, c: 3, d: 4};
+    let copy = Options.selectOptionsFromKeys(options, {a: true, c: true, x: true, y: true});
+    expect(copy).toEqual({a: 1, c: 3});
+    //
+    //  selectOptionsFromKeys() handles empty source list
+    //
+    copy = Options.selectOptionsFromKeys({}, options);
+    expect(copy).toEqual({});
+    //
+    //  selectOptionsFromKeys() handles empty key list;
+    //
+    copy = Options.selectOptionsFromKeys(options, {});
+    expect(copy).toEqual({});
+  });
+
+  test('separateOptions()', () => {
+    //
+    //  separateOptions() works with one set
+    //
+    const options = {a: 1, b: 2, c: 3, d: 4, e: 5};
+    let result = Options.separateOptions(options, {a: true, c: true});
+    expect(result).toEqual([{b: 2, d: 4, e: 5}, {a: 1, c: 3}]);
+
+    //
+    //  separateOptions() works with two sets
+    //
+    result = Options.separateOptions(options, {a: true, c: true}, {d: true});
+    expect(result).toEqual([{b: 2, e: 5}, {a: 1, c: 3}, {d: 4}]);
+
+    //
+    //  separateOptions() works with no sets
+    //
+    result = Options.separateOptions(options);
+    expect(result).toEqual([options]);
+
+    //
+    //  separateOptions() works with unknown keys
+    //
+    result = Options.separateOptions(options, {a: true, c: true, x: true});
+    expect(result).toEqual([{b: 2, d: 4, e: 5}, {a: 1, c: 3}]);
+
+    //
+    //  separateOptions() works with empty options
+    //
+    result = Options.separateOptions({}, {a: true});
+    expect(result).toEqual([{}, {}]);
+
+    //
+    //  separateOptions() works with no options
+    //
+    result = Options.separateOptions(null, {a: true});
+    expect(result).toEqual([{}, {}]);
+  });
+
+  test('OPTIONS settings', () => {
+    let copy: Options.OptionList;
+
+    //
+    //  Fatal throws an error
+    //
+    OPTIONS.invalidOption = 'fatal';
+    try {
+      copy = Options.userOptions({}, {a: 1});
+    } catch(err) {
+      expect(err.message).toBe('Invalid option "a" (no default value).');
+    }
+    expect(copy).toEqual(undefined);
+
+    //
+    //  Warn does not throw an error
+    //
+    const warn = console.warn;
+    console.warn = () => {}
+    OPTIONS.invalidOption = 'warn';
+    try {
+      copy = Options.userOptions({}, {a: 1});
+    } catch(err) {}
+    expect(copy).toEqual({});
+    console.warn = warn;
+
+  });
+
+  test('makeArray()', () => {
+    expect(Options.makeArray([1, 2])).toEqual([1, 2]);
+    expect(Options.makeArray(1)).toEqual([1]);
+  });
+
+  test('lookup()', () => {
+    const options = {a: 1, b: 'x'};
+    expect(Options.lookup('a', options)).toBe(1);
+    expect(Options.lookup('c', options, 'default')).toBe('default');
+    expect(Options.lookup('c', options)).toBe(null);
+  });
+
+});

--- a/testsuite/tests/util/PrioritizedList.test.ts
+++ b/testsuite/tests/util/PrioritizedList.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from '@jest/globals';
+import {PrioritizedList} from '#js/util/PrioritizedList.js';
+
+//
+//  Turn the item list into a list of just that data
+//
+function ARRAY(list: PrioritizedList<any>) {
+  let array = [];
+  for (const {item} of list) array.push(item);
+  return array;
+}
+
+describe('PrioritizedList functionality', () => {
+  test('Empty list is empty array', () => {
+    expect(ARRAY(new PrioritizedList())).toEqual([]);
+  });
+
+  test('Adding one item', () => {
+    const list = new PrioritizedList();
+    const item = list.add(0);
+    expect(Array.from(list)).toHaveLength(1);
+    expect(Array.from(list)).toEqual([{item: 0, priority: 5}]);
+    expect(item).toBe(0);
+  });
+
+  test('Removing one item', () => {
+    const list = new PrioritizedList();
+    list.add(0);
+    const item = list.remove(0);
+    expect(Array.from(list)).toEqual([]);
+    expect(item).toBe(list);
+  });
+
+  test('Sorting of list', () => {
+    const list = new PrioritizedList();
+    for (const i of [5, 0, 2, 1, 6, 3, 4]) {list.add(i, i)}
+    expect(ARRAY(list)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  test('Iterator', () => {
+    const list = new PrioritizedList();
+    for (const i of [5, 0, 2, 1, 6, 3, 4]) {list.add(i, i)}
+    let j = 0;
+    for (const item of list) {
+      if (item.item === j) j++; else break;
+    }
+    expect(j).toBe(7);
+  });
+
+  test('Removing from longer list', () => {
+    const list = new PrioritizedList();
+    for (const i of [5, 0, 2, 1, 6, 3, 4]) {list.add(i, i)}
+    list.remove(3); // remove from middle
+    expect(ARRAY(list)).toEqual([0, 1, 2, 4, 5, 6]);
+    list.remove(0); // remove first
+    expect(ARRAY(list)).toEqual([1, 2, 4, 5, 6]);
+    list.remove(6); // remove last
+    expect(ARRAY(list)).toEqual([1, 2, 4, 5]);
+  });
+
+  test('Adding with same priority', () => {
+    const list = new PrioritizedList();
+    list.add(3);
+    list.add(1,1);
+    list.add(4);
+    list.add(2,1);
+    expect(ARRAY(list)).toEqual([1, 2, 3, 4]);
+  });
+
+});

--- a/testsuite/tests/util/Retries.test.ts
+++ b/testsuite/tests/util/Retries.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from '@jest/globals';
+import {handleRetriesFor, retryAfter} from '#js/util/Retries.js';
+import {MathJax as MJX, MathJaxObject} from '#js/components/global.js';
+
+/**
+ * Add the legacy MathJax.CallBack for teting v2-style restarts
+ */
+type MathJaxGlobal = MathJaxObject & {
+  Callback: {
+    After(code: Function): void,
+    mock(): Function
+  }
+};
+const MathJax: MathJaxGlobal = Object.assign(MJX, {
+  Callback: {
+    After(code: Function) {
+      setTimeout(code, 10);
+    },
+    mock() {return Object.assign(() => {}, {isCallback: true})}
+  }
+});
+
+describe('handleRetriesFor() and retryAfter()', () => {
+
+  test('handleRetriesFor() then/catch getting called', () => {
+    expect(handleRetriesFor(() => 'success')).resolves.toBe('success');
+    expect(handleRetriesFor(() => {throw Error('failed')})).rejects.toThrow('failed');
+  });
+
+  test('handleRetriesFor().then called after 3 retries', () => {
+    let n = 0;
+    expect(
+      handleRetriesFor(() => {
+        if (++n < 3) {
+          let p = new Promise<void>((ok, _fail) => {
+            setTimeout(() => ok(), 10);
+          });
+          retryAfter(p);
+        }
+        return 'success';
+      }).then((result: string) => {
+        expect(result).toBe('success');
+        expect(n).toBe(3);
+      })
+    )
+  });
+
+  test('handleRetriesFor().catch called for fail on 3rd retry', () => {
+    let n = 0;
+    expect(
+      handleRetriesFor(() => {
+        if (++n < 3) {
+          let p = new Promise<void>((ok, fail) => {
+            setTimeout(() => n < 2 ? ok() : fail('fail'), 10);
+          });
+          retryAfter(p);
+        }
+        return 'success';
+      }).catch((result: string) => {
+        expect(result).toBe('fail');
+        expect(n).toBe(2);
+      })
+    )
+  });
+
+  test('handleRetriesFor().catch called for error on 3rd retry', () => {
+    let n = 0;
+    expect(
+      handleRetriesFor(() => {
+        if (++n < 3) {
+          let p = new Promise<void>((ok, _fail) => {
+            setTimeout(() => ok(), 10);
+          });
+          retryAfter(p);
+        }
+        throw Error('fail');
+      }).catch((err: Error) => {
+        expect(err.message).toBe('fail');
+        expect(n).toBe(3);
+      })
+    )
+  });
+
+  test('v2 retry', () => {
+    let n = 0;
+    expect(handleRetriesFor(() => {
+        if (++n < 3) {
+          throw Object.assign(new Error('restart'), {
+            restart: MathJax.Callback.mock()  // mark this error as a v2 restart
+          });
+        }
+        return 'success';
+      }).then((result: string) => {
+        expect(result).toBe('success');
+        expect(n).toBe(3);
+      })
+    )
+  });
+
+});

--- a/testsuite/tests/util/StyleList.test.ts
+++ b/testsuite/tests/util/StyleList.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from '@jest/globals';
+import {CssStyles} from '#js/util/StyleList.js';
+
+describe('CssStyles object', () => {
+
+  test('CssStyle creation', () => {
+    expect(new CssStyles().cssText).toBe('');
+    expect(new CssStyles({'.mjx': {padding: '0px'}}).cssText).toBe('.mjx {\n  padding: 0px;\n}');
+    expect(new CssStyles({
+      '.mjx': {
+        padding: '0px',
+        'font-size': '150%'
+      },
+      p: {
+        'font-weight': 'bold'
+      }
+    }).cssText).toBe([
+      '.mjx {',
+      '  padding: 0px;',
+      '  font-size: 150%;',
+      '}',
+      '',
+      'p {',
+      '  font-weight: bold;',
+      '}'
+    ].join('\n'));
+  });
+
+  test('Add/remove styles', () => {
+    const styles = new CssStyles();
+    styles.addStyles({p: {'font-weight': 'bold'}, h1: {'font-size': '150%'}, 'h2': {}});
+    expect(styles.cssText).toBe('p {\n  font-weight: bold;\n}\n\nh1 {\n  font-size: 150%;\n}\n\nh2 {\n\n}');
+    styles.removeStyles('h1', 'h2');
+    expect(styles.cssText).toBe('p {\n  font-weight: bold;\n}');
+    styles.clear();
+    expect(styles.cssText).toBe('');
+  });
+
+});

--- a/testsuite/tests/util/Styles.test.ts
+++ b/testsuite/tests/util/Styles.test.ts
@@ -1,0 +1,331 @@
+import { describe, test, expect } from '@jest/globals';
+import {Styles, StyleList} from '#js/util/Styles.js';
+
+function cssTest(css: string, list: StyleList, text: string = css + ';') {
+  const styles = new Styles(css);
+  expect(styles.styleList).toEqual(list);
+  expect(styles.cssText).toBe(text);
+}
+
+function cssFontTest(css: string, list: StyleList) {
+  const test = Array.from(Object.keys(list)).map((k) => `${k}: ${list[k]};`).join(' ');
+  return cssTest(css, list, test);
+}
+
+describe('CssStyles object', () => {
+
+  test('Styles parsing', () => {
+    cssTest('', {}, ''); // emtpy list
+    cssTest('font-size: 150%', {'font-size': '150%'}); // one style
+    cssTest('abc-def: 0', {'abc-def': '0'}); // unknown style is retained
+    cssTest('a: 0; b: 1px', {a: '0', b: '1px'}); // multiple styles
+    cssTest('a: 0; /*b: 1px*/ c: bold', {a: '0', c: 'bold'}, 'a: 0; c: bold;'); // comments
+    cssTest('  a  : \n  0  ;   b\n :   1px \n ', {a: '0', b: '1px'}, 'a: 0; b: 1px;'); // extra spaces
+    cssTest('abc: ; xyz: 0', {xyz: '0'}, 'xyz: 0;'); // missing value
+    cssTest('abc xyz: 1px', {}, ''); // malformed CSS string
+  });
+
+  test('padding', () => {
+    cssTest('padding: 3px', {
+      'padding': '3px',
+      'padding-bottom': '3px',
+      'padding-left': '3px',
+      'padding-right': '3px',
+      'padding-top': '3px'
+    });
+    cssTest('padding: 3px; padding-right: 1px', {
+      'padding': '3px 1px 3px 3px',
+      'padding-bottom': '3px',
+      'padding-left': '3px',
+      'padding-right': '1px',
+      'padding-top': '3px'
+    }, 'padding: 3px 1px 3px 3px;');
+    cssTest('padding-top: 0; padding-right: 1px; padding-bottom: 0; padding-left: 1px', {
+      'padding': '0 1px',
+      'padding-bottom': '0',
+      'padding-left': '1px',
+      'padding-right': '1px',
+      'padding-top': '0'
+    }, 'padding: 0 1px;');
+    cssTest('padding-top: 0; padding-right: 1px; padding-bottom: 2px; padding-left: 1px', {
+      'padding': '0 1px 2px',
+      'padding-bottom': '2px',
+      'padding-left': '1px',
+      'padding-right': '1px',
+      'padding-top': '0'
+    }, 'padding: 0 1px 2px;');
+    cssTest('padding-top: 0; padding-right: 0; padding-bottom: 0; padding-left: 0', {
+      'padding': '0',
+      'padding-bottom': '0',
+      'padding-left': '0',
+      'padding-right': '0',
+      'padding-top': '0'
+    }, 'padding: 0;');
+    cssTest('padding:', {}, '');
+  });
+
+  test('border', () => {
+    cssTest('border: 3px solid red', {
+      'border': '3px solid red',
+      'border-top': '3px solid red',
+      'border-top-color': 'red',
+      'border-top-style': 'solid',
+      'border-top-width': '3px',
+      'border-right': '3px solid red',
+      'border-right-color': 'red',
+      'border-right-style': 'solid',
+      'border-right-width': '3px',
+      'border-bottom': '3px solid red',
+      'border-bottom-color': 'red',
+      'border-bottom-style': 'solid',
+      'border-bottom-width': '3px',
+      'border-left': '3px solid red',
+      'border-left-color': 'red',
+      'border-left-style': 'solid',
+      'border-left-width': '3px'
+    });
+    cssTest('border: 3px solid red; border-top: inset blue 2px', {
+      'border-top': 'inset blue 2px',
+      'border-top-color': 'blue',
+      'border-top-style': 'inset',
+      'border-top-width': '2px',
+      'border-right': '3px solid red',
+      'border-right-color': 'red',
+      'border-right-style': 'solid',
+      'border-right-width': '3px',
+      'border-bottom': '3px solid red',
+      'border-bottom-color': 'red',
+      'border-bottom-style': 'solid',
+      'border-bottom-width': '3px',
+      'border-left': '3px solid red',
+      'border-left-color': 'red',
+      'border-left-style': 'solid',
+      'border-left-width': '3px'
+    }, [
+      'border-top: inset blue 2px; border-right: 3px solid red;',
+      'border-bottom: 3px solid red; border-left: 3px solid red;'
+    ].join(' '));
+    cssTest('border: 3px solid red; border-top-color: blue', {
+      'border-top': '3px solid blue',
+      'border-top-color': 'blue',
+      'border-top-style': 'solid',
+      'border-top-width': '3px',
+      'border-right': '3px solid red',
+      'border-right-color': 'red',
+      'border-right-style': 'solid',
+      'border-right-width': '3px',
+      'border-bottom': '3px solid red',
+      'border-bottom-color': 'red',
+      'border-bottom-style': 'solid',
+      'border-bottom-width': '3px',
+      'border-left': '3px solid red',
+      'border-left-color': 'red',
+      'border-left-style': 'solid',
+      'border-left-width': '3px'
+    }, [
+      'border-top: 3px solid blue; border-right: 3px solid red;',
+      'border-bottom: 3px solid red; border-left: 3px solid red;'
+    ].join(' '));
+    cssTest('border-top: 3px solid red; border-top-color: blue', {
+      'border-top': '3px solid blue',
+      'border-top-color': 'blue',
+      'border-top-style': 'solid',
+      'border-top-width': '3px',
+    }, 'border-top: 3px solid blue;');
+    cssTest('border-top: 3px solid red; border-top-style: groove', {
+      'border-top': '3px groove red',
+      'border-top-color': 'red',
+      'border-top-style': 'groove',
+      'border-top-width': '3px',
+    }, 'border-top: 3px groove red;');
+    cssTest('border-top: 3px solid red; border-top-width: 2px', {
+      'border-top': '2px solid red',
+      'border-top-color': 'red',
+      'border-top-style': 'solid',
+      'border-top-width': '2px',
+    }, 'border-top: 2px solid red;');
+    cssTest('border: 3px solid', {
+      'border': '3px solid',
+      'border-bottom': '3px solid',
+      'border-bottom-style': 'solid',
+      'border-bottom-width': '3px',
+      'border-left': '3px solid',
+      'border-left-style': 'solid',
+      'border-left-width': '3px',
+      'border-right': '3px solid',
+      'border-right-style': 'solid',
+      'border-right-width': '3px',
+      'border-top': '3px solid',
+      'border-top-style': 'solid',
+      'border-top-width': '3px',
+    });
+    cssTest('border: 3px blue', {
+      'border': '3px blue',
+      'border-bottom': '3px blue',
+      'border-bottom-color': 'blue',
+      'border-bottom-width': '3px',
+      'border-left': '3px blue',
+      'border-left-color': 'blue',
+      'border-left-width': '3px',
+      'border-right': '3px blue',
+      'border-right-color': 'blue',
+      'border-right-width': '3px',
+      'border-top': '3px blue',
+      'border-top-color': 'blue',
+      'border-top-width': '3px',
+    });
+    cssTest('border: solid blue', {
+      'border': 'solid blue',
+      'border-bottom': 'solid blue',
+      'border-bottom-color': 'blue',
+      'border-bottom-style': 'solid',
+      'border-left': 'solid blue',
+      'border-left-color': 'blue',
+      'border-left-style': 'solid',
+      'border-right': 'solid blue',
+      'border-right-color': 'blue',
+      'border-right-style': 'solid',
+      'border-top': 'solid blue',
+      'border-top-color': 'blue',
+      'border-top-style': 'solid',
+    });
+    cssTest('border-top: red; border-right: red; border-bottom: red; border-left: red', {
+      'border': 'red',
+      'border-bottom': 'red',
+      'border-bottom-color': 'red',
+      'border-left': 'red',
+      'border-left-color': 'red',
+      'border-right': 'red',
+      'border-right-color': 'red',
+      'border-top': 'red',
+      'border-top-color': 'red',
+    }, 'border: red;');
+    cssTest('border: 3px solid red; border-width: 2px', {
+      'border': '2px solid red',
+      'border-bottom': '2px solid red',
+      'border-bottom-color': 'red',
+      'border-bottom-style': 'solid',
+      'border-bottom-width': '2px',
+      'border-left': '2px solid red',
+      'border-left-color': 'red',
+      'border-left-style': 'solid',
+      'border-left-width': '2px',
+      'border-right': '2px solid red',
+      'border-right-color': 'red',
+      'border-right-style': 'solid',
+      'border-right-width': '2px',
+      'border-top': '2px solid red',
+      'border-top-color': 'red',
+      'border-top-style': 'solid',
+      'border-top-width': '2px',
+    }, 'border: 2px solid red;');
+    cssTest('border: red; border-left-color:', {
+      'border-bottom': 'red',
+      'border-bottom-color': 'red',
+      'border-right': 'red',
+      'border-right-color': 'red',
+      'border-top': 'red',
+      'border-top-color': 'red',
+    }, 'border-top: red; border-right: red; border-bottom: red;');
+  });
+
+  test('font', () => {
+    cssFontTest('font-family: arial', {'font-family': 'arial'});
+    cssFontTest('font-size: 120%', {'font-size': '120%'});
+    cssFontTest('font-style: italic', {'font-style': 'italic'});
+    cssFontTest('font-weight: bold', {'font-weight': 'bold'});
+    cssFontTest('font: arial 120%', {
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font:   arial   120%', {
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: 120% arial', {
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial small', {
+      'font-size': 'small',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial 16px', {
+      'font-size': '16px',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial bold 120%', {
+      'font-weight': 'bold',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial lighter 120%', {
+      'font-weight': 'lighter',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial italic 120%', {
+      'font-style': 'italic',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial bold italic 120%', {
+      'font-style': 'italic',
+      'font-weight': 'bold',
+      'font-size': '120%',
+      'font-family': 'arial',
+    });
+    cssFontTest('font: arial full-width 120%', {
+      'font-variant': 'full-width',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial full-width simplified 120%', {
+      'font-variant': 'full-width simplified',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial condensed 120%', {
+      'font-stretch': 'condensed',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial semi-condensed 120%', {
+      'font-stretch': 'semi-condensed',
+      'font-size': '120%',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial small/.75', {
+      'line-height': '.75',
+      'font-size': 'small',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial small/12px', {
+      'line-height': '12px',
+      'font-size': 'small',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial small/75%', {
+      'line-height': '75%',
+      'font-size': 'small',
+      'font-family': 'arial'
+    });
+    cssFontTest('font: arial bold 120%; font-style: italic', {
+      'font-weight': 'bold',
+      'font-size': '120%',
+      'font-family': 'arial',
+      'font-style': 'italic'
+    });
+  });
+
+  test('get()', () => {
+    const styles = new Styles('padding: 0; padding-left: 1px');
+    expect(styles.get('padding')).toBe('0 0 0 1px');
+    expect(styles.get('padding-top')).toBe('0');
+    expect(styles.get('padding-right')).toBe('0');
+    expect(styles.get('padding-bottom')).toBe('0');
+    expect(styles.get('padding-left')).toBe('1px');
+    expect(styles.get('border')).toBe('');
+  });
+
+});

--- a/testsuite/tests/util/asyncLoad/dirname.cjs
+++ b/testsuite/tests/util/asyncLoad/dirname.cjs
@@ -1,0 +1,3 @@
+const path = require('path');
+
+module.exports.dirname = path.resolve(__dirname, path.join('..', '..', '..', '..', 'mjs', 'util', 'asyncLoad'));

--- a/testsuite/tests/util/asyncLoad/dirname.mjs
+++ b/testsuite/tests/util/asyncLoad/dirname.mjs
@@ -1,0 +1,3 @@
+import {dirname} from './dirname.cjs';
+
+global.__dirname = dirname;

--- a/testsuite/tests/util/asyncLoad/esm.test.ts
+++ b/testsuite/tests/util/asyncLoad/esm.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from '@jest/globals';
+import {asyncLoad} from '#js/util/AsyncLoad.js';
+import {setBaseURL} from '#js/util/asyncLoad/esm.js';
+import * as path from 'path';
+
+const root = new URL(path.resolve('..', 'mjs'), 'file://').href;
+const lib = new URL(path.resolve('lib'), 'file://').href;
+
+describe('asyncLoad() for esm', () => {
+
+  test('asyncLoad()', async () => {
+    const cjsFile = path.join('..', 'testsuite', 'lib', 'AsyncLoad.child.cjs');
+    const mjsFile = path.join('..', 'testsuite', 'lib', 'AsyncLoad.child.mjs');
+    const relUnknown = path.join('..', 'testsuite', 'lib', 'AsyncLoad.unknown.cjs');
+    const absFile = path.join(root, cjsFile);
+    const absUnknown = path.join(root, relUnknown);
+
+    await expect(asyncLoad(cjsFile)).resolves.toEqual({loaded: true});          // relative file found
+    await expect(asyncLoad(relUnknown).catch(() => true)).resolves.toBe(true);  // relative file not found
+    await expect(asyncLoad(absFile)).resolves.toEqual({loaded: true});          // absolute file found
+    await expect(asyncLoad(absUnknown).catch(() => true)).resolves.toBe(true);  // absolute file not found
+
+    await expect(asyncLoad(mjsFile).then((result: any) => result.loaded)).resolves.toBe(true);  // mjs file loads
+  });
+
+  test('serBaseURL() for esm', async () => {
+    setBaseURL(lib);
+    const relFile = './AsyncLoad.child.cjs';
+    const relUnknown = './AsyncLoad.unknown.cjs';
+    await expect(asyncLoad(relFile)).resolves.toEqual({loaded: true});          // relative file found
+    await expect(asyncLoad(relUnknown).catch(() => true)).resolves.toBe(true);  // relative file not found
+  });
+
+});

--- a/testsuite/tests/util/asyncLoad/node.test.ts
+++ b/testsuite/tests/util/asyncLoad/node.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from '@jest/globals';
+import './dirname.mjs';
+import '#source/../require.mjs';
+import {asyncLoad} from '#js/util/AsyncLoad.js';
+import {setBaseURL} from '#js/util/asyncLoad/node.js';
+import * as path from 'path';
+
+const root = path.dirname(path.dirname(__dirname));
+const lib = path.resolve('lib');
+
+describe('asyncLoad() for node', () => {
+
+  test('asyncLoad()', async () => {
+    const cjsFile = path.join('..', 'testsuite', 'lib', 'AsyncLoad.child.cjs');
+    const mjsFile = path.join('..', 'testsuite', 'lib', 'AsyncLoad.child.mjs');
+    const relUnknown = path.join('..', 'testsuite', 'lib', 'AsyncLoad.unknown.cjs');
+    const absFile = path.join(root, cjsFile);
+    const absUnknown = path.join(root, relUnknown);
+
+    await expect(asyncLoad(cjsFile)).resolves.toEqual({loaded: true});          // relative file found
+    await expect(asyncLoad(relUnknown).catch(() => true)).resolves.toBe(true);  // relative file not found
+    await expect(asyncLoad(absFile)).resolves.toEqual({loaded: true});          // absolute file found
+    await expect(asyncLoad(absUnknown).catch(() => true)).resolves.toBe(true);  // absolute file not found
+
+    await expect(asyncLoad(mjsFile).catch(() => true)).resolves.toBe(true);     // mjs file fails
+  });
+
+  test('serBaseURL() for node', async () => {
+    setBaseURL(lib);
+    const relFile = './AsyncLoad.child.cjs';
+    const relUnknown = './AsyncLoad.unknown.cjs';
+    await expect(asyncLoad(relFile)).resolves.toEqual({loaded: true});          // relative file found
+    await expect(asyncLoad(relUnknown).catch(() => true)).resolves.toBe(true);  // relative file not found
+  });
+
+});

--- a/testsuite/tests/util/asyncLoad/system.cjs
+++ b/testsuite/tests/util/asyncLoad/system.cjs
@@ -1,0 +1,11 @@
+const path = require('path');
+
+/**
+ *  Fake SystemJS, which is hard to run within jest
+ */
+System = {
+  import(name, root) {
+    return import(new URL(name, root).href);
+  }
+}
+

--- a/testsuite/tests/util/asyncLoad/system.test.ts
+++ b/testsuite/tests/util/asyncLoad/system.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from '@jest/globals';
+import './dirname.mjs';
+import './system.cjs';
+import {asyncLoad} from '#js/util/AsyncLoad.js';
+import {setBaseURL} from '#js/util/asyncLoad/system.js';
+import * as path from 'path';
+
+const root = new URL(path.resolve('..', 'mjs'), 'file://').href;
+const lib = new URL(path.resolve('lib'), 'file://').href;
+
+describe('asyncLoad() for node', () => {
+
+  test('asyncLoad()', async () => {
+    const cjsFile = path.join('..', 'testsuite', 'lib', 'AsyncLoad.child.cjs');
+    const mjsFile = path.join('..', 'testsuite', 'lib', 'AsyncLoad.child.mjs');
+    const relUnknown = path.join('..', 'testsuite', 'lib', 'AsyncLoad.unknown.cjs');
+    const absFile = path.join(root, cjsFile);
+    const absUnknown = path.join(root, relUnknown);
+
+    await expect(asyncLoad(cjsFile)).resolves.toEqual({loaded: true});          // relative file found
+    await expect(asyncLoad(relUnknown).catch(() => true)).resolves.toBe(true);  // relative file not found
+    await expect(asyncLoad(absFile)).resolves.toEqual({loaded: true});          // absolute file found
+    await expect(asyncLoad(absUnknown).catch(() => true)).resolves.toBe(true);  // absolute file not found
+
+    await expect(asyncLoad(mjsFile).then((result: any) => result.loaded)).resolves.toBe(true);  // mjs file loads
+  });
+
+  test('serBaseURL() for node', async () => {
+    setBaseURL(lib);
+    const relFile = './AsyncLoad.child.cjs';
+    const relUnknown = './AsyncLoad.unknown.cjs';
+    await expect(asyncLoad(relFile)).resolves.toEqual({loaded: true});          // relative file found
+    await expect(asyncLoad(relUnknown).catch(() => true)).resolves.toBe(true);  // relative file not found
+  });
+
+});

--- a/testsuite/tests/util/length.test.ts
+++ b/testsuite/tests/util/length.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import * as Length from '#js/util/lengths.js';
 
-function convertLengthDim(str: string) {
+function convertLengthDim(str: string | number) {
   return Length.length2em(str);
 }
 
@@ -19,4 +19,61 @@ describe('Dimension conversion from length', () => {
   it('9cm', () => expect(convertLengthDim('9cm')).toBe(21.259842519685037));
   it('9mm', () => expect(convertLengthDim('9mm')).toBe(2.125984251968504));
   it('9mu', () => expect(convertLengthDim('9mu')).toBe(0.5));
+  it('9%', () => expect(convertLengthDim('9%')).toBe(0));
+  it('number 9', () => expect(convertLengthDim(9)).toBe(0));
+  it('thinmathspace', () => expect(convertLengthDim('thinmathspace')).toBe(3/18));
+  it('em', () => expect(convertLengthDim('em')).toBe(1));
+});
+
+describe('Dimension conversion with default', () => {
+  it('9', () => expect(Length.length2em('9', 100)).toBe(900));
+  it('empty', () => expect(Length.length2em('', 100)).toBe(100));
+  it('nix', () => expect(Length.length2em('nix', 100)).toBe(100));
+  it('9nix', () => expect(Length.length2em('9nix', 100)).toBe(900));
+  it('9%', () => expect(Length.length2em('9%', 100)).toBe(9));
+  it('number 9', () => expect(Length.length2em(9, 100)).toBe(900));
+});
+
+describe('Dimension conversion with scale', () => {
+  it('9px', () => expect(Length.length2em('9px', 0, 2)).toBe(0.5625 / 2));
+  it('9in', () => expect(Length.length2em('9in', 0, 2)).toBe(54 / 2));
+  it('9cm', () => expect(Length.length2em('9cm', 0, 2)).toBe(21.259842519685037 / 2));
+  it('9mm', () => expect(Length.length2em('9mm', 0, 2)).toBe(2.125984251968504 / 2));
+});
+
+describe('Dimension conversion with scale', () => {
+  it('9px', () => expect(Length.length2em('9px', 0, 1, 8)).toBe(0.5625 * 2));
+  it('9in', () => expect(Length.length2em('9in', 0, 1, 8)).toBe(54 * 2));
+  it('9cm', () => expect(Length.length2em('9cm', 0, 1, 8)).toBe(21.259842519685037 * 2));
+  it('9mm', () => expect(Length.length2em('9mm', 0, 1, 8)).toBe(2.125984251968504 * 2));
+});
+
+describe('percent()', () => {
+  it('.75', () => expect(Length.percent(.75)).toBe('75%'));
+  it('1.75', () => expect(Length.percent(1.75)).toBe('175%'));
+  it('.754321', () => expect(Length.percent(.754321)).toBe('75.4%'));
+  it('1.754321', () => expect(Length.percent(1.754321)).toBe('175.4%'));
+  it('1', () => expect(Length.percent(1)).toBe('100%'));
+});
+
+describe('em()', () => {
+  it('.75', () => expect(Length.em(.75)).toBe('0.75em'));
+  it('1.75', () => expect(Length.em(1.75)).toBe('1.75em'));
+  it('.754321', () => expect(Length.em(.754321)).toBe('0.754em'));
+  it('1.754321', () => expect(Length.em(1.754321)).toBe('1.754em'));
+  it('1', () => expect(Length.em(1)).toBe('1em'));
+  it('0', () => expect(Length.em(0)).toBe('0'));
+  it('0.0001', () => expect(Length.em(0.0001)).toBe('0'));
+});
+
+describe('px()', () => {
+  it('.75', () => expect(Length.px(.75)).toBe('12px'));
+  it('1.75', () => expect(Length.px(1.75)).toBe('28px'));
+  it('.754321', () => expect(Length.px(.754321)).toBe('12.1px'));
+  it('1.754321', () => expect(Length.px(1.754321)).toBe('28.1px'));
+  it('1', () => expect(Length.px(1)).toBe('16px'));
+  it('0', () => expect(Length.px(0)).toBe('0'));
+  it('0.001', () => expect(Length.px(0.001)).toBe('0'));
+  it('min=1', () => expect(Length.px(0.001, 1)).toBe('1px'));
+  it('em=8', () => expect(Length.px(1, 1, 8)).toBe('8px'));
 });

--- a/testsuite/tests/util/numeric.test.ts
+++ b/testsuite/tests/util/numeric.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from '@jest/globals';
+import * as numeric from '#js/util/numeric.js';
+
+describe('numeric functions', () => {
+
+  test('sum', () => {
+    expect(numeric.sum([1, 2, 3, 4, 5])).toBe(15);
+    expect(numeric.sum([])).toBe(0);
+  });
+
+  test('max', () => {
+    expect(numeric.max([5, 2, 10, 3, 50, -5])).toBe(50);
+    expect(numeric.max([])).toBe(0);
+  });
+
+});

--- a/testsuite/tests/util/string.test.ts
+++ b/testsuite/tests/util/string.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from '@jest/globals';
+import * as string from '#js/util/string.js';
+
+describe('string functions', () => {
+
+  test('sortLength()', () => {
+    expect(['a', '', 'aaa', 'aa'].sort(string.sortLength)).toEqual(['aaa', 'aa', 'a', '']);
+    expect(['a', '', 'aaa', 'a', 'aa'].sort(string.sortLength)).toEqual(['aaa', 'aa', 'a', 'a', '']);
+    expect(['a', 'ccc', '', 'aaa', 'bb', 'aa', 'bbb'].sort(string.sortLength)).toEqual(
+      ['aaa', 'bbb', 'ccc', 'aa', 'bb', 'a', '']
+    );
+    expect(['a'].sort(string.sortLength)).toEqual(['a']);
+    expect([].sort(string.sortLength)).toEqual([]);
+  });
+
+  test('quotePattern()', () => {
+    expect(string.quotePattern('[({.*+?^$-|:\\})]')).toBe('\\[\\(\\{\\.\\*\\+\\?\\^\\$\\-\\|\\:\\\\\\}\\)\\]');
+  });
+
+  test('unicodeChars()', () => {
+    expect(string.unicodeChars('aA\u00AA\u2212\uFFFD\u{1D410}')).toEqual([0x61, 0x41, 0xAA, 0x2212, 0xFFFD, 0x1D410]);
+    expect(string.unicodeChars('')).toEqual([]);
+  });
+
+  test('uncideString()', () => {
+    expect(string.unicodeString([0x61, 0x41, 0xAA, 0x2212, 0xFFFD, 0x1D410])).toBe('aA\u00AA\u2212\uFFFD\u{1D410}');
+    expect(string.unicodeString([])).toBe('');
+  });
+
+  test('isPercent()', () => {
+    expect(string.isPercent('10%')).toBe(true);
+    expect(string.isPercent('10 % ')).toBe(true);
+    expect(string.isPercent('10%10')).toBe(false);
+  });
+
+  test('split()', () => {
+    expect(string.split('a bbb cc')).toEqual(['a', 'bbb', 'cc']);
+    expect(string.split('  a  bbb    cc ')).toEqual(['a', 'bbb', 'cc']);
+    expect(string.split('abc')).toEqual(['abc']);
+    expect(string.split('')).toEqual(['']);
+  });
+
+  test('replaceUnicode()', () => {
+    expect(string.replaceUnicode(String.raw`\U0061`)).toBe('a');
+    expect(string.replaceUnicode(String.raw`a \U0062`)).toBe('a b');
+    expect(string.replaceUnicode(String.raw`\U{61}`)).toBe('a');
+    expect(string.replaceUnicode(String.raw`\U006D`)).toBe('m');
+    expect(string.replaceUnicode(String.raw`\U006d`)).toBe('m');
+    expect(string.replaceUnicode(String.raw`\U{6D}`)).toBe('m');
+    expect(string.replaceUnicode(String.raw`\U{6d}`)).toBe('m');
+    expect(string.replaceUnicode(String.raw`a \U{62} c`)).toBe('a b c');
+    expect(string.replaceUnicode(String.raw`\\U{61}`)).toBe(String.raw`\\U{61}`);
+    expect(string.replaceUnicode(String.raw`\\\U{61}`)).toBe(String.raw`\\a`);
+    expect(string.replaceUnicode(String.raw`\\\\U{61}`)).toBe(String.raw`\\\\U{61}`);
+    expect(string.replaceUnicode(String.raw`\\\\\U{61}`)).toBe(String.raw`\\\\a`);
+    expect(string.replaceUnicode(String.raw`x\\U{61}`)).toBe(String.raw`x\\U{61}`);
+    expect(string.replaceUnicode(String.raw`x\\\U{61}`)).toBe(String.raw`x\\a`);
+    expect(string.replaceUnicode(String.raw`x\\\\U{61}`)).toBe(String.raw`x\\\\U{61}`);
+    expect(string.replaceUnicode(String.raw`x\\\\\U{61}`)).toBe(String.raw`x\\\\a`);
+  });
+
+});

--- a/testsuite/tsconfig.json
+++ b/testsuite/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "../tsconfig/mjs.json"
+  "extends": "../tsconfig/mjs.json",
+  "compilerOptions": {
+    "outDir": "./js",
+    "paths": {
+      "#js/*": ["../mjs/*"],
+      "#source/*": ["../components/mjs/*"]
+    }
+  },
+  "include": ["./tests/**/*.ts"]
 }

--- a/testsuite/tsconfig.json
+++ b/testsuite/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "extends": "../tsconfig/mjs.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "./js",
+    "moduleResolution": "bundler",
     "paths": {
       "#js/*": ["../mjs/*"],
-      "#source/*": ["../components/mjs/*"]
+      "#source/*": ["../components/mjs/*"],
+      "#helpers": ["./src/index.js"]
     }
   },
-  "include": ["./tests/**/*.ts"]
+  "include": ["./tests/**/*.ts", "./src/*.ts"]
 }

--- a/ts/util/AsyncLoad.ts
+++ b/ts/util/AsyncLoad.ts
@@ -29,7 +29,7 @@ import {mathjax} from '../mathjax.js';
  * @param {string} name  The name of the file to load
  * @return {Promise}     The promise that is satisfied when the file is loaded
  */
-export function asyncLoad(name: string): Promise<void> {
+export function asyncLoad(name: string): Promise<any> {
   if (!mathjax.asyncLoad) {
     return Promise.reject(`Can't load '${name}': No asyncLoad method specified`);
   }

--- a/ts/util/BBox.ts
+++ b/ts/util/BBox.ts
@@ -98,7 +98,7 @@ export class BBox {
 
   /**
    * Set up a bbox for append() and combine() operations
-   * @return {BBox}  the boox itself (for chaining calls)
+   * @return {BBox}  the bbox itself (for chaining calls)
    */
   public empty(): BBox {
     this.w = 0;

--- a/ts/util/BitField.ts
+++ b/ts/util/BitField.ts
@@ -115,7 +115,7 @@ export class BitField {
  * @return {typeof AbstractBitField}  The bit-field class with names allocated
  */
 export function BitFieldClass(...names: string[]): typeof BitField {
-  const Bits = class extends BitField {};
-  Bits.allocate(...names);
-  return Bits;
+  const bits = class extends BitField {};
+  bits.allocate(...names);
+  return bits;
 }

--- a/ts/util/FunctionList.ts
+++ b/ts/util/FunctionList.ts
@@ -73,7 +73,7 @@ export class FunctionList extends PrioritizedList<Function> {
    *                       depending on whether some function returned
    *                       false or not).
    */
-  public asyncExecute(...data: any[]): Promise<void> {
+  public asyncExecute(...data: any[]): Promise<boolean> {
     let i = -1;
     let items = this.items;
     return new Promise((ok: Function, fail: Function) => {

--- a/ts/util/LinkedList.ts
+++ b/ts/util/LinkedList.ts
@@ -179,8 +179,9 @@ export class LinkedList<DataClass> {
    * Remove items from the list
    *
    * @param {DataClass[]} items   The items to remove
+   * @return {LinkedList}  The LinkedList object (for chaining)
    */
-  public remove(...items: DataClass[]) {
+  public remove(...items: DataClass[]): LinkedList<DataClass> {
     const map = new Map<DataClass, boolean>();
     for (const item of items) {
       map.set(item, true);
@@ -195,6 +196,7 @@ export class LinkedList<DataClass> {
       }
       item = next;
     }
+    return this;
   }
 
   /**

--- a/ts/util/PrioritizedList.ts
+++ b/ts/util/PrioritizedList.ts
@@ -102,9 +102,10 @@ export class PrioritizedList<DataClass> {
   /**
    * Remove an item from the list
    *
-   * @param {DataClass} item   The data for the item to be removed
+   * @param {DataClass} item    The data for the item to be removed
+   * @return {PrioritizedList}  The list (for chaining of calls)
    */
-  public remove(item: DataClass) {
+  public remove(item: DataClass): PrioritizedList<DataClass> {
     let i = this.items.length;
     do {
       i--;
@@ -112,5 +113,6 @@ export class PrioritizedList<DataClass> {
     if (i >= 0) {
       this.items.splice(i, 1);
     }
+    return this;
   }
 }

--- a/ts/util/asyncLoad/esm.ts
+++ b/ts/util/asyncLoad/esm.ts
@@ -23,11 +23,11 @@
 
 import {mathjax} from '../../mathjax.js';
 
-let root = new URL(import.meta.url).href.replace(/\/util\/asyncLoad\/esm.js$/, '');
+let root = new URL(import.meta.url).href.replace(/\/util\/asyncLoad\/esm.js$/, '/');
 
 if (!mathjax.asyncLoad) {
-  mathjax.asyncLoad = (name: string) => {
-    return import(new URL(name, root).href);
+  mathjax.asyncLoad = async (name: string) => {
+    return import(new URL(name, root).href).then((result) => result?.default || result);
   };
 }
 

--- a/ts/util/asyncLoad/node.ts
+++ b/ts/util/asyncLoad/node.ts
@@ -27,10 +27,20 @@ import * as path from 'path';
 declare var require: (name: string) => any;
 declare var __dirname: string;
 
-const root = path.dirname(path.dirname(__dirname));
+let root = path.dirname(path.dirname(__dirname));
 
 if (!mathjax.asyncLoad && typeof require !== 'undefined') {
   mathjax.asyncLoad = (name: string) => {
     return require(name.charAt(0) === '.' ? path.resolve(root, name) : name);
   };
+}
+
+/**
+ * @param {string} URL   the base URL to use for loading relative paths
+ */
+export function setBaseURL(URL: string) {
+  root = URL;
+  if (!root.match(/\/$/)) {
+    root += '/';
+  }
 }

--- a/ts/util/asyncLoad/system.ts
+++ b/ts/util/asyncLoad/system.ts
@@ -26,11 +26,11 @@ import {mathjax} from '../../mathjax.js';
 declare var System: {import: (name: string, url?: string) => any};
 declare var __dirname: string;
 
-let root = 'file://' + __dirname.replace(/\/\/[^\/]*$/, '/');
+let root = 'file://' + __dirname.replace(/\/[^\/]*\/[^\/]*$/, '/');
 
 if (!mathjax.asyncLoad && typeof System !== 'undefined' && System.import) {
   mathjax.asyncLoad = (name: string) => {
-    return System.import(name, root);
+    return System.import(name, root).then((result: any) => result?.default || result);
   };
 }
 

--- a/ts/util/lengths.ts
+++ b/ts/util/lengths.ts
@@ -98,7 +98,7 @@ export function length2em(length: string | number, size: number = 0, scale: numb
     return MATHSPACE[length];
   }
   let match = length.match(/^\s*([-+]?(?:\.\d+|\d+(?:\.\d*)?))?(pt|em|ex|mu|px|pc|in|mm|cm|%)?/);
-  if (!match) {
+  if (!match || match[0] === '') {
     return size;
   }
   let m = parseFloat(match[1] || '1'), unit = match[2];
@@ -130,18 +130,6 @@ export function em(m: number): string {
   if (Math.abs(m) < .001) return '0';
   return (m.toFixed(3).replace(/\.?0+$/, '')) + 'em';
 }
-
-/**
- * @param {number} m   A number to be shown in ems, but rounded to pixel boundaries
- * @param {number} em  The number of pixels in an em
- * @return {string}    The number with units of em
- */
-export function emRounded(m: number, em: number = 16): string {
-  m = (Math.round(m * em) + .05) / em;
-  if (Math.abs(m) < .001) return '0em';
-  return m.toFixed(3).replace(/\.?0+$/, '') + 'em';
-}
-
 
 /**
  * @param {number} m   A number of em's to be shown as pixels

--- a/ts/util/string.ts
+++ b/ts/util/string.ts
@@ -40,7 +40,7 @@ export function sortLength(a: string, b: string): number {
  * @return {string}  The quoted string
  */
 export function quotePattern(text: string): string {
-  return text.replace(/([\^$(){}+*?\-|\[\]\:\\])/g, '\\$1');
+  return text.replace(/([\^$(){}.+*?\-|\[\]\:\\])/g, '\\$1');
 }
 
 /**
@@ -90,6 +90,6 @@ export function split(x: string): string[] {
  * @return {string}       The string with the unicode characters in place of \U{...}
  */
 export function replaceUnicode(text: string): string {
-  return text.replace(/((?:^|[^\\])(?:\\\\)*)\\U\s*(?:([0-9A-F])|\{\s*([0-9A-F]{1,6})\s*\})/g,
-                      (_m, pre, h1, h2) => pre + String.fromCodePoint(parseInt(h1 || h2, 16)));
+  return text.replace(/((?:^|[^\\])(?:\\\\)*)\\U(?:([0-9A-Fa-f]{4})|\{\s*([0-9A-Fa-f]{1,6})\s*\})/g,
+                     (_m, pre, h1, h2) => pre + String.fromCodePoint(parseInt(h1 || h2, 16)));
 }


### PR DESCRIPTION
This PR adds tests for all `ts/util` files and updates the length tests to 100% coverage.  While writing the tests, some issues were found with the util files, and these are also fixed here (they are at the bottom of the list).

I've also added some coverage exclusions to the jest configuration file to prevent some files from showing own the coverage that aren't needed.