### PR TITLE
Tests cleanup after AllPackage removal.

### DIFF
--- a/testsuite/src/setupTex.ts
+++ b/testsuite/src/setupTex.ts
@@ -4,7 +4,6 @@ import {liteAdaptor} from '#js/adaptors/liteAdaptor';
 import {STATE} from '#js/core/MathItem';
 import {SerializedMmlVisitor} from '#js/core/MmlTree/SerializedMmlVisitor';
 import {MmlNode} from '#js/core/MmlTree/MmlNode';
-import '#js/input/tex/AllPackages';
 
 let convert: (tex: string) => string;
 

--- a/testsuite/tests/input/tex/Action.test.ts
+++ b/testsuite/tests/input/tex/Action.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/action/ActionConfiguration';
 
 beforeEach(() => setupTex(['base', 'action']));
 

--- a/testsuite/tests/input/tex/Ams.test.ts
+++ b/testsuite/tests/input/tex/Ams.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/ams/AmsConfiguration';
 
 beforeEach(() => setupTex(['ams', 'base']));
 

--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/amscd/AmsCdConfiguration';
 
 beforeEach(() => setupTex(['base', 'amscd']));
 

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
-import '#js/input/tex/base/BaseConfiguration';
 
 beforeEach(() => setupTex(['base']));
 

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/base/BaseConfiguration';
 
 beforeEach(() => setupTex(['base']));
 

--- a/testsuite/tests/input/tex/Bbox.test.ts
+++ b/testsuite/tests/input/tex/Bbox.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/bbox/BboxConfiguration';
 
 beforeEach(() => setupTex(['base', 'bbox']));
 

--- a/testsuite/tests/input/tex/Boldsymbol.test.ts
+++ b/testsuite/tests/input/tex/Boldsymbol.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/boldsymbol/BoldsymbolConfiguration';
 
 beforeEach(() => setupTex(['base', 'boldsymbol']));
 

