### PR TITLE
Fix bounding box computation for some embellished operators.  (mathjax/MathJax#3250)

### DIFF
--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -257,7 +257,9 @@ export function CommonMrowMixin<
         breaks && this.computeChildLineBBox(child, i);
       }
       bbox.clean();
-      breaks && this.computeLinebreakBBox(bbox);
+      if (breaks && !this.coreMO().node.isEmbellished) {
+        this.computeLinebreakBBox(bbox);
+      }
       if (this.fixesPWidth && this.setChildPWidths(recompute)) {
         this.computeBBox(bbox, true);
       }


### PR DESCRIPTION
This PR fixes a bounding box computation for some embellished operators when inline breaking is enabled.  For example:

``` xml
<math xmlns="http://www.w3.org/1998/Math/MathML">
  <mn>1</mn>
  <mrow data-mjx-texclass="REL" mathbackground="red">
    <mover>
      <mo stretchy="false">&#x27F5;</mo>
      <mi>a</mi>
    </mover>
  </mrow>
  <mn>2</mn>
</math>
```

or 

``` js
1 \style{background-color: red}{\stackrel{a}{\longleftarrow}} 2
```

will show the wrong sized red rectangle in SVG output when in-line breaking is enabled.  This PR fixes that.

Resolves issue mathjax/MathJax#3250.

