### PR TITLE
Corrects Duplicate use of Error Messages

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -436,7 +436,7 @@ export const ParseUtil = {
       }
       if (match !== '') {
         // @test Internal Math Error
-        throw new TexError('MathNotTerminated', 'Math not terminated in text box');
+        throw new TexError('MathNotTerminated', 'Math mode is not properly terminated');
       }
     }
     if (k < text.length) {

--- a/ts/input/tex/bussproofs/BussproofsMethods.ts
+++ b/ts/input/tex/bussproofs/BussproofsMethods.ts
@@ -113,13 +113,13 @@ function parseFCenterLine(parser: TexParser, name: string): MmlNode {
   let dollar = parser.GetNext();
   if (dollar !== '$') {
     throw new TexError('IllegalUseOfCommand',
-                       'Use of %1 does not match it\'s definition.', name);
+                       'Use of %1 does not match its definition.', name);
   }
   parser.i++;
   let axiom = parser.GetUpTo(name, '$');
   if (axiom.indexOf('\\fCenter') === -1) {
-    throw new TexError('IllegalUseOfCommand',
-                       'Missing \\fCenter in %1.', name);
+    throw new TexError('MissingProofCommand',
+                       'Missing %1 in %2.', '\\fCenter', name);
   }
   // Check for fCenter and throw error?
   let [prem, conc] = axiom.split('\\fCenter');

--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -88,7 +88,7 @@ export const TextMacrosMethods = {
         break;
       }
     }
-    parser.Error('MathNotTerminated', 'Math-mode is not properly terminated');
+    parser.Error('MathNotTerminated', 'Math mode is not properly terminated');
   },
 
   /**
@@ -104,7 +104,7 @@ export const TextMacrosMethods = {
    * @param {string} c            The character that called this function
    */
   Misplaced(parser: TextParser, c: string) {
-    parser.Error('Misplaced', '\'%1\' can not be used here', c);
+    parser.Error('Misplaced', 'Misplaced \'%1\'', c);
   },
 
   /**


### PR DESCRIPTION
Some cleanup for upcoming l10n efforts.

Some error messages are used multiple times, but differ in the actual message string. This PR corrects this. In particular:

* `IllegalUseOfCommand`: corrects its second use to reflect the actual error
* `MathNotTerminated` unifies message
* `Misplaced` unifies messages to a simple  `"Misplaced %1"`


