### PR TITLE
make typesetPromise() wait for speech to be attached, add synchronous option, and copy ARIA labels to internal MathML

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -301,7 +301,8 @@ export namespace Startup {
 
   /**
    * The default pageReady() function called when the page is ready to be processed,
-   * which returns the function that performs the initial typesetting, if needed.
+   * which returns a promise that does any initial font loading, plus the initial
+   * typesetting, if needed.
    *
    * Setting Mathjax.startup.pageReady in the configuration will override this.
    */
@@ -310,7 +311,8 @@ export namespace Startup {
             (output as COMMONJAX).font.loadDynamicFiles() : Promise.resolve())
       .then(CONFIG.typeset && MathJax.typesetPromise ?
             () => typesetPromise(CONFIG.elements) :
-            Promise.resolve());
+            Promise.resolve())
+      .then(() => promiseResolve());
   }
 
   /**
@@ -321,6 +323,9 @@ export namespace Startup {
     document.reset();
     return mathjax.handleRetriesFor(() => {
       document.render();
+      const promise = Promise.all(document.renderPromises);
+      document.renderPromises = [];
+      return promise;
     });
   }
 

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -30,7 +30,6 @@ import {MmlNode, TextNode} from './MmlTree/MmlNode.js';
 import {MmlFactory} from '../core/MmlTree/MmlFactory.js';
 import {DOMAdaptor} from '../core/DOMAdaptor.js';
 import {BitField, BitFieldClass} from '../util/BitField.js';
-
 import {PrioritizedList} from '../util/PrioritizedList.js';
 
 /*****************************************************************/
@@ -320,6 +319,11 @@ export interface MathDocument<N, T, D> {
   renderActions: RenderList<N, T, D>;
 
   /**
+   * The promises that indicate when rendering is fully complete
+   */
+  renderPromises: Promise<void>[];
+
+  /**
    * This object tracks what operations have been performed, so that (when
    *  asynchronous operations are used), the ones that have already been
    *  completed won't be performed again.
@@ -603,6 +607,11 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
   public renderActions: RenderList<N, T, D>;
 
   /**
+   * The render action promise list
+   */
+  public renderPromises: Promise<void>[];
+
+  /**
    * The bit-field used to tell what steps have been taken on the document (for retries)
    */
   public processed: BitField;
@@ -640,6 +649,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     this.math = new (this.options['MathList'] || DefaultMathList)();
     this.renderActions = RenderList.create<N, T, D>(this.options['renderActions']);
+    this.renderPromises = [];
     this.processed = new AbstractMathDocument.ProcessBits();
     this.outputJax = this.options['OutputJax'] || new DefaultOutputJax<N, T, D>();
     let inputJax = this.options['InputJax'] || [new DefaultInputJax<N, T, D>()];
@@ -694,6 +704,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<N, T
    * @override
    */
   public render() {
+    this.renderPromises = [];
     this.renderActions.renderDoc(this);
     return this;
   }


### PR DESCRIPTION
This PR implements the ideas we discussed in our meeting yesterday:

* A new `renderPromises` array is added to the MathDocument that holds promises that are created by the render actions.
* The `typesetPromise()` function now waits for those promises to resolve before its own promise resolves.
* The `attachSpeech()` action now creates a promise that resolves when the speech loop completes so that `typesetPromise()` will wait for it to complete.
* A new `asynchronous` option is added to the `speechTiming` configuration object, initially set to `true`, that controls whether the speech is added synchronously or asynchronously.  (When set to `false`, the speech is added during the `renderAction` processing directly, which will be useful for node-based page preprocessing.)

In addition, a bug with the `defaultPageReady()` call is fixed, so that it will resolve the initial typesetting promise.  That way, if a user provides a `pageReady()` configuration function, it can call the promise-based converters, which now wait on that promise before they run.  That was causing a catch-22 where the `pageReady()` call never completed because the initial typeset promise was being resolved only in the `ready()` function (which calls `pageReady()`).