--- a/testsuite/tests/input/tex/Braket.test.ts
+++ b/testsuite/tests/input/tex/Braket.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/braket/BraketConfiguration';
 
 beforeEach(() => setupTex(['base', 'braket']));
 

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTexWithOutput, tex2mml } from '#helpers';
+import '#js/input/tex/bussproofs/BussproofsConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
 
 beforeEach(() => setupTexWithOutput(['base', 'ams', 'bussproofs']));
 

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -312,25 +312,25 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:left;bspr_inference:1;bspr_proof:true\">
-        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" display="block">
+      <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
+        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\LeftLabel{L}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>A</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -340,11 +340,11 @@ describe('BussproofsRegInf', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>B</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
@@ -357,20 +357,20 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex=\"\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:right;bspr_inference:1;bspr_proof:true\">
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
+      <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>A</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -380,17 +380,17 @@ describe('BussproofsRegInf', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>B</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -402,25 +402,25 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:both;bspr_inference:1;bspr_proof:true\">
-        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
+      <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
+        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>A</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -430,17 +430,17 @@ describe('BussproofsRegInf', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>B</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -605,25 +605,25 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:left;bspr_inference:1;bspr_proof:true\">
-        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" display="block">
+      <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
+        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\LeftLabel{L}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>A</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -633,11 +633,11 @@ describe('BussproofsRegInf', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>B</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
@@ -650,20 +650,20 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex=\"\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:right;bspr_inference:1;bspr_proof:true\">
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
+      <mrow data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>A</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -673,17 +673,17 @@ describe('BussproofsRegInf', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>B</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -695,25 +695,25 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:both;bspr_inference:1;bspr_proof:true\">
-        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
+      <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
+        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>A</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -723,17 +723,17 @@ describe('BussproofsRegInf', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>B</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+          <mstyle displaystyle="false" scriptlevel="0">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -748,63 +748,63 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" display=\"block\">
-      <mrow semantics=\"bspr_inference:2;bspr_proof:true\">
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_inferenceRule:down\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:2;bspr_proof:true">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>D</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                   <mtd></mtd>
-                  <mtd rowalign=\"bottom\">
-                    <mrow semantics=\"bspr_inference:2\">
-                      <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{E}\" semantics=\"bspr_inferenceRule:down\">
+                  <mtd rowalign="bottom">
+                    <mrow semantics="bspr_inference:2">
+                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
                         <mtr>
                           <mtd>
-                            <mtable framespacing=\"0 0\">
+                            <mtable framespacing="0 0">
                               <mtr>
-                                <mtd rowalign=\"bottom\">
-                                  <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                    <mspace width=\".5ex\"></mspace>
-                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtd rowalign="bottom">
+                                  <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                    <mspace width=".5ex"></mspace>
+                                    <mstyle displaystyle="false" scriptlevel="0">
                                       <mtext>A</mtext>
                                     </mstyle>
-                                    <mspace width=\".5ex\"></mspace>
+                                    <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
                                 <mtd></mtd>
-                                <mtd rowalign=\"bottom\">
-                                  <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+                                <mtd rowalign="bottom">
+                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
                                     <mtr>
                                       <mtd>
-                                        <mtable framespacing=\"0 0\">
+                                        <mtable framespacing="0 0">
                                           <mtr>
-                                            <mtd rowalign=\"bottom\">
-                                              <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                <mspace width=\".5ex\"></mspace>
-                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mtd rowalign="bottom">
+                                              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                <mspace width=".5ex"></mspace>
+                                                <mstyle displaystyle="false" scriptlevel="0">
                                                   <mtext>B</mtext>
                                                 </mstyle>
-                                                <mspace width=\".5ex\"></mspace>
+                                                <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
                                             <mtd></mtd>
-                                            <mtd rowalign=\"bottom\">
-                                              <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
-                                                <mspace width=\".5ex\"></mspace>
-                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mtd rowalign="bottom">
+                                              <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                <mspace width=".5ex"></mspace>
+                                                <mstyle displaystyle="false" scriptlevel="0">
                                                   <mtext>R</mtext>
                                                 </mstyle>
-                                                <mspace width=\".5ex\"></mspace>
+                                                <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
                                           </mtr>
@@ -814,17 +814,17 @@ describe('BussproofsRegProofs', () => {
                                     <mtr>
                                       <mtd>
                                         <mrow>
-                                          <mspace width=\".5ex\"></mspace>
-                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                            <mrow data-mjx-texclass=\"ORD\">
-                                              <mi data-latex=\"C\">C</mi>
-                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                              <mi data-latex=\"D\">D</mi>
-                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                              <mi data-latex=\"Q\">Q</mi>
+                                          <mspace width=".5ex"></mspace>
+                                          <mstyle displaystyle="false" scriptlevel="0">
+                                            <mrow data-mjx-texclass="ORD">
+                                              <mi data-latex="C">C</mi>
+                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                              <mi data-latex="D">D</mi>
+                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                              <mi data-latex="Q">Q</mi>
                                             </mrow>
                                           </mstyle>
-                                          <mspace width=\".5ex\"></mspace>
+                                          <mspace width=".5ex"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -837,16 +837,16 @@ describe('BussproofsRegProofs', () => {
                         <mtr>
                           <mtd>
                             <mrow>
-                              <mspace width=\".5ex\"></mspace>
-                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                              <mspace width=".5ex"></mspace>
+                              <mstyle displaystyle="false" scriptlevel="0">
                                 <mtext>E</mtext>
                               </mstyle>
-                              <mspace width=\".5ex\"></mspace>
+                              <mspace width=".5ex"></mspace>
                             </mrow>
                           </mtd>
                         </mtr>
                       </mtable>
-                      <mspace width=\"-3.795em\"></mspace>
+                      <mspace width="-3.795em"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -856,16 +856,16 @@ describe('BussproofsRegProofs', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>F</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mspace width=\"3.795em\"></mspace>
+        <mspace width="3.795em"></mspace>
       </mrow>
     </math>`
     ));
@@ -874,70 +874,70 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" display=\"block\">
-      <mrow data-latex-item=\"{prooftree}\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" semantics=\"bspr_proof:true\">
-        <mrow data-mjx-texclass=\"ORD\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
+      <mrow data-latex-item="{prooftree}" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" semantics="bspr_proof:true">
+        <mrow data-mjx-texclass="ORD">
           <mo>$</mo>
         </mrow>
         <mi>&#x3B1;</mi>
-        <mrow data-mjx-texclass=\"ORD\">
+        <mrow data-mjx-texclass="ORD">
           <mo>$</mo>
         </mrow>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{F}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down;bspr_inference:2">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>D</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                   <mtd></mtd>
-                  <mtd rowalign=\"bottom\">
-                    <mrow semantics=\"bspr_inference:2\">
-                      <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{E}\" semantics=\"bspr_inferenceRule:down\">
+                  <mtd rowalign="bottom">
+                    <mrow semantics="bspr_inference:2">
+                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
                         <mtr>
                           <mtd>
-                            <mtable framespacing=\"0 0\">
+                            <mtable framespacing="0 0">
                               <mtr>
-                                <mtd rowalign=\"bottom\">
-                                  <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                    <mspace width=\".5ex\"></mspace>
-                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtd rowalign="bottom">
+                                  <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                    <mspace width=".5ex"></mspace>
+                                    <mstyle displaystyle="false" scriptlevel="0">
                                       <mtext>A</mtext>
                                     </mstyle>
-                                    <mspace width=\".5ex\"></mspace>
+                                    <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
                                 <mtd></mtd>
-                                <mtd rowalign=\"bottom\">
-                                  <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+                                <mtd rowalign="bottom">
+                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
                                     <mtr>
                                       <mtd>
-                                        <mtable framespacing=\"0 0\">
+                                        <mtable framespacing="0 0">
                                           <mtr>
-                                            <mtd rowalign=\"bottom\">
-                                              <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                <mspace width=\".5ex\"></mspace>
-                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mtd rowalign="bottom">
+                                              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                <mspace width=".5ex"></mspace>
+                                                <mstyle displaystyle="false" scriptlevel="0">
                                                   <mtext>B</mtext>
                                                 </mstyle>
-                                                <mspace width=\".5ex\"></mspace>
+                                                <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
                                             <mtd></mtd>
-                                            <mtd rowalign=\"bottom\">
-                                              <mrow data-latex=\"$\" semantics=\"bspr_axiom:true\">
-                                                <mspace width=\".5ex\"></mspace>
-                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mtd rowalign="bottom">
+                                              <mrow data-latex="$" semantics="bspr_axiom:true">
+                                                <mspace width=".5ex"></mspace>
+                                                <mstyle displaystyle="false" scriptlevel="0">
                                                   <mtext>R</mtext>
                                                 </mstyle>
-                                                <mspace width=\".5ex\"></mspace>
+                                                <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
                                           </mtr>
@@ -947,17 +947,17 @@ describe('BussproofsRegProofs', () => {
                                     <mtr>
                                       <mtd>
                                         <mrow>
-                                          <mspace width=\".5ex\"></mspace>
-                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                            <mrow data-mjx-texclass=\"ORD\">
-                                              <mi data-latex=\"C\">C</mi>
-                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                              <mi data-latex=\"D\">D</mi>
-                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                              <mi data-latex=\"Q\">Q</mi>
+                                          <mspace width=".5ex"></mspace>
+                                          <mstyle displaystyle="false" scriptlevel="0">
+                                            <mrow data-mjx-texclass="ORD">
+                                              <mi data-latex="C">C</mi>
+                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                              <mi data-latex="D">D</mi>
+                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                              <mi data-latex="Q">Q</mi>
                                             </mrow>
                                           </mstyle>
-                                          <mspace width=\".5ex\"></mspace>
+                                          <mspace width=".5ex"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -970,16 +970,16 @@ describe('BussproofsRegProofs', () => {
                         <mtr>
                           <mtd>
                             <mrow>
-                              <mspace width=\".5ex\"></mspace>
-                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                              <mspace width=".5ex"></mspace>
+                              <mstyle displaystyle="false" scriptlevel="0">
                                 <mtext>E</mtext>
                               </mstyle>
-                              <mspace width=\".5ex\"></mspace>
+                              <mspace width=".5ex"></mspace>
                             </mrow>
                           </mtd>
                         </mtr>
                       </mtable>
-                      <mspace width=\"-3.795em\"></mspace>
+                      <mspace width="-3.795em"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -989,16 +989,16 @@ describe('BussproofsRegProofs', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
                   <mtext>F</mtext>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mspace width=\"3.795em\"></mspace>
+        <mspace width="3.795em"></mspace>
       </mrow>
     </math>`
     ));
@@ -1007,57 +1007,57 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" display=\"block\">
-      <mrow semantics=\"bspr_inference:2;bspr_proof:true\">
-        <mspace width=\"8.227em\"></mspace>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_inferenceRule:down\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:2;bspr_proof:true">
+        <mspace width="8.227em"></mspace>
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow semantics=\"bspr_inference:2\">
-                      <mspace width=\"-4.953em\"></mspace>
-                      <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{F}\" semantics=\"bspr_inferenceRule:down\">
+                  <mtd rowalign="bottom">
+                    <mrow semantics="bspr_inference:2">
+                      <mspace width="-4.953em"></mspace>
+                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down">
                         <mtr>
                           <mtd>
-                            <mtable framespacing=\"0 0\">
+                            <mtable framespacing="0 0">
                               <mtr>
-                                <mtd rowalign=\"bottom\">
-                                  <mrow semantics=\"bspr_inference:3\">
-                                    <mspace width=\"-3.274em\"></mspace>
-                                    <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\TrinaryInfC{Q}\" semantics=\"bspr_inferenceRule:down\">
+                                <mtd rowalign="bottom">
+                                  <mrow semantics="bspr_inference:3">
+                                    <mspace width="-3.274em"></mspace>
+                                    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\TrinaryInfC{Q}" semantics="bspr_inferenceRule:down">
                                       <mtr>
                                         <mtd>
-                                          <mtable framespacing=\"0 0\">
+                                          <mtable framespacing="0 0">
                                             <mtr>
-                                              <mtd rowalign=\"bottom\">
-                                                <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtd rowalign="bottom">
+                                                <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>D</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                               <mtd></mtd>
-                                              <mtd rowalign=\"bottom\">
-                                                <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtd rowalign="bottom">
+                                                <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>A1</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                               <mtd></mtd>
-                                              <mtd rowalign=\"bottom\">
-                                                <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtd rowalign="bottom">
+                                                <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>A2</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
@@ -1067,11 +1067,11 @@ describe('BussproofsRegProofs', () => {
                                       <mtr>
                                         <mtd>
                                           <mrow>
-                                            <mspace width=\".5ex\"></mspace>
-                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mspace width=".5ex"></mspace>
+                                            <mstyle displaystyle="false" scriptlevel="0">
                                               <mtext>Q</mtext>
                                             </mstyle>
-                                            <mspace width=\".5ex\"></mspace>
+                                            <mspace width=".5ex"></mspace>
                                           </mrow>
                                         </mtd>
                                       </mtr>
@@ -1079,46 +1079,46 @@ describe('BussproofsRegProofs', () => {
                                   </mrow>
                                 </mtd>
                                 <mtd></mtd>
-                                <mtd rowalign=\"bottom\">
-                                  <mrow semantics=\"bspr_inference:2\">
-                                    <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{E}\" semantics=\"bspr_inferenceRule:down\">
+                                <mtd rowalign="bottom">
+                                  <mrow semantics="bspr_inference:2">
+                                    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
                                       <mtr>
                                         <mtd>
-                                          <mtable framespacing=\"0 0\">
+                                          <mtable framespacing="0 0">
                                             <mtr>
-                                              <mtd rowalign=\"bottom\">
-                                                <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtd rowalign="bottom">
+                                                <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>A</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                               <mtd></mtd>
-                                              <mtd rowalign=\"bottom\">
-                                                <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+                                              <mtd rowalign="bottom">
+                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
                                                   <mtr>
                                                     <mtd>
-                                                      <mtable framespacing=\"0 0\">
+                                                      <mtable framespacing="0 0">
                                                         <mtr>
-                                                          <mtd rowalign=\"bottom\">
-                                                            <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                              <mspace width=\".5ex\"></mspace>
-                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtd rowalign="bottom">
+                                                            <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                              <mspace width=".5ex"></mspace>
+                                                              <mstyle displaystyle="false" scriptlevel="0">
                                                                 <mtext>B</mtext>
                                                               </mstyle>
-                                                              <mspace width=\".5ex\"></mspace>
+                                                              <mspace width=".5ex"></mspace>
                                                             </mrow>
                                                           </mtd>
                                                           <mtd></mtd>
-                                                          <mtd rowalign=\"bottom\">
-                                                            <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
-                                                              <mspace width=\".5ex\"></mspace>
-                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtd rowalign="bottom">
+                                                            <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                              <mspace width=".5ex"></mspace>
+                                                              <mstyle displaystyle="false" scriptlevel="0">
                                                                 <mtext>R</mtext>
                                                               </mstyle>
-                                                              <mspace width=\".5ex\"></mspace>
+                                                              <mspace width=".5ex"></mspace>
                                                             </mrow>
                                                           </mtd>
                                                         </mtr>
@@ -1128,17 +1128,17 @@ describe('BussproofsRegProofs', () => {
                                                   <mtr>
                                                     <mtd>
                                                       <mrow>
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                                          <mrow data-mjx-texclass=\"ORD\">
-                                                            <mi data-latex=\"C\">C</mi>
-                                                            <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                            <mi data-latex=\"D\">D</mi>
-                                                            <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                            <mi data-latex=\"Q\">Q</mi>
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
+                                                          <mrow data-mjx-texclass="ORD">
+                                                            <mi data-latex="C">C</mi>
+                                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                            <mi data-latex="D">D</mi>
+                                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                            <mi data-latex="Q">Q</mi>
                                                           </mrow>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
@@ -1151,16 +1151,16 @@ describe('BussproofsRegProofs', () => {
                                       <mtr>
                                         <mtd>
                                           <mrow>
-                                            <mspace width=\".5ex\"></mspace>
-                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mspace width=".5ex"></mspace>
+                                            <mstyle displaystyle="false" scriptlevel="0">
                                               <mtext>E</mtext>
                                             </mstyle>
-                                            <mspace width=\".5ex\"></mspace>
+                                            <mspace width=".5ex"></mspace>
                                           </mrow>
                                         </mtd>
                                       </mtr>
                                     </mtable>
-                                    <mspace width=\"-3.795em\"></mspace>
+                                    <mspace width="-3.795em"></mspace>
                                   </mrow>
                                 </mtd>
                               </mtr>
@@ -1170,11 +1170,11 @@ describe('BussproofsRegProofs', () => {
                         <mtr>
                           <mtd>
                             <mrow>
-                              <mspace width=\".5ex\"></mspace>
-                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                              <mspace width=".5ex"></mspace>
+                              <mstyle displaystyle="false" scriptlevel="0">
                                 <mtext>F</mtext>
                               </mstyle>
-                              <mspace width=\".5ex\"></mspace>
+                              <mspace width=".5ex"></mspace>
                             </mrow>
                           </mtd>
                         </mtr>
@@ -1182,15 +1182,15 @@ describe('BussproofsRegProofs', () => {
                     </mrow>
                   </mtd>
                   <mtd>
-                    <mspace width=\"3.795em\"></mspace>
+                    <mspace width="3.795em"></mspace>
                   </mtd>
-                  <mtd rowalign=\"bottom\">
-                    <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
-                      <mspace width=\".5ex\"></mspace>
-                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtd rowalign="bottom">
+                    <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                      <mspace width=".5ex"></mspace>
+                      <mstyle displaystyle="false" scriptlevel="0">
                         <mtext>M</mtext>
                       </mstyle>
-                      <mspace width=\".5ex\"></mspace>
+                      <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -1200,15 +1200,15 @@ describe('BussproofsRegProofs', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                  <mrow data-mjx-texclass=\"ORD\">
-                    <mi data-latex=\"N\">N</mi>
-                    <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                    <mi data-latex=\"R\">R</mi>
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
+                  <mrow data-mjx-texclass="ORD">
+                    <mi data-latex="N">N</mi>
+                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                    <mi data-latex="R">R</mi>
                   </mrow>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
@@ -1221,61 +1221,61 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}\" display=\"block\">
-      <mrow semantics=\"bspr_inference:2;bspr_proof:true;bspr_labelledRule:right\">
-        <mspace width=\"8.227em\"></mspace>
-        <mrow data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}\" data-latex-item=\"{prooftree}\">
-          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:right">
+        <mspace width="8.227em"></mspace>
+        <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
             <mtr>
               <mtd>
-                <mtable framespacing=\"0 0\">
+                <mtable framespacing="0 0">
                   <mtr>
-                    <mtd rowalign=\"bottom\">
-                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                        <mspace width=\"-8.227em\"></mspace>
+                    <mtd rowalign="bottom">
+                      <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                        <mspace width="-8.227em"></mspace>
                         <mrow>
-                          <mspace width=\"3.274em\"></mspace>
-                          <mrow data-latex=\"\\RightLabel{QERE}\">
-                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                          <mspace width="3.274em"></mspace>
+                          <mrow data-latex="\\RightLabel{QERE}">
+                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
                                 <mtd>
-                                  <mtable framespacing=\"0 0\">
+                                  <mtable framespacing="0 0">
                                     <mtr>
-                                      <mtd rowalign=\"bottom\">
-                                        <mrow semantics=\"bspr_inference:3\">
-                                          <mspace width=\"-3.274em\"></mspace>
-                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\RightLabel{AAAA}\" semantics=\"bspr_inferenceRule:down\">
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:3">
+                                          <mspace width="-3.274em"></mspace>
+                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
                                             <mtr>
                                               <mtd>
-                                                <mtable framespacing=\"0 0\">
+                                                <mtable framespacing="0 0">
                                                   <mtr>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>D</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A1</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A2</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
@@ -1285,11 +1285,11 @@ describe('BussproofsRegProofs', () => {
                                             <mtr>
                                               <mtd>
                                                 <mrow>
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>Q</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
@@ -1297,49 +1297,49 @@ describe('BussproofsRegProofs', () => {
                                         </mrow>
                                       </mtd>
                                       <mtd></mtd>
-                                      <mtd rowalign=\"bottom\">
-                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                                          <mrow data-latex=\"\\RightLabel{CCCCC}\">
-                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                          <mrow data-latex="\\RightLabel{CCCCC}">
+                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
                                                 <mtd>
-                                                  <mtable framespacing=\"0 0\">
+                                                  <mtable framespacing="0 0">
                                                     <mtr>
-                                                      <mtd rowalign=\"bottom\">
-                                                        <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                                          <mspace width=\".5ex\"></mspace>
-                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtd rowalign="bottom">
+                                                        <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                          <mspace width=".5ex"></mspace>
+                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                             <mtext>A</mtext>
                                                           </mstyle>
-                                                          <mspace width=\".5ex\"></mspace>
+                                                          <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                       <mtd></mtd>
-                                                      <mtd rowalign=\"bottom\">
-                                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                                                          <mrow data-latex=\"\\RightLabel{BBB}\">
-                                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                      <mtd rowalign="bottom">
+                                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                          <mrow data-latex="\\RightLabel{BBB}">
+                                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                               <mtr>
                                                                 <mtd>
-                                                                  <mtable framespacing=\"0 0\">
+                                                                  <mtable framespacing="0 0">
                                                                     <mtr>
-                                                                      <mtd rowalign=\"bottom\">
-                                                                        <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                                          <mspace width=\".5ex\"></mspace>
-                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                      <mtd rowalign="bottom">
+                                                                        <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                                             <mtext>B</mtext>
                                                                           </mstyle>
-                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
                                                                       <mtd></mtd>
-                                                                      <mtd rowalign=\"bottom\">
-                                                                        <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
-                                                                          <mspace width=\".5ex\"></mspace>
-                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                      <mtd rowalign="bottom">
+                                                                        <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                                             <mtext>R</mtext>
                                                                           </mstyle>
-                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
                                                                     </mtr>
@@ -1349,28 +1349,28 @@ describe('BussproofsRegProofs', () => {
                                                               <mtr>
                                                                 <mtd>
                                                                   <mrow>
-                                                                    <mspace width=\".5ex\"></mspace>
-                                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                                                      <mrow data-mjx-texclass=\"ORD\">
-                                                                        <mi data-latex=\"C\">C</mi>
-                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                        <mi data-latex=\"D\">D</mi>
-                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                        <mi data-latex=\"Q\">Q</mi>
+                                                                    <mspace width=".5ex"></mspace>
+                                                                    <mstyle displaystyle="false" scriptlevel="0">
+                                                                      <mrow data-mjx-texclass="ORD">
+                                                                        <mi data-latex="C">C</mi>
+                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                        <mi data-latex="D">D</mi>
+                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                        <mi data-latex="Q">Q</mi>
                                                                       </mrow>
                                                                     </mstyle>
-                                                                    <mspace width=\".5ex\"></mspace>
+                                                                    <mspace width=".5ex"></mspace>
                                                                   </mrow>
                                                                 </mtd>
                                                               </mtr>
                                                             </mtable>
-                                                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                              <mstyle displaystyle="false" scriptlevel="0">
                                                                 <mtext>AAAA</mtext>
                                                               </mstyle>
                                                             </mpadded>
                                                           </mrow>
-                                                          <mspace width=\"-3.216em\"></mspace>
+                                                          <mspace width="-3.216em"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                     </mtr>
@@ -1380,22 +1380,22 @@ describe('BussproofsRegProofs', () => {
                                               <mtr>
                                                 <mtd>
                                                   <mrow>
-                                                    <mspace width=\".5ex\"></mspace>
-                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mspace width=".5ex"></mspace>
+                                                    <mstyle displaystyle="false" scriptlevel="0">
                                                       <mtext>E</mtext>
                                                     </mstyle>
-                                                    <mspace width=\".5ex\"></mspace>
+                                                    <mspace width=".5ex"></mspace>
                                                   </mrow>
                                                 </mtd>
                                               </mtr>
                                             </mtable>
-                                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                              <mstyle displaystyle="false" scriptlevel="0">
                                                 <mtext>BBB</mtext>
                                               </mstyle>
                                             </mpadded>
                                           </mrow>
-                                          <mspace width=\"-6.134em\"></mspace>
+                                          <mspace width="-6.134em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -1405,17 +1405,17 @@ describe('BussproofsRegProofs', () => {
                               <mtr>
                                 <mtd>
                                   <mrow>
-                                    <mspace width=\".5ex\"></mspace>
-                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                    <mspace width=".5ex"></mspace>
+                                    <mstyle displaystyle="false" scriptlevel="0">
                                       <mtext>F</mtext>
                                     </mstyle>
-                                    <mspace width=\".5ex\"></mspace>
+                                    <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
                               </mtr>
                             </mtable>
-                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                              <mstyle displaystyle="false" scriptlevel="0">
                                 <mtext>CCCCC</mtext>
                               </mstyle>
                             </mpadded>
@@ -1424,15 +1424,15 @@ describe('BussproofsRegProofs', () => {
                       </mrow>
                     </mtd>
                     <mtd>
-                      <mspace width=\"3.185em\"></mspace>
+                      <mspace width="3.185em"></mspace>
                     </mtd>
-                    <mtd rowalign=\"bottom\">
-                      <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
-                        <mspace width=\".5ex\"></mspace>
-                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                    <mtd rowalign="bottom">
+                      <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                        <mspace width=".5ex"></mspace>
+                        <mstyle displaystyle="false" scriptlevel="0">
                           <mtext>M</mtext>
                         </mstyle>
-                        <mspace width=\".5ex\"></mspace>
+                        <mspace width=".5ex"></mspace>
                       </mrow>
                     </mtd>
                   </mtr>
@@ -1442,21 +1442,21 @@ describe('BussproofsRegProofs', () => {
             <mtr>
               <mtd>
                 <mrow>
-                  <mspace width=\".5ex\"></mspace>
-                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                    <mrow data-mjx-texclass=\"ORD\">
-                      <mi data-latex=\"N\">N</mi>
-                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                      <mi data-latex=\"R\">R</mi>
+                  <mspace width=".5ex"></mspace>
+                  <mstyle displaystyle="false" scriptlevel="0">
+                    <mrow data-mjx-texclass="ORD">
+                      <mi data-latex="N">N</mi>
+                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                      <mi data-latex="R">R</mi>
                     </mrow>
                   </mstyle>
-                  <mspace width=\".5ex\"></mspace>
+                  <mspace width=".5ex"></mspace>
                 </mrow>
               </mtd>
             </mtr>
           </mtable>
-          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+            <mstyle displaystyle="false" scriptlevel="0">
               <mtext>QERE</mtext>
             </mstyle>
           </mpadded>
@@ -1469,72 +1469,72 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" display=\"block\">
-      <mrow semantics=\"bspr_inference:2;bspr_proof:true;bspr_labelledRule:left\">
-        <mspace width=\"3.835em\"></mspace>
-        <mrow data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" data-latex-item=\"{prooftree}\">
-          <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:left">
+        <mspace width="3.835em"></mspace>
+        <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+          <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+            <mstyle displaystyle="false" scriptlevel="0">
               <mtext>QERE</mtext>
             </mstyle>
           </mpadded>
-          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
             <mtr>
               <mtd>
-                <mtable framespacing=\"0 0\">
+                <mtable framespacing="0 0">
                   <mtr>
-                    <mtd rowalign=\"bottom\">
-                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
-                        <mspace width=\"-6.927em\"></mspace>
+                    <mtd rowalign="bottom">
+                      <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                        <mspace width="-6.927em"></mspace>
                         <mrow>
-                          <mspace width=\"-0.551em\"></mspace>
-                          <mrow data-latex=\"\\LeftLabel{QERE}\">
-                            <mspace width=\"0.551em\"></mspace>
-                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                          <mspace width="-0.551em"></mspace>
+                          <mrow data-latex="\\LeftLabel{QERE}">
+                            <mspace width="0.551em"></mspace>
+                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                              <mstyle displaystyle="false" scriptlevel="0">
                                 <mtext>CCCCC</mtext>
                               </mstyle>
                             </mpadded>
-                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
                                 <mtd>
-                                  <mtable framespacing=\"0 0\">
+                                  <mtable framespacing="0 0">
                                     <mtr>
-                                      <mtd rowalign=\"bottom\">
-                                        <mrow semantics=\"bspr_inference:3\">
-                                          <mspace width=\"-3.274em\"></mspace>
-                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\LeftLabel{AAAA}\" semantics=\"bspr_inferenceRule:down\">
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:3">
+                                          <mspace width="-3.274em"></mspace>
+                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\LeftLabel{AAAA}" semantics="bspr_inferenceRule:down">
                                             <mtr>
                                               <mtd>
-                                                <mtable framespacing=\"0 0\">
+                                                <mtable framespacing="0 0">
                                                   <mtr>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>D</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A1</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A2</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
@@ -1544,11 +1544,11 @@ describe('BussproofsRegProofs', () => {
                                             <mtr>
                                               <mtd>
                                                 <mrow>
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>Q</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
@@ -1556,58 +1556,58 @@ describe('BussproofsRegProofs', () => {
                                         </mrow>
                                       </mtd>
                                       <mtd></mtd>
-                                      <mtd rowalign=\"bottom\">
-                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
-                                          <mrow data-latex=\"\\LeftLabel{CCCCC}\">
-                                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                                          <mrow data-latex="\\LeftLabel{CCCCC}">
+                                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                              <mstyle displaystyle="false" scriptlevel="0">
                                                 <mtext>BBB</mtext>
                                               </mstyle>
                                             </mpadded>
-                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
                                                 <mtd>
-                                                  <mtable framespacing=\"0 0\">
+                                                  <mtable framespacing="0 0">
                                                     <mtr>
-                                                      <mtd rowalign=\"bottom\">
-                                                        <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                                          <mspace width=\".5ex\"></mspace>
-                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtd rowalign="bottom">
+                                                        <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                          <mspace width=".5ex"></mspace>
+                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                             <mtext>A</mtext>
                                                           </mstyle>
-                                                          <mspace width=\".5ex\"></mspace>
+                                                          <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                       <mtd></mtd>
-                                                      <mtd rowalign=\"bottom\">
-                                                        <mrow data-latex=\"\\LeftLabel{BBB}\" semantics=\"bspr_labelledRule:left;bspr_inference:2\">
-                                                          <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-                                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtd rowalign="bottom">
+                                                        <mrow data-latex="\\LeftLabel{BBB}" semantics="bspr_labelledRule:left;bspr_inference:2">
+                                                          <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                            <mstyle displaystyle="false" scriptlevel="0">
                                                               <mtext>AAAA</mtext>
                                                             </mstyle>
                                                           </mpadded>
-                                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                             <mtr>
                                                               <mtd>
-                                                                <mtable framespacing=\"0 0\">
+                                                                <mtable framespacing="0 0">
                                                                   <mtr>
-                                                                    <mtd rowalign=\"bottom\">
-                                                                      <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                                        <mspace width=\".5ex\"></mspace>
-                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                    <mtd rowalign="bottom">
+                                                                      <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                        <mspace width=".5ex"></mspace>
+                                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                                           <mtext>B</mtext>
                                                                         </mstyle>
-                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
                                                                     <mtd></mtd>
-                                                                    <mtd rowalign=\"bottom\">
-                                                                      <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
-                                                                        <mspace width=\".5ex\"></mspace>
-                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                    <mtd rowalign="bottom">
+                                                                      <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                        <mspace width=".5ex"></mspace>
+                                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                                           <mtext>R</mtext>
                                                                         </mstyle>
-                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
                                                                   </mtr>
@@ -1617,17 +1617,17 @@ describe('BussproofsRegProofs', () => {
                                                             <mtr>
                                                               <mtd>
                                                                 <mrow>
-                                                                  <mspace width=\".5ex\"></mspace>
-                                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                                                    <mrow data-mjx-texclass=\"ORD\">
-                                                                      <mi data-latex=\"C\">C</mi>
-                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                      <mi data-latex=\"D\">D</mi>
-                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                      <mi data-latex=\"Q\">Q</mi>
+                                                                  <mspace width=".5ex"></mspace>
+                                                                  <mstyle displaystyle="false" scriptlevel="0">
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <mi data-latex="C">C</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="D">D</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="Q">Q</mi>
                                                                     </mrow>
                                                                   </mstyle>
-                                                                  <mspace width=\".5ex\"></mspace>
+                                                                  <mspace width=".5ex"></mspace>
                                                                 </mrow>
                                                               </mtd>
                                                             </mtr>
@@ -1641,17 +1641,17 @@ describe('BussproofsRegProofs', () => {
                                               <mtr>
                                                 <mtd>
                                                   <mrow>
-                                                    <mspace width=\".5ex\"></mspace>
-                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mspace width=".5ex"></mspace>
+                                                    <mstyle displaystyle="false" scriptlevel="0">
                                                       <mtext>E</mtext>
                                                     </mstyle>
-                                                    <mspace width=\".5ex\"></mspace>
+                                                    <mspace width=".5ex"></mspace>
                                                   </mrow>
                                                 </mtd>
                                               </mtr>
                                             </mtable>
                                           </mrow>
-                                          <mspace width=\"-5.403em\"></mspace>
+                                          <mspace width="-5.403em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -1661,11 +1661,11 @@ describe('BussproofsRegProofs', () => {
                               <mtr>
                                 <mtd>
                                   <mrow>
-                                    <mspace width=\".5ex\"></mspace>
-                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                    <mspace width=".5ex"></mspace>
+                                    <mstyle displaystyle="false" scriptlevel="0">
                                       <mtext>F</mtext>
                                     </mstyle>
-                                    <mspace width=\".5ex\"></mspace>
+                                    <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
                               </mtr>
@@ -1675,15 +1675,15 @@ describe('BussproofsRegProofs', () => {
                       </mrow>
                     </mtd>
                     <mtd>
-                      <mspace width=\"5.403em\"></mspace>
+                      <mspace width="5.403em"></mspace>
                     </mtd>
-                    <mtd rowalign=\"bottom\">
-                      <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
-                        <mspace width=\".5ex\"></mspace>
-                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                    <mtd rowalign="bottom">
+                      <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                        <mspace width=".5ex"></mspace>
+                        <mstyle displaystyle="false" scriptlevel="0">
                           <mtext>M</mtext>
                         </mstyle>
-                        <mspace width=\".5ex\"></mspace>
+                        <mspace width=".5ex"></mspace>
                       </mrow>
                     </mtd>
                   </mtr>
@@ -1693,15 +1693,15 @@ describe('BussproofsRegProofs', () => {
             <mtr>
               <mtd>
                 <mrow>
-                  <mspace width=\".5ex\"></mspace>
-                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                    <mrow data-mjx-texclass=\"ORD\">
-                      <mi data-latex=\"N\">N</mi>
-                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                      <mi data-latex=\"R\">R</mi>
+                  <mspace width=".5ex"></mspace>
+                  <mstyle displaystyle="false" scriptlevel="0">
+                    <mrow data-mjx-texclass="ORD">
+                      <mi data-latex="N">N</mi>
+                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                      <mi data-latex="R">R</mi>
                     </mrow>
                   </mstyle>
-                  <mspace width=\".5ex\"></mspace>
+                  <mspace width=".5ex"></mspace>
                 </mrow>
               </mtd>
             </mtr>
@@ -1715,72 +1715,72 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" display=\"block\">
-      <mrow semantics=\"bspr_inference:2;bspr_proof:true;bspr_labelledRule:both\">
-        <mspace width=\"4.379em\"></mspace>
-        <mrow data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" data-latex-item=\"{prooftree}\">
-          <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
+        <mspace width="4.379em"></mspace>
+        <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+          <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+            <mstyle displaystyle="false" scriptlevel="0">
               <mtext>DD</mtext>
             </mstyle>
           </mpadded>
-          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
             <mtr>
               <mtd>
-                <mtable framespacing=\"0 0\">
+                <mtable framespacing="0 0">
                   <mtr>
-                    <mtd rowalign=\"bottom\">
-                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
-                        <mspace width=\"-6.123em\"></mspace>
+                    <mtd rowalign="bottom">
+                      <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                        <mspace width="-6.123em"></mspace>
                         <mrow>
-                          <mspace width=\"-0.551em\"></mspace>
-                          <mrow data-latex=\"\\LeftLabel{DD}\">
-                            <mspace width=\"0.551em\"></mspace>
-                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                          <mspace width="-0.551em"></mspace>
+                          <mrow data-latex="\\LeftLabel{DD}">
+                            <mspace width="0.551em"></mspace>
+                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                              <mstyle displaystyle="false" scriptlevel="0">
                                 <mtext>CCCCC</mtext>
                               </mstyle>
                             </mpadded>
-                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
                                 <mtd>
-                                  <mtable framespacing=\"0 0\">
+                                  <mtable framespacing="0 0">
                                     <mtr>
-                                      <mtd rowalign=\"bottom\">
-                                        <mrow semantics=\"bspr_inference:3\">
-                                          <mspace width=\"-3.274em\"></mspace>
-                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\RightLabel{AAAA}\" semantics=\"bspr_inferenceRule:down\">
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:3">
+                                          <mspace width="-3.274em"></mspace>
+                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
                                             <mtr>
                                               <mtd>
-                                                <mtable framespacing=\"0 0\">
+                                                <mtable framespacing="0 0">
                                                   <mtr>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>D</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A1</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A2</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
@@ -1790,11 +1790,11 @@ describe('BussproofsRegProofs', () => {
                                             <mtr>
                                               <mtd>
                                                 <mrow>
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>Q</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
@@ -1802,54 +1802,54 @@ describe('BussproofsRegProofs', () => {
                                         </mrow>
                                       </mtd>
                                       <mtd></mtd>
-                                      <mtd rowalign=\"bottom\">
-                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
-                                          <mrow data-latex=\"\\LeftLabel{CCCCC}\">
-                                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
-                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                                          <mrow data-latex="\\LeftLabel{CCCCC}">
+                                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                              <mstyle displaystyle="false" scriptlevel="0">
                                                 <mtext>BBB</mtext>
                                               </mstyle>
                                             </mpadded>
-                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
                                                 <mtd>
-                                                  <mtable framespacing=\"0 0\">
+                                                  <mtable framespacing="0 0">
                                                     <mtr>
-                                                      <mtd rowalign=\"bottom\">
-                                                        <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                                          <mspace width=\".5ex\"></mspace>
-                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtd rowalign="bottom">
+                                                        <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                          <mspace width=".5ex"></mspace>
+                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                             <mtext>A</mtext>
                                                           </mstyle>
-                                                          <mspace width=\".5ex\"></mspace>
+                                                          <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                       <mtd></mtd>
-                                                      <mtd rowalign=\"bottom\">
-                                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                                                          <mrow data-latex=\"\\LeftLabel{BBB}\">
-                                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                      <mtd rowalign="bottom">
+                                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                          <mrow data-latex="\\LeftLabel{BBB}">
+                                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                               <mtr>
                                                                 <mtd>
-                                                                  <mtable framespacing=\"0 0\">
+                                                                  <mtable framespacing="0 0">
                                                                     <mtr>
-                                                                      <mtd rowalign=\"bottom\">
-                                                                        <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                                          <mspace width=\".5ex\"></mspace>
-                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                      <mtd rowalign="bottom">
+                                                                        <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                                             <mtext>B</mtext>
                                                                           </mstyle>
-                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
                                                                       <mtd></mtd>
-                                                                      <mtd rowalign=\"bottom\">
-                                                                        <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
-                                                                          <mspace width=\".5ex\"></mspace>
-                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                      <mtd rowalign="bottom">
+                                                                        <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mstyle displaystyle="false" scriptlevel="0">
                                                                             <mtext>R</mtext>
                                                                           </mstyle>
-                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
                                                                     </mtr>
@@ -1859,28 +1859,28 @@ describe('BussproofsRegProofs', () => {
                                                               <mtr>
                                                                 <mtd>
                                                                   <mrow>
-                                                                    <mspace width=\".5ex\"></mspace>
-                                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                                                      <mrow data-mjx-texclass=\"ORD\">
-                                                                        <mi data-latex=\"C\">C</mi>
-                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                        <mi data-latex=\"D\">D</mi>
-                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                        <mi data-latex=\"Q\">Q</mi>
+                                                                    <mspace width=".5ex"></mspace>
+                                                                    <mstyle displaystyle="false" scriptlevel="0">
+                                                                      <mrow data-mjx-texclass="ORD">
+                                                                        <mi data-latex="C">C</mi>
+                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                        <mi data-latex="D">D</mi>
+                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                        <mi data-latex="Q">Q</mi>
                                                                       </mrow>
                                                                     </mstyle>
-                                                                    <mspace width=\".5ex\"></mspace>
+                                                                    <mspace width=".5ex"></mspace>
                                                                   </mrow>
                                                                 </mtd>
                                                               </mtr>
                                                             </mtable>
-                                                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                              <mstyle displaystyle="false" scriptlevel="0">
                                                                 <mtext>AAAA</mtext>
                                                               </mstyle>
                                                             </mpadded>
                                                           </mrow>
-                                                          <mspace width=\"-3.216em\"></mspace>
+                                                          <mspace width="-3.216em"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                     </mtr>
@@ -1890,17 +1890,17 @@ describe('BussproofsRegProofs', () => {
                                               <mtr>
                                                 <mtd>
                                                   <mrow>
-                                                    <mspace width=\".5ex\"></mspace>
-                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mspace width=".5ex"></mspace>
+                                                    <mstyle displaystyle="false" scriptlevel="0">
                                                       <mtext>E</mtext>
                                                     </mstyle>
-                                                    <mspace width=\".5ex\"></mspace>
+                                                    <mspace width=".5ex"></mspace>
                                                   </mrow>
                                                 </mtd>
                                               </mtr>
                                             </mtable>
                                           </mrow>
-                                          <mspace width=\"-3.795em\"></mspace>
+                                          <mspace width="-3.795em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -1910,11 +1910,11 @@ describe('BussproofsRegProofs', () => {
                               <mtr>
                                 <mtd>
                                   <mrow>
-                                    <mspace width=\".5ex\"></mspace>
-                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                    <mspace width=".5ex"></mspace>
+                                    <mstyle displaystyle="false" scriptlevel="0">
                                       <mtext>F</mtext>
                                     </mstyle>
-                                    <mspace width=\".5ex\"></mspace>
+                                    <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
                               </mtr>
@@ -1924,15 +1924,15 @@ describe('BussproofsRegProofs', () => {
                       </mrow>
                     </mtd>
                     <mtd>
-                      <mspace width=\"7.01em\"></mspace>
+                      <mspace width="7.01em"></mspace>
                     </mtd>
-                    <mtd rowalign=\"bottom\">
-                      <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
-                        <mspace width=\".5ex\"></mspace>
-                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                    <mtd rowalign="bottom">
+                      <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                        <mspace width=".5ex"></mspace>
+                        <mstyle displaystyle="false" scriptlevel="0">
                           <mtext>M</mtext>
                         </mstyle>
-                        <mspace width=\".5ex\"></mspace>
+                        <mspace width=".5ex"></mspace>
                       </mrow>
                     </mtd>
                   </mtr>
@@ -1942,21 +1942,21 @@ describe('BussproofsRegProofs', () => {
             <mtr>
               <mtd>
                 <mrow>
-                  <mspace width=\".5ex\"></mspace>
-                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                    <mrow data-mjx-texclass=\"ORD\">
-                      <mi data-latex=\"N\">N</mi>
-                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                      <mi data-latex=\"R\">R</mi>
+                  <mspace width=".5ex"></mspace>
+                  <mstyle displaystyle="false" scriptlevel="0">
+                    <mrow data-mjx-texclass="ORD">
+                      <mi data-latex="N">N</mi>
+                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                      <mi data-latex="R">R</mi>
                     </mrow>
                   </mstyle>
-                  <mspace width=\".5ex\"></mspace>
+                  <mspace width=".5ex"></mspace>
                 </mrow>
               </mtd>
             </mtr>
           </mtable>
-          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+            <mstyle displaystyle="false" scriptlevel="0">
               <mtext>QERE</mtext>
             </mstyle>
           </mpadded>
@@ -1969,61 +1969,61 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" display=\"block\">
-      <mrow semantics=\"bspr_inference:2;bspr_proof:true\">
-        <mspace width=\"9.835em\"></mspace>
-        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_inferenceRule:down\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:2;bspr_proof:true">
+        <mspace width="9.835em"></mspace>
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
-              <mtable framespacing=\"0 0\">
+              <mtable framespacing="0 0">
                 <mtr>
-                  <mtd rowalign=\"bottom\">
-                    <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                      <mspace width=\"-9.835em\"></mspace>
+                  <mtd rowalign="bottom">
+                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                      <mspace width="-9.835em"></mspace>
                       <mrow>
-                        <mspace width=\"3.274em\"></mspace>
-                        <mrow data-latex=\"\\RightLabel{QERE}\">
-                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                        <mspace width="3.274em"></mspace>
+                        <mrow data-latex="\\RightLabel{QERE}">
+                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                             <mtr>
                               <mtd>
-                                <mtable framespacing=\"0 0\">
+                                <mtable framespacing="0 0">
                                   <mtr>
-                                    <mtd rowalign=\"bottom\">
-                                      <mrow semantics=\"bspr_inference:3;bspr_labelledRule:right\">
-                                        <mspace width=\"-3.274em\"></mspace>
-                                        <mrow data-latex=\"\\RightLabel{Nowhere}\">
-                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                    <mtd rowalign="bottom">
+                                      <mrow semantics="bspr_inference:3;bspr_labelledRule:right">
+                                        <mspace width="-3.274em"></mspace>
+                                        <mrow data-latex="\\RightLabel{Nowhere}">
+                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                             <mtr>
                                               <mtd>
-                                                <mtable framespacing=\"0 0\">
+                                                <mtable framespacing="0 0">
                                                   <mtr>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>D</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A1</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\RightLabel{AAAA}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\RightLabel{AAAA}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A2</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
@@ -2033,17 +2033,17 @@ describe('BussproofsRegProofs', () => {
                                             <mtr>
                                               <mtd>
                                                 <mrow>
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>Q</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
                                           </mtable>
-                                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                            <mstyle displaystyle="false" scriptlevel="0">
                                               <mtext>AAAA</mtext>
                                             </mstyle>
                                           </mpadded>
@@ -2051,49 +2051,49 @@ describe('BussproofsRegProofs', () => {
                                       </mrow>
                                     </mtd>
                                     <mtd></mtd>
-                                    <mtd rowalign=\"bottom\">
-                                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                                        <mrow data-latex=\"\\RightLabel{CCCCC}\">
-                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                    <mtd rowalign="bottom">
+                                      <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                        <mrow data-latex="\\RightLabel{CCCCC}">
+                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                             <mtr>
                                               <mtd>
-                                                <mtable framespacing=\"0 0\">
+                                                <mtable framespacing="0 0">
                                                   <mtr>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>A</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                     <mtd></mtd>
-                                                    <mtd rowalign=\"bottom\">
-                                                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
-                                                        <mrow data-latex=\"\\RightLabel{BBB}\">
-                                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                    <mtd rowalign="bottom">
+                                                      <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                        <mrow data-latex="\\RightLabel{BBB}">
+                                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                             <mtr>
                                                               <mtd>
-                                                                <mtable framespacing=\"0 0\">
+                                                                <mtable framespacing="0 0">
                                                                   <mtr>
-                                                                    <mtd rowalign=\"bottom\">
-                                                                      <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
-                                                                        <mspace width=\".5ex\"></mspace>
-                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                    <mtd rowalign="bottom">
+                                                                      <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                        <mspace width=".5ex"></mspace>
+                                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                                           <mtext>B</mtext>
                                                                         </mstyle>
-                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
                                                                     <mtd></mtd>
-                                                                    <mtd rowalign=\"bottom\">
-                                                                      <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
-                                                                        <mspace width=\".5ex\"></mspace>
-                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                    <mtd rowalign="bottom">
+                                                                      <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                        <mspace width=".5ex"></mspace>
+                                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                                           <mtext>R</mtext>
                                                                         </mstyle>
-                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
                                                                   </mtr>
@@ -2103,28 +2103,28 @@ describe('BussproofsRegProofs', () => {
                                                             <mtr>
                                                               <mtd>
                                                                 <mrow>
-                                                                  <mspace width=\".5ex\"></mspace>
-                                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                                                                    <mrow data-mjx-texclass=\"ORD\">
-                                                                      <mi data-latex=\"C\">C</mi>
-                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                      <mi data-latex=\"D\">D</mi>
-                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                                                                      <mi data-latex=\"Q\">Q</mi>
+                                                                  <mspace width=".5ex"></mspace>
+                                                                  <mstyle displaystyle="false" scriptlevel="0">
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <mi data-latex="C">C</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="D">D</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="Q">Q</mi>
                                                                     </mrow>
                                                                   </mstyle>
-                                                                  <mspace width=\".5ex\"></mspace>
+                                                                  <mspace width=".5ex"></mspace>
                                                                 </mrow>
                                                               </mtd>
                                                             </mtr>
                                                           </mtable>
-                                                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                            <mstyle displaystyle="false" scriptlevel="0">
                                                               <mtext>Nowhere</mtext>
                                                             </mstyle>
                                                           </mpadded>
                                                         </mrow>
-                                                        <mspace width=\"-4.023em\"></mspace>
+                                                        <mspace width="-4.023em"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
@@ -2134,22 +2134,22 @@ describe('BussproofsRegProofs', () => {
                                             <mtr>
                                               <mtd>
                                                 <mrow>
-                                                  <mspace width=\".5ex\"></mspace>
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mspace width=".5ex"></mspace>
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>E</mtext>
                                                   </mstyle>
-                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
                                           </mtable>
-                                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                            <mstyle displaystyle="false" scriptlevel="0">
                                               <mtext>BBB</mtext>
                                             </mstyle>
                                           </mpadded>
                                         </mrow>
-                                        <mspace width=\"-6.135em\"></mspace>
+                                        <mspace width="-6.135em"></mspace>
                                       </mrow>
                                     </mtd>
                                   </mtr>
@@ -2159,17 +2159,17 @@ describe('BussproofsRegProofs', () => {
                             <mtr>
                               <mtd>
                                 <mrow>
-                                  <mspace width=\".5ex\"></mspace>
-                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                  <mspace width=".5ex"></mspace>
+                                  <mstyle displaystyle="false" scriptlevel="0">
                                     <mtext>F</mtext>
                                   </mstyle>
-                                  <mspace width=\".5ex\"></mspace>
+                                  <mspace width=".5ex"></mspace>
                                 </mrow>
                               </mtd>
                             </mtr>
                           </mtable>
-                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                            <mstyle displaystyle="false" scriptlevel="0">
                               <mtext>CCCCC</mtext>
                             </mstyle>
                           </mpadded>
@@ -2178,35 +2178,35 @@ describe('BussproofsRegProofs', () => {
                     </mrow>
                   </mtd>
                   <mtd>
-                    <mspace width=\"3.993em\"></mspace>
+                    <mspace width="3.993em"></mspace>
                   </mtd>
-                  <mtd rowalign=\"bottom\">
-                    <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\UnaryInfC{More and more}\" semantics=\"bspr_inferenceRule:down;bspr_inference:1\">
+                  <mtd rowalign="bottom">
+                    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down;bspr_inference:1">
                       <mtr>
                         <mtd>
-                          <mtable framespacing=\"0 0\">
+                          <mtable framespacing="0 0">
                             <mtr>
-                              <mtd rowalign=\"bottom\">
-                                <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\UnaryInfC{More and more}\" semantics=\"bspr_inferenceRule:down;bspr_inference:1\">
+                              <mtd rowalign="bottom">
+                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down;bspr_inference:1">
                                   <mtr>
                                     <mtd>
-                                      <mtable framespacing=\"0 0\">
+                                      <mtable framespacing="0 0">
                                         <mtr>
-                                          <mtd rowalign=\"bottom\">
-                                            <mrow semantics=\"bspr_inference:1;bspr_labelledRule:right\">
-                                              <mrow data-latex=\"\\UnaryInfC{More and more}\">
-                                                <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                          <mtd rowalign="bottom">
+                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                              <mrow data-latex="\\UnaryInfC{More and more}">
+                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                   <mtr>
                                                     <mtd>
-                                                      <mtable framespacing=\"0 0\">
+                                                      <mtable framespacing="0 0">
                                                         <mtr>
-                                                          <mtd rowalign=\"bottom\">
-                                                            <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
-                                                              <mspace width=\".5ex\"></mspace>
-                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtd rowalign="bottom">
+                                                            <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                                                              <mspace width=".5ex"></mspace>
+                                                              <mstyle displaystyle="false" scriptlevel="0">
                                                                 <mtext>M</mtext>
                                                               </mstyle>
-                                                              <mspace width=\".5ex\"></mspace>
+                                                              <mspace width=".5ex"></mspace>
                                                             </mrow>
                                                           </mtd>
                                                         </mtr>
@@ -2216,22 +2216,22 @@ describe('BussproofsRegProofs', () => {
                                                   <mtr>
                                                     <mtd>
                                                       <mrow>
-                                                        <mspace width=\".5ex\"></mspace>
-                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
                                                           <mtext>More and more</mtext>
                                                         </mstyle>
-                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
                                                 </mtable>
-                                                <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
-                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                  <mstyle displaystyle="false" scriptlevel="0">
                                                     <mtext>QERE</mtext>
                                                   </mstyle>
                                                 </mpadded>
                                               </mrow>
-                                              <mspace width=\"-3.092em\"></mspace>
+                                              <mspace width="-3.092em"></mspace>
                                             </mrow>
                                           </mtd>
                                         </mtr>
@@ -2241,11 +2241,11 @@ describe('BussproofsRegProofs', () => {
                                   <mtr>
                                     <mtd>
                                       <mrow>
-                                        <mspace width=\".5ex\"></mspace>
-                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                        <mspace width=".5ex"></mspace>
+                                        <mstyle displaystyle="false" scriptlevel="0">
                                           <mtext>More and more</mtext>
                                         </mstyle>
-                                        <mspace width=\".5ex\"></mspace>
+                                        <mspace width=".5ex"></mspace>
                                       </mrow>
                                     </mtd>
                                   </mtr>
@@ -2258,11 +2258,11 @@ describe('BussproofsRegProofs', () => {
                       <mtr>
                         <mtd>
                           <mrow>
-                            <mspace width=\".5ex\"></mspace>
-                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                            <mspace width=".5ex"></mspace>
+                            <mstyle displaystyle="false" scriptlevel="0">
                               <mtext>More and more</mtext>
                             </mstyle>
-                            <mspace width=\".5ex\"></mspace>
+                            <mspace width=".5ex"></mspace>
                           </mrow>
                         </mtd>
                       </mtr>
@@ -2275,20 +2275,20 @@ describe('BussproofsRegProofs', () => {
           <mtr>
             <mtd>
               <mrow>
-                <mspace width=\".5ex\"></mspace>
-                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
-                  <mrow data-mjx-texclass=\"ORD\">
-                    <mi data-latex=\"N\">N</mi>
-                    <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
-                    <mi data-latex=\"R\">R</mi>
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
+                  <mrow data-mjx-texclass="ORD">
+                    <mi data-latex="N">N</mi>
+                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                    <mi data-latex="R">R</mi>
                   </mrow>
                 </mstyle>
-                <mspace width=\".5ex\"></mspace>
+                <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
-        <mspace width=\"3.091em\"></mspace>
+        <mspace width="3.091em"></mspace>
       </mrow>
     </math>`
     ));
@@ -2302,7 +2302,7 @@ describe('BussproofsRegProofs', () => {
     <mrow>
       <mspace width="13.248em"></mspace>
       <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" data-latex-item="{prooftree}">
-        <mspace width=\"-1.155em\"></mspace>
+        <mspace width="-1.155em"></mspace>
         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
@@ -2620,7 +2620,7 @@ describe('BussproofsRegProofs', () => {
     <mrow>
       <mspace width="13.248em"></mspace>
       <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\alwaysRootAtBottom\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" data-latex-item="{prooftree}">
-        <mspace width=\"-1.155em\"></mspace>
+        <mspace width="-1.155em"></mspace>
         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -312,140 +312,140 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>L</mtext>
-      </mstyle>
-    </mpadded>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>A</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>B</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-  </mrow>
-</math>`
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:left;bspr_inference:1;bspr_proof:true\">
+        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>L</mtext>
+          </mstyle>
+        </mpadded>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\LeftLabel{L}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>A</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>B</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+      </mrow>
+    </math>`
     ));
   it('Label Right', () =>
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>A</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>B</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>R</mtext>
-      </mstyle>
-    </mpadded>
-  </mrow>
-</math>`
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex=\"\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:right;bspr_inference:1;bspr_proof:true\">
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>A</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>B</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>R</mtext>
+          </mstyle>
+        </mpadded>
+      </mrow>
+    </math>`
     ));
   it('Label Both', () =>
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>L</mtext>
-      </mstyle>
-    </mpadded>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>A</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>B</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>R</mtext>
-      </mstyle>
-    </mpadded>
-  </mrow>
-</math>`
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex=\"\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:both;bspr_inference:1;bspr_proof:true\">
+        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>L</mtext>
+          </mstyle>
+        </mpadded>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>A</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>B</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>R</mtext>
+          </mstyle>
+        </mpadded>
+      </mrow>
+    </math>`
     ));
   it('Single Axiom Abbr', () =>
     toXmlMatch(
@@ -605,140 +605,140 @@ describe('BussproofsRegInf', () => {
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>L</mtext>
-      </mstyle>
-    </mpadded>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>A</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>B</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-  </mrow>
-</math>`
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:left;bspr_inference:1;bspr_proof:true\">
+        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>L</mtext>
+          </mstyle>
+        </mpadded>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\LeftLabel{L}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>A</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>B</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+      </mrow>
+    </math>`
     ));
   it('Label Right Abbr', () =>
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>A</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>B</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>R</mtext>
-      </mstyle>
-    </mpadded>
-  </mrow>
-</math>`
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex=\"\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:right;bspr_inference:1;bspr_proof:true\">
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>A</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>B</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>R</mtext>
+          </mstyle>
+        </mpadded>
+      </mrow>
+    </math>`
     ));
   it('Label Both Abbr', () =>
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>L</mtext>
-      </mstyle>
-    </mpadded>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>A</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>B</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mtext>R</mtext>
-      </mstyle>
-    </mpadded>
-  </mrow>
-</math>`
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex=\"\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_labelledRule:both;bspr_inference:1;bspr_proof:true\">
+        <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>L</mtext>
+          </mstyle>
+        </mpadded>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\RightLabel{R}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>A</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>B</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+            <mtext>R</mtext>
+          </mstyle>
+        </mpadded>
+      </mrow>
+    </math>`
     ));
 });
 
@@ -748,1419 +748,87 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true">
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>D</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-              <mtd></mtd>
-              <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2">
-                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
-                    <mtr>
-                      <mtd>
-                        <mtable framespacing="0 0">
-                          <mtr>
-                            <mtd rowalign="bottom">
-                              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                <mspace width=".5ex"></mspace>
-                                <mstyle displaystyle="false" scriptlevel="0">
-                                  <mtext>A</mtext>
-                                </mstyle>
-                                <mspace width=".5ex"></mspace>
-                              </mrow>
-                            </mtd>
-                            <mtd></mtd>
-                            <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:2">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>B</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>R</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mrow data-mjx-texclass="ORD">
-                                            <mi data-latex="C">C</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="D">D</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="Q">Q</mi>
-                                          </mrow>
-                                        </mstyle>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                                <mspace width="0em"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </mtd>
-                    </mtr>
-                    <mtr>
-                      <mtd>
-                        <mrow>
-                          <mspace width=".5ex"></mspace>
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>E</mtext>
-                          </mstyle>
-                          <mspace width=".5ex"></mspace>
-                        </mrow>
-                      </mtd>
-                    </mtr>
-                  </mtable>
-                  <mspace width="-3.795em"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>F</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mspace width="3.795em"></mspace>
-  </mrow>
-</math>`
-    ));
-  it('Simple Proof Noise', () =>
-    toXmlMatch(
-      tex2mml(
-        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
-      ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\$\\alpha\$\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
-  <mrow data-latex-item="{prooftree}" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\$\\alpha\$\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" semantics="bspr_proof:true">
-    <mrow data-mjx-texclass="ORD">
-      <mo>\$</mo>
-    </mrow>
-    <mi>&#x3B1;</mi>
-    <mrow data-mjx-texclass="ORD">
-      <mo>\$</mo>
-    </mrow>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down;bspr_inference:2">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>D</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-              <mtd></mtd>
-              <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2">
-                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
-                    <mtr>
-                      <mtd>
-                        <mtable framespacing="0 0">
-                          <mtr>
-                            <mtd rowalign="bottom">
-                              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                <mspace width=".5ex"></mspace>
-                                <mstyle displaystyle="false" scriptlevel="0">
-                                  <mtext>A</mtext>
-                                </mstyle>
-                                <mspace width=".5ex"></mspace>
-                              </mrow>
-                            </mtd>
-                            <mtd></mtd>
-                            <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:2">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>B</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="$" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>R</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mrow data-mjx-texclass="ORD">
-                                            <mi data-latex="C">C</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="D">D</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="Q">Q</mi>
-                                          </mrow>
-                                        </mstyle>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                                <mspace width="0em"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </mtd>
-                    </mtr>
-                    <mtr>
-                      <mtd>
-                        <mrow>
-                          <mspace width=".5ex"></mspace>
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>E</mtext>
-                          </mstyle>
-                          <mspace width=".5ex"></mspace>
-                        </mrow>
-                      </mtd>
-                    </mtr>
-                  </mtable>
-                  <mspace width="-3.795em"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mtext>F</mtext>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mspace width="3.795em"></mspace>
-  </mrow>
-</math>`
-    ));
-  it('Simple Proof Large', () =>
-    toXmlMatch(
-      tex2mml(
-        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
-      ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true">
-    <mspace width="8.227em"></mspace>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2">
-                  <mspace width="-4.953em"></mspace>
-                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down">
-                    <mtr>
-                      <mtd>
-                        <mtable framespacing="0 0">
-                          <mtr>
-                            <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:3">
-                                <mspace width="-3.274em"></mspace>
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\TrinaryInfC{Q}" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>D</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>A1</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>A2</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mtext>Q</mtext>
-                                        </mstyle>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                              </mrow>
-                            </mtd>
-                            <mtd></mtd>
-                            <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:2">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>A</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:2">
-                                              <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}" semantics="bspr_inferenceRule:down">
-                                                <mtr>
-                                                  <mtd>
-                                                    <mtable framespacing="0 0">
-                                                      <mtr>
-                                                        <mtd rowalign="bottom">
-                                                          <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                            <mspace width=".5ex"></mspace>
-                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                              <mtext>B</mtext>
-                                                            </mstyle>
-                                                            <mspace width=".5ex"></mspace>
-                                                          </mrow>
-                                                        </mtd>
-                                                        <mtd></mtd>
-                                                        <mtd rowalign="bottom">
-                                                          <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                            <mspace width=".5ex"></mspace>
-                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                              <mtext>R</mtext>
-                                                            </mstyle>
-                                                            <mspace width=".5ex"></mspace>
-                                                          </mrow>
-                                                        </mtd>
-                                                      </mtr>
-                                                    </mtable>
-                                                  </mtd>
-                                                </mtr>
-                                                <mtr>
-                                                  <mtd>
-                                                    <mrow>
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mrow data-mjx-texclass="ORD">
-                                                          <mi data-latex="C">C</mi>
-                                                          <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                          <mi data-latex="D">D</mi>
-                                                          <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                          <mi data-latex="Q">Q</mi>
-                                                        </mrow>
-                                                      </mstyle>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                              <mspace width="0em"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mtext>E</mtext>
-                                        </mstyle>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                                <mspace width="-3.795em"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </mtd>
-                    </mtr>
-                    <mtr>
-                      <mtd>
-                        <mrow>
-                          <mspace width=".5ex"></mspace>
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>F</mtext>
-                          </mstyle>
-                          <mspace width=".5ex"></mspace>
-                        </mrow>
-                      </mtd>
-                    </mtr>
-                  </mtable>
-                </mrow>
-              </mtd>
-              <mtd>
-                <mspace width="3.795055555555555em"></mspace>
-              </mtd>
-              <mtd rowalign="bottom">
-                <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                  <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mtext>M</mtext>
-                  </mstyle>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mrow data-mjx-texclass="ORD">
-                <mi data-latex="N">N</mi>
-                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                <mi data-latex="R">R</mi>
-              </mrow>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-  </mrow>
-</math>`
-    ));
-  it('Simple Proofs Right Labels', () =>
-    toXmlMatch(
-      tex2mml(
-        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}'
-      ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:right">
-    <mspace width="8.227em"></mspace>
-    <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-        <mtr>
-          <mtd>
-            <mtable framespacing="0 0">
-              <mtr>
-                <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                    <mspace width="-8.227em"></mspace>
-                    <mrow>
-                      <mspace width="3.274em"></mspace>
-                      <mrow data-latex="\\RightLabel{QERE}">
-                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                          <mtr>
-                            <mtd>
-                              <mtable framespacing="0 0">
-                                <mtr>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3">
-                                      <mspace width="-3.274em"></mspace>
-                                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
-                                        <mtr>
-                                          <mtd>
-                                            <mtable framespacing="0 0">
-                                              <mtr>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>D</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A1</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A2</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mtd>
-                                        </mtr>
-                                        <mtr>
-                                          <mtd>
-                                            <mrow>
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>Q</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mrow>
-                                  </mtd>
-                                  <mtd></mtd>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                      <mrow data-latex="\\RightLabel{CCCCC}">
-                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                          <mtr>
-                                            <mtd>
-                                              <mtable framespacing="0 0">
-                                                <mtr>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>A</mtext>
-                                                      </mstyle>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                  <mtd></mtd>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                      <mrow data-latex="\\RightLabel{BBB}">
-                                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mtable framespacing="0 0">
-                                                                <mtr>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>B</mtext>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                  <mtd></mtd>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>R</mtext>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                </mtr>
-                                                              </mtable>
-                                                            </mtd>
-                                                          </mtr>
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <mi data-latex="C">C</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="D">D</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="Q">Q</mi>
-                                                                  </mrow>
-                                                                </mstyle>
-                                                                <mspace width=".5ex"></mspace>
-                                                              </mrow>
-                                                            </mtd>
-                                                          </mtr>
-                                                        </mtable>
-                                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>AAAA</mtext>
-                                                          </mstyle>
-                                                        </mpadded>
-                                                      </mrow>
-                                                      <mspace width="-3.5em"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                            </mtd>
-                                          </mtr>
-                                          <mtr>
-                                            <mtd>
-                                              <mrow>
-                                                <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>E</mtext>
-                                                </mstyle>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>BBB</mtext>
-                                          </mstyle>
-                                        </mpadded>
-                                      </mrow>
-                                      <mspace width="-6.419em"></mspace>
-                                    </mrow>
-                                  </mtd>
-                                </mtr>
-                              </mtable>
-                            </mtd>
-                          </mtr>
-                          <mtr>
-                            <mtd>
-                              <mrow>
-                                <mspace width=".5ex"></mspace>
-                                <mstyle displaystyle="false" scriptlevel="0">
-                                  <mtext>F</mtext>
-                                </mstyle>
-                                <mspace width=".5ex"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>CCCCC</mtext>
-                          </mstyle>
-                        </mpadded>
-                      </mrow>
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" display=\"block\">
+      <mrow semantics=\"bspr_inference:2;bspr_proof:true\">
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>D</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
                     </mrow>
-                  </mrow>
-                </mtd>
-                <mtd>
-                  <mspace width="2.309055555555555em"></mspace>
-                </mtd>
-                <mtd rowalign="bottom">
-                  <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                    <mspace width=".5ex"></mspace>
-                    <mstyle displaystyle="false" scriptlevel="0">
-                      <mtext>M</mtext>
-                    </mstyle>
-                    <mspace width=".5ex"></mspace>
-                  </mrow>
-                </mtd>
-              </mtr>
-            </mtable>
-          </mtd>
-        </mtr>
-        <mtr>
-          <mtd>
-            <mrow>
-              <mspace width=".5ex"></mspace>
-              <mstyle displaystyle="false" scriptlevel="0">
-                <mrow data-mjx-texclass="ORD">
-                  <mi data-latex="N">N</mi>
-                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                  <mi data-latex="R">R</mi>
-                </mrow>
-              </mstyle>
-              <mspace width=".5ex"></mspace>
-            </mrow>
-          </mtd>
-        </mtr>
-      </mtable>
-      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-        <mstyle displaystyle="false" scriptlevel="0">
-          <mtext>QERE</mtext>
-        </mstyle>
-      </mpadded>
-    </mrow>
-  </mrow>
-</math>`
-    ));
-  it('Simple Proofs Left Labels', () =>
-    toXmlMatch(
-      tex2mml(
-        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
-      ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:left">
-    <mspace width="7.038em"></mspace>
-    <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-        <mstyle displaystyle="false" scriptlevel="0">
-          <mtext>QERE</mtext>
-        </mstyle>
-      </mpadded>
-      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-        <mtr>
-          <mtd>
-            <mtable framespacing="0 0">
-              <mtr>
-                <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                    <mspace width="-10.414em"></mspace>
-                    <mrow>
-                      <mspace width="-0.836em"></mspace>
-                      <mrow data-latex="\\LeftLabel{QERE}">
-                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>CCCCC</mtext>
-                          </mstyle>
-                        </mpadded>
-                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                          <mtr>
-                            <mtd>
-                              <mtable framespacing="0 0">
-                                <mtr>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3">
-                                      <mspace width="-3.274em"></mspace>
-                                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\LeftLabel{AAAA}" semantics="bspr_inferenceRule:down">
-                                        <mtr>
-                                          <mtd>
-                                            <mtable framespacing="0 0">
-                                              <mtr>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>D</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A1</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A2</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mtd>
-                                        </mtr>
-                                        <mtr>
-                                          <mtd>
-                                            <mrow>
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>Q</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mrow>
-                                  </mtd>
-                                  <mtd></mtd>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                                      <mrow data-latex="\\LeftLabel{CCCCC}">
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>BBB</mtext>
-                                          </mstyle>
-                                        </mpadded>
-                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                          <mtr>
-                                            <mtd>
-                                              <mtable framespacing="0 0">
-                                                <mtr>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>A</mtext>
-                                                      </mstyle>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                  <mtd></mtd>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                                                      <mrow data-latex="\\LeftLabel{BBB}">
-                                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>AAAA</mtext>
-                                                          </mstyle>
-                                                        </mpadded>
-                                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mtable framespacing="0 0">
-                                                                <mtr>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>B</mtext>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                  <mtd></mtd>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>R</mtext>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                </mtr>
-                                                              </mtable>
-                                                            </mtd>
-                                                          </mtr>
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <mi data-latex="C">C</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="D">D</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="Q">Q</mi>
-                                                                  </mrow>
-                                                                </mstyle>
-                                                                <mspace width=".5ex"></mspace>
-                                                              </mrow>
-                                                            </mtd>
-                                                          </mtr>
-                                                        </mtable>
-                                                      </mrow>
-                                                      <mspace width="0em"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                            </mtd>
-                                          </mtr>
-                                          <mtr>
-                                            <mtd>
-                                              <mrow>
-                                                <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>E</mtext>
-                                                </mstyle>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                      </mrow>
-                                      <mspace width="-5.545em"></mspace>
-                                    </mrow>
-                                  </mtd>
-                                </mtr>
-                              </mtable>
-                            </mtd>
-                          </mtr>
-                          <mtr>
-                            <mtd>
-                              <mrow>
-                                <mspace width=".5ex"></mspace>
-                                <mstyle displaystyle="false" scriptlevel="0">
-                                  <mtext>F</mtext>
-                                </mstyle>
-                                <mspace width=".5ex"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </mrow>
-                    </mrow>
-                  </mrow>
-                </mtd>
-                <mtd>
-                  <mspace width="5.545055555555556em"></mspace>
-                </mtd>
-                <mtd rowalign="bottom">
-                  <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                    <mspace width=".5ex"></mspace>
-                    <mstyle displaystyle="false" scriptlevel="0">
-                      <mtext>M</mtext>
-                    </mstyle>
-                    <mspace width=".5ex"></mspace>
-                  </mrow>
-                </mtd>
-              </mtr>
-            </mtable>
-          </mtd>
-        </mtr>
-        <mtr>
-          <mtd>
-            <mrow>
-              <mspace width=".5ex"></mspace>
-              <mstyle displaystyle="false" scriptlevel="0">
-                <mrow data-mjx-texclass="ORD">
-                  <mi data-latex="N">N</mi>
-                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                  <mi data-latex="R">R</mi>
-                </mrow>
-              </mstyle>
-              <mspace width=".5ex"></mspace>
-            </mrow>
-          </mtd>
-        </mtr>
-      </mtable>
-    </mrow>
-  </mrow>
-</math>`
-    ));
-  it('Simple Proofs Mixed Labels', () =>
-    toXmlMatch(
-      tex2mml(
-        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
-      ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
-    <mspace width="7.511em"></mspace>
-    <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{\$N \\rightarrow R\$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-        <mstyle displaystyle="false" scriptlevel="0">
-          <mtext>DD</mtext>
-        </mstyle>
-      </mpadded>
-      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-        <mtr>
-          <mtd>
-            <mtable framespacing="0 0">
-              <mtr>
-                <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                    <mspace width="-9.539em"></mspace>
-                    <mrow>
-                      <mspace width="-0.836em"></mspace>
-                      <mrow data-latex="\\LeftLabel{DD}">
-                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>CCCCC</mtext>
-                          </mstyle>
-                        </mpadded>
-                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                          <mtr>
-                            <mtd>
-                              <mtable framespacing="0 0">
-                                <mtr>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3">
-                                      <mspace width="-3.274em"></mspace>
-                                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
-                                        <mtr>
-                                          <mtd>
-                                            <mtable framespacing="0 0">
-                                              <mtr>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>D</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A1</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A2</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mtd>
-                                        </mtr>
-                                        <mtr>
-                                          <mtd>
-                                            <mrow>
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>Q</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mrow>
-                                  </mtd>
-                                  <mtd></mtd>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                                      <mrow data-latex="\\LeftLabel{CCCCC}">
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>BBB</mtext>
-                                          </mstyle>
-                                        </mpadded>
-                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                          <mtr>
-                                            <mtd>
-                                              <mtable framespacing="0 0">
-                                                <mtr>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>A</mtext>
-                                                      </mstyle>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                  <mtd></mtd>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                      <mrow data-latex="\\LeftLabel{BBB}">
-                                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mtable framespacing="0 0">
-                                                                <mtr>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>B</mtext>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                  <mtd></mtd>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>R</mtext>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                </mtr>
-                                                              </mtable>
-                                                            </mtd>
-                                                          </mtr>
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <mi data-latex="C">C</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="D">D</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="Q">Q</mi>
-                                                                  </mrow>
-                                                                </mstyle>
-                                                                <mspace width=".5ex"></mspace>
-                                                              </mrow>
-                                                            </mtd>
-                                                          </mtr>
-                                                        </mtable>
-                                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>AAAA</mtext>
-                                                          </mstyle>
-                                                        </mpadded>
-                                                      </mrow>
-                                                      <mspace width="-3.5em"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                            </mtd>
-                                          </mtr>
-                                          <mtr>
-                                            <mtd>
-                                              <mrow>
-                                                <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>E</mtext>
-                                                </mstyle>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                      </mrow>
-                                      <mspace width="-3.795em"></mspace>
-                                    </mrow>
-                                  </mtd>
-                                </mtr>
-                              </mtable>
-                            </mtd>
-                          </mtr>
-                          <mtr>
-                            <mtd>
-                              <mrow>
-                                <mspace width=".5ex"></mspace>
-                                <mstyle displaystyle="false" scriptlevel="0">
-                                  <mtext>F</mtext>
-                                </mstyle>
-                                <mspace width=".5ex"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </mrow>
-                    </mrow>
-                  </mrow>
-                </mtd>
-                <mtd>
-                  <mspace width="3.795055555555555em"></mspace>
-                </mtd>
-                <mtd rowalign="bottom">
-                  <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                    <mspace width=".5ex"></mspace>
-                    <mstyle displaystyle="false" scriptlevel="0">
-                      <mtext>M</mtext>
-                    </mstyle>
-                    <mspace width=".5ex"></mspace>
-                  </mrow>
-                </mtd>
-              </mtr>
-            </mtable>
-          </mtd>
-        </mtr>
-        <mtr>
-          <mtd>
-            <mrow>
-              <mspace width=".5ex"></mspace>
-              <mstyle displaystyle="false" scriptlevel="0">
-                <mrow data-mjx-texclass="ORD">
-                  <mi data-latex="N">N</mi>
-                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                  <mi data-latex="R">R</mi>
-                </mrow>
-              </mstyle>
-              <mspace width=".5ex"></mspace>
-            </mrow>
-          </mtd>
-        </mtr>
-      </mtable>
-      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-        <mstyle displaystyle="false" scriptlevel="0">
-          <mtext>QERE</mtext>
-        </mstyle>
-      </mpadded>
-    </mrow>
-  </mrow>
-</math>`
-    ));
-  it('Proof Very Right Label', () =>
-    toXmlMatch(
-      tex2mml(
-        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
-      ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{\$N \\rightarrow R\$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true">
-    <mspace width="9.977em"></mspace>
-    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{\$N \\rightarrow R\$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
-      <mtr>
-        <mtd>
-          <mtable framespacing="0 0">
-            <mtr>
-              <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                  <mspace width="-9.977em"></mspace>
-                  <mrow>
-                    <mspace width="3.274em"></mspace>
-                    <mrow data-latex="\\RightLabel{QERE}">
-                      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                  </mtd>
+                  <mtd></mtd>
+                  <mtd rowalign=\"bottom\">
+                    <mrow semantics=\"bspr_inference:2\">
+                      <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{E}\" semantics=\"bspr_inferenceRule:down\">
                         <mtr>
                           <mtd>
-                            <mtable framespacing="0 0">
+                            <mtable framespacing=\"0 0\">
                               <mtr>
-                                <mtd rowalign="bottom">
-                                  <mrow semantics="bspr_inference:3;bspr_labelledRule:right">
-                                    <mspace width="-3.274em"></mspace>
-                                    <mrow data-latex="\\RightLabel{Nowhere}">
-                                      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                        <mtr>
-                                          <mtd>
-                                            <mtable framespacing="0 0">
-                                              <mtr>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>D</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A1</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\RightLabel{AAAA}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A2</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mtd>
-                                        </mtr>
-                                        <mtr>
-                                          <mtd>
-                                            <mrow>
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>Q</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mtext>AAAA</mtext>
-                                        </mstyle>
-                                      </mpadded>
-                                    </mrow>
+                                <mtd rowalign=\"bottom\">
+                                  <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                    <mspace width=\".5ex\"></mspace>
+                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtext>A</mtext>
+                                    </mstyle>
+                                    <mspace width=\".5ex\"></mspace>
                                   </mrow>
                                 </mtd>
                                 <mtd></mtd>
-                                <mtd rowalign="bottom">
-                                  <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                    <mrow data-latex="\\RightLabel{CCCCC}">
-                                      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                        <mtr>
-                                          <mtd>
-                                            <mtable framespacing="0 0">
-                                              <mtr>
-                                                <mtd rowalign="bottom">
-                                                  <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>A</mtext>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                                <mtd></mtd>
-                                                <mtd rowalign="bottom">
-                                                  <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                    <mrow data-latex="\\RightLabel{BBB}">
-                                                      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                        <mtr>
-                                                          <mtd>
-                                                            <mtable framespacing="0 0">
-                                                              <mtr>
-                                                                <mtd rowalign="bottom">
-                                                                  <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                    <mspace width=".5ex"></mspace>
-                                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                                      <mtext>B</mtext>
-                                                                    </mstyle>
-                                                                    <mspace width=".5ex"></mspace>
-                                                                  </mrow>
-                                                                </mtd>
-                                                                <mtd></mtd>
-                                                                <mtd rowalign="bottom">
-                                                                  <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                    <mspace width=".5ex"></mspace>
-                                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                                      <mtext>R</mtext>
-                                                                    </mstyle>
-                                                                    <mspace width=".5ex"></mspace>
-                                                                  </mrow>
-                                                                </mtd>
-                                                              </mtr>
-                                                            </mtable>
-                                                          </mtd>
-                                                        </mtr>
-                                                        <mtr>
-                                                          <mtd>
-                                                            <mrow>
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mrow data-mjx-texclass="ORD">
-                                                                  <mi data-latex="C">C</mi>
-                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                  <mi data-latex="D">D</mi>
-                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                  <mi data-latex="Q">Q</mi>
-                                                                </mrow>
-                                                              </mstyle>
-                                                              <mspace width=".5ex"></mspace>
-                                                            </mrow>
-                                                          </mtd>
-                                                        </mtr>
-                                                      </mtable>
-                                                      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>Nowhere</mtext>
-                                                        </mstyle>
-                                                      </mpadded>
-                                                    </mrow>
-                                                    <mspace width="-4.308em"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mtd>
-                                        </mtr>
-                                        <mtr>
-                                          <mtd>
-                                            <mrow>
-                                              <mspace width=".5ex"></mspace>
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>E</mtext>
-                                              </mstyle>
-                                              <mspace width=".5ex"></mspace>
+                                <mtd rowalign=\"bottom\">
+                                  <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+                                    <mtr>
+                                      <mtd>
+                                        <mtable framespacing=\"0 0\">
+                                          <mtr>
+                                            <mtd rowalign=\"bottom\">
+                                              <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                <mspace width=\".5ex\"></mspace>
+                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mtext>B</mtext>
+                                                </mstyle>
+                                                <mspace width=\".5ex\"></mspace>
+                                              </mrow>
+                                            </mtd>
+                                            <mtd></mtd>
+                                            <mtd rowalign=\"bottom\">
+                                              <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
+                                                <mspace width=\".5ex\"></mspace>
+                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mtext>R</mtext>
+                                                </mstyle>
+                                                <mspace width=\".5ex\"></mspace>
+                                              </mrow>
+                                            </mtd>
+                                          </mtr>
+                                        </mtable>
+                                      </mtd>
+                                    </mtr>
+                                    <mtr>
+                                      <mtd>
+                                        <mrow>
+                                          <mspace width=\".5ex\"></mspace>
+                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mrow data-mjx-texclass=\"ORD\">
+                                              <mi data-latex=\"C\">C</mi>
+                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                              <mi data-latex=\"D\">D</mi>
+                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                              <mi data-latex=\"Q\">Q</mi>
                                             </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mtext>BBB</mtext>
-                                        </mstyle>
-                                      </mpadded>
-                                    </mrow>
-                                    <mspace width="-6.419em"></mspace>
-                                  </mrow>
+                                          </mstyle>
+                                          <mspace width=\".5ex\"></mspace>
+                                        </mrow>
+                                      </mtd>
+                                    </mtr>
+                                  </mtable>
                                 </mtd>
                               </mtr>
                             </mtable>
@@ -2169,56 +837,288 @@ describe('BussproofsRegProofs', () => {
                         <mtr>
                           <mtd>
                             <mrow>
-                              <mspace width=".5ex"></mspace>
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>F</mtext>
+                              <mspace width=\".5ex\"></mspace>
+                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtext>E</mtext>
                               </mstyle>
-                              <mspace width=".5ex"></mspace>
+                              <mspace width=\".5ex\"></mspace>
                             </mrow>
                           </mtd>
                         </mtr>
                       </mtable>
-                      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                        <mstyle displaystyle="false" scriptlevel="0">
-                          <mtext>CCCCC</mtext>
-                        </mstyle>
-                      </mpadded>
+                      <mspace width=\"-3.795em\"></mspace>
                     </mrow>
-                  </mrow>
-                </mrow>
-              </mtd>
-              <mtd>
-                <mspace width="2.309055555555555em"></mspace>
-              </mtd>
-              <mtd rowalign="bottom">
-                <mrow semantics="bspr_inference:1">
-                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down">
-                    <mtr>
-                      <mtd>
-                        <mtable framespacing="0 0">
-                          <mtr>
-                            <mtd rowalign="bottom">
-                              <mrow semantics="bspr_inference:1">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
-                                              <mrow data-latex="\\UnaryInfC{More and more}">
-                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>F</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mspace width=\"3.795em\"></mspace>
+      </mrow>
+    </math>`
+    ));
+  it('Simple Proof Noise', () =>
+    toXmlMatch(
+      tex2mml(
+        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
+      ),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" display=\"block\">
+      <mrow data-latex-item=\"{prooftree}\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}\" semantics=\"bspr_proof:true\">
+        <mrow data-mjx-texclass=\"ORD\">
+          <mo>$</mo>
+        </mrow>
+        <mi>&#x3B1;</mi>
+        <mrow data-mjx-texclass=\"ORD\">
+          <mo>$</mo>
+        </mrow>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{F}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>D</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                  <mtd></mtd>
+                  <mtd rowalign=\"bottom\">
+                    <mrow semantics=\"bspr_inference:2\">
+                      <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{E}\" semantics=\"bspr_inferenceRule:down\">
+                        <mtr>
+                          <mtd>
+                            <mtable framespacing=\"0 0\">
+                              <mtr>
+                                <mtd rowalign=\"bottom\">
+                                  <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                    <mspace width=\".5ex\"></mspace>
+                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtext>A</mtext>
+                                    </mstyle>
+                                    <mspace width=\".5ex\"></mspace>
+                                  </mrow>
+                                </mtd>
+                                <mtd></mtd>
+                                <mtd rowalign=\"bottom\">
+                                  <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
+                                    <mtr>
+                                      <mtd>
+                                        <mtable framespacing=\"0 0\">
+                                          <mtr>
+                                            <mtd rowalign=\"bottom\">
+                                              <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                <mspace width=\".5ex\"></mspace>
+                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mtext>B</mtext>
+                                                </mstyle>
+                                                <mspace width=\".5ex\"></mspace>
+                                              </mrow>
+                                            </mtd>
+                                            <mtd></mtd>
+                                            <mtd rowalign=\"bottom\">
+                                              <mrow data-latex=\"$\" semantics=\"bspr_axiom:true\">
+                                                <mspace width=\".5ex\"></mspace>
+                                                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                  <mtext>R</mtext>
+                                                </mstyle>
+                                                <mspace width=\".5ex\"></mspace>
+                                              </mrow>
+                                            </mtd>
+                                          </mtr>
+                                        </mtable>
+                                      </mtd>
+                                    </mtr>
+                                    <mtr>
+                                      <mtd>
+                                        <mrow>
+                                          <mspace width=\".5ex\"></mspace>
+                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                            <mrow data-mjx-texclass=\"ORD\">
+                                              <mi data-latex=\"C\">C</mi>
+                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                              <mi data-latex=\"D\">D</mi>
+                                              <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                              <mi data-latex=\"Q\">Q</mi>
+                                            </mrow>
+                                          </mstyle>
+                                          <mspace width=\".5ex\"></mspace>
+                                        </mrow>
+                                      </mtd>
+                                    </mtr>
+                                  </mtable>
+                                </mtd>
+                              </mtr>
+                            </mtable>
+                          </mtd>
+                        </mtr>
+                        <mtr>
+                          <mtd>
+                            <mrow>
+                              <mspace width=\".5ex\"></mspace>
+                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtext>E</mtext>
+                              </mstyle>
+                              <mspace width=\".5ex\"></mspace>
+                            </mrow>
+                          </mtd>
+                        </mtr>
+                      </mtable>
+                      <mspace width=\"-3.795em\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mtext>F</mtext>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mspace width=\"3.795em\"></mspace>
+      </mrow>
+    </math>`
+    ));
+  it('Simple Proof Large', () =>
+    toXmlMatch(
+      tex2mml(
+        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
+      ),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" display=\"block\">
+      <mrow semantics=\"bspr_inference:2;bspr_proof:true\">
+        <mspace width=\"8.227em\"></mspace>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow semantics=\"bspr_inference:2\">
+                      <mspace width=\"-4.953em\"></mspace>
+                      <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{F}\" semantics=\"bspr_inferenceRule:down\">
+                        <mtr>
+                          <mtd>
+                            <mtable framespacing=\"0 0\">
+                              <mtr>
+                                <mtd rowalign=\"bottom\">
+                                  <mrow semantics=\"bspr_inference:3\">
+                                    <mspace width=\"-3.274em\"></mspace>
+                                    <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\TrinaryInfC{Q}\" semantics=\"bspr_inferenceRule:down\">
+                                      <mtr>
+                                        <mtd>
+                                          <mtable framespacing=\"0 0\">
+                                            <mtr>
+                                              <mtd rowalign=\"bottom\">
+                                                <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>D</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                              <mtd></mtd>
+                                              <mtd rowalign=\"bottom\">
+                                                <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>A1</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                              <mtd></mtd>
+                                              <mtd rowalign=\"bottom\">
+                                                <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>A2</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                        </mtd>
+                                      </mtr>
+                                      <mtr>
+                                        <mtd>
+                                          <mrow>
+                                            <mspace width=\".5ex\"></mspace>
+                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtext>Q</mtext>
+                                            </mstyle>
+                                            <mspace width=\".5ex\"></mspace>
+                                          </mrow>
+                                        </mtd>
+                                      </mtr>
+                                    </mtable>
+                                  </mrow>
+                                </mtd>
+                                <mtd></mtd>
+                                <mtd rowalign=\"bottom\">
+                                  <mrow semantics=\"bspr_inference:2\">
+                                    <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{E}\" semantics=\"bspr_inferenceRule:down\">
+                                      <mtr>
+                                        <mtd>
+                                          <mtable framespacing=\"0 0\">
+                                            <mtr>
+                                              <mtd rowalign=\"bottom\">
+                                                <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>A</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                              <mtd></mtd>
+                                              <mtd rowalign=\"bottom\">
+                                                <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\" semantics=\"bspr_inferenceRule:down;bspr_inference:2\">
                                                   <mtr>
                                                     <mtd>
-                                                      <mtable framespacing="0 0">
+                                                      <mtable framespacing=\"0 0\">
                                                         <mtr>
-                                                          <mtd rowalign="bottom">
-                                                            <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mtext>M</mtext>
+                                                          <mtd rowalign=\"bottom\">
+                                                            <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                              <mspace width=\".5ex\"></mspace>
+                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                <mtext>B</mtext>
                                                               </mstyle>
-                                                              <mspace width=".5ex"></mspace>
+                                                              <mspace width=\".5ex\"></mspace>
+                                                            </mrow>
+                                                          </mtd>
+                                                          <mtd></mtd>
+                                                          <mtd rowalign=\"bottom\">
+                                                            <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
+                                                              <mspace width=\".5ex\"></mspace>
+                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                <mtext>R</mtext>
+                                                              </mstyle>
+                                                              <mspace width=\".5ex\"></mspace>
                                                             </mrow>
                                                           </mtd>
                                                         </mtr>
@@ -2228,22 +1128,1110 @@ describe('BussproofsRegProofs', () => {
                                                   <mtr>
                                                     <mtd>
                                                       <mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>More and more</mtext>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mrow data-mjx-texclass=\"ORD\">
+                                                            <mi data-latex=\"C\">C</mi>
+                                                            <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                            <mi data-latex=\"D\">D</mi>
+                                                            <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                            <mi data-latex=\"Q\">Q</mi>
+                                                          </mrow>
                                                         </mstyle>
-                                                        <mspace width=".5ex"></mspace>
+                                                        <mspace width=\".5ex\"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
                                                 </mtable>
-                                                <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
-                                                  <mstyle displaystyle="false" scriptlevel="0">
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                        </mtd>
+                                      </mtr>
+                                      <mtr>
+                                        <mtd>
+                                          <mrow>
+                                            <mspace width=\".5ex\"></mspace>
+                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtext>E</mtext>
+                                            </mstyle>
+                                            <mspace width=\".5ex\"></mspace>
+                                          </mrow>
+                                        </mtd>
+                                      </mtr>
+                                    </mtable>
+                                    <mspace width=\"-3.795em\"></mspace>
+                                  </mrow>
+                                </mtd>
+                              </mtr>
+                            </mtable>
+                          </mtd>
+                        </mtr>
+                        <mtr>
+                          <mtd>
+                            <mrow>
+                              <mspace width=\".5ex\"></mspace>
+                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtext>F</mtext>
+                              </mstyle>
+                              <mspace width=\".5ex\"></mspace>
+                            </mrow>
+                          </mtd>
+                        </mtr>
+                      </mtable>
+                    </mrow>
+                  </mtd>
+                  <mtd>
+                    <mspace width=\"3.795em\"></mspace>
+                  </mtd>
+                  <mtd rowalign=\"bottom\">
+                    <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
+                      <mspace width=\".5ex\"></mspace>
+                      <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                        <mtext>M</mtext>
+                      </mstyle>
+                      <mspace width=\".5ex\"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mrow data-mjx-texclass=\"ORD\">
+                    <mi data-latex=\"N\">N</mi>
+                    <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                    <mi data-latex=\"R\">R</mi>
+                  </mrow>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+      </mrow>
+    </math>`
+    ));
+  it('Simple Proofs Right Labels', () =>
+    toXmlMatch(
+      tex2mml(
+        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}'
+      ),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}\" display=\"block\">
+      <mrow semantics=\"bspr_inference:2;bspr_proof:true;bspr_labelledRule:right\">
+        <mspace width=\"8.227em\"></mspace>
+        <mrow data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}\" data-latex-item=\"{prooftree}\">
+          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+            <mtr>
+              <mtd>
+                <mtable framespacing=\"0 0\">
+                  <mtr>
+                    <mtd rowalign=\"bottom\">
+                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                        <mspace width=\"-8.227em\"></mspace>
+                        <mrow>
+                          <mspace width=\"3.274em\"></mspace>
+                          <mrow data-latex=\"\\RightLabel{QERE}\">
+                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                              <mtr>
+                                <mtd>
+                                  <mtable framespacing=\"0 0\">
+                                    <mtr>
+                                      <mtd rowalign=\"bottom\">
+                                        <mrow semantics=\"bspr_inference:3\">
+                                          <mspace width=\"-3.274em\"></mspace>
+                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\RightLabel{AAAA}\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtr>
+                                              <mtd>
+                                                <mtable framespacing=\"0 0\">
+                                                  <mtr>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>D</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A1</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A2</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                              </mtd>
+                                            </mtr>
+                                            <mtr>
+                                              <mtd>
+                                                <mrow>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>Q</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                        </mrow>
+                                      </mtd>
+                                      <mtd></mtd>
+                                      <mtd rowalign=\"bottom\">
+                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                                          <mrow data-latex=\"\\RightLabel{CCCCC}\">
+                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                              <mtr>
+                                                <mtd>
+                                                  <mtable framespacing=\"0 0\">
+                                                    <mtr>
+                                                      <mtd rowalign=\"bottom\">
+                                                        <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                                          <mspace width=\".5ex\"></mspace>
+                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                            <mtext>A</mtext>
+                                                          </mstyle>
+                                                          <mspace width=\".5ex\"></mspace>
+                                                        </mrow>
+                                                      </mtd>
+                                                      <mtd></mtd>
+                                                      <mtd rowalign=\"bottom\">
+                                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                                                          <mrow data-latex=\"\\RightLabel{BBB}\">
+                                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                              <mtr>
+                                                                <mtd>
+                                                                  <mtable framespacing=\"0 0\">
+                                                                    <mtr>
+                                                                      <mtd rowalign=\"bottom\">
+                                                                        <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                            <mtext>B</mtext>
+                                                                          </mstyle>
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                      <mtd></mtd>
+                                                                      <mtd rowalign=\"bottom\">
+                                                                        <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                            <mtext>R</mtext>
+                                                                          </mstyle>
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                  </mtable>
+                                                                </mtd>
+                                                              </mtr>
+                                                              <mtr>
+                                                                <mtd>
+                                                                  <mrow>
+                                                                    <mspace width=\".5ex\"></mspace>
+                                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                      <mrow data-mjx-texclass=\"ORD\">
+                                                                        <mi data-latex=\"C\">C</mi>
+                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                        <mi data-latex=\"D\">D</mi>
+                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                        <mi data-latex=\"Q\">Q</mi>
+                                                                      </mrow>
+                                                                    </mstyle>
+                                                                    <mspace width=\".5ex\"></mspace>
+                                                                  </mrow>
+                                                                </mtd>
+                                                              </mtr>
+                                                            </mtable>
+                                                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                <mtext>AAAA</mtext>
+                                                              </mstyle>
+                                                            </mpadded>
+                                                          </mrow>
+                                                          <mspace width=\"-3.216em\"></mspace>
+                                                        </mrow>
+                                                      </mtd>
+                                                    </mtr>
+                                                  </mtable>
+                                                </mtd>
+                                              </mtr>
+                                              <mtr>
+                                                <mtd>
+                                                  <mrow>
+                                                    <mspace width=\".5ex\"></mspace>
+                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtext>E</mtext>
+                                                    </mstyle>
+                                                    <mspace width=\".5ex\"></mspace>
+                                                  </mrow>
+                                                </mtd>
+                                              </mtr>
+                                            </mtable>
+                                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                <mtext>BBB</mtext>
+                                              </mstyle>
+                                            </mpadded>
+                                          </mrow>
+                                          <mspace width=\"-6.134em\"></mspace>
+                                        </mrow>
+                                      </mtd>
+                                    </mtr>
+                                  </mtable>
+                                </mtd>
+                              </mtr>
+                              <mtr>
+                                <mtd>
+                                  <mrow>
+                                    <mspace width=\".5ex\"></mspace>
+                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtext>F</mtext>
+                                    </mstyle>
+                                    <mspace width=\".5ex\"></mspace>
+                                  </mrow>
+                                </mtd>
+                              </mtr>
+                            </mtable>
+                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtext>CCCCC</mtext>
+                              </mstyle>
+                            </mpadded>
+                          </mrow>
+                        </mrow>
+                      </mrow>
+                    </mtd>
+                    <mtd>
+                      <mspace width=\"3.185em\"></mspace>
+                    </mtd>
+                    <mtd rowalign=\"bottom\">
+                      <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
+                        <mspace width=\".5ex\"></mspace>
+                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                          <mtext>M</mtext>
+                        </mstyle>
+                        <mspace width=\".5ex\"></mspace>
+                      </mrow>
+                    </mtd>
+                  </mtr>
+                </mtable>
+              </mtd>
+            </mtr>
+            <mtr>
+              <mtd>
+                <mrow>
+                  <mspace width=\".5ex\"></mspace>
+                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                    <mrow data-mjx-texclass=\"ORD\">
+                      <mi data-latex=\"N\">N</mi>
+                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                      <mi data-latex=\"R\">R</mi>
+                    </mrow>
+                  </mstyle>
+                  <mspace width=\".5ex\"></mspace>
+                </mrow>
+              </mtd>
+            </mtr>
+          </mtable>
+          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+              <mtext>QERE</mtext>
+            </mstyle>
+          </mpadded>
+        </mrow>
+      </mrow>
+    </math>`
+    ));
+  it('Simple Proofs Left Labels', () =>
+    toXmlMatch(
+      tex2mml(
+        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
+      ),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" display=\"block\">
+      <mrow semantics=\"bspr_inference:2;bspr_proof:true;bspr_labelledRule:left\">
+        <mspace width=\"3.835em\"></mspace>
+        <mrow data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" data-latex-item=\"{prooftree}\">
+          <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+              <mtext>QERE</mtext>
+            </mstyle>
+          </mpadded>
+          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+            <mtr>
+              <mtd>
+                <mtable framespacing=\"0 0\">
+                  <mtr>
+                    <mtd rowalign=\"bottom\">
+                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
+                        <mspace width=\"-6.927em\"></mspace>
+                        <mrow>
+                          <mspace width=\"-0.551em\"></mspace>
+                          <mrow data-latex=\"\\LeftLabel{QERE}\">
+                            <mspace width=\"0.551em\"></mspace>
+                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtext>CCCCC</mtext>
+                              </mstyle>
+                            </mpadded>
+                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                              <mtr>
+                                <mtd>
+                                  <mtable framespacing=\"0 0\">
+                                    <mtr>
+                                      <mtd rowalign=\"bottom\">
+                                        <mrow semantics=\"bspr_inference:3\">
+                                          <mspace width=\"-3.274em\"></mspace>
+                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\LeftLabel{AAAA}\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtr>
+                                              <mtd>
+                                                <mtable framespacing=\"0 0\">
+                                                  <mtr>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>D</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A1</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A2</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                              </mtd>
+                                            </mtr>
+                                            <mtr>
+                                              <mtd>
+                                                <mrow>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>Q</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                        </mrow>
+                                      </mtd>
+                                      <mtd></mtd>
+                                      <mtd rowalign=\"bottom\">
+                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
+                                          <mrow data-latex=\"\\LeftLabel{CCCCC}\">
+                                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                <mtext>BBB</mtext>
+                                              </mstyle>
+                                            </mpadded>
+                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                              <mtr>
+                                                <mtd>
+                                                  <mtable framespacing=\"0 0\">
+                                                    <mtr>
+                                                      <mtd rowalign=\"bottom\">
+                                                        <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                                          <mspace width=\".5ex\"></mspace>
+                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                            <mtext>A</mtext>
+                                                          </mstyle>
+                                                          <mspace width=\".5ex\"></mspace>
+                                                        </mrow>
+                                                      </mtd>
+                                                      <mtd></mtd>
+                                                      <mtd rowalign=\"bottom\">
+                                                        <mrow data-latex=\"\\LeftLabel{BBB}\" semantics=\"bspr_labelledRule:left;bspr_inference:2\">
+                                                          <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+                                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                              <mtext>AAAA</mtext>
+                                                            </mstyle>
+                                                          </mpadded>
+                                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                            <mtr>
+                                                              <mtd>
+                                                                <mtable framespacing=\"0 0\">
+                                                                  <mtr>
+                                                                    <mtd rowalign=\"bottom\">
+                                                                      <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                          <mtext>B</mtext>
+                                                                        </mstyle>
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                      </mrow>
+                                                                    </mtd>
+                                                                    <mtd></mtd>
+                                                                    <mtd rowalign=\"bottom\">
+                                                                      <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                          <mtext>R</mtext>
+                                                                        </mstyle>
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                      </mrow>
+                                                                    </mtd>
+                                                                  </mtr>
+                                                                </mtable>
+                                                              </mtd>
+                                                            </mtr>
+                                                            <mtr>
+                                                              <mtd>
+                                                                <mrow>
+                                                                  <mspace width=\".5ex\"></mspace>
+                                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                    <mrow data-mjx-texclass=\"ORD\">
+                                                                      <mi data-latex=\"C\">C</mi>
+                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                      <mi data-latex=\"D\">D</mi>
+                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                      <mi data-latex=\"Q\">Q</mi>
+                                                                    </mrow>
+                                                                  </mstyle>
+                                                                  <mspace width=\".5ex\"></mspace>
+                                                                </mrow>
+                                                              </mtd>
+                                                            </mtr>
+                                                          </mtable>
+                                                        </mrow>
+                                                      </mtd>
+                                                    </mtr>
+                                                  </mtable>
+                                                </mtd>
+                                              </mtr>
+                                              <mtr>
+                                                <mtd>
+                                                  <mrow>
+                                                    <mspace width=\".5ex\"></mspace>
+                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtext>E</mtext>
+                                                    </mstyle>
+                                                    <mspace width=\".5ex\"></mspace>
+                                                  </mrow>
+                                                </mtd>
+                                              </mtr>
+                                            </mtable>
+                                          </mrow>
+                                          <mspace width=\"-5.403em\"></mspace>
+                                        </mrow>
+                                      </mtd>
+                                    </mtr>
+                                  </mtable>
+                                </mtd>
+                              </mtr>
+                              <mtr>
+                                <mtd>
+                                  <mrow>
+                                    <mspace width=\".5ex\"></mspace>
+                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtext>F</mtext>
+                                    </mstyle>
+                                    <mspace width=\".5ex\"></mspace>
+                                  </mrow>
+                                </mtd>
+                              </mtr>
+                            </mtable>
+                          </mrow>
+                        </mrow>
+                      </mrow>
+                    </mtd>
+                    <mtd>
+                      <mspace width=\"5.403em\"></mspace>
+                    </mtd>
+                    <mtd rowalign=\"bottom\">
+                      <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
+                        <mspace width=\".5ex\"></mspace>
+                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                          <mtext>M</mtext>
+                        </mstyle>
+                        <mspace width=\".5ex\"></mspace>
+                      </mrow>
+                    </mtd>
+                  </mtr>
+                </mtable>
+              </mtd>
+            </mtr>
+            <mtr>
+              <mtd>
+                <mrow>
+                  <mspace width=\".5ex\"></mspace>
+                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                    <mrow data-mjx-texclass=\"ORD\">
+                      <mi data-latex=\"N\">N</mi>
+                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                      <mi data-latex=\"R\">R</mi>
+                    </mrow>
+                  </mstyle>
+                  <mspace width=\".5ex\"></mspace>
+                </mrow>
+              </mtd>
+            </mtr>
+          </mtable>
+        </mrow>
+      </mrow>
+    </math>`
+    ));
+  it('Simple Proofs Mixed Labels', () =>
+    toXmlMatch(
+      tex2mml(
+        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
+      ),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" display=\"block\">
+      <mrow semantics=\"bspr_inference:2;bspr_proof:true;bspr_labelledRule:both\">
+        <mspace width=\"4.379em\"></mspace>
+        <mrow data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}\" data-latex-item=\"{prooftree}\">
+          <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+              <mtext>DD</mtext>
+            </mstyle>
+          </mpadded>
+          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+            <mtr>
+              <mtd>
+                <mtable framespacing=\"0 0\">
+                  <mtr>
+                    <mtd rowalign=\"bottom\">
+                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
+                        <mspace width=\"-6.123em\"></mspace>
+                        <mrow>
+                          <mspace width=\"-0.551em\"></mspace>
+                          <mrow data-latex=\"\\LeftLabel{DD}\">
+                            <mspace width=\"0.551em\"></mspace>
+                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                <mtext>CCCCC</mtext>
+                              </mstyle>
+                            </mpadded>
+                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                              <mtr>
+                                <mtd>
+                                  <mtable framespacing=\"0 0\">
+                                    <mtr>
+                                      <mtd rowalign=\"bottom\">
+                                        <mrow semantics=\"bspr_inference:3\">
+                                          <mspace width=\"-3.274em\"></mspace>
+                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\RightLabel{AAAA}\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtr>
+                                              <mtd>
+                                                <mtable framespacing=\"0 0\">
+                                                  <mtr>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>D</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A1</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A2}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A2</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                              </mtd>
+                                            </mtr>
+                                            <mtr>
+                                              <mtd>
+                                                <mrow>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>Q</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                        </mrow>
+                                      </mtd>
+                                      <mtd></mtd>
+                                      <mtd rowalign=\"bottom\">
+                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:left\">
+                                          <mrow data-latex=\"\\LeftLabel{CCCCC}\">
+                                            <mpadded height=\".25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" semantics=\"bspr_prooflabel:left\">
+                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                <mtext>BBB</mtext>
+                                              </mstyle>
+                                            </mpadded>
+                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                              <mtr>
+                                                <mtd>
+                                                  <mtable framespacing=\"0 0\">
+                                                    <mtr>
+                                                      <mtd rowalign=\"bottom\">
+                                                        <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                                          <mspace width=\".5ex\"></mspace>
+                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                            <mtext>A</mtext>
+                                                          </mstyle>
+                                                          <mspace width=\".5ex\"></mspace>
+                                                        </mrow>
+                                                      </mtd>
+                                                      <mtd></mtd>
+                                                      <mtd rowalign=\"bottom\">
+                                                        <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                                                          <mrow data-latex=\"\\LeftLabel{BBB}\">
+                                                            <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                              <mtr>
+                                                                <mtd>
+                                                                  <mtable framespacing=\"0 0\">
+                                                                    <mtr>
+                                                                      <mtd rowalign=\"bottom\">
+                                                                        <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                            <mtext>B</mtext>
+                                                                          </mstyle>
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                      <mtd></mtd>
+                                                                      <mtd rowalign=\"bottom\">
+                                                                        <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                          <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                            <mtext>R</mtext>
+                                                                          </mstyle>
+                                                                          <mspace width=\".5ex\"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                  </mtable>
+                                                                </mtd>
+                                                              </mtr>
+                                                              <mtr>
+                                                                <mtd>
+                                                                  <mrow>
+                                                                    <mspace width=\".5ex\"></mspace>
+                                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                      <mrow data-mjx-texclass=\"ORD\">
+                                                                        <mi data-latex=\"C\">C</mi>
+                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                        <mi data-latex=\"D\">D</mi>
+                                                                        <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                        <mi data-latex=\"Q\">Q</mi>
+                                                                      </mrow>
+                                                                    </mstyle>
+                                                                    <mspace width=\".5ex\"></mspace>
+                                                                  </mrow>
+                                                                </mtd>
+                                                              </mtr>
+                                                            </mtable>
+                                                            <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                <mtext>AAAA</mtext>
+                                                              </mstyle>
+                                                            </mpadded>
+                                                          </mrow>
+                                                          <mspace width=\"-3.216em\"></mspace>
+                                                        </mrow>
+                                                      </mtd>
+                                                    </mtr>
+                                                  </mtable>
+                                                </mtd>
+                                              </mtr>
+                                              <mtr>
+                                                <mtd>
+                                                  <mrow>
+                                                    <mspace width=\".5ex\"></mspace>
+                                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                      <mtext>E</mtext>
+                                                    </mstyle>
+                                                    <mspace width=\".5ex\"></mspace>
+                                                  </mrow>
+                                                </mtd>
+                                              </mtr>
+                                            </mtable>
+                                          </mrow>
+                                          <mspace width=\"-3.795em\"></mspace>
+                                        </mrow>
+                                      </mtd>
+                                    </mtr>
+                                  </mtable>
+                                </mtd>
+                              </mtr>
+                              <mtr>
+                                <mtd>
+                                  <mrow>
+                                    <mspace width=\".5ex\"></mspace>
+                                    <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                      <mtext>F</mtext>
+                                    </mstyle>
+                                    <mspace width=\".5ex\"></mspace>
+                                  </mrow>
+                                </mtd>
+                              </mtr>
+                            </mtable>
+                          </mrow>
+                        </mrow>
+                      </mrow>
+                    </mtd>
+                    <mtd>
+                      <mspace width=\"7.01em\"></mspace>
+                    </mtd>
+                    <mtd rowalign=\"bottom\">
+                      <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
+                        <mspace width=\".5ex\"></mspace>
+                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                          <mtext>M</mtext>
+                        </mstyle>
+                        <mspace width=\".5ex\"></mspace>
+                      </mrow>
+                    </mtd>
+                  </mtr>
+                </mtable>
+              </mtd>
+            </mtr>
+            <mtr>
+              <mtd>
+                <mrow>
+                  <mspace width=\".5ex\"></mspace>
+                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                    <mrow data-mjx-texclass=\"ORD\">
+                      <mi data-latex=\"N\">N</mi>
+                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                      <mi data-latex=\"R\">R</mi>
+                    </mrow>
+                  </mstyle>
+                  <mspace width=\".5ex\"></mspace>
+                </mrow>
+              </mtd>
+            </mtr>
+          </mtable>
+          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+              <mtext>QERE</mtext>
+            </mstyle>
+          </mpadded>
+        </mrow>
+      </mrow>
+    </math>`
+    ));
+  it('Proof Very Right Label', () =>
+    toXmlMatch(
+      tex2mml(
+        '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
+      ),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" display=\"block\">
+      <mrow semantics=\"bspr_inference:2;bspr_proof:true\">
+        <mspace width=\"9.835em\"></mspace>
+        <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}\" data-latex-item=\"{prooftree}\" semantics=\"bspr_inferenceRule:down\">
+          <mtr>
+            <mtd>
+              <mtable framespacing=\"0 0\">
+                <mtr>
+                  <mtd rowalign=\"bottom\">
+                    <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                      <mspace width=\"-9.835em\"></mspace>
+                      <mrow>
+                        <mspace width=\"3.274em\"></mspace>
+                        <mrow data-latex=\"\\RightLabel{QERE}\">
+                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                            <mtr>
+                              <mtd>
+                                <mtable framespacing=\"0 0\">
+                                  <mtr>
+                                    <mtd rowalign=\"bottom\">
+                                      <mrow semantics=\"bspr_inference:3;bspr_labelledRule:right\">
+                                        <mspace width=\"-3.274em\"></mspace>
+                                        <mrow data-latex=\"\\RightLabel{Nowhere}\">
+                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtr>
+                                              <mtd>
+                                                <mtable framespacing=\"0 0\">
+                                                  <mtr>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{D}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>D</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A1}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A1</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\RightLabel{AAAA}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A2</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                              </mtd>
+                                            </mtr>
+                                            <mtr>
+                                              <mtd>
+                                                <mrow>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>Q</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtext>AAAA</mtext>
+                                            </mstyle>
+                                          </mpadded>
+                                        </mrow>
+                                      </mrow>
+                                    </mtd>
+                                    <mtd></mtd>
+                                    <mtd rowalign=\"bottom\">
+                                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                                        <mrow data-latex=\"\\RightLabel{CCCCC}\">
+                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                            <mtr>
+                                              <mtd>
+                                                <mtable framespacing=\"0 0\">
+                                                  <mtr>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow data-latex=\"\\AxiomC{A}\" semantics=\"bspr_axiom:true\">
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>A</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                    <mtd></mtd>
+                                                    <mtd rowalign=\"bottom\">
+                                                      <mrow semantics=\"bspr_inference:2;bspr_labelledRule:right\">
+                                                        <mrow data-latex=\"\\RightLabel{BBB}\">
+                                                          <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                            <mtr>
+                                                              <mtd>
+                                                                <mtable framespacing=\"0 0\">
+                                                                  <mtr>
+                                                                    <mtd rowalign=\"bottom\">
+                                                                      <mrow data-latex=\"\\AxiomC{B}\" semantics=\"bspr_axiom:true\">
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                          <mtext>B</mtext>
+                                                                        </mstyle>
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                      </mrow>
+                                                                    </mtd>
+                                                                    <mtd></mtd>
+                                                                    <mtd rowalign=\"bottom\">
+                                                                      <mrow data-latex=\"\\AxiomC{R}\" semantics=\"bspr_axiom:true\">
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                          <mtext>R</mtext>
+                                                                        </mstyle>
+                                                                        <mspace width=\".5ex\"></mspace>
+                                                                      </mrow>
+                                                                    </mtd>
+                                                                  </mtr>
+                                                                </mtable>
+                                                              </mtd>
+                                                            </mtr>
+                                                            <mtr>
+                                                              <mtd>
+                                                                <mrow>
+                                                                  <mspace width=\".5ex\"></mspace>
+                                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                    <mrow data-mjx-texclass=\"ORD\">
+                                                                      <mi data-latex=\"C\">C</mi>
+                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                      <mi data-latex=\"D\">D</mi>
+                                                                      <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                                                                      <mi data-latex=\"Q\">Q</mi>
+                                                                    </mrow>
+                                                                  </mstyle>
+                                                                  <mspace width=\".5ex\"></mspace>
+                                                                </mrow>
+                                                              </mtd>
+                                                            </mtr>
+                                                          </mtable>
+                                                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                              <mtext>Nowhere</mtext>
+                                                            </mstyle>
+                                                          </mpadded>
+                                                        </mrow>
+                                                        <mspace width=\"-4.023em\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                              </mtd>
+                                            </mtr>
+                                            <mtr>
+                                              <mtd>
+                                                <mrow>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                    <mtext>E</mtext>
+                                                  </mstyle>
+                                                  <mspace width=\".5ex\"></mspace>
+                                                </mrow>
+                                              </mtd>
+                                            </mtr>
+                                          </mtable>
+                                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                              <mtext>BBB</mtext>
+                                            </mstyle>
+                                          </mpadded>
+                                        </mrow>
+                                        <mspace width=\"-6.135em\"></mspace>
+                                      </mrow>
+                                    </mtd>
+                                  </mtr>
+                                </mtable>
+                              </mtd>
+                            </mtr>
+                            <mtr>
+                              <mtd>
+                                <mrow>
+                                  <mspace width=\".5ex\"></mspace>
+                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                    <mtext>F</mtext>
+                                  </mstyle>
+                                  <mspace width=\".5ex\"></mspace>
+                                </mrow>
+                              </mtd>
+                            </mtr>
+                          </mtable>
+                          <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                              <mtext>CCCCC</mtext>
+                            </mstyle>
+                          </mpadded>
+                        </mrow>
+                      </mrow>
+                    </mrow>
+                  </mtd>
+                  <mtd>
+                    <mspace width=\"3.993em\"></mspace>
+                  </mtd>
+                  <mtd rowalign=\"bottom\">
+                    <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\UnaryInfC{More and more}\" semantics=\"bspr_inferenceRule:down;bspr_inference:1\">
+                      <mtr>
+                        <mtd>
+                          <mtable framespacing=\"0 0\">
+                            <mtr>
+                              <mtd rowalign=\"bottom\">
+                                <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" data-latex=\"\\UnaryInfC{More and more}\" semantics=\"bspr_inferenceRule:down;bspr_inference:1\">
+                                  <mtr>
+                                    <mtd>
+                                      <mtable framespacing=\"0 0\">
+                                        <mtr>
+                                          <mtd rowalign=\"bottom\">
+                                            <mrow semantics=\"bspr_inference:1;bspr_labelledRule:right\">
+                                              <mrow data-latex=\"\\UnaryInfC{More and more}\">
+                                                <mtable align=\"top 2\" rowlines=\"solid\" framespacing=\"0 0\" semantics=\"bspr_inferenceRule:down\">
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mtable framespacing=\"0 0\">
+                                                        <mtr>
+                                                          <mtd rowalign=\"bottom\">
+                                                            <mrow data-latex=\"\\AxiomC{M}\" semantics=\"bspr_axiom:true\">
+                                                              <mspace width=\".5ex\"></mspace>
+                                                              <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                                <mtext>M</mtext>
+                                                              </mstyle>
+                                                              <mspace width=\".5ex\"></mspace>
+                                                            </mrow>
+                                                          </mtd>
+                                                        </mtr>
+                                                      </mtable>
+                                                    </mtd>
+                                                  </mtr>
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mrow>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                                                          <mtext>More and more</mtext>
+                                                        </mstyle>
+                                                        <mspace width=\".5ex\"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                                <mpadded height=\"-.25em\" depth=\"+.25em\" width=\"+.5ex\" voffset=\"-.25em\" lspace=\".5ex\" semantics=\"bspr_prooflabel:right\">
+                                                  <mstyle displaystyle=\"false\" scriptlevel=\"0\">
                                                     <mtext>QERE</mtext>
                                                   </mstyle>
                                                 </mpadded>
                                               </mrow>
-                                              <mspace width="-3.376em"></mspace>
+                                              <mspace width=\"-3.092em\"></mspace>
                                             </mrow>
                                           </mtd>
                                         </mtr>
@@ -2253,60 +2241,56 @@ describe('BussproofsRegProofs', () => {
                                   <mtr>
                                     <mtd>
                                       <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mstyle displaystyle="false" scriptlevel="0">
+                                        <mspace width=\".5ex\"></mspace>
+                                        <mstyle displaystyle=\"false\" scriptlevel=\"0\">
                                           <mtext>More and more</mtext>
                                         </mstyle>
-                                        <mspace width=".5ex"></mspace>
+                                        <mspace width=\".5ex\"></mspace>
                                       </mrow>
                                     </mtd>
                                   </mtr>
                                 </mtable>
-                                <mspace width="0em"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                      </mtd>
-                    </mtr>
-                    <mtr>
-                      <mtd>
-                        <mrow>
-                          <mspace width=".5ex"></mspace>
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>More and more</mtext>
-                          </mstyle>
-                          <mspace width=".5ex"></mspace>
-                        </mrow>
-                      </mtd>
-                    </mtr>
-                  </mtable>
-                  <mspace width="0em"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mrow>
-            <mspace width=".5ex"></mspace>
-            <mstyle displaystyle="false" scriptlevel="0">
-              <mrow data-mjx-texclass="ORD">
-                <mi data-latex="N">N</mi>
-                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                <mi data-latex="R">R</mi>
+                              </mtd>
+                            </mtr>
+                          </mtable>
+                        </mtd>
+                      </mtr>
+                      <mtr>
+                        <mtd>
+                          <mrow>
+                            <mspace width=\".5ex\"></mspace>
+                            <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                              <mtext>More and more</mtext>
+                            </mstyle>
+                            <mspace width=\".5ex\"></mspace>
+                          </mrow>
+                        </mtd>
+                      </mtr>
+                    </mtable>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=\".5ex\"></mspace>
+                <mstyle displaystyle=\"false\" scriptlevel=\"0\">
+                  <mrow data-mjx-texclass=\"ORD\">
+                    <mi data-latex=\"N\">N</mi>
+                    <mo stretchy=\"false\" data-latex=\"\\rightarrow\">&#x2192;</mo>
+                    <mi data-latex=\"R\">R</mi>
+                  </mrow>
+                </mstyle>
+                <mspace width=\".5ex\"></mspace>
               </mrow>
-            </mstyle>
-            <mspace width=".5ex"></mspace>
-          </mrow>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mspace width="0em"></mspace>
-  </mrow>
-</math>`
+            </mtd>
+          </mtr>
+        </mtable>
+        <mspace width=\"3.091em\"></mspace>
+      </mrow>
+    </math>`
     ));
   it('Proof Complex', () =>
     toXmlMatch(
@@ -2316,8 +2300,9 @@ describe('BussproofsRegProofs', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" display="block">
   <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
     <mrow>
-      <mspace width="13.852em"></mspace>
+      <mspace width="13.248em"></mspace>
       <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" data-latex-item="{prooftree}">
+        <mspace width=\"-1.155em\"></mspace>
         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
@@ -2326,9 +2311,9 @@ describe('BussproofsRegProofs', () => {
                   <mtd rowalign="bottom">
                     <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
                       <mrow>
-                        <mspace width="-13.852em"></mspace>
+                        <mspace width="-13.248em"></mspace>
                         <mrow>
-                          <mspace width="9.465em"></mspace>
+                          <mspace width="9.11em"></mspace>
                           <mrow data-latex="\\RL{\${\\rightarrow_I}^1\$}">
                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
@@ -2337,9 +2322,9 @@ describe('BussproofsRegProofs', () => {
                                     <mtr>
                                       <mtd rowalign="bottom">
                                         <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mspace width="-9.465em"></mspace>
+                                          <mspace width="-9.11em"></mspace>
                                           <mrow>
-                                            <mspace width="3.734em"></mspace>
+                                            <mspace width="3.592em"></mspace>
                                             <mrow data-latex="\\BIC{\$R\$}">
                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                 <mtr>
@@ -2348,7 +2333,7 @@ describe('BussproofsRegProofs', () => {
                                                       <mtr>
                                                         <mtd rowalign="bottom">
                                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                            <mspace width="-3.734em"></mspace>
+                                                            <mspace width="-3.592em"></mspace>
                                                             <mrow data-latex="\\BIC{\$Q^2\$}">
                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                                 <mtr>
@@ -2383,7 +2368,7 @@ describe('BussproofsRegProofs', () => {
                                                                                 </mtd>
                                                                               </mtr>
                                                                             </mtable>
-                                                                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                                               <mstyle displaystyle="false" scriptlevel="0">
                                                                                 <mrow data-mjx-texclass="ORD">
                                                                                   <mi data-latex="H">H</mi>
@@ -2434,7 +2419,7 @@ describe('BussproofsRegProofs', () => {
                                                                   </mtd>
                                                                 </mtr>
                                                               </mtable>
-                                                              <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                                 <mstyle displaystyle="false" scriptlevel="0">
                                                                   <mrow data-mjx-texclass="ORD">
                                                                     <msub data-latex="\\rightarrow_E">
@@ -2479,7 +2464,7 @@ describe('BussproofsRegProofs', () => {
                                                   </mtd>
                                                 </mtr>
                                               </mtable>
-                                              <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                 <mstyle displaystyle="false" scriptlevel="0">
                                                   <mrow data-mjx-texclass="ORD">
                                                     <msub data-latex="\\rightarrow_E">
@@ -2531,7 +2516,7 @@ describe('BussproofsRegProofs', () => {
                                                 </mtd>
                                               </mtr>
                                             </mtable>
-                                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                               <mstyle displaystyle="false" scriptlevel="0">
                                                 <mtext>Rit</mtext>
                                                 <mrow data-mjx-texclass="ORD">
@@ -2543,7 +2528,7 @@ describe('BussproofsRegProofs', () => {
                                               </mstyle>
                                             </mpadded>
                                           </mrow>
-                                          <mspace width="-2.34em"></mspace>
+                                          <mspace width="-2.055em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -2566,7 +2551,7 @@ describe('BussproofsRegProofs', () => {
                                 </mtd>
                               </mtr>
                             </mtable>
-                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                               <mstyle displaystyle="false" scriptlevel="0">
                                 <mrow data-mjx-texclass="ORD">
                                   <msub data-latex="\\wedge_I">
@@ -2579,7 +2564,7 @@ describe('BussproofsRegProofs', () => {
                           </mrow>
                         </mrow>
                       </mrow>
-                      <mspace width="-5.989em"></mspace>
+                      <mspace width="-5.455em"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -2604,7 +2589,7 @@ describe('BussproofsRegProofs', () => {
             </mtd>
           </mtr>
         </mtable>
-        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
           <mstyle displaystyle="false" scriptlevel="0">
             <mrow data-mjx-texclass="ORD">
               <msup data-latex="{\\rightarrow_I}^1 ">
@@ -2621,7 +2606,7 @@ describe('BussproofsRegProofs', () => {
         </mpadded>
       </mrow>
     </mrow>
-    <mspace width="3.618em"></mspace>
+    <mspace width="2.952em"></mspace>
   </mrow>
 </math>`
     ));
@@ -2633,8 +2618,9 @@ describe('BussproofsRegProofs', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\alwaysRootAtBottom\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" display="block">
   <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
     <mrow>
-      <mspace width="13.852em"></mspace>
+      <mspace width="13.248em"></mspace>
       <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\alwaysRootAtBottom\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" data-latex-item="{prooftree}">
+        <mspace width=\"-1.155em\"></mspace>
         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
           <mtr>
             <mtd>
@@ -2643,9 +2629,9 @@ describe('BussproofsRegProofs', () => {
                   <mtd rowalign="bottom">
                     <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
                       <mrow>
-                        <mspace width="-13.852em"></mspace>
+                        <mspace width="-13.248em"></mspace>
                         <mrow>
-                          <mspace width="9.465em"></mspace>
+                          <mspace width="9.11em"></mspace>
                           <mrow data-latex="\\RL{\${\\rightarrow_I}^1\$}">
                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
@@ -2654,9 +2640,9 @@ describe('BussproofsRegProofs', () => {
                                     <mtr>
                                       <mtd rowalign="bottom">
                                         <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mspace width="-9.465em"></mspace>
+                                          <mspace width="-9.11em"></mspace>
                                           <mrow>
-                                            <mspace width="3.734em"></mspace>
+                                            <mspace width="3.592em"></mspace>
                                             <mrow data-latex="\\BIC{\$R\$}">
                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                 <mtr>
@@ -2665,7 +2651,7 @@ describe('BussproofsRegProofs', () => {
                                                       <mtr>
                                                         <mtd rowalign="bottom">
                                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                            <mspace width="-3.734em"></mspace>
+                                                            <mspace width="-3.592em"></mspace>
                                                             <mrow data-latex="\\alwaysRootAtBottom">
                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
                                                                 <mtr>
@@ -2716,7 +2702,7 @@ describe('BussproofsRegProofs', () => {
                                                                                 </mtd>
                                                                               </mtr>
                                                                             </mtable>
-                                                                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                                               <mstyle displaystyle="false" scriptlevel="0">
                                                                                 <mrow data-mjx-texclass="ORD">
                                                                                   <mi data-latex="H">H</mi>
@@ -2751,7 +2737,7 @@ describe('BussproofsRegProofs', () => {
                                                                   </mtd>
                                                                 </mtr>
                                                               </mtable>
-                                                              <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                                 <mstyle displaystyle="false" scriptlevel="0">
                                                                   <mrow data-mjx-texclass="ORD">
                                                                     <msub data-latex="\\rightarrow_E">
@@ -2796,7 +2782,7 @@ describe('BussproofsRegProofs', () => {
                                                   </mtd>
                                                 </mtr>
                                               </mtable>
-                                              <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                 <mstyle displaystyle="false" scriptlevel="0">
                                                   <mrow data-mjx-texclass="ORD">
                                                     <msub data-latex="\\rightarrow_E">
@@ -2848,7 +2834,7 @@ describe('BussproofsRegProofs', () => {
                                                 </mtd>
                                               </mtr>
                                             </mtable>
-                                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                               <mstyle displaystyle="false" scriptlevel="0">
                                                 <mtext>Rit</mtext>
                                                 <mrow data-mjx-texclass="ORD">
@@ -2860,7 +2846,7 @@ describe('BussproofsRegProofs', () => {
                                               </mstyle>
                                             </mpadded>
                                           </mrow>
-                                          <mspace width="-2.34em"></mspace>
+                                          <mspace width="-2.055em"></mspace>
                                         </mrow>
                                       </mtd>
                                     </mtr>
@@ -2883,7 +2869,7 @@ describe('BussproofsRegProofs', () => {
                                 </mtd>
                               </mtr>
                             </mtable>
-                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                               <mstyle displaystyle="false" scriptlevel="0">
                                 <mrow data-mjx-texclass="ORD">
                                   <msub data-latex="\\wedge_I">
@@ -2896,7 +2882,7 @@ describe('BussproofsRegProofs', () => {
                           </mrow>
                         </mrow>
                       </mrow>
-                      <mspace width="-5.989em"></mspace>
+                      <mspace width="-5.455em"></mspace>
                     </mrow>
                   </mtd>
                 </mtr>
@@ -2921,7 +2907,7 @@ describe('BussproofsRegProofs', () => {
             </mtd>
           </mtr>
         </mtable>
-        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
           <mstyle displaystyle="false" scriptlevel="0">
             <mrow data-mjx-texclass="ORD">
               <msup data-latex="{\\rightarrow_I}^1 ">
@@ -2938,7 +2924,7 @@ describe('BussproofsRegProofs', () => {
         </mpadded>
       </mrow>
     </mrow>
-    <mspace width="3.618em"></mspace>
+    <mspace width="2.952em"></mspace>
   </mrow>
 </math>`
     ));
@@ -2949,9 +2935,9 @@ describe('BussproofsRegProofs', () => {
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
   <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
-    <mspace width="16.672em"></mspace>
+    <mspace width="16.317em"></mspace>
     <mrow data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
+      <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
         <mstyle displaystyle="false" scriptlevel="0">
           <mtext>BBB</mtext>
         </mstyle>
@@ -2963,11 +2949,11 @@ describe('BussproofsRegProofs', () => {
               <mtr>
                 <mtd rowalign="bottom">
                   <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
-                    <mspace width="-19.296em"></mspace>
+                    <mspace width="-18.656em"></mspace>
                     <mrow>
                       <mspace width="3.94em"></mspace>
                       <mrow data-latex="\\RightLabel{QERE}">
-                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
+                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                           <mstyle displaystyle="false" scriptlevel="0">
                             <mtext>WWW</mtext>
                           </mstyle>
@@ -2979,9 +2965,9 @@ describe('BussproofsRegProofs', () => {
                                 <mtr>
                                   <mtd rowalign="bottom">
                                     <mrow semantics="bspr_inference:3;bspr_labelledRule:both">
-                                      <mspace width="-7.524em"></mspace>
+                                      <mspace width="-7.239em"></mspace>
                                       <mrow data-latex="\\RightLabel{AAAA}">
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
+                                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                           <mstyle displaystyle="false" scriptlevel="0">
                                             <mtext>HHHHH</mtext>
                                           </mstyle>
@@ -3036,7 +3022,7 @@ describe('BussproofsRegProofs', () => {
                                             </mtd>
                                           </mtr>
                                         </mtable>
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                           <mstyle displaystyle="false" scriptlevel="0">
                                             <mtext>11111111111111111</mtext>
                                           </mstyle>
@@ -3048,7 +3034,7 @@ describe('BussproofsRegProofs', () => {
                                   <mtd rowalign="bottom">
                                     <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
                                       <mrow data-latex="\\LL{WWW}">
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
+                                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                           <mstyle displaystyle="false" scriptlevel="0">
                                             <mtext>BBBB</mtext>
                                           </mstyle>
@@ -3071,7 +3057,7 @@ describe('BussproofsRegProofs', () => {
                                                   <mtd rowalign="bottom">
                                                     <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
                                                       <mrow data-latex="\\RightLabel{MMM}">
-                                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:left">
+                                                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
                                                           <mstyle displaystyle="false" scriptlevel="0">
                                                             <mtext>qqqq</mtext>
                                                           </mstyle>
@@ -3122,13 +3108,13 @@ describe('BussproofsRegProofs', () => {
                                                             </mtd>
                                                           </mtr>
                                                         </mtable>
-                                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                                           <mstyle displaystyle="false" scriptlevel="0">
                                                             <mtext>AAAA</mtext>
                                                           </mstyle>
                                                         </mpadded>
                                                       </mrow>
-                                                      <mspace width="-3.5em"></mspace>
+                                                      <mspace width="-3.216em"></mspace>
                                                     </mrow>
                                                   </mtd>
                                                 </mtr>
@@ -3147,13 +3133,13 @@ describe('BussproofsRegProofs', () => {
                                             </mtd>
                                           </mtr>
                                         </mtable>
-                                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                                           <mstyle displaystyle="false" scriptlevel="0">
                                             <mtext>MMM</mtext>
                                           </mstyle>
                                         </mpadded>
                                       </mrow>
-                                      <mspace width="-8.352em"></mspace>
+                                      <mspace width="-7.925em"></mspace>
                                     </mrow>
                                   </mtd>
                                 </mtr>
@@ -3172,7 +3158,7 @@ describe('BussproofsRegProofs', () => {
                             </mtd>
                           </mtr>
                         </mtable>
-                        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
                           <mstyle displaystyle="false" scriptlevel="0">
                             <mtext>CCCCC</mtext>
                           </mstyle>
@@ -3182,7 +3168,7 @@ describe('BussproofsRegProofs', () => {
                   </mrow>
                 </mtd>
                 <mtd>
-                  <mspace width="4.242055555555558em"></mspace>
+                  <mspace width="4.349em"></mspace>
                 </mtd>
                 <mtd rowalign="bottom">
                   <mrow data-latex="\\LL{BBB}" semantics="bspr_axiom:true">
@@ -3213,7 +3199,7 @@ describe('BussproofsRegProofs', () => {
           </mtd>
         </mtr>
       </mtable>
-      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+      <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
         <mstyle displaystyle="false" scriptlevel="0">
           <mtext>QERE</mtext>
         </mstyle>

--- a/testsuite/tests/input/tex/Cancel.test.ts
+++ b/testsuite/tests/input/tex/Cancel.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/cancel/CancelConfiguration';
 
 beforeEach(() => setupTex(['base', 'cancel']));
 

--- a/testsuite/tests/input/tex/Colorv2.test.ts
+++ b/testsuite/tests/input/tex/Colorv2.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/colorv2/ColorV2Configuration';
 
 beforeEach(() => setupTex(['base', 'colorv2']));
 

--- a/testsuite/tests/input/tex/ConfigMacros.test.ts
+++ b/testsuite/tests/input/tex/ConfigMacros.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/configmacros/ConfigMacrosConfiguration';
 
 beforeEach(() => {});
 

--- a/testsuite/tests/input/tex/Enclose.test.ts
+++ b/testsuite/tests/input/tex/Enclose.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/enclose/EncloseConfiguration';
 
 beforeEach(() => setupTex(['base', 'enclose']));
 

--- a/testsuite/tests/input/tex/Extpfeil.test.ts
+++ b/testsuite/tests/input/tex/Extpfeil.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/extpfeil/ExtpfeilConfiguration';
 
 beforeEach(() => setupTex(['base', 'extpfeil']));
 

--- a/testsuite/tests/input/tex/Html.test.ts
+++ b/testsuite/tests/input/tex/Html.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/html/HtmlConfiguration';
 
 beforeEach(() => setupTex(['base', 'html']));
 

--- a/testsuite/tests/input/tex/Mhchem.test.ts
+++ b/testsuite/tests/input/tex/Mhchem.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/mhchem/MhchemConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
 
 beforeEach(() => setupTex(['base', 'mhchem']));
 

--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/newcommand/NewcommandConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
+import '#js/input/tex/colorv2/ColorV2Configuration';
 
 describe('Newcommand', () => {
   beforeEach(() => setupTex(['base', 'newcommand']));

--- a/testsuite/tests/input/tex/Noerrors.test.ts
+++ b/testsuite/tests/input/tex/Noerrors.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/noerrors/NoErrorsConfiguration';
 
 beforeEach(() => setupTex(['base', 'noerrors']));
 

--- a/testsuite/tests/input/tex/Noundefined.test.ts
+++ b/testsuite/tests/input/tex/Noundefined.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/noundefined/NoUndefinedConfiguration';
 
 beforeEach(() => setupTex(['base', 'noundefined']));
 

--- a/testsuite/tests/input/tex/Physics.test.ts
+++ b/testsuite/tests/input/tex/Physics.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/physics/PhysicsConfiguration';
+
 
 beforeEach(() => setupTex(['base', 'physics']));
 

--- a/testsuite/tests/input/tex/Tag.test.ts
+++ b/testsuite/tests/input/tex/Tag.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/base/BaseConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
 
 describe('TagAll', () => {
   beforeEach(() => setupTex(['ams', 'base'], { tags: 'all' }));

--- a/testsuite/tests/input/tex/Tag.test.ts
+++ b/testsuite/tests/input/tex/Tag.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
-import '#js/input/tex/base/BaseConfiguration';
 import '#js/input/tex/ams/AmsConfiguration';
 
 describe('TagAll', () => {

--- a/testsuite/tests/input/tex/Unicode.test.ts
+++ b/testsuite/tests/input/tex/Unicode.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/unicode/UnicodeConfiguration';
 
 beforeEach(() => setupTex(['base', 'unicode']));
 

--- a/testsuite/tests/input/tex/Verb.test.ts
+++ b/testsuite/tests/input/tex/Verb.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it } from '@jest/globals';
 import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/verb/VerbConfiguration';
 
 beforeEach(() => setupTex(['base', 'verb']));
 


### PR DESCRIPTION
PR updates tests to work again after PR #1110 and #1115
* Configurations are included in the test files directly, that limits the actual code that is loaded (and not used) during tests.
* Busproofs tests are updated mainly wrt. to new spacings.