### PR TITLE
Fix inlkine breaking in Safari. (mathjax/MathJax#3252)

### DIFF
--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -268,7 +268,7 @@ CommonWrapper<
       const space = this.em(dimen);
       if (breakable && name === 'space') {
         const node = adaptor.node('mjx-break', SPACE[space] ? {size: SPACE[space]} :
-                                  {style: `letter-spacing: ${this.em(dimen - 1)}`});
+                                  {style: `letter-spacing: ${this.em(dimen - 1)}`}, [adaptor.text(' ')]);
         adaptor.insert(node, this.dom[i]);
       } else if (dimen) {
         if (SPACE[space]) {

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -128,9 +128,9 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
       //  For inline breakpoints, use a space that is 1em width, make it breakable,
       //    and then set the letter-spacing to make the sace the proper size.
       //
-      'mjx-container[jax="CHTML"] mjx-break::after': {
-        content: '" "',
+      'mjx-container[jax="CHTML"] mjx-break': {
         'white-space': 'normal',
+        'line-height': '0',
         'font-family': 'MJX-BRK'
       },
       'mjx-break[size="0"]': {

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -430,13 +430,14 @@ CommonOutputJax<
     const adaptor = this.adaptor;
     const space = LENGTHS.em(dimen);
     if (!forced) {
-      adaptor.insert(adaptor.node('mjx-break', {prebreak: true}), nsvg);
+      adaptor.insert(adaptor.node('mjx-break', {prebreak: true}, [adaptor.text(' ')]), nsvg);
     }
     adaptor.insert(
       adaptor.node(
         'mjx-break',
         !forced ? {newline: true} :
-        SPACE[space] ? {size: SPACE[space]} : {style: `letter-spacing: ${LENGTHS.em(dimen - 1)}`}
+        SPACE[space] ? {size: SPACE[space]} : {style: `letter-spacing: ${LENGTHS.em(dimen - 1)}`},
+        [adaptor.text(' ')]
       ),
       nsvg
     );

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -111,8 +111,7 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
       //  For inline breakpoints, use a space that is 1em width, make it breakable,
       //    and then set the letter-spacing to make the sace the proper size.
       //
-      'mjx-container[jax="SVG"] mjx-break::after': {
-        content: '" "',
+      'mjx-container[jax="SVG"] mjx-break': {
         'white-space': 'normal',
         'line-height': '0',
         'font-family': 'MJX-ZERO'


### PR DESCRIPTION
This PF works around an issue with Safari where in-line line breaks aren't being honored.  It appears that Safari doesn't break at spaces that are in `content` CSS like all other browsers, so we add the space manually instead.

Resolves issue mathjax/MathJax#3252.