### PR TITLE
Create regions only when needed

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -248,6 +248,7 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
         options.a11y.speechRules = `${options.sre.domain}-${options.sre.style}`;
       }
       options.MathItem = ExplorerMathItemMixin(options.MathItem, toMathML);
+      this.explorerRegions = new RegionPool(this);
     }
 
     /**
@@ -258,9 +259,6 @@ export function ExplorerMathDocumentMixin<B extends MathDocumentConstructor<HTML
     public explorable(): ExplorerMathDocument {
       if (!this.processed.isSet('explorer')) {
         if (this.options.enableExplorer) {
-          if (!this.explorerRegions) {
-            this.explorerRegions = new RegionPool(this);
-          }
           for (const math of this.math) {
             (math as ExplorerMathItem).explorable(this);
           }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -502,7 +502,7 @@ export class SpeechExplorer extends AbstractExplorer<string> implements KeyExplo
         () => this.brailleRegion.Show(this.node, this.highlighter));
     }
     if (options.a11y.keyMagnifier) {
-      this.magnifyRegion.Show(this.node, this.highlighter);
+      this.magnifyRegion.Show(this.current, this.highlighter);
     }
     this.Update();
   }

--- a/ts/a11y/explorer/MouseExplorer.ts
+++ b/ts/a11y/explorer/MouseExplorer.ts
@@ -94,12 +94,6 @@ export abstract class AbstractMouseExplorer<T> extends AbstractExplorer<T> imple
 export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
 
   /**
-   * Remember the last position to avoid flickering.
-   * @type {[number, number]}
-   */
-  protected coord: [number, number];
-
-  /**
    * @constructor
    * @extends {AbstractMouseExplorer<T>}
    *
@@ -127,10 +121,6 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
    * @override
    */
   public MouseOut(event: MouseEvent) {
-    if (event.clientX === this.coord[0] &&
-        event.clientY === this.coord[1]) {
-      return;
-    }
     this.highlighter.unhighlight();
     this.region.Hide();
     super.MouseOut(event);
@@ -143,7 +133,6 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
   public MouseOver(event: MouseEvent) {
     super.MouseOver(event);
     let target = event.target as HTMLElement;
-    this.coord = [event.clientX, event.clientY];
     let [node, kind] = this.getNode(target);
     if (!node) {
       return;

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -545,7 +545,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
         'box-shadow': '0px 10px 20px #888', border: '2px solid #CCCCCC'
       },
       ['.' + HoverRegion.className + ' > div']: {
-        'clip-path': 'rect(100% 0 0 100%)'
+        overflow: 'hidden'
       }
     });
 

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -112,7 +112,6 @@ export abstract class AbstractRegion<T> implements Region<T> {
   constructor(public document: A11yDocument) {
     this.CLASS = this.constructor as typeof AbstractRegion;
     this.AddStyles();
-    this.AddElement();
   }
 
 
@@ -136,9 +135,9 @@ export abstract class AbstractRegion<T> implements Region<T> {
    * @override
    */
   public AddElement() {
+    if (this.div) return;
     let element = this.document.adaptor.node('div');
     element.classList.add(this.CLASS.className);
-    element.style.backgroundColor = 'white';
     this.div = element;
     this.inner = this.document.adaptor.node('div');
     this.div.appendChild(this.inner);
@@ -153,6 +152,7 @@ export abstract class AbstractRegion<T> implements Region<T> {
    * @override
    */
   public Show(node: HTMLElement, highlighter: Sre.highlighter) {
+    this.AddElement();
     this.position(node);
     this.highlight(highlighter);
     this.div.classList.add(this.CLASS.className + '_Show');
@@ -177,7 +177,10 @@ export abstract class AbstractRegion<T> implements Region<T> {
    * @override
    */
   public Hide() {
-    this.div.classList.remove(this.CLASS.className + '_Show');
+    if (!this.div) return;
+    this.div.parentNode.removeChild(this.div);
+    this.div = null;
+    this.inner = null;
   }
 
 
@@ -198,6 +201,7 @@ export abstract class AbstractRegion<T> implements Region<T> {
    * @param {HTMLElement} node The reference node.
    */
   protected stackRegions(node: HTMLElement) {
+    this.AddElement();
     // TODO: This could be made more efficient by caching regions of a class.
     const rect = node.getBoundingClientRect();
     let baseBottom = 0;
@@ -270,6 +274,7 @@ export class StringRegion extends AbstractRegion<string> {
    * @override
    */
   public Clear(): void {
+    if (!this.div) return;
     this.Update('');
     this.inner.style.top = '';
     this.inner.style.backgroundColor = '';
@@ -280,8 +285,13 @@ export class StringRegion extends AbstractRegion<string> {
    * @override
    */
   public Update(speech: string) {
-    this.inner.textContent = '';
-    this.inner.textContent = speech;
+    if (speech) {
+      this.AddElement();
+    }
+    if (this.inner) {
+      this.inner.textContent = '';
+      this.inner.textContent = speech;
+    }
   }
 
   /**
@@ -296,6 +306,7 @@ export class StringRegion extends AbstractRegion<string> {
    * @override
    */
   protected highlight(highlighter: Sre.highlighter) {
+    if (!this.div) return;
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
     this.inner.style.color = color.foreground;
@@ -317,13 +328,11 @@ export class ToolTip extends StringRegion {
   protected static style: CssStyles =
     new CssStyles({
       ['.' + ToolTip.className]: {
-        display: 'none',
-      },
-      ['.' + ToolTip.className + '_Show']: {
         width: 'auto', height: 'auto', opacity: 1, 'text-align': 'center',
         'border-radius': '6px', padding: 0,
         'border-bottom': '1px dotted black',
         position: 'absolute', display: 'inline-block',
+        'background-color': 'white',
         'z-index': 202
       }
     });
@@ -344,14 +353,12 @@ export class LiveRegion extends StringRegion {
   protected static style: CssStyles =
     new CssStyles({
       ['.' + LiveRegion.className]: {
-        display: 'none'
-      },
-      ['.' + LiveRegion.className + '_Show']: {
         position: 'absolute', top: 0,
         display: 'block', width: 'auto', height: 'auto',
         padding: 0, opacity: 1, 'z-index': '202',
         left: 0, right: 0, 'margin': '0 auto',
-        'background-color': 'rgba(0, 0, 255, 0.2)', 'box-shadow': '0px 5px 20px #888',
+        'background-color': 'white',
+        'box-shadow': '0px 5px 20px #888',
         border: '2px solid #CCCCCC'
       }
     });
@@ -531,26 +538,16 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
   protected static style: CssStyles =
     new CssStyles({
       ['.' + HoverRegion.className]: {
-        display: 'none'
-      },
-      ['.' + HoverRegion.className + '_Show']: {
         display: 'block', position: 'absolute',
         width: 'max-content', height: 'auto',
         padding: 0, opacity: 1, 'z-index': '202', 'margin': '0 auto',
-        'background-color': 'rgba(0, 0, 255, 0.2)',
+        'background-color': 'white', 'line-height': 0,
         'box-shadow': '0px 10px 20px #888', border: '2px solid #CCCCCC'
+      },
+      ['.' + HoverRegion.className + ' > div']: {
+        'clip-path': 'rect(100% 0 0 100%)'
       }
     });
-
-
-  /**
-   * @constructor
-   * @param {A11yDocument} document The document the live region is added to.
-   */
-  constructor(public document: A11yDocument) {
-    super(document);
-    this.inner.style.lineHeight = '0';
-  }
 
   /**
    * Sets the position of the region with respect to align parameter.  There are
@@ -568,7 +565,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
     let top;
     switch (this.document.options.a11y.align) {
     case 'top':
-      top = nodeRect.top - divRect.height - 10 ;
+      top = nodeRect.top - divRect.height - 10;
       break;
     case 'bottom':
       top = nodeRect.bottom + 10;
@@ -588,6 +585,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    * @override
    */
   protected highlight(highlighter: Sre.highlighter) {
+    if (!this.div) return;
     // TODO Do this with styles to avoid the interaction of SVG/CHTML.
     if (this.inner.firstChild &&
         !(this.inner.firstChild as HTMLElement).hasAttribute('sre-highlight')) {
@@ -602,6 +600,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    * @override
    */
   public Show(node: HTMLElement, highlighter: Sre.highlighter) {
+    this.AddElement();
     this.div.style.fontSize = this.document.options.a11y.magnify;
     this.Update(node);
     super.Show(node, highlighter);
@@ -611,6 +610,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    * @override
    */
   public Clear() {
+    if (!this.div) return;
     this.inner.textContent = '';
     this.inner.style.top = '';
     this.inner.style.backgroundColor = '';
@@ -620,9 +620,11 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
    * @override
    */
   public Update(node: HTMLElement) {
+    if (!this.div) return;
     this.Clear();
     let mjx = this.cloneNode(node);
     this.inner.appendChild(mjx);
+    this.position(node);
   }
 
   /**

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -474,6 +474,10 @@ export function EnrichedMathDocumentMixin<N, T, D, B extends MathDocumentConstru
         this.attachSpeechDone();
       }
       this.awaitingSpeech = Array.from(this.math);
+      if (this.awaitingSpeech.length === 0) {
+        this.awaitingSpeech = null;
+        return;
+      }
       this.renderPromises.push(new Promise<void>((ok, _fail) => {
         this.attachSpeechDone = ok;
       }));


### PR DESCRIPTION
In the current incarnation of the explorer, the live regions and other regions associated with an expression are all created and appended to the document body when the expression is processed.  There are 6 such regions for each expression, so the number of these extra divs can get quite large, even for pages with only a moderate number of expressions.  Furthermore, these regions are created during a `convert()` call (like those used in `MathJax.tex2chtml()` or other conversion methods), even when the result is never put into the document DOM.  Finally, these regions are never removed from the page, even if the typeset expressions are removed.  For example, in the situation where an editor has a live preview and re-typesets the input as a user types it, even if the previewer correctly removes the previous math before the new preview it processed, the 6 regions will remain for each of the original expressions, and 6 more will be created for each new one.  So these regions can quickly balloon  during the preview process.

This PR addresses each of these problems.  The main change is to only create the region div elements when they are actually needed.  This means that there will actually be only two or three regions total (regardless of the number of expressions) when one is being explored, and none when the explorers are not active.  This prevents a buildup of divs, and means there is nothing extra to be removed from the DOM when an expression is removed.

These changes are in `Region.ts`, which you should look at first.  The idea is to have functions that require the region, like `Update()` and `Show()`, call `AddElement()` to create it, but have `AddElement()` check if it already exists and return immediately if not, and to remove `AddElement()` from the constructor function.  That way, the div will be created only when needed.  Then `Hide()` can remove the div from the DOM rather than setting `display: none`.  Other functions that use `this.inner` check to make sure that it exists first.  The styles are simplified, since there is no `display: none` state.  We still keep the `_Show` classes, since they are used in the `stackRegions()` function, even though they don't affect the CSS anymore.  I also moved some CSS to the styles that were being applied directly to elements.

Several other issues are addressed here, as well.  One important one is with the mouse-based magnification.  It turns out that there was an unexpected depth to the HoverRegion that was putting an invisible box over top of the areas below the hover region.  That means you can't click on the expression below the div, and it was causing unwanted `mouseout` events when the hover div shows up.  The current code records the coordinates of the original `mouseover` event, and ignores the `mouseout` if it has the same coordinates.  This allowed highlighting and the hover region to remain in place even though the mouse has moved away from the expression, and interfered with changing the magnified characters to the nearby ones, which were also covered by the invisible depth of the box.

This PR uses a `clip-path` on the hover region to remove the excess depth, which avoids the unwanted `mouseout`, allows the expression below the hover region to be clicked, and properly moves to the neighboring characters when the mouse moves over them.  It also means there is no need to record the coordinates of the `mouseover`, so those are removed from `MouseExplorer.ts`.

The key explorer now positions the hover region over the selected characters, just as the mouse explorer does.

In `explorer.ts`, the initialization of the `explorerRegions` was being done in the document's `explore()` call, but that code is only reached if a page-based typeset occurs, and if there is actually math in the page.  If neither of those is true (e.g., the initial typesetting is suppressed, or no math is on the page), and one of the `convert()` methods is called (like `MathJax.tex2svg()`), then an error occurs when `explorerRegions` is accessed by the MathItem during the conversion.  The `explorerRegions` were originally instantiated in the document's `explore()` call because this created the region divs, and in node applications, that caused errors due to the lack of a DOM (and the direct DOM access used by some of the region and explorer code).  This allowed node applications to set the preferences to avoid that.  Now that the divs are not being created until needed, we can move the initialization of `explorerRegions` into the the document's constructor, so that they will be available to convert commands immediately.

Finally, there is a change in `semantic-enrich.ts` that prevents the speech loop from running if there are no MathItems in the documents math list (this caused an error in the loop, since we always try to process at least one MathItem).