### PR TITLE
Update the asyncLoad implementations to be more consistent, and update tests.

### DIFF
--- a/testsuite/tests/util/asyncLoad/esm.test.ts
+++ b/testsuite/tests/util/asyncLoad/esm.test.ts
@@ -1,10 +1,11 @@
 import { describe, test, expect } from '@jest/globals';
+import {mathjax} from '#js/mathjax.js';
 import {asyncLoad} from '#js/util/AsyncLoad.js';
 import {setBaseURL} from '#js/util/asyncLoad/esm.js';
 import * as path from 'path';
 
-const root = new URL(path.resolve('..', 'mjs'), 'file://').href;
-const lib = new URL(path.resolve('lib'), 'file://').href;
+const root = path.resolve('..', 'mjs');
+const lib = path.resolve('lib');
 
 describe('asyncLoad() for esm', () => {
 
@@ -20,10 +21,16 @@ describe('asyncLoad() for esm', () => {
     await expect(asyncLoad(absFile)).resolves.toEqual({loaded: true});          // absolute file found
     await expect(asyncLoad(absUnknown).catch(() => true)).resolves.toBe(true);  // absolute file not found
 
+    await expect(asyncLoad('#js/components/version.js')                         // load using package exports
+                 .then((result: any) => result.VERSION)).resolves.toBe(mathjax.version);
+    await expect(asyncLoad('mathjax-full/js/components/version.js')             // load from module
+                 .then((result: any) => result.VERSION)).resolves.toBe(mathjax.version);
+
     await expect(asyncLoad(mjsFile).then((result: any) => result.loaded)).resolves.toBe(true);  // mjs file loads
+    expect(mathjax.asyncIsSynchronous).toBe(false);                             // esm.js is asynchronous
   });
 
-  test('serBaseURL() for esm', async () => {
+  test('setBaseURL() for esm', async () => {
     setBaseURL(lib);
     const relFile = './AsyncLoad.child.cjs';
     const relUnknown = './AsyncLoad.unknown.cjs';

--- a/testsuite/tests/util/asyncLoad/node.test.ts
+++ b/testsuite/tests/util/asyncLoad/node.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from '@jest/globals';
 import './dirname.mjs';
 import '#source/../require.mjs';
+import {mathjax} from '#js/mathjax.js';
 import {asyncLoad} from '#js/util/AsyncLoad.js';
 import {setBaseURL} from '#js/util/asyncLoad/node.js';
 import * as path from 'path';
@@ -22,10 +23,16 @@ describe('asyncLoad() for node', () => {
     await expect(asyncLoad(absFile)).resolves.toEqual({loaded: true});          // absolute file found
     await expect(asyncLoad(absUnknown).catch(() => true)).resolves.toBe(true);  // absolute file not found
 
+    await expect(asyncLoad('#js/../cjs/components/version.js')                  // load using package exports
+                 .then((result: any) => result.VERSION)).resolves.toBe(mathjax.version);
+    await expect(asyncLoad('mathjax-full/js/components/version.js')             // load from module
+                 .then((result: any) => result.VERSION)).resolves.toBe(mathjax.version);
+
     await expect(asyncLoad(mjsFile).catch(() => true)).resolves.toBe(true);     // mjs file fails
+    expect(mathjax.asyncIsSynchronous).toBe(true);                              // node.js is synchronous
   });
 
-  test('serBaseURL() for node', async () => {
+  test('setBaseURL() for node', async () => {
     setBaseURL(lib);
     const relFile = './AsyncLoad.child.cjs';
     const relUnknown = './AsyncLoad.unknown.cjs';

--- a/testsuite/tests/util/asyncLoad/system.test.ts
+++ b/testsuite/tests/util/asyncLoad/system.test.ts
@@ -1,12 +1,13 @@
 import { describe, test, expect } from '@jest/globals';
 import './dirname.mjs';
 import './system.cjs';
+import {mathjax} from '#js/mathjax.js';
 import {asyncLoad} from '#js/util/AsyncLoad.js';
 import {setBaseURL} from '#js/util/asyncLoad/system.js';
 import * as path from 'path';
 
-const root = new URL(path.resolve('..', 'mjs'), 'file://').href;
-const lib = new URL(path.resolve('lib'), 'file://').href;
+const root = path.resolve('..', 'mjs');
+const lib = path.resolve('lib');
 
 describe('asyncLoad() for node', () => {
 
@@ -22,10 +23,16 @@ describe('asyncLoad() for node', () => {
     await expect(asyncLoad(absFile)).resolves.toEqual({loaded: true});          // absolute file found
     await expect(asyncLoad(absUnknown).catch(() => true)).resolves.toBe(true);  // absolute file not found
 
+    await expect(asyncLoad('#js/components/version.js')                         // can't load using package exports
+                 .catch(() => true)).resolves.toBe(true);
+    await expect(asyncLoad('mathjax-full/js/components/version.js')             // can't load from module
+                 .catch(() => true)).resolves.toBe(true);
+
     await expect(asyncLoad(mjsFile).then((result: any) => result.loaded)).resolves.toBe(true);  // mjs file loads
+    expect(mathjax.asyncIsSynchronous).toBe(false);                             // system.js is asynchronous
   });
 
-  test('serBaseURL() for node', async () => {
+  test('setBaseURL() for node', async () => {
     setBaseURL(lib);
     const relFile = './AsyncLoad.child.cjs';
     const relUnknown = './AsyncLoad.unknown.cjs';

--- a/ts/mathjax.ts
+++ b/ts/mathjax.ts
@@ -64,4 +64,8 @@ export const mathjax = {
    */
   asyncLoad: null as ((file: string) => any),
 
+  /**
+   * When asyncLoad uses require(), it actually operates synchronously and this is true
+   */
+  asyncIsSynchronous: false,
 };

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -22,11 +22,11 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import {mathjax} from '../../mathjax.js';
 import {OptionList, defaultOptions, userOptions} from '../../util/Options.js';
 import {StyleList} from '../../util/StyleList.js';
 import {asyncLoad} from '../../util/AsyncLoad.js';
 import {retryAfter} from '../../util/Retries.js';
-import {mathjax} from '../../mathjax.js';
 import {DIRECTION} from './Direction.js';
 export {DIRECTION} from './Direction.js';
 
@@ -1101,7 +1101,7 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
     const prefix = (!dynamic.extension ? this.options.dynamicPrefix :
                     this.CLASS.dynamicExtensions.get(dynamic.extension).prefix);
     return (dynamic.file.match(/^(?:[\/\[]|[a-z]+:\/\/|[a-z]:)/i) ? dynamic.file :
-      prefix + '/' + dynamic.file.replace(/\.js$/, ''));
+      prefix + '/' + dynamic.file.replace(/(?<!\.js)$/, '.js'));
   }
 
   /**
@@ -1141,8 +1141,9 @@ export class FontData<C extends CharOptions, V extends VariantData<C>, D extends
    *   synchronous loading function, as in util/asyncLoad/node.ts.
    */
   public loadDynamicFilesSync() {
-    if (!mathjax.asyncLoad) {
-      throw Error('MathJax(loadDynamicFilesSync): mathjax.asyncLoad must be specified and synchronous');
+    if (!mathjax.asyncIsSynchronous) {
+      throw Error('MathJax(loadDynamicFilesSync): mathjax.asyncLoad must be specified and synchronous\n' +
+                 '    Try importing #js/../components/require.mjs and #js/util/asyncLoad/node.js');
     }
     const dynamicFiles = this.CLASS.dynamicFiles;
     Object.keys(dynamicFiles).forEach(name => this.loadDynamicFileSync(dynamicFiles[name]));

--- a/ts/util/AsyncLoad.ts
+++ b/ts/util/AsyncLoad.ts
@@ -31,7 +31,7 @@ import {mathjax} from '../mathjax.js';
  */
 export function asyncLoad(name: string): Promise<any> {
   if (!mathjax.asyncLoad) {
-    return Promise.reject(`Can't load '${name}': No asyncLoad method specified`);
+    return Promise.reject(`Can't load '${name}': No mathjax.asyncLoad method specified`);
   }
   return new Promise((ok, fail) => {
     const result = mathjax.asyncLoad(name);

--- a/ts/util/asyncLoad/esm.ts
+++ b/ts/util/asyncLoad/esm.ts
@@ -27,15 +27,16 @@ let root = new URL(import.meta.url).href.replace(/\/util\/asyncLoad\/esm.js$/, '
 
 if (!mathjax.asyncLoad) {
   mathjax.asyncLoad = async (name: string) => {
-    return import(new URL(name, root).href).then((result) => result?.default || result);
+    const file = (name.charAt(0) === '.' ? new URL(name, root).pathname : name);
+    return import(file).then((result) => result?.default || result);
   };
 }
 
 /**
- * @param {string} URL   the base URL to use for loading relative paths
+ * @param {string} url   the base URL to use for loading relative paths
  */
-export function setBaseURL(URL: string) {
-  root = URL;
+export function setBaseURL(url: string) {
+  root = new URL(url, 'file://').href;
   if (!root.match(/\/$/)) {
     root += '/';
   }

--- a/ts/util/asyncLoad/node.ts
+++ b/ts/util/asyncLoad/node.ts
@@ -23,17 +23,19 @@
 
 import {mathjax} from '../../mathjax.js';
 import * as path from 'path';
+import {src} from '#source/source.cjs';
 
 declare var require: (name: string) => any;
-declare var __dirname: string;
 
-let root = path.dirname(path.dirname(__dirname));
+let root = path.resolve(src, '..', '..', 'cjs');
 
 if (!mathjax.asyncLoad && typeof require !== 'undefined') {
   mathjax.asyncLoad = (name: string) => {
     return require(name.charAt(0) === '.' ? path.resolve(root, name) : name);
   };
+  mathjax.asyncIsSynchronous = true;
 }
+
 
 /**
  * @param {string} URL   the base URL to use for loading relative paths

--- a/ts/util/asyncLoad/path.d.ts
+++ b/ts/util/asyncLoad/path.d.ts
@@ -1,4 +1,4 @@
 declare module 'path' {
     export function dirname(dir: string): string;
-    export function resolve(root: string, name: string): string;
+    export function resolve(root: string, ...name: string[]): string;
 }

--- a/ts/util/asyncLoad/system.ts
+++ b/ts/util/asyncLoad/system.ts
@@ -30,15 +30,16 @@ let root = 'file://' + __dirname.replace(/\/[^\/]*\/[^\/]*$/, '/');
 
 if (!mathjax.asyncLoad && typeof System !== 'undefined' && System.import) {
   mathjax.asyncLoad = (name: string) => {
-    return System.import(name, root).then((result: any) => result?.default || result);
+    const file = (name.charAt(0) === '.' ? new URL(name, root) : new URL(name, 'file://')).href;
+    return System.import(file).then((result: any) => result?.default || result);
   };
 }
 
 /**
- * @param {string} URL   the base URL to use for loading relative paths
+ * @param {string} url   the base URL to use for loading relative paths
  */
-export function setBaseURL(URL: string) {
-  root = URL;
+export function setBaseURL(url: string) {
+  root = new URL(url, 'file://').href;
   if (!root.match(/\/$/)) {
     root += '/';
   }


### PR DESCRIPTION
This PR makes the various `asyncLoad` implementations (`node`, `esm`, and `system`) operate more consistently, and updates their tests.  In particular, relative file names are resolved using the `root` directory, while other names are used as is.  That allows using package names like `mathjax-full`, for example (at least in the implementation where that is possible).

In addition, there is a new flag that indicates whether the asyncLoad command is synchronous, use by the font's dynamic file loading command `loadDynamicFilesSync()` to determine if it can work or not.

There is also a fix to `FontData.js` that resolves a problem with having removed the `.js` from file names, which are needed by `asyncLoad()`.

The `asyncLoad/node.js` implementation is modified to be able to be used by both ESM and CJS modules (by calling on the `#source/srouce.js` file to obtain the `__dirname` value used to construct the `root`).

Finally, all the tests are updated to include tests for non-relative file names, and for the synchronous flag.