### PR TITLE
prettier with comma options all

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,3 @@
 {
-  "singleQuote": true,
-  "trailingComma": "es5"
+  "singleQuote": true
 }

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -103,7 +103,7 @@ export function AssistiveMmlMathItemMixin<
      */
     public assistiveMml(
       document: AssistiveMmlMathDocument<N, T, D>,
-      force: boolean = false
+      force: boolean = false,
     ) {
       if (this.state() >= STATE.ASSISTIVEMML) return;
       if (!this.isEscaped && (document.options.enableAssistiveMml || force)) {
@@ -119,7 +119,7 @@ export function AssistiveMmlMathItemMixin<
         // Parse is as HTML and retrieve the <math> element
         //
         const mmlNodes = adaptor.firstChild(
-          adaptor.body(adaptor.parse(mml, 'text/html'))
+          adaptor.body(adaptor.parse(mml, 'text/html')),
         );
         //
         // Create a container for the hidden MathML
@@ -130,7 +130,7 @@ export function AssistiveMmlMathItemMixin<
             unselectable: 'on',
             display: this.display ? 'block' : 'inline',
           },
-          [mmlNodes]
+          [mmlNodes],
         );
         //
         // Hide the typeset math from assistive technology and append the MathML that is visually
@@ -139,7 +139,7 @@ export function AssistiveMmlMathItemMixin<
         adaptor.setAttribute(
           adaptor.firstChild(this.typesetRoot) as N,
           'aria-hidden',
-          'true'
+          'true',
         );
         adaptor.setStyle(this.typesetRoot, 'position', 'relative');
         adaptor.append(this.typesetRoot, node);
@@ -191,7 +191,7 @@ export function AssistiveMmlMathDocumentMixin<
   D,
   B extends MathDocumentConstructor<AbstractMathDocument<N, T, D>>,
 >(
-  BaseDocument: B
+  BaseDocument: B,
 ): MathDocumentConstructor<AssistiveMmlMathDocument<N, T, D>> & B {
   return class BaseClass extends BaseDocument {
     /**
@@ -315,7 +315,7 @@ export function AssistiveMmlMathDocumentMixin<
  * @template D  The Document class
  */
 export function AssistiveMmlHandler<N, T, D>(
-  handler: Handler<N, T, D>
+  handler: Handler<N, T, D>,
 ): Handler<N, T, D> {
   handler.documentClass = AssistiveMmlMathDocumentMixin<
     N,

--- a/ts/a11y/complexity.ts
+++ b/ts/a11y/complexity.ts
@@ -90,7 +90,7 @@ export interface ComplexityMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
  */
 export function ComplexityMathItemMixin<N, T, D, B extends EMItemC<N, T, D>>(
   BaseMathItem: B,
-  computeComplexity: (node: MmlNode) => void
+  computeComplexity: (node: MmlNode) => void,
 ): CMItemC<N, T, D> & B {
   return class extends BaseMathItem {
     /**
@@ -99,7 +99,7 @@ export function ComplexityMathItemMixin<N, T, D, B extends EMItemC<N, T, D>>(
      */
     public complexity(
       document: ComplexityMathDocument<N, T, D>,
-      force: boolean = false
+      force: boolean = false,
     ) {
       if (this.state() >= STATE.COMPLEXITY) return;
       if (!this.isEscaped && (document.options.enableComplexity || force)) {
@@ -142,7 +142,7 @@ export interface ComplexityMathDocument<N, T, D>
  * @template B  The MathDocument class to extend
  */
 export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
-  BaseDocument: B
+  BaseDocument: B,
 ): CMDocC<N, T, D> & B {
   return class extends BaseDocument {
     /**
@@ -178,11 +178,11 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
       }
       const visitorOptions = selectOptionsFromKeys(
         this.options,
-        this.options.ComplexityVisitor.OPTIONS
+        this.options.ComplexityVisitor.OPTIONS,
       );
       this.complexityVisitor = new this.options.ComplexityVisitor(
         this.mmlFactory,
-        visitorOptions
+        visitorOptions,
       );
       const computeComplexity = (node: MmlNode) =>
         this.complexityVisitor.visitTree(node);
@@ -237,13 +237,13 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
  */
 export function ComplexityHandler<N, T, D>(
   handler: Handler<N, T, D>,
-  MmlJax: MathML<N, T, D> = null
+  MmlJax: MathML<N, T, D> = null,
 ): Handler<N, T, D> {
   if (!handler.documentClass.prototype.enrich && MmlJax) {
     handler = EnrichHandler(handler, MmlJax);
   }
   handler.documentClass = ComplexityMathDocumentMixin<N, T, D, EMDocC<N, T, D>>(
-    handler.documentClass as any
+    handler.documentClass as any,
   );
   return handler;
 }

--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -156,7 +156,7 @@ export class Collapse {
             node,
             complexity,
             this.getText(node.childNodes[0]) +
-              this.getText(node.childNodes[node.childNodes.length - 1])
+              this.getText(node.childNodes[node.childNodes.length - 1]),
           );
         }
         return complexity;
@@ -194,7 +194,7 @@ export class Collapse {
           complexity = this.recordCollapse(
             node,
             complexity,
-            this.marker.sqrt as string
+            this.marker.sqrt as string,
           );
         }
         return complexity;
@@ -208,7 +208,7 @@ export class Collapse {
           complexity = this.recordCollapse(
             node,
             complexity,
-            this.marker.sqrt as string
+            this.marker.sqrt as string,
           );
         }
         return complexity;
@@ -229,7 +229,7 @@ export class Collapse {
             complexity = this.recordCollapse(
               node,
               this.complexity.visitNode(node, false),
-              marker
+              marker,
             );
           }
         }
@@ -303,7 +303,7 @@ export class Collapse {
           complexity = this.recordCollapse(
             node,
             complexity,
-            this.marker.superscript as string
+            this.marker.superscript as string,
           );
         }
         return complexity;
@@ -317,7 +317,7 @@ export class Collapse {
           complexity = this.recordCollapse(
             node,
             complexity,
-            this.marker.subscript as string
+            this.marker.subscript as string,
           );
         }
         return complexity;
@@ -331,7 +331,7 @@ export class Collapse {
           complexity = this.recordCollapse(
             node,
             complexity,
-            this.marker.subsup as string
+            this.marker.subsup as string,
           );
         }
         return complexity;
@@ -382,7 +382,7 @@ export class Collapse {
   protected defaultCheck(
     node: MmlNode,
     complexity: number,
-    type: string
+    type: string,
   ): number {
     const role = node.attributes.get('data-semantic-role') as string;
     const check = this.cutoff[type];
@@ -406,7 +406,7 @@ export class Collapse {
   protected recordCollapse(
     node: MmlNode,
     complexity: number,
-    text: string
+    text: string,
   ): number {
     text = '\u25C2' + text + '\u25B8';
     node.setProperty('collapse-marker', text);
@@ -437,7 +437,7 @@ export class Collapse {
   protected canUncollapse(
     node: MmlNode,
     n: number,
-    m: number = 1
+    m: number = 1,
   ): MmlNode | null {
     if (this.splitAttribute(node, 'children').length === m) {
       const mml =
@@ -465,7 +465,7 @@ export class Collapse {
     complexity: number,
     node: MmlNode,
     n: number,
-    m: number = 1
+    m: number = 1,
   ): number {
     const child = this.canUncollapse(node, n, m);
     if (child) {
@@ -485,7 +485,7 @@ export class Collapse {
    */
   protected splitAttribute(node: MmlNode, id: string): string[] {
     return ((node.attributes.get('data-semantic-' + id) as string) || '').split(
-      /,/
+      /,/,
     );
   }
 
@@ -573,19 +573,19 @@ export class Collapse {
         'data-collapsible': true,
         id: this.makeId(),
         'data-semantic-complexity': node.attributes.get(
-          'data-semantic-complexity'
+          'data-semantic-complexity',
         ),
       },
       [
         factory.create('mtext', { mathcolor: 'blue' }, [
           (factory.create('text') as TextNode).setText(marker),
         ]),
-      ]
+      ],
     );
     maction.inheritAttributesFrom(node);
     node.attributes.set(
       'data-semantic-complexity',
-      node.getProperty('collapse-complexity')
+      node.getProperty('collapse-complexity'),
     );
     node.removeProperty('collapse-marker');
     node.removeProperty('collapse-complexity');
@@ -604,7 +604,7 @@ export class Collapse {
     const mrow = this.complexity.factory.create(
       'mrow',
       null,
-      node.childNodes[0].childNodes
+      node.childNodes[0].childNodes,
     );
     node.childNodes[0].setChildren([mrow]);
 
@@ -623,7 +623,7 @@ export class Collapse {
     mrow.setProperty('collapse-marker', node.getProperty('collapse-marker'));
     mrow.setProperty(
       'collapse-complexity',
-      node.getProperty('collapse-complexity')
+      node.getProperty('collapse-complexity'),
     );
     node.removeProperty('collapse-marker');
     node.removeProperty('collapse-complexity');

--- a/ts/a11y/complexity/visitor.ts
+++ b/ts/a11y/complexity/visitor.ts
@@ -220,7 +220,7 @@ export class ComplexityVisitor extends MmlVisitor {
     let complexity =
       Math.max(
         sub ? this.getComplexity(sub) : 0,
-        sup ? this.getComplexity(sup) : 0
+        sup ? this.getComplexity(sup) : 0,
       ) * this.complexity.script;
     complexity += this.complexity.child * ((sub ? 1 : 0) + (sup ? 1 : 0));
     complexity += base ? this.getComplexity(base) + this.complexity.child : 0;
@@ -259,7 +259,7 @@ export class ComplexityVisitor extends MmlVisitor {
     let complexity =
       Math.max(
         under ? this.getComplexity(under) : 0,
-        over ? this.getComplexity(over) : 0
+        over ? this.getComplexity(over) : 0,
       ) * this.complexity.script;
     if (base) {
       complexity = Math.max(this.getComplexity(base), complexity);

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -87,7 +87,7 @@ export interface ExplorerMathItem extends HTMLMATHITEM {
  */
 export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
   BaseMathItem: B,
-  toMathML: (node: MmlNode) => string
+  toMathML: (node: MmlNode) => string,
 ): Constructor<ExplorerMathItem> & B {
   return class extends BaseMathItem {
     /**
@@ -124,7 +124,7 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
      */
     public rerender(
       document: ExplorerMathDocument,
-      start: number = STATE.RERENDER
+      start: number = STATE.RERENDER,
     ) {
       if (this.explorers) {
         let speech = this.explorers.speech;
@@ -290,13 +290,13 @@ export function ExplorerMathDocumentMixin<
  */
 export function ExplorerHandler(
   handler: HANDLER,
-  MmlJax: MATHML = null
+  MmlJax: MATHML = null,
 ): HANDLER {
   if (!handler.documentClass.prototype.enrich && MmlJax) {
     handler = EnrichHandler(handler, MmlJax);
   }
   handler.documentClass = ExplorerMathDocumentMixin(
-    handler.documentClass as any
+    handler.documentClass as any,
   );
   return handler;
 }
@@ -312,7 +312,7 @@ export function ExplorerHandler(
  */
 export function setA11yOptions(
   document: HTMLDOCUMENT,
-  options: { [key: string]: any }
+  options: { [key: string]: any },
 ) {
   let sreOptions = Sre.engineSetup() as { [name: string]: string };
   for (let key in options) {
@@ -337,7 +337,7 @@ export function setA11yOptions(
 export function setA11yOption(
   document: HTMLDOCUMENT,
   option: string,
-  value: string | boolean
+  value: string | boolean,
 ) {
   switch (option) {
     case 'speechRules':

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -100,7 +100,7 @@ let allExplorers: { [options: string]: ExplorerInit } = {
       doc.explorerRegions.brailleRegion,
       doc.explorerRegions.magnifier,
       rest[0],
-      rest[1]
+      rest[1],
     ) as SpeechExplorer;
     explorer.sound = true;
     return explorer;
@@ -117,7 +117,7 @@ let allExplorers: { [options: string]: ExplorerInit } = {
       doc.explorerRegions.magnifier,
       node,
       (x: HTMLElement) => x.hasAttribute('data-semantic-type'),
-      (x: HTMLElement) => x
+      (x: HTMLElement) => x,
     ),
   hover: (
     doc: ExplorerMathDocument,
@@ -137,7 +137,7 @@ let allExplorers: { [options: string]: ExplorerInit } = {
       doc.explorerRegions.tooltip1,
       node,
       (x: HTMLElement) => x.hasAttribute('data-semantic-type'),
-      (x: HTMLElement) => x.getAttribute('data-semantic-type')
+      (x: HTMLElement) => x.getAttribute('data-semantic-type'),
     ),
   infoRole: (
     doc: ExplorerMathDocument,
@@ -151,7 +151,7 @@ let allExplorers: { [options: string]: ExplorerInit } = {
       doc.explorerRegions.tooltip2,
       node,
       (x: HTMLElement) => x.hasAttribute('data-semantic-role'),
-      (x: HTMLElement) => x.getAttribute('data-semantic-role')
+      (x: HTMLElement) => x.getAttribute('data-semantic-role'),
     ),
   infoPrefix: (
     doc: ExplorerMathDocument,
@@ -165,7 +165,7 @@ let allExplorers: { [options: string]: ExplorerInit } = {
       doc.explorerRegions.tooltip3,
       node,
       (x: HTMLElement) => x.hasAttribute('data-semantic-prefix'),
-      (x: HTMLElement) => x.getAttribute('data-semantic-prefix')
+      (x: HTMLElement) => x.getAttribute('data-semantic-prefix'),
     ),
   flame: (
     doc: ExplorerMathDocument,
@@ -256,7 +256,7 @@ export class ExplorerPool {
     document: ExplorerMathDocument,
     node: HTMLElement,
     mml: string,
-    item: ExplorerMathItem
+    item: ExplorerMathItem,
   ) {
     this.document = document;
     this.mml = mml;
@@ -268,7 +268,7 @@ export class ExplorerPool {
         this,
         this.node,
         this.mml,
-        item
+        item,
       );
     }
     this.setSecondaryHighlighter();
@@ -295,7 +295,7 @@ export class ExplorerPool {
         keyExplorers.unshift(explorer);
         if (
           this.speechExplorerKeys.some(
-            (exKey) => this.document.options.a11y[exKey]
+            (exKey) => this.document.options.a11y[exKey],
           )
         ) {
           explorer.Attach();
@@ -367,7 +367,7 @@ export class ExplorerPool {
     this.secondaryHighlighter = Sre.getHighlighter(
       { color: 'red' },
       { color: 'black' },
-      { renderer: this.document.outputJax.name, browser: 'v3' }
+      { renderer: this.document.outputJax.name, browser: 'v3' },
     );
     (this.speech.region as SpeechRegion).highlighter =
       this.secondaryHighlighter;

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -438,7 +438,7 @@ export class SpeechExplorer
     public brailleRegion: LiveRegion,
     public magnifyRegion: HoverRegion,
     _mml: MmlNode,
-    public item: ExplorerMathItem
+    public item: ExplorerMathItem,
   ) {
     super(document, pool, null, node);
   }
@@ -461,20 +461,20 @@ export class SpeechExplorer
       // node or we assume that it is inside the collapsed expression tree and
       // focus on the collapsed element.
       this.current = this.node.querySelector(
-        `[data-semantic-id="${this.restarted}"]`
+        `[data-semantic-id="${this.restarted}"]`,
       );
       if (!this.current) {
         const dummies = Array.from(
-          this.node.querySelectorAll('[data-semantic-type="dummy"]')
+          this.node.querySelectorAll('[data-semantic-type="dummy"]'),
         ).map((x) => x.getAttribute('data-semantic-id'));
         let internal = this.generators.element.querySelector(
-          `[data-semantic-id="${this.restarted}"]`
+          `[data-semantic-id="${this.restarted}"]`,
         );
         while (internal && internal !== this.generators.element) {
           let sid = internal.getAttribute('data-semantic-id');
           if (dummies.indexOf(sid) !== -1) {
             this.current = this.node.querySelector(
-              `[data-semantic-id="${sid}"]`
+              `[data-semantic-id="${sid}"]`,
             );
             break;
           }
@@ -525,7 +525,7 @@ export class SpeechExplorer
     this.generators.updateRegions(
       this.current,
       this.region,
-      this.brailleRegion
+      this.brailleRegion,
     );
     this.magnifyRegion.Update(this.current);
   }
@@ -535,7 +535,7 @@ export class SpeechExplorer
    */
   public Speech() {
     this.item.outputData.speech = this.generators.updateSpeech(
-      this.item.typesetRoot
+      this.item.typesetRoot,
     );
   }
 
@@ -660,7 +660,7 @@ export class SpeechExplorer
     const stree = this.generators.speechGenerator.getRebuilt()?.stree;
     if (!stree) return null;
     const snode = stree.root.querySelectorAll(
-      (x: any) => x.id.toString() === id
+      (x: any) => x.id.toString() === id,
     )[0];
     return snode || stree.root;
   }

--- a/ts/a11y/explorer/MouseExplorer.ts
+++ b/ts/a11y/explorer/MouseExplorer.ts
@@ -104,7 +104,7 @@ export abstract class Hoverer<T> extends AbstractMouseExplorer<T> {
     public region: Region<T>,
     protected node: HTMLElement,
     protected nodeQuery: (node: HTMLElement) => boolean,
-    protected nodeAccess: (node: HTMLElement) => T
+    protected nodeAccess: (node: HTMLElement) => T,
   ) {
     super(document, pool, region, node);
   }
@@ -194,7 +194,7 @@ export class FlameHoverer extends Hoverer<void> {
     public document: A11yDocument,
     public pool: ExplorerPool,
     _ignore: any,
-    protected node: HTMLElement
+    protected node: HTMLElement,
   ) {
     super(
       document,
@@ -202,7 +202,7 @@ export class FlameHoverer extends Hoverer<void> {
       new DummyRegion(document),
       node,
       (x) => this.highlighter.isMactionNode(x),
-      () => {}
+      () => {},
     );
   }
 }

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -193,14 +193,14 @@ export abstract class AbstractRegion<T> implements Region<T> {
     let baseBottom = 0;
     let baseLeft = Number.POSITIVE_INFINITY;
     let regions = this.document.adaptor.document.getElementsByClassName(
-      this.CLASS.className + '_Show'
+      this.CLASS.className + '_Show',
     );
     // Get all the shown regions (one is this element!) and append at bottom.
     for (let i = 0, region; (region = regions[i]); i++) {
       if (region !== this.div) {
         baseBottom = Math.max(
           region.getBoundingClientRect().bottom,
-          baseBottom
+          baseBottom,
         );
         baseLeft = Math.min(region.getBoundingClientRect().left, baseLeft);
       }
@@ -382,7 +382,7 @@ export class SpeechRegion extends LiveRegion {
   public highlighter: Sre.highlighter = Sre.getHighlighter(
     { color: 'red' },
     { color: 'black' },
-    { renderer: this.document.outputJax.name, browser: 'v3' }
+    { renderer: this.document.outputJax.name, browser: 'v3' },
   );
 
   /**
@@ -407,7 +407,7 @@ export class SpeechRegion extends LiveRegion {
       return;
     }
     speechSynthesis.onvoiceschanged = (() => (this.voiceRequest = true)).bind(
-      this
+      this,
     );
     super.Update('\u00a0'); // Ensures region shown and cannot be overwritten.
     const promise = new Promise((resolve) => {
@@ -435,7 +435,7 @@ export class SpeechRegion extends LiveRegion {
     let [text, ssml] = buildSpeech(
       speech,
       this.document.options.sre.locale,
-      this.document.options.sre.rate
+      this.document.options.sre.rate,
     );
     super.Update(text);
     if (this.active && text) {
@@ -501,7 +501,7 @@ export class SpeechRegion extends LiveRegion {
   private highlightNode(id: string, init: boolean = false) {
     this.highlighter.unhighlight();
     let nodes = Array.from(
-      this.node.querySelectorAll(`[data-semantic-id="${id}"]`)
+      this.node.querySelectorAll(`[data-semantic-id="${id}"]`),
     );
     if (!this.clear || init) {
       this.highlighter.highlight(nodes as HTMLElement[]);
@@ -645,14 +645,14 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
         if (mjx.nodeName === 'svg') {
           (mjx.firstChild as HTMLElement).setAttribute(
             'transform',
-            'matrix(1 0 0 -1 0 0)'
+            'matrix(1 0 0 -1 0 0)',
           );
           const W = parseFloat(mjx.getAttribute('viewBox').split(/ /)[2]);
           const w = parseFloat(mjx.getAttribute('width'));
           const { x, y, width, height } = (node as any).getBBox();
           mjx.setAttribute(
             'viewBox',
-            [x, -(y + height), width, height].join(' ')
+            [x, -(y + height), width, height].join(' '),
           );
           mjx.removeAttribute('style');
           mjx.setAttribute('width', (w / W) * width + 'ex');

--- a/ts/a11y/explorer/TreeExplorer.ts
+++ b/ts/a11y/explorer/TreeExplorer.ts
@@ -38,7 +38,7 @@ export class AbstractTreeExplorer extends AbstractExplorer<void> {
     public pool: ExplorerPool,
     public region: Region<void>,
     protected node: HTMLElement,
-    protected mml: HTMLElement
+    protected mml: HTMLElement,
   ) {
     super(document, pool, null, node);
   }

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -160,7 +160,7 @@ export function EnrichedMathItemMixin<
 >(
   BaseMathItem: B,
   MmlJax: MathML<N, T, D>,
-  toMathML: (node: MmlNode, math: MathItem<N, T, D>) => string
+  toMathML: (node: MmlNode, math: MathItem<N, T, D>) => string,
 ): Constructor<EnrichedMathItem<N, T, D>> & B {
   return class extends BaseMathItem {
     /**
@@ -255,7 +255,7 @@ export function EnrichedMathItemMixin<
       return mml.replace(
         /(data-maction-id="(\d+)" selection=)"\d+"/g,
         (_match: string, prefix: string, id: number) =>
-          `${prefix}"${maction[id].attributes.get('selection')}"`
+          `${prefix}"${maction[id].attributes.get('selection')}"`,
       );
     }
 
@@ -270,7 +270,7 @@ export function EnrichedMathItemMixin<
       let speech = attributes.get('aria-label') as string;
       if (!speech) {
         speech = buildSpeech(
-          (attributes.get('data-semantic-speech') as string) || ''
+          (attributes.get('data-semantic-speech') as string) || '',
         )[0];
       }
       let braille = (attributes.get('aria-braillelabel') ||
@@ -298,7 +298,7 @@ export function EnrichedMathItemMixin<
         try {
           [newSpeech, newBraille] = this.generatorPool.computeSpeech(
             this.typesetRoot,
-            this.toMathML(this.root, this)
+            this.toMathML(this.root, this),
           );
           if (newSpeech) {
             newSpeech = buildSpeech(newSpeech)[0];
@@ -362,7 +362,7 @@ export interface EnrichedMathDocument<N, T, D>
   enrichError(
     doc: EnrichedMathDocument<N, T, D>,
     math: EnrichedMathItem<N, T, D>,
-    err: Error
+    err: Error,
   ): void;
 
   /**
@@ -373,7 +373,7 @@ export interface EnrichedMathDocument<N, T, D>
   speechError(
     doc: EnrichedMathDocument<N, T, D>,
     math: EnrichedMathItem<N, T, D>,
-    err: Error
+    err: Error,
   ): void;
 }
 
@@ -396,7 +396,7 @@ export function EnrichedMathDocumentMixin<
   B extends MathDocumentConstructor<AbstractMathDocument<N, T, D>>,
 >(
   BaseDocument: B,
-  MmlJax: MathML<N, T, D>
+  MmlJax: MathML<N, T, D>,
 ): MathDocumentConstructor<EnrichedMathDocument<N, T, D>> & B {
   return class extends BaseDocument {
     /**
@@ -410,12 +410,12 @@ export function EnrichedMathDocumentMixin<
       enrichError: (
         doc: EnrichedMathDocument<N, T, D>,
         math: EnrichedMathItem<N, T, D>,
-        err: Error
+        err: Error,
       ) => doc.enrichError(doc, math, err),
       speechError: (
         doc: EnrichedMathDocument<N, T, D>,
         math: EnrichedMathItem<N, T, D>,
-        err: Error
+        err: Error,
       ) => doc.speechError(doc, math, err),
       renderActions: expandable({
         ...BaseDocument.OPTIONS.renderActions,
@@ -530,11 +530,11 @@ export function EnrichedMathDocumentMixin<
       this.renderPromises.push(
         new Promise<void>((ok, _fail) => {
           this.attachSpeechDone = ok;
-        })
+        }),
       );
       this.speechTimeout = setTimeout(
         () => this.attachSpeechLoop(),
-        this.options.speechTiming.initial
+        this.options.speechTiming.initial,
       );
     }
 
@@ -553,7 +553,7 @@ export function EnrichedMathDocumentMixin<
       if (awaitingSpeech.length) {
         this.speechTimeout = setTimeout(
           () => this.attachSpeechLoop(),
-          timing.intermediate
+          timing.intermediate,
         );
       } else {
         this.speechTimeout = 0;
@@ -581,7 +581,7 @@ export function EnrichedMathDocumentMixin<
     public enrichError(
       _doc: EnrichedMathDocument<N, T, D>,
       _math: EnrichedMathItem<N, T, D>,
-      err: Error
+      err: Error,
     ) {
       console.warn('Enrichment error:', err);
     }
@@ -591,7 +591,7 @@ export function EnrichedMathDocumentMixin<
     public speechError(
       _doc: EnrichedMathDocument<N, T, D>,
       _math: EnrichedMathItem<N, T, D>,
-      err: Error
+      err: Error,
     ) {
       console.warn('Speech generation error:', err);
     }
@@ -632,7 +632,7 @@ export function EnrichedMathDocumentMixin<
  */
 export function EnrichHandler<N, T, D>(
   handler: Handler<N, T, D>,
-  MmlJax: MathML<N, T, D>
+  MmlJax: MathML<N, T, D>,
 ): Handler<N, T, D> {
   MmlJax.setAdaptor(handler.adaptor);
   handler.documentClass = EnrichedMathDocumentMixin<

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -85,14 +85,14 @@ export class GeneratorPool<N, T, D> {
         modality: 'speech',
         markup: 'ssml',
         automark: true,
-      })
+      }),
     );
     this.summaryGenerator.setOptions(
       Object.assign({}, options?.sre || {}, {
         modality: 'summary',
         markup: 'ssml',
         automark: true,
-      })
+      }),
     );
     this.brailleGenerator.setOptions({
       locale: options?.sre?.braille,
@@ -203,7 +203,7 @@ export class GeneratorPool<N, T, D> {
       this.adaptor.setAttribute(
         node,
         'aria-label',
-        buildSpeech(this.getLabel(node))[0]
+        buildSpeech(this.getLabel(node))[0],
       );
     }
     this.lastMove = InPlace.NONE;
@@ -245,7 +245,7 @@ export class GeneratorPool<N, T, D> {
   public updateRegions(
     node: N,
     speechRegion: LiveRegion,
-    brailleRegion: LiveRegion
+    brailleRegion: LiveRegion,
   ) {
     let speech = this.getLabel(node, this.lastSpeech);
     speechRegion.Update(speech);
@@ -285,7 +285,7 @@ export class GeneratorPool<N, T, D> {
    */
   public nextStyle(node: N) {
     this.speechGenerator.nextStyle(
-      this.adaptor.getAttribute(node, 'data-semantic-id')
+      this.adaptor.getAttribute(node, 'data-semantic-id'),
     );
     this.updateSummaryGenerator();
   }
@@ -326,7 +326,7 @@ export class GeneratorPool<N, T, D> {
       this.adaptor.getAttribute(node, 'data-semantic-prefix'),
       // TODO: check if we need this or if it is automatic by the screen readers.
       this.adaptor.getAttribute(node, 'data-semantic-postfix'),
-      sep
+      sep,
     );
   }
 
@@ -383,7 +383,7 @@ export class GeneratorPool<N, T, D> {
         this.adaptor.setAttribute(
           node,
           'aria-label',
-          buildSpeech(speech, locale)[0]
+          buildSpeech(speech, locale)[0],
         );
       }
     }
@@ -410,10 +410,10 @@ export class GeneratorPool<N, T, D> {
       return this.lastSpeech;
     }
     let postfix = this.summaryGenerator.getActionable(
-      actionable ? (this.adaptor.childNodes(node).length === 0 ? -1 : 1) : 0
+      actionable ? (this.adaptor.childNodes(node).length === 0 ? -1 : 1) : 0,
     );
     const depth = this.summaryGenerator.getLevel(
-      this.adaptor.getAttribute(node, 'aria-level')
+      this.adaptor.getAttribute(node, 'aria-level'),
     );
     this.lastSpeech = `${depth} ${postfix}`;
     return this.lastSpeech;

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -49,14 +49,14 @@ function csPrefsVariables(menu: MJContextMenu, prefs: string[]) {
           csPrefsSetting[pref] = value;
           srVariable.setValue(
             'clearspeak-' +
-              Sre.clearspeakPreferences.toPreference(csPrefsSetting)
+              Sre.clearspeakPreferences.toPreference(csPrefsSetting),
           );
         },
         getter: () => {
           return csPrefsSetting[pref] || 'Auto';
         },
       },
-      menu.pool
+      menu.pool,
     );
   }
 }
@@ -94,7 +94,7 @@ function csSelectionBox(menu: MJContextMenu, locale: string) {
       grid: 'square',
       selections: items,
     },
-    menu
+    menu,
   );
   return {
     type: 'command',
@@ -174,7 +174,7 @@ function smartPreferences(previous: string, smart: string, locale: string) {
           );
         },
       };
-    })
+    }),
   );
 }
 
@@ -206,7 +206,7 @@ export function clearspeakMenu(menu: MJContextMenu, sub: Submenu) {
       items: items,
       id: 'Clearspeak',
     },
-    sub
+    sub,
   );
 }
 MJContextMenu.DynamicSubmenus.set('Clearspeak', [clearspeakMenu, 'speech']);
@@ -243,7 +243,7 @@ export function localeMenu(menu: MJContextMenu, sub: Submenu) {
       items: radios,
       id: 'Language',
     },
-    sub
+    sub,
   );
   return LOCALE_MENU;
 }

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -68,7 +68,7 @@ function recurseSsml(
   nodes: Node[],
   instr: SsmlElement[],
   text: String[],
-  prosody: ProsodyElement = {}
+  prosody: ProsodyElement = {},
 ) {
   for (let node of nodes) {
     if (node.nodeType === 3) {
@@ -90,7 +90,7 @@ function recurseSsml(
           Array.from(node.childNodes),
           instr,
           text,
-          getProsody(element, prosody)
+          getProsody(element, prosody),
         );
         continue;
       }
@@ -179,7 +179,7 @@ export function buildLabel(
   speech: string,
   prefix: string,
   postfix: string,
-  sep: string = ' '
+  sep: string = ' ',
 ) {
   if (!speech) {
     return '';
@@ -206,14 +206,14 @@ export function buildLabel(
 export function buildSpeech(
   speech: string,
   locale: string = 'en',
-  rate: string = '100'
+  rate: string = '100',
 ): [string, SsmlElement[]] {
   return ssmlParsing(
     '<?xml version="1.0"?><speak version="1.1"' +
       ' xmlns="http://www.w3.org/2001/10/synthesis"' +
       ` xml:lang="${locale}">` +
       `<prosody rate="${rate}%">${speech}` +
-      '</prosody></speak>'
+      '</prosody></speak>',
   );
 }
 

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -85,7 +85,7 @@ export interface MinHTMLElement<N, T> {
   getElementsByTagName(name: string): N[] | HTMLCollectionOf<Element>;
   getElementsByTagNameNS(
     ns: string,
-    name: string
+    name: string,
   ): N[] | HTMLCollectionOf<Element>;
   contains(child: N | T): boolean;
   appendChild(child: N | T): N | T | Node;
@@ -290,7 +290,7 @@ export class HTMLAdaptor<
     for (const node of nodes) {
       if (typeof node === 'string') {
         containers = containers.concat(
-          Array.from(this.document.querySelectorAll(node))
+          Array.from(this.document.querySelectorAll(node)),
         );
       } else if (Array.isArray(node)) {
         containers = containers.concat(Array.from(node) as N[]);

--- a/ts/adaptors/NodeMixin.ts
+++ b/ts/adaptors/NodeMixin.ts
@@ -54,7 +54,7 @@ export const NodeMixinOptions: OptionList = {
  */
 export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
   Base: A,
-  options: typeof NodeMixinOptions = {}
+  options: typeof NodeMixinOptions = {},
 ): A {
   options = userOptions(defaultOptions({}, NodeMixinOptions), options);
 
@@ -98,7 +98,7 @@ export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
         '\u{20000}-\u{3FFFD}', // CJK Unified Ideographs Extension B ... Tertiary Ideographic Plane
         ']',
       ].join(''),
-      'gu'
+      'gu',
     );
 
     /**

--- a/ts/adaptors/jsdomAdaptor.ts
+++ b/ts/adaptors/jsdomAdaptor.ts
@@ -50,7 +50,7 @@ export class JsdomAdaptor extends NodeMixin<
  */
 export function jsdomAdaptor(
   JSDOM: any,
-  options: OptionList = null
+  options: OptionList = null,
 ): JsdomAdaptor {
   return new JsdomAdaptor(new JSDOM().window, options);
 }

--- a/ts/adaptors/linkedomAdaptor.ts
+++ b/ts/adaptors/linkedomAdaptor.ts
@@ -71,7 +71,7 @@ export class LinkedomAdaptor extends NodeMixin<
  */
 export function linkedomAdaptor(
   parseHTML: any,
-  options: OptionList = null
+  options: OptionList = null,
 ): LinkedomAdaptor {
   const window = parseHTML('<html></html>');
   //

--- a/ts/adaptors/lite/Element.ts
+++ b/ts/adaptors/lite/Element.ts
@@ -74,7 +74,7 @@ export class LiteElement {
   constructor(
     kind: string,
     attributes: LiteAttributeList = {},
-    children: LiteNode[] = []
+    children: LiteNode[] = [],
   ) {
     this.kind = kind;
     this.attributes = { ...attributes };

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -119,7 +119,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   public parseFromString(
     text: string,
     _format: string = 'text/html',
-    adaptor: LiteAdaptor = null
+    adaptor: LiteAdaptor = null,
   ) {
     const root = adaptor.createDocument();
     let node = adaptor.body(root);
@@ -157,7 +157,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   protected addText(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    text: string
+    text: string,
   ): LiteText {
     text = Entities.translate(text);
     return adaptor.append(node, adaptor.text(text)) as LiteText;
@@ -172,7 +172,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   protected addComment(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    comment: string
+    comment: string,
   ): LiteComment {
     return adaptor.append(node, new LiteComment(comment)) as LiteComment;
   }
@@ -186,7 +186,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   protected closeTag(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    tag: string
+    tag: string,
   ): LiteElement {
     const kind = tag.slice(2, tag.length - 1).toLowerCase();
     while (adaptor.parent(node) && adaptor.kind(node) !== kind) {
@@ -206,7 +206,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     adaptor: LiteAdaptor,
     node: LiteElement,
     tag: string,
-    parts: string[]
+    parts: string[],
   ): LiteElement {
     const PCDATA = (this.constructor as typeof LiteParser).PCDATA;
     const SELF_CLOSING = (this.constructor as typeof LiteParser).SELF_CLOSING;
@@ -257,7 +257,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   protected addAttributes(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    attributes: string[]
+    attributes: string[],
   ) {
     while (attributes.length) {
       let [, name, v1, v2, v3] = attributes.splice(0, 5);
@@ -276,7 +276,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     adaptor: LiteAdaptor,
     node: LiteElement,
     kind: string,
-    parts: string[]
+    parts: string[],
   ) {
     const pcdata = [] as string[];
     const etag = '</' + kind + '>';
@@ -382,7 +382,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   public serialize(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    xml: boolean = false
+    xml: boolean = false,
   ): string {
     const SELF_CLOSING = (this.constructor as typeof LiteParser).SELF_CLOSING;
     const tag = adaptor.kind(node);
@@ -411,7 +411,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   public serializeInner(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    xml: boolean = false
+    xml: boolean = false,
   ): string {
     const PCDATA = (this.constructor as typeof LiteParser).PCDATA;
     if (PCDATA.hasOwnProperty(node.kind)) {
@@ -442,7 +442,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
   protected allAttributes(
     adaptor: LiteAdaptor,
     node: LiteElement,
-    xml: boolean
+    xml: boolean,
   ): AttributeData[] {
     let attributes = adaptor.allAttributes(node);
     //

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -210,7 +210,7 @@ export class LiteBase extends AbstractDOMAdaptor<
    */
   public getElements(
     nodes: (string | LiteElement | LiteElement[])[],
-    document: LiteDocument
+    document: LiteDocument,
   ) {
     let containers = [] as LiteElement[];
     const body = this.body(document);
@@ -223,7 +223,7 @@ export class LiteBase extends AbstractDOMAdaptor<
           }
         } else if (node.charAt(0) === '.') {
           containers = containers.concat(
-            this.elementsByClass(body, node.slice(1))
+            this.elementsByClass(body, node.slice(1)),
           );
         } else if (node.match(/^[-a-z][-a-z0-9]*$/i)) {
           containers = containers.concat(this.tags(body, node));
@@ -461,7 +461,7 @@ export class LiteBase extends AbstractDOMAdaptor<
     node: LiteElement,
     name: string,
     value: string | number,
-    ns: string = null
+    ns: string = null,
   ) {
     if (typeof value !== 'string') {
       value = String(value);

--- a/ts/components/latest.ts
+++ b/ts/components/latest.ts
@@ -163,7 +163,7 @@ function Error(message: string) {
  */
 function scriptData(
   script: HTMLScriptElement,
-  cdn: CdnData = null
+  cdn: CdnData = null,
 ): ScriptData {
   script.parentNode.removeChild(script);
   let src = script.src;
@@ -310,7 +310,7 @@ function loadVersion(version: string) {
   }
   loadMathJax(
     script.cdn.base + version + script.dir + '/' + script.file,
-    script.id
+    script.id,
   );
 }
 
@@ -364,7 +364,7 @@ function getXMLHttpRequest(): XMLHttpRequest {
 function requestXML(
   cdn: CdnData,
   action: (json: JSON | JSON[]) => boolean,
-  failure: () => void
+  failure: () => void,
 ) {
   const request = getXMLHttpRequest();
   if (request) {
@@ -375,7 +375,7 @@ function requestXML(
           !action(JSON.parse(request.responseText)) && failure();
         } else {
           Error(
-            'Problem acquiring MathJax version: status = ' + request.status
+            'Problem acquiring MathJax version: status = ' + request.status,
           );
           failure();
         }
@@ -406,7 +406,7 @@ function loadLatestGitVersion() {
       }
       return false;
     },
-    loadDefaultMathJax
+    loadDefaultMathJax,
   );
 }
 
@@ -429,7 +429,7 @@ function loadLatestCdnVersion() {
       }
       return true;
     },
-    loadDefaultMathJax
+    loadDefaultMathJax,
   );
 }
 

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -195,10 +195,10 @@ export namespace Loader {
           if (!CONFIG.versionWarnings) return;
           if (extension.isLoaded && !versions.has(Package.resolvePath(name))) {
             console.warn(
-              `No version information available for component ${name}`
+              `No version information available for component ${name}`,
             );
           }
-        }) as Promise<null>
+        }) as Promise<null>,
       );
     }
     Package.loadAll();
@@ -281,12 +281,12 @@ export namespace Loader {
   export function checkVersion(
     name: string,
     version: string,
-    _type?: string
+    _type?: string,
   ): boolean {
     saveVersion(name);
     if (CONFIG.versionWarnings && version !== VERSION) {
       console.warn(
-        `Component ${name} uses ${version} of MathJax; version in use is ${VERSION}`
+        `Component ${name} uses ${version} of MathJax; version in use is ${VERSION}`,
       );
       return true;
     }

--- a/ts/components/mjs/root.ts
+++ b/ts/components/mjs/root.ts
@@ -27,6 +27,6 @@
 export function mjxRoot(): string {
   return new URL(import.meta.url).pathname.replace(
     /[cm]js\/components\/[cm]js\/root.js$/,
-    (_) => 'bundle'
+    (_) => 'bundle',
   );
 }

--- a/ts/components/package.ts
+++ b/ts/components/package.ts
@@ -54,7 +54,7 @@ export type PackageReady = (name: string) => string | void;
 export type PackageFailed = (message: PackageError) => void;
 export type PackagePromise = (
   resolve: PackageReady,
-  reject: PackageFailed
+  reject: PackageFailed,
 ) => void;
 
 /**
@@ -160,7 +160,7 @@ export class Package {
   public static loadPromise(name: string): Promise<void> {
     const config = (CONFIG[name] || {}) as PackageConfig;
     const promise = Promise.all(
-      (config.extraLoads || []).map((name) => Loader.load(name))
+      (config.extraLoads || []).map((name) => Loader.load(name)),
     );
     const checkReady = config.checkReady || (() => Promise.resolve());
     return promise.then(() => checkReady()) as Promise<void>;
@@ -175,7 +175,7 @@ export class Package {
    */
   public static resolvePath(
     name: string,
-    addExtension: boolean = true
+    addExtension: boolean = true,
   ): string {
     const data = { name, original: name, addExtension };
     Loader.pathFilters.execute(data);
@@ -265,7 +265,7 @@ export class Package {
     const config = (CONFIG[this.name] || {}) as PackageConfig;
     if (config.ready) {
       promise = promise.then((_name: string) =>
-        config.ready(this.name)
+        config.ready(this.name),
       ) as Promise<string>;
     }
     //
@@ -276,7 +276,7 @@ export class Package {
     if (promises.length) {
       promises.push(promise);
       promise = Promise.all(promises).then((names: string[]) =>
-        names.join(', ')
+        names.join(', '),
       );
     }
     //
@@ -285,7 +285,7 @@ export class Package {
     //
     if (config.failed) {
       promise.catch((message: string) =>
-        config.failed(new PackageError(message, this.name))
+        config.failed(new PackageError(message, this.name)),
       );
     }
     //
@@ -319,7 +319,7 @@ export class Package {
         result
           .then(() => this.checkLoad())
           .catch((err) =>
-            this.failed('Can\'t load "' + url + '"\n' + err.message.trim())
+            this.failed('Can\'t load "' + url + '"\n' + err.message.trim()),
           );
       } else {
         this.checkLoad();

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -299,7 +299,7 @@ export namespace Startup {
    */
   export function extendHandler(
     extend: HandlerExtension,
-    priority: number = 10
+    priority: number = 10,
   ) {
     extensions.add(extend, priority);
   }
@@ -340,7 +340,7 @@ export namespace Startup {
       .then(
         CONFIG.typeset && MathJax.typesetPromise
           ? () => typesetPromise(CONFIG.elements)
-          : Promise.resolve()
+          : Promise.resolve(),
       )
       .then(() => promiseResolve());
   }
@@ -457,7 +457,7 @@ export namespace Startup {
   export function makeOutputMethods(
     iname: string,
     oname: string,
-    input: INPUTJAX
+    input: INPUTJAX,
   ) {
     const name = iname + '2' + oname;
     MathJax[name] = (math: string, options: OptionList = {}) => {
@@ -499,13 +499,13 @@ export namespace Startup {
     };
     MathJax[name + '2mmlPromise'] = (
       math: string,
-      options: OptionList = {}
+      options: OptionList = {},
     ) => {
       promise = promise.then(() => {
         options.end = STATE.CONVERT;
         options.format = input.name;
         return mathjax.handleRetriesFor(() =>
-          toMML(document.convert(math, options))
+          toMML(document.convert(math, options)),
         );
       });
       return promise;
@@ -536,7 +536,7 @@ export namespace Startup {
         jax.push(jax[name]);
       } else {
         throw Error(
-          'Input Jax "' + name + '" is not defined (has it been loaded?)'
+          'Input Jax "' + name + '" is not defined (has it been loaded?)',
         );
       }
     }
@@ -552,7 +552,7 @@ export namespace Startup {
     const outputClass = constructors[name];
     if (!outputClass) {
       throw Error(
-        'Output Jax "' + name + '" is not defined (has it been loaded?)'
+        'Output Jax "' + name + '" is not defined (has it been loaded?)',
       );
     }
     return new outputClass(MathJax.config[name]);
@@ -568,7 +568,7 @@ export namespace Startup {
     const adaptor = constructors[name];
     if (!adaptor) {
       throw Error(
-        'DOMAdaptor "' + name + '" is not defined (has it been loaded?)'
+        'DOMAdaptor "' + name + '" is not defined (has it been loaded?)',
       );
     }
     return adaptor(MathJax.config[name]);
@@ -583,7 +583,7 @@ export namespace Startup {
     const handlerClass = constructors[name];
     if (!handlerClass) {
       throw Error(
-        'Handler "' + name + '" is not defined (has it been loaded?)'
+        'Handler "' + name + '" is not defined (has it been loaded?)',
       );
     }
     let handler = new handlerClass(adaptor, 5);

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -261,7 +261,7 @@ export interface DOMAdaptor<N, T, D> {
     node: N,
     name: string,
     value: string | number,
-    ns?: string
+    ns?: string,
   ): void;
 
   /**
@@ -421,7 +421,7 @@ export abstract class AbstractDOMAdaptor<N, T, D>
     kind: string,
     def: OptionList = {},
     children: (N | T)[] = [],
-    ns?: string
+    ns?: string,
   ) {
     const node = this.create(kind, ns);
     this.setAttributes(node, def);
@@ -453,7 +453,7 @@ export abstract class AbstractDOMAdaptor<N, T, D>
         this.setStyle(
           node,
           key.replace(/-([a-z])/g, (_m, c) => c.toUpperCase()),
-          def.style[key]
+          def.style[key],
         );
       }
     }
@@ -615,7 +615,7 @@ export abstract class AbstractDOMAdaptor<N, T, D>
     node: N,
     name: string,
     value: string,
-    ns?: string
+    ns?: string,
   ): void;
 
   /**
@@ -710,7 +710,7 @@ export abstract class AbstractDOMAdaptor<N, T, D>
   public abstract nodeSize(
     node: N,
     em?: number,
-    local?: boolean
+    local?: boolean,
   ): [number, number];
 
   /**

--- a/ts/core/Handler.ts
+++ b/ts/core/Handler.ts
@@ -150,7 +150,7 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
     return new this.documentClass(
       document,
       this.adaptor,
-      options
+      options,
     ) as MathDocument<N, T, D>;
   }
 }

--- a/ts/core/HandlerList.ts
+++ b/ts/core/HandlerList.ts
@@ -75,7 +75,7 @@ export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>> {
    */
   public document(
     document: any,
-    options: OptionList = null
+    options: OptionList = null,
   ): MathDocument<N, T, D> {
     return this.handlesDocument(document).create(document, options);
   }

--- a/ts/core/InputJax.ts
+++ b/ts/core/InputJax.ts
@@ -217,7 +217,7 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
    */
   public abstract compile(
     math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>
+    document: MathDocument<N, T, D>,
   ): MmlNode;
 
   /**
@@ -234,7 +234,7 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
     filters: FunctionList,
     math: MathItem<N, T, D>,
     document: MathDocument<N, T, D>,
-    data: any
+    data: any,
   ): any {
     let args = { math: math, document: document, data: data };
     filters.execute(args);

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -57,7 +57,7 @@ export type RenderDoc<N, T, D> = (document: MathDocument<N, T, D>) => boolean;
  */
 export type RenderMath<N, T, D> = (
   math: MathItem<N, T, D>,
-  document: MathDocument<N, T, D>
+  document: MathDocument<N, T, D>,
 ) => boolean;
 
 /**
@@ -121,7 +121,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @returns {RenderList}    The newly created prioritied list
    */
   public static create<N, T, D>(
-    actions: RenderActions<N, T, D>
+    actions: RenderActions<N, T, D>,
   ): RenderList<N, T, D> {
     const list = new this<N, T, D>();
     for (const id of Object.keys(actions)) {
@@ -143,7 +143,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    */
   public static action<N, T, D>(
     id: string,
-    action: RenderAction<N, T, D>
+    action: RenderAction<N, T, D>,
   ): [RenderData<N, T, D>, number] {
     let renderDoc, renderMath;
     let convert = true;
@@ -201,7 +201,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    */
   public renderDoc(
     document: MathDocument<N, T, D>,
-    start: number = STATE.UNPROCESSED
+    start: number = STATE.UNPROCESSED,
   ) {
     for (const item of this.items) {
       if (item.priority >= start) {
@@ -220,7 +220,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
   public renderMath(
     math: MathItem<N, T, D>,
     document: MathDocument<N, T, D>,
-    start: number = STATE.UNPROCESSED
+    start: number = STATE.UNPROCESSED,
   ) {
     for (const item of this.items) {
       if (item.priority >= start) {
@@ -239,7 +239,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
   public renderConvert(
     math: MathItem<N, T, D>,
     document: MathDocument<N, T, D>,
-    end: number = STATE.LAST
+    end: number = STATE.LAST,
   ) {
     for (const item of this.items) {
       if (item.priority > end) return;
@@ -551,7 +551,7 @@ class DefaultOutputJax<N, T, D> extends AbstractOutputJax<N, T, D> {
    */
   public typeset(
     _math: MathItem<N, T, D>,
-    _document: MathDocument<N, T, D> = null
+    _document: MathDocument<N, T, D> = null,
   ) {
     return null as N;
   }
@@ -609,14 +609,14 @@ export abstract class AbstractMathDocument<N, T, D>
     compileError: (
       doc: AbstractMathDocument<any, any, any>,
       math: MathItem<any, any, any>,
-      err: Error
+      err: Error,
     ) => {
       doc.compileError(math, err);
     },
     typesetError: (
       doc: AbstractMathDocument<any, any, any>,
       math: MathItem<any, any, any>,
-      err: Error
+      err: Error,
     ) => {
       doc.typesetError(math, err);
     },
@@ -637,7 +637,7 @@ export abstract class AbstractMathDocument<N, T, D>
     'compile',
     'getMetrics',
     'typeset',
-    'updateDocument'
+    'updateDocument',
   );
 
   /**
@@ -701,7 +701,7 @@ export abstract class AbstractMathDocument<N, T, D>
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
     this.math = new (this.options['MathList'] || DefaultMathList)();
     this.renderActions = RenderList.create<N, T, D>(
-      this.options['renderActions']
+      this.options['renderActions'],
     );
     this.renderPromises = [];
     this.processed = new AbstractMathDocument.ProcessBits();
@@ -743,7 +743,7 @@ export abstract class AbstractMathDocument<N, T, D>
   public addRenderAction(id: string, ...action: any[]) {
     const [fn, p] = RenderList.action<N, T, D>(
       id,
-      action as RenderAction<N, T, D>
+      action as RenderAction<N, T, D>,
     );
     this.renderActions.add(fn, p);
   }
@@ -792,14 +792,14 @@ export abstract class AbstractMathDocument<N, T, D>
           scale: 1,
           family: '',
         },
-        options
+        options,
       );
     if (containerWidth === null) {
       containerWidth = 80 * ex;
     }
     const jax = this.inputJax.reduce(
       (jax, ijax) => (ijax.name === format ? ijax : jax),
-      null
+      null,
     );
     const mitem = new this.options.MathItem(math, jax, display);
     mitem.start.node = this.adaptor.body(this.document);
@@ -881,10 +881,10 @@ export abstract class AbstractMathDocument<N, T, D>
         [
           this.mmlFactory.create('mtext', null, [
             (this.mmlFactory.create('text') as TextNode).setText(
-              'Math input error'
+              'Math input error',
             ),
           ]),
-        ]
+        ],
       ),
     ]);
     if (math.display) {
@@ -939,9 +939,9 @@ export abstract class AbstractMathDocument<N, T, D>
               'line-height': 'normal',
             },
           },
-          [this.adaptor.text('Math output error')]
+          [this.adaptor.text('Math output error')],
         ),
-      ]
+      ],
     );
     if (math.display) {
       this.adaptor.setAttributes(math.typesetRoot, {

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -238,7 +238,7 @@ export function protoItem<N, T>(
   n: number,
   start: number,
   end: number,
-  display: boolean = null
+  display: boolean = null,
 ) {
   let item: ProtoItem<N, T> = {
     open: open,
@@ -335,7 +335,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
     jax: InputJax<N, T, D>,
     display: boolean = true,
     start: Location<N, T> = { i: 0, n: 0, delim: '' },
-    end: Location<N, T> = { i: 0, n: 0, delim: '' }
+    end: Location<N, T> = { i: 0, n: 0, delim: '' },
   ) {
     this.math = math;
     this.inputJax = jax;
@@ -361,7 +361,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
    */
   public rerender(
     document: MathDocument<N, T, D>,
-    start: number = STATE.RERENDER
+    start: number = STATE.RERENDER,
   ) {
     if (this.state() >= start) {
       this.state(start - 1);

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -242,7 +242,7 @@ export interface MmlNode extends Node<MmlNode, MmlNodeClass> {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ): void;
 
   /**
@@ -295,7 +295,7 @@ export interface MmlNodeClass extends NodeClass<MmlNode, MmlNodeClass> {
   new (
     factory: MmlFactory,
     attributes?: PropertyList,
-    children?: MmlNode[]
+    children?: MmlNode[],
   ): MmlNode;
 }
 
@@ -439,7 +439,7 @@ export abstract class AbstractMmlNode
   constructor(
     factory: MmlFactory,
     attributes: PropertyList = {},
-    children: MmlNode[] = []
+    children: MmlNode[] = [],
   ) {
     super(factory);
     if (this.arity < 0) {
@@ -449,7 +449,7 @@ export abstract class AbstractMmlNode
     this.setChildren(children);
     this.attributes = new Attributes(
       factory.getNodeClass(this.kind).defaults,
-      factory.getNodeClass('math').defaults
+      factory.getNodeClass('math').defaults,
     );
     this.attributes.setList(attributes);
   }
@@ -751,7 +751,7 @@ export abstract class AbstractMmlNode
     attributes: AttributeList = {},
     display: boolean = false,
     level: number = 0,
-    prime: boolean = false
+    prime: boolean = false,
   ) {
     let defaults = this.attributes.getAllDefaults();
     for (const key of Object.keys(attributes)) {
@@ -831,7 +831,7 @@ export abstract class AbstractMmlNode
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     for (const child of this.childNodes) {
       child.setInheritedAttributes(attributes, display, level, prime);
@@ -846,7 +846,7 @@ export abstract class AbstractMmlNode
    */
   protected addInheritedAttributes(
     current: AttributeList,
-    attributes: PropertyList
+    attributes: PropertyList,
   ) {
     let updated: AttributeList = { ...current };
     for (const name of Object.keys(attributes)) {
@@ -902,7 +902,7 @@ export abstract class AbstractMmlNode
         this.mError(
           'Wrong number of children for "' + this.kind + '" node',
           options,
-          true
+          true,
         );
       }
     }
@@ -932,7 +932,7 @@ export abstract class AbstractMmlNode
       if (bad.length) {
         this.mError(
           'Unknown attributes for ' + this.kind + ' node: ' + bad.join(', '),
-          options
+          options,
         );
       }
     }
@@ -970,7 +970,7 @@ export abstract class AbstractMmlNode
   public mError(
     message: string,
     options: PropertyList,
-    short: boolean = false
+    short: boolean = false,
   ): MmlNode {
     if (this.parent && this.parent.isKind('merror')) {
       return null;
@@ -1042,7 +1042,7 @@ export abstract class AbstractMmlTokenNode extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     for (const child of this.childNodes) {
       if (child instanceof AbstractMmlNode) {
@@ -1359,7 +1359,7 @@ export abstract class AbstractMmlEmptyNode
     _attributes: AttributeList,
     _display: boolean,
     _level: number,
-    _prime: boolean
+    _prime: boolean,
   ) {}
 
   /**
@@ -1382,7 +1382,7 @@ export abstract class AbstractMmlEmptyNode
   public mError(
     _message: string,
     _options: PropertyList,
-    _short: boolean = false
+    _short: boolean = false,
   ) {
     return null as MmlNode;
   }
@@ -1474,7 +1474,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
    */
   public setXML(
     xml: Object,
-    adaptor: DOMAdaptor<any, any, any> = null
+    adaptor: DOMAdaptor<any, any, any> = null,
   ): XMLNode {
     this.xml = xml;
     this.adaptor = adaptor;
@@ -1493,7 +1493,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
    */
   public copy(): XMLNode {
     return (this.factory.create(this.kind) as XMLNode).setXML(
-      this.adaptor.clone(this.xml)
+      this.adaptor.clone(this.xml),
     );
   }
 

--- a/ts/core/MmlTree/MmlNodes/HtmlNode.ts
+++ b/ts/core/MmlTree/MmlNodes/HtmlNode.ts
@@ -53,7 +53,7 @@ export class HtmlNode<N> extends XMLNode {
    */
   public setHTML(
     html: N,
-    adaptor: DOMAdaptor<any, any, any> = null
+    adaptor: DOMAdaptor<any, any, any> = null,
   ): HtmlNode<N> {
     //
     // Test if the HTML element has attributes and wrap in a <span> if not

--- a/ts/core/MmlTree/MmlNodes/TeXAtom.ts
+++ b/ts/core/MmlTree/MmlNodes/TeXAtom.ts
@@ -73,7 +73,7 @@ export class TeXAtom extends AbstractMmlBaseNode {
   constructor(
     factory: MmlFactory,
     attributes: PropertyList,
-    children: MmlNode[]
+    children: MmlNode[],
   ) {
     super(factory, attributes, children);
     this.setProperty('texClass', this.texClass); // needed for serialization to include the texClass

--- a/ts/core/MmlTree/MmlNodes/maction.ts
+++ b/ts/core/MmlTree/MmlNodes/maction.ts
@@ -126,7 +126,7 @@ export class MmlMaction extends AbstractMmlNode {
   public nextToggleSelection() {
     let selection = Math.max(
       1,
-      parseInt(this.attributes.get('selection') as string) + 1
+      parseInt(this.attributes.get('selection') as string) + 1,
     );
     if (selection > this.childNodes.length) {
       selection = 1;
@@ -141,7 +141,7 @@ export class MmlMaction extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     if (
       (this.attributes.get('actiontype') as String).toLowerCase() !== 'tooltip'
@@ -153,7 +153,7 @@ export class MmlMaction extends AbstractMmlNode {
       attributes,
       display,
       level,
-      prime
+      prime,
     );
     this.childNodes[1]?.setInheritedAttributes(attributes, false, 1, false);
   }

--- a/ts/core/MmlTree/MmlNodes/maligngroup.ts
+++ b/ts/core/MmlTree/MmlNodes/maligngroup.ts
@@ -62,11 +62,11 @@ export class MmlMaligngroup extends AbstractMmlLayoutNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     attributes = this.addInheritedAttributes(
       attributes,
-      this.attributes.getAllAttributes()
+      this.attributes.getAllAttributes(),
     );
     super.setChildInheritedAttributes(attributes, display, level, prime);
   }

--- a/ts/core/MmlTree/MmlNodes/math.ts
+++ b/ts/core/MmlTree/MmlNodes/math.ts
@@ -99,14 +99,14 @@ export class MmlMath extends AbstractMmlLayoutNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     if (this.attributes.get('mode') === 'display') {
       this.attributes.setInherited('display', 'block');
     }
     attributes = this.addInheritedAttributes(
       attributes,
-      this.attributes.getAllAttributes()
+      this.attributes.getAllAttributes(),
     );
     display =
       !!this.attributes.get('displaystyle') ||

--- a/ts/core/MmlTree/MmlNodes/mathchoice.ts
+++ b/ts/core/MmlTree/MmlNodes/mathchoice.ts
@@ -73,7 +73,7 @@ export class MathChoice extends AbstractMmlBaseNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     const selection = display ? 0 : Math.max(0, Math.min(level, 2)) + 1;
     const child = this.childNodes[selection] || this.factory.create('mrow');

--- a/ts/core/MmlTree/MmlNodes/mfenced.ts
+++ b/ts/core/MmlTree/MmlNodes/mfenced.ts
@@ -110,7 +110,7 @@ export class MmlMfenced extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     this.addFakeNodes();
     for (const child of [this.open, this.close].concat(this.separators)) {
@@ -128,7 +128,7 @@ export class MmlMfenced extends AbstractMmlNode {
     let { open, close, separators } = this.attributes.getList(
       'open',
       'close',
-      'separators'
+      'separators',
     ) as { open: string; close: string; separators: string };
     open = open.replace(/[ \t\n\r]/g, '');
     close = close.replace(/[ \t\n\r]/g, '');
@@ -140,7 +140,7 @@ export class MmlMfenced extends AbstractMmlNode {
       this.open = this.fakeNode(
         open,
         { fence: true, form: 'prefix' },
-        TEXCLASS.OPEN
+        TEXCLASS.OPEN,
       );
     }
     //
@@ -164,7 +164,7 @@ export class MmlMfenced extends AbstractMmlNode {
       this.close = this.fakeNode(
         close,
         { fence: true, form: 'postfix' },
-        TEXCLASS.CLOSE
+        TEXCLASS.CLOSE,
       );
     }
   }
@@ -178,7 +178,7 @@ export class MmlMfenced extends AbstractMmlNode {
   protected fakeNode(
     c: string,
     properties: PropertyList = {},
-    texClass: number = null
+    texClass: number = null,
   ): MmlNode {
     let text = (this.factory.create('text') as TextNode).setText(c);
     let node = this.factory.create('mo', properties, [text]);

--- a/ts/core/MmlTree/MmlNodes/mfrac.ts
+++ b/ts/core/MmlTree/MmlNodes/mfrac.ts
@@ -92,7 +92,7 @@ export class MmlMfrac extends AbstractMmlBaseNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     if (!display || level > 0) {
       level++;
@@ -108,7 +108,7 @@ export class MmlMfrac extends AbstractMmlBaseNode {
         indentshiftfirst: '0',
         indentalignlast: 'indentalign',
         indentshiftlast: 'indentshift',
-      }
+      },
     );
     const denAttributes = this.addInheritedAttributes(
       { ...attributes },
@@ -119,19 +119,19 @@ export class MmlMfrac extends AbstractMmlBaseNode {
         indentshiftfirst: '0',
         indentalignlast: 'indentalign',
         indentshiftlast: 'indentshift',
-      }
+      },
     );
     this.childNodes[0].setInheritedAttributes(
       numAttributes,
       false,
       level,
-      prime
+      prime,
     );
     this.childNodes[1].setInheritedAttributes(
       denAttributes,
       false,
       level,
-      true
+      true,
     );
   }
 }

--- a/ts/core/MmlTree/MmlNodes/mglyph.ts
+++ b/ts/core/MmlTree/MmlNodes/mglyph.ts
@@ -62,13 +62,13 @@ export class MmlMglyph extends AbstractMmlTokenNode {
     const { src, fontfamily, index } = this.attributes.getList(
       'src',
       'fontfamily',
-      'index'
+      'index',
     );
     if (src === '' && (fontfamily === '' || index === '')) {
       this.mError(
         'mglyph must have either src or fontfamily and index attributes',
         options,
-        true
+        true,
       );
     } else {
       super.verifyAttributes(options);

--- a/ts/core/MmlTree/MmlNodes/mi.ts
+++ b/ts/core/MmlTree/MmlNodes/mi.ts
@@ -74,7 +74,7 @@ export class MmlMi extends AbstractMmlTokenNode {
     attributes: AttributeList = {},
     display: boolean = false,
     level: number = 0,
-    prime: boolean = false
+    prime: boolean = false,
   ) {
     super.setInheritedAttributes(attributes, display, level, prime);
     let text = this.getText();

--- a/ts/core/MmlTree/MmlNodes/mmultiscripts.ts
+++ b/ts/core/MmlTree/MmlNodes/mmultiscripts.ts
@@ -65,13 +65,13 @@ export class MmlMmultiscripts extends MmlMsubsup {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     this.childNodes[0].setInheritedAttributes(
       attributes,
       display,
       level,
-      prime
+      prime,
     );
     let prescripts = false;
     for (let i = 1, n = 0; i < this.childNodes.length; i++) {
@@ -98,7 +98,7 @@ export class MmlMmultiscripts extends MmlMsubsup {
         attributes,
         false,
         level + 1,
-        prime
+        prime,
       );
     }
   }
@@ -118,14 +118,14 @@ export class MmlMmultiscripts extends MmlMsubsup {
           child.mError(
             child.kind + ' can only appear once in ' + this.kind,
             options,
-            true
+            true,
           );
         } else {
           prescripts = true;
           if (i % 2 === 0 && !fix) {
             this.mError(
               'There must be an equal number of prescripts of each type',
-              options
+              options,
             );
           }
         }
@@ -134,7 +134,7 @@ export class MmlMmultiscripts extends MmlMsubsup {
     if (this.childNodes.length % 2 === (prescripts ? 1 : 0) && !fix) {
       this.mError(
         'There must be an equal number of scripts of each type',
-        options
+        options,
       );
     }
     super.verifyChildren(options);
@@ -179,7 +179,7 @@ export class MmlMprescripts extends AbstractMmlNode {
       this.mError(
         this.kind + ' must be a child of mmultiscripts',
         options,
-        true
+        true,
       );
     }
   }
@@ -223,7 +223,7 @@ export class MmlNone extends AbstractMmlNode {
       this.mError(
         this.kind + ' must be a child of mmultiscripts',
         options,
-        true
+        true,
       );
     }
   }

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -111,7 +111,7 @@ export class MmlMo extends AbstractMmlTokenNode {
       '^["\'',
       '\u2018-\u201F', // Various double and single quotation marks (up and down)
       ']+$',
-    ].join('')
+    ].join(''),
   );
 
   /**
@@ -409,7 +409,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     attributes: AttributeList = {},
     display: boolean = false,
     level: number = 0,
-    prime: boolean = false
+    prime: boolean = false,
   ) {
     super.setInheritedAttributes(attributes, display, level, prime);
     let mo = this.getText();

--- a/ts/core/MmlTree/MmlNodes/mroot.ts
+++ b/ts/core/MmlTree/MmlNodes/mroot.ts
@@ -93,14 +93,14 @@ export class MmlMroot extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     this.childNodes[0].setInheritedAttributes(attributes, display, level, true);
     this.childNodes[1].setInheritedAttributes(
       attributes,
       false,
       level + 2,
-      prime
+      prime,
     );
   }
 }

--- a/ts/core/MmlTree/MmlNodes/msqrt.ts
+++ b/ts/core/MmlTree/MmlNodes/msqrt.ts
@@ -89,7 +89,7 @@ export class MmlMsqrt extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    _prime: boolean
+    _prime: boolean,
   ) {
     this.childNodes[0].setInheritedAttributes(attributes, display, level, true);
   }

--- a/ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -69,7 +69,7 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     let scriptlevel = this.attributes.getExplicit('scriptlevel');
     if (scriptlevel != null) {
@@ -92,13 +92,13 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
     }
     attributes = this.addInheritedAttributes(
       attributes,
-      this.attributes.getAllAttributes()
+      this.attributes.getAllAttributes(),
     );
     this.childNodes[0].setInheritedAttributes(
       attributes,
       display,
       level,
-      prime
+      prime,
     );
   }
 }

--- a/ts/core/MmlTree/MmlNodes/msubsup.ts
+++ b/ts/core/MmlTree/MmlNodes/msubsup.ts
@@ -84,7 +84,7 @@ export class MmlMsubsup extends AbstractMmlBaseNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     let nodes = this.childNodes;
     nodes[0].setInheritedAttributes(attributes, display, level, prime);
@@ -92,7 +92,7 @@ export class MmlMsubsup extends AbstractMmlBaseNode {
       attributes,
       false,
       level + 1,
-      prime || this.sub === 1
+      prime || this.sub === 1,
     );
     if (!nodes[2]) {
       return;
@@ -101,7 +101,7 @@ export class MmlMsubsup extends AbstractMmlBaseNode {
       attributes,
       false,
       level + 1,
-      prime || this.sub === 2
+      prime || this.sub === 2,
     );
   }
 }

--- a/ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/ts/core/MmlTree/MmlNodes/mtable.ts
@@ -105,7 +105,7 @@ export class MmlMtable extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     //
     // Force inheritance of shift and align values (since they are needed to output tables with labels)
@@ -133,7 +133,7 @@ export class MmlMtable extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    _prime: boolean
+    _prime: boolean,
   ) {
     for (const child of this.childNodes) {
       if (!child.isKind('mtr')) {
@@ -190,7 +190,7 @@ export class MmlMtable extends AbstractMmlNode {
           const merror = child.mError(
             'Children of ' + this.kind + ' must be mtr or mlabeledtr',
             options,
-            isMtd
+            isMtd,
           );
           mtr.childNodes[mtr.childNodes.length - 1].appendChild(merror); // append the error to the mtd in the mtr
         }

--- a/ts/core/MmlTree/MmlNodes/mtd.ts
+++ b/ts/core/MmlTree/MmlNodes/mtd.ts
@@ -84,7 +84,7 @@ export class MmlMtd extends AbstractMmlBaseNode {
       this.mError(
         this.kind + ' can only be a child of an mtr or mlabeledtr',
         options,
-        true
+        true,
       );
       return;
     }

--- a/ts/core/MmlTree/MmlNodes/mtr.ts
+++ b/ts/core/MmlTree/MmlNodes/mtr.ts
@@ -75,7 +75,7 @@ export class MmlMtr extends AbstractMmlNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     for (const child of this.childNodes) {
       if (!child.isKind('mtd')) {
@@ -113,7 +113,7 @@ export class MmlMtr extends AbstractMmlNode {
       this.mError(
         this.kind + ' can only be a child of an mtable',
         options,
-        true
+        true,
       );
       return;
     }

--- a/ts/core/MmlTree/MmlNodes/munderover.ts
+++ b/ts/core/MmlTree/MmlNodes/munderover.ts
@@ -101,14 +101,14 @@ export class MmlMunderover extends AbstractMmlBaseNode {
     attributes: AttributeList,
     display: boolean,
     level: number,
-    prime: boolean
+    prime: boolean,
   ) {
     let nodes = this.childNodes;
     nodes[0].setInheritedAttributes(
       attributes,
       display,
       level,
-      prime || !!nodes[this.over]
+      prime || !!nodes[this.over],
     );
     let force = !!(
       !display && nodes[0].coreMO().attributes.get('movablelimits')
@@ -118,7 +118,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
       attributes,
       false,
       this.getScriptlevel(ACCENTS[1], force, level),
-      prime || this.under === 1
+      prime || this.under === 1,
     );
     this.setInheritedAccent(1, ACCENTS[1], display, level, prime, force);
     if (!nodes[2]) {
@@ -128,7 +128,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
       attributes,
       false,
       this.getScriptlevel(ACCENTS[2], force, level),
-      prime || this.under === 2
+      prime || this.under === 2,
     );
     this.setInheritedAccent(2, ACCENTS[2], display, level, prime, force);
   }
@@ -142,7 +142,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
   protected getScriptlevel(
     accent: string,
     force: boolean,
-    level: number
+    level: number,
   ): number {
     if (force || !this.attributes.get(accent)) {
       level++;
@@ -168,7 +168,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
     display: boolean,
     level: number,
     prime: boolean,
-    force: boolean
+    force: boolean,
   ) {
     let node = this.childNodes[n];
     if (!this.attributes.hasExplicit(accent) && node.isEmbellished) {
@@ -179,7 +179,7 @@ export class MmlMunderover extends AbstractMmlBaseNode {
           {},
           display,
           this.getScriptlevel(accent, force, level),
-          prime
+          prime,
         );
       }
     }

--- a/ts/core/MmlTree/MmlVisitor.ts
+++ b/ts/core/MmlTree/MmlVisitor.ts
@@ -141,7 +141,7 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
       {},
       defaults,
       this.getDataAttributes(node),
-      node.attributes.getAllAttributes()
+      node.attributes.getAllAttributes(),
     ) as PropertyList;
     const variants = CLASS.variants;
     if (attributes.hasOwnProperty('mathvariant')) {
@@ -198,7 +198,7 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
         this.setDataAttribute(
           data,
           'texclass',
-          texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass]
+          texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass],
         );
     }
     node.getProperty('scriptlevel') &&

--- a/ts/core/MmlTree/OperatorDictionary.ts
+++ b/ts/core/MmlTree/OperatorDictionary.ts
@@ -42,7 +42,7 @@ export function OPDEF(
   lspace: number,
   rspace: number,
   texClass: number = TEXCLASS.BIN,
-  properties: PropertyList = null
+  properties: PropertyList = null,
 ): OperatorDef {
   return [lspace, rspace, texClass, properties] as OperatorDef;
 }

--- a/ts/core/MmlTree/TestMmlVisitor.ts
+++ b/ts/core/MmlTree/TestMmlVisitor.ts
@@ -66,7 +66,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
           texClass: node.texClass,
         },
         '{',
-        '}'
+        '}',
       ) +
       '>' +
       nl;
@@ -111,7 +111,7 @@ export class TestMmlVisitor extends SerializedMmlVisitor {
   protected attributeString(
     attributes: PropertyList,
     open: string,
-    close: string
+    close: string,
   ): string {
     let ATTR = '';
     for (const name of Object.keys(attributes)) {

--- a/ts/core/OutputJax.ts
+++ b/ts/core/OutputJax.ts
@@ -185,7 +185,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
    */
   public abstract typeset(
     math: MathItem<N, T, D>,
-    document?: MathDocument<N, T, D>
+    document?: MathDocument<N, T, D>,
   ): N;
 
   /**
@@ -193,7 +193,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
    */
   public abstract escaped(
     math: MathItem<N, T, D>,
-    document?: MathDocument<N, T, D>
+    document?: MathDocument<N, T, D>,
   ): N;
 
   /**
@@ -229,7 +229,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
     filters: FunctionList,
     math: MathItem<N, T, D>,
     document: MathDocument<N, T, D>,
-    data: any
+    data: any,
   ): any {
     let args = { math, document, data };
     filters.execute(args);

--- a/ts/core/Tree/Node.ts
+++ b/ts/core/Tree/Node.ts
@@ -145,7 +145,7 @@ export interface NodeClass<N extends Node<N, C>, C extends NodeClass<N, C>> {
   new (
     factory: NodeFactory<N, C>,
     properties?: PropertyList,
-    children?: N[]
+    children?: N[],
   ): N;
 }
 
@@ -187,7 +187,7 @@ export abstract class AbstractNode<
   constructor(
     readonly factory: NodeFactory<N, C>,
     properties: PropertyList = {},
-    children: N[] = []
+    children: N[] = [],
   ) {
     for (const name of Object.keys(properties)) {
       this.setProperty(name, properties[name]);

--- a/ts/core/Tree/NodeFactory.ts
+++ b/ts/core/Tree/NodeFactory.ts
@@ -61,7 +61,7 @@ export abstract class AbstractNodeFactory<
   public create(
     kind: string,
     properties: PropertyList = {},
-    children: N[] = []
+    children: N[] = [],
   ) {
     return this.node[kind](properties, children);
   }

--- a/ts/core/Tree/Visitor.ts
+++ b/ts/core/Tree/Visitor.ts
@@ -129,7 +129,7 @@ export abstract class AbstractVisitor<N extends VisitorNode<N>>
       'visit' +
       (kind.charAt(0).toUpperCase() + kind.substring(1)).replace(
         /[^a-z0-9_]/gi,
-        '_'
+        '_',
       ) +
       'Node'
     );

--- a/ts/core/Tree/Wrapper.ts
+++ b/ts/core/Tree/Wrapper.ts
@@ -141,7 +141,7 @@ export class AbstractWrapper<
    */
   constructor(
     factory: WrapperFactory<N, C, W, WrapperClass<N, C, W>>,
-    node: N
+    node: N,
   ) {
     this.factory = factory;
     this.node = node;

--- a/ts/handlers/html.ts
+++ b/ts/handlers/html.ts
@@ -36,7 +36,7 @@ import { DOMAdaptor } from '../core/DOMAdaptor.js';
  * @template D  The Document class
  */
 export function RegisterHTMLHandler<N, T, D>(
-  adaptor: DOMAdaptor<N, T, D>
+  adaptor: DOMAdaptor<N, T, D>,
 ): HTMLHandler<N, T, D> {
   const handler = new HTMLHandler<N, T, D>(adaptor);
   mathjax.handlers.register(handler);

--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -96,7 +96,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   constructor(
     document: any,
     adaptor: DOMAdaptor<N, T, D>,
-    options: OptionList
+    options: OptionList,
   ) {
     let [html, dom] = separateOptions(options, HTMLDomStrings.OPTIONS);
     super(document, adaptor, html);
@@ -121,7 +121,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     N: number,
     index: number,
     delim: string,
-    nodes: HTMLNodeArray<N, T>
+    nodes: HTMLNodeArray<N, T>,
   ): Location<N, T> {
     const adaptor = this.adaptor;
     for (const list of nodes[N]) {
@@ -146,7 +146,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   protected mathItem(
     item: ProtoItem<N, T>,
     jax: InputJax<N, T, D>,
-    nodes: HTMLNodeArray<N, T>
+    nodes: HTMLNodeArray<N, T>,
   ): HTMLMathItem<N, T, D> {
     let math = item.math;
     let start = this.findPosition(item.n, item.start.n, item.open, nodes);
@@ -156,7 +156,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
       jax,
       item.display,
       start,
-      end
+      end,
     ) as HTMLMathItem<N, T, D>;
   }
 
@@ -184,11 +184,11 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         {
           elements: this.options.elements || [this.adaptor.body(this.document)],
         },
-        options
+        options,
       );
       const containers = this.adaptor.getElements(
         options.elements,
-        this.document
+        this.document,
       );
       for (const jax of this.inputJax) {
         const list = jax.processStrings
@@ -210,7 +210,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    */
   protected findMathFromStrings(
     jax: InputJax<N, T, D>,
-    containers: N[]
+    containers: N[],
   ): HTMLMathList<N, T, D> {
     const strings = [] as string[];
     const nodes = [] as HTMLNodeArray<N, T>;
@@ -235,7 +235,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    */
   protected findMathFromDOM(
     jax: InputJax<N, T, D>,
-    containers: N[]
+    containers: N[],
   ): HTMLMathList<N, T, D> {
     const items = [] as HTMLMathItem<N, T, D>[];
     for (const container of containers) {
@@ -246,8 +246,8 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
             jax,
             math.display,
             math.start,
-            math.end
-          )
+            math.end,
+          ),
         );
       }
     }

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -156,7 +156,7 @@ export class HTMLDomStrings<N, T, D> {
     let process = makeArray(this.options['processHtmlClass']);
     this.skipHtmlTags = new RegExp('^(?:' + skip.join('|') + ')$', 'i');
     this.ignoreHtmlClass = new RegExp(
-      '(?:^| )(?:' + ignore.join('|') + ')(?: |$)'
+      '(?:^| )(?:' + ignore.join('|') + ')(?: |$)',
     );
     this.processHtmlClass = new RegExp('(?:^| )(?:' + process + ')(?: |$)');
   }

--- a/ts/handlers/html/HTMLMathItem.ts
+++ b/ts/handlers/html/HTMLMathItem.ts
@@ -49,7 +49,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
     jax: InputJax<N, T, D>,
     display: boolean = true,
     start: Location<N, T> = { node: null, n: 0, delim: '' },
-    end: Location<N, T> = { node: null, n: 0, delim: '' }
+    end: Location<N, T> = { node: null, n: 0, delim: '' },
   ) {
     super(math, jax, display, start, end);
   }

--- a/ts/input/asciimath.ts
+++ b/ts/input/asciimath.ts
@@ -63,7 +63,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
     let [, find, am] = separateOptions(
       options,
       FindAsciiMath.OPTIONS,
-      AsciiMath.OPTIONS
+      AsciiMath.OPTIONS,
     );
     super(am);
     this.findAsciiMath =

--- a/ts/input/asciimath/FindAsciiMath.ts
+++ b/ts/input/asciimath/FindAsciiMath.ts
@@ -82,7 +82,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     let starts: string[] = [];
     this.end = {};
     options['delimiters'].forEach((delims: Delims) =>
-      this.addPattern(starts, delims, false)
+      this.addPattern(starts, delims, false),
     );
     this.start = new RegExp(starts.join('|'), 'g');
     this.hasPatterns = starts.length > 0;
@@ -114,7 +114,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     text: string,
     n: number,
     start: RegExpExecArray,
-    end: EndItem
+    end: EndItem,
   ): ProtoItem<N, T> {
     let [, display, pattern] = end;
     let i = (pattern.lastIndex = start.index + start[0].length);
@@ -128,7 +128,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
           n,
           start.index,
           match.index + match[0].length,
-          display
+          display,
         );
   }
 

--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -89,7 +89,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
     let [mml, find, compile] = separateOptions(
       options,
       FindMathML.OPTIONS,
-      MathMLCompile.OPTIONS
+      MathMLCompile.OPTIONS,
     );
     super(mml);
     this.findMathML =
@@ -155,13 +155,13 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         this.preFilters,
         math,
         document,
-        (math.math || '<math></math>').trim()
+        (math.math || '<math></math>').trim(),
       );
       if (this.options['parseAs'] === 'html') {
         mathml = `<html><head></head><body>${mathml}</body></html>`;
       }
       let doc = this.checkForErrors(
-        this.adaptor.parse(mathml, 'text/' + this.options['parseAs'])
+        this.adaptor.parse(mathml, 'text/' + this.options['parseAs']),
       );
       let body = this.adaptor.body(doc);
       if (this.adaptor.childNodes(body).length !== 1) {
@@ -172,7 +172,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
         this.error(
           'MathML must be formed by a <math> element, not <' +
             this.adaptor.kind(mml) +
-            '>'
+            '>',
         );
       }
     }

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -152,7 +152,7 @@ export class MathMLCompile<N, T, D> {
     type: string,
     node: N,
     texClass: string,
-    limits: boolean
+    limits: boolean,
   ): MmlNode {
     let mml = this.factory.create(type);
     if (type === 'TeXAtom' && texClass === 'OP' && !limits) {
@@ -183,7 +183,7 @@ export class MathMLCompile<N, T, D> {
     ) {
       return (this.factory.create('html') as HtmlNode<N>).setHTML(
         node,
-        this.adaptor
+        this.adaptor,
       );
     }
     this.error('Unknown node type "' + type + '"');
@@ -281,7 +281,7 @@ export class MathMLCompile<N, T, D> {
         this.addText(mml, child);
       } else if (mml.isKind('annotation-xml')) {
         mml.appendChild(
-          (this.factory.create('XML') as XMLNode).setXML(child, adaptor)
+          (this.factory.create('XML') as XMLNode).setXML(child, adaptor),
         );
       } else {
         let childMml = mml.appendChild(this.makeNode(child));
@@ -296,7 +296,7 @@ export class MathMLCompile<N, T, D> {
             childMml.mError(
               'There should not be children for ' + childMml.kind + ' nodes',
               this.options['verify'],
-              true
+              true,
             );
           }
         }
@@ -339,7 +339,7 @@ export class MathMLCompile<N, T, D> {
         } else if (name.substring(0, 11) !== 'MJX-TeXAtom') {
           mml.attributes.set(
             'mathvariant',
-            this.fixCalligraphic(name.substring(3))
+            this.fixCalligraphic(name.substring(3)),
           );
         }
       } else {

--- a/ts/input/mathml/mml3/mml3.ts
+++ b/ts/input/mathml/mml3/mml3.ts
@@ -74,7 +74,7 @@ export class Mml3<N, T, D> {
       const processor = new XSLTProcessor();
       const parsed = document.adaptor.parse(
         Mml3.XSLT,
-        'text/xml'
+        'text/xml',
       ) as any as Node;
       processor.importStylesheet(parsed);
       this.transform = (node: N) => {
@@ -82,7 +82,7 @@ export class Mml3<N, T, D> {
         const div = adaptor.node('div', {}, [adaptor.clone(node)]);
         const dom = adaptor.parse(adaptor.serializeXML(div), 'text/xml');
         const mml = processor.transformToDocument(
-          dom as any as Node
+          dom as any as Node,
         ) as any as N;
         return mml ? adaptor.tags(mml, 'math')[0] : node;
       };
@@ -105,7 +105,7 @@ export class Mml3<N, T, D> {
  *  Add Mml3 support into the handler.
  */
 export function Mml3Handler<N, T, D>(
-  handler: Handler<N, T, D>
+  handler: Handler<N, T, D>,
 ): Handler<N, T, D> {
   handler.documentClass = class extends handler.documentClass {
     /**

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -107,7 +107,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    * @return {Configuration} The configuration object.
    */
   protected static configure(
-    packages: (string | [string, number])[]
+    packages: (string | [string, number])[],
   ): ParserConfiguration {
     let configuration = new ParserConfiguration(packages, ['tex']);
     configuration.init();
@@ -122,7 +122,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    */
   protected static tags(
     options: ParseOptions,
-    configuration: ParserConfiguration
+    configuration: ParserConfiguration,
   ) {
     TagsFactory.addTags(configuration.tags);
     TagsFactory.setDefault(options.options.tags);
@@ -137,7 +137,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     const [rest, tex, find] = separateOptions(
       options,
       TeX.OPTIONS,
-      FindTeX.OPTIONS
+      FindTeX.OPTIONS,
     );
     super(tex);
     this.findTeX = this.options['FindTeX'] || new FindTeX(find);
@@ -185,7 +185,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
    */
   public compile(
     math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>
+    document: MathDocument<N, T, D>,
   ): MmlNode {
     this.parseOptions.clear();
     this.parseOptions.mathItem = math;
@@ -199,7 +199,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
       parser = new TexParser(
         this.latex,
         { display: math.display, isInner: false },
-        this.parseOptions
+        this.parseOptions,
       );
       node = parser.mml();
       globalEnv = parser.stack.global;
@@ -251,7 +251,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
       'error',
       message,
       err.id,
-      this.latex
+      this.latex,
     );
   }
 }

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -135,7 +135,7 @@ export class ColumnParser {
       if (n++ > this.MAXCOLUMNS) {
         throw new TexError(
           'MaxColumns',
-          'Too many column specifiers (perhaps looping column definitions?)'
+          'Too many column specifiers (perhaps looping column definitions?)',
         );
       }
       const code = state.template.codePointAt(state.i);
@@ -243,7 +243,7 @@ export class ColumnParser {
   public getColumn(
     state: ColumnState,
     ralign: string,
-    calign: string = 'left'
+    calign: string = 'left',
   ) {
     state.calign[state.j] = calign || this.getAlign(state);
     state.cwidth[state.j] = this.getDimen(state);
@@ -266,7 +266,7 @@ export class ColumnParser {
       throw new TexError(
         'MissingColumnDimOrUnits',
         'Missing dimension or its units for %1 column declaration',
-        state.c
+        state.c,
       );
     }
     return dim;
@@ -282,7 +282,7 @@ export class ColumnParser {
     return lookup(
       align.toLowerCase(),
       { l: 'left', c: 'center', r: 'right' },
-      ''
+      '',
     );
   }
 
@@ -297,7 +297,7 @@ export class ColumnParser {
       throw new TexError(
         'MissingArgForColumn',
         'Missing argument for %1 column declaration',
-        state.c
+        state.c,
       );
     }
     if (state.template[state.i] !== '{') {
@@ -406,7 +406,7 @@ export class ColumnParser {
       throw new TexError(
         'ColArgNotNum',
         'First argument to %1 column specifier must be a number',
-        '*'
+        '*',
       );
     }
     state.template =

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -39,7 +39,7 @@ export type ProtoProcessor<T> = Processor<T> | T;
 export type ProcessorList = Processor<Function>[];
 export type ConfigMethod = (
   c: ParserConfiguration,
-  j: TeX<any, any, any>
+  j: TeX<any, any, any>,
 ) => void;
 export type InitMethod = (c: ParserConfiguration) => void;
 
@@ -53,7 +53,7 @@ export class Configuration {
    */
   private static makeProcessor<T>(
     func: ProtoProcessor<T>,
-    priority: number
+    priority: number,
   ): Processor<T> {
     return Array.isArray(func) ? func : [func, priority];
   }
@@ -79,7 +79,7 @@ export class Configuration {
       [ConfigurationType.CONFIG]?: ProtoProcessor<ConfigMethod>;
       [ConfigurationType.PRIORITY]?: number;
       [ConfigurationType.PARSER]?: string;
-    } = {}
+    } = {},
   ): Configuration {
     let priority = config.priority || PrioritizedList.DEFAULTPRIORITY;
     let init = config.init ? this.makeProcessor(config.init, priority) : null;
@@ -87,10 +87,10 @@ export class Configuration {
       ? this.makeProcessor(config.config, priority)
       : null;
     let preprocessors = (config.preprocessors || []).map((pre) =>
-      this.makeProcessor(pre, priority)
+      this.makeProcessor(pre, priority),
     );
     let postprocessors = (config.postprocessors || []).map((post) =>
-      this.makeProcessor(post, priority)
+      this.makeProcessor(post, priority),
     );
     let parser = config.parser || 'tex';
     return new Configuration(
@@ -106,7 +106,7 @@ export class Configuration {
       init,
       conf,
       priority,
-      parser
+      parser,
     );
   }
 
@@ -147,7 +147,7 @@ export class Configuration {
       [ConfigurationType.CONFIG]?: ProtoProcessor<ConfigMethod>;
       [ConfigurationType.PRIORITY]?: number;
       [ConfigurationType.PARSER]?: string;
-    } = {}
+    } = {},
   ): Configuration {
     let configuration = Configuration._create(name, config);
     ConfigurationHandler.set(name, configuration);
@@ -174,7 +174,7 @@ export class Configuration {
       [ConfigurationType.CONFIG]?: ProtoProcessor<ConfigMethod>;
       [ConfigurationType.PRIORITY]?: number;
       [ConfigurationType.PARSER]?: string;
-    } = {}
+    } = {},
   ): Configuration {
     return Configuration._create('', config);
   }
@@ -195,7 +195,7 @@ export class Configuration {
     readonly initMethod: Processor<InitMethod> = null,
     readonly configMethod: Processor<ConfigMethod> = null,
     public priority: number,
-    readonly parser: string
+    readonly parser: string,
   ) {
     this.handler = Object.assign(
       {
@@ -204,7 +204,7 @@ export class Configuration {
         [HandlerType.MACRO]: [],
         [HandlerType.ENVIRONMENT]: [],
       },
-      handler
+      handler,
     );
   }
 
@@ -324,7 +324,7 @@ export class ParserConfiguration {
    */
   constructor(
     packages: (string | [string, number])[],
-    parsers: string[] = ['tex']
+    parsers: string[] = ['tex'],
   ) {
     this.parsers = parsers;
     for (const pkg of packages.slice().reverse()) {
@@ -363,7 +363,7 @@ export class ParserConfiguration {
     conf &&
       this.configurations.add(
         conf,
-        typeof pkg === 'string' ? conf.priority : pkg[1]
+        typeof pkg === 'string' ? conf.priority : pkg[1],
       );
   }
 

--- a/ts/input/tex/FilterUtil.ts
+++ b/ts/input/tex/FilterUtil.ts
@@ -68,7 +68,7 @@ namespace FilterUtil {
         return;
       }
       const keep = new Set(
-        ((attribs.get('mjx-keep-attrs') as string) || '').split(/ /)
+        ((attribs.get('mjx-keep-attrs') as string) || '').split(/ /),
       );
       attribs.unset('mjx-keep-attrs');
       for (const key of attribs.getExplicitNames()) {
@@ -154,7 +154,7 @@ namespace FilterUtil {
   let _copyExplicit = function (
     attrs: string[],
     node1: MmlNode,
-    node2: MmlNode
+    node2: MmlNode,
   ) {
     let attr1 = node1.attributes;
     let attr2 = node2.attributes;
@@ -260,7 +260,7 @@ namespace FilterUtil {
   let _moveLimits = function (
     options: ParseOptions,
     underover: string,
-    subsup: string
+    subsup: string,
   ) {
     const remove: MmlNode[] = [];
     for (const mml of options.getList(underover)) {

--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -113,10 +113,10 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
     this.env = this.sub = 0;
     let i = 1;
     options['inlineMath'].forEach((delims: Delims) =>
-      this.addPattern(starts, delims, false)
+      this.addPattern(starts, delims, false),
     );
     options['displayMath'].forEach((delims: Delims) =>
-      this.addPattern(starts, delims, true)
+      this.addPattern(starts, delims, true),
     );
     if (starts.length) {
       parts.push(starts.sort(sortLength).join('|'));
@@ -163,7 +163,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
   protected endPattern(end: string, endp?: string): RegExp {
     return new RegExp(
       (endp || quotePattern(end)) + '|\\\\(?:[a-zA-Z]|.)|[{}]',
-      'g'
+      'g',
     );
   }
 
@@ -182,7 +182,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
     text: string,
     n: number,
     start: RegExpExecArray,
-    end: EndItem
+    end: EndItem,
   ): ProtoItem<N, T> {
     let [close, display, pattern] = end;
     let i = (pattern.lastIndex = start.index + start[0].length);
@@ -197,7 +197,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
           n,
           start.index,
           match.index + match[0].length,
-          display
+          display,
         );
       } else if (match[0] === '{') {
         braces++;
@@ -241,7 +241,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
             '',
             n,
             start.index,
-            end
+            end,
           );
         } else {
           match = protoItem<N, T>('', math, '', n, start.index, end, false);

--- a/ts/input/tex/MapHandler.ts
+++ b/ts/input/tex/MapHandler.ts
@@ -71,7 +71,7 @@ export class SubHandler {
   public add(
     maps: string[],
     fallback: ParseMethod,
-    priority: number = PrioritizedList.DEFAULTPRIORITY
+    priority: number = PrioritizedList.DEFAULTPRIORITY,
   ) {
     for (const name of maps.slice().reverse()) {
       let map = MapHandler.getMap(name);
@@ -182,7 +182,7 @@ export class SubHandlers {
   public add(
     handlers: HandlerConfig,
     fallbacks: FallbackConfig,
-    priority: number = PrioritizedList.DEFAULTPRIORITY
+    priority: number = PrioritizedList.DEFAULTPRIORITY,
   ): void {
     for (const key of Object.keys(handlers)) {
       let name = key as HandlerType;

--- a/ts/input/tex/NodeFactory.ts
+++ b/ts/input/tex/NodeFactory.ts
@@ -70,7 +70,7 @@ export class NodeFactory {
     kind: string,
     children: MmlNode[] = [],
     def: any = {},
-    text?: TextNode
+    text?: TextNode,
   ): MmlNode {
     const node = factory.mmlFactory.create(kind);
     node.setChildren(children);
@@ -93,7 +93,7 @@ export class NodeFactory {
     factory: NodeFactory,
     kind: string,
     def: any = {},
-    text: string = ''
+    text: string = '',
   ): MmlNode {
     const textNode = factory.create('text', text);
     return factory.create('node', kind, [], def, textNode);

--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -198,7 +198,7 @@ namespace ParseMethods {
     parser: TexParser,
     env: string,
     func: Function,
-    args: any[]
+    args: any[],
   ) {
     const end = args[0];
     let mml = parser.itemFactory

--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -149,7 +149,7 @@ export default class ParseOptions {
    */
   public constructor(
     configuration: ParserConfiguration,
-    options: OptionList[] = []
+    options: OptionList[] = [],
   ) {
     this.handlers = configuration.handlers;
     // Add node factory methods from packages.

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -39,7 +39,7 @@ export class KeyValueType<T> {
   constructor(
     public name: string,
     public verify: (value: string) => boolean,
-    public convert: (value: string) => T
+    public convert: (value: string) => T,
   ) {}
 }
 
@@ -60,33 +60,33 @@ export const KeyValueTypes: {
   boolean: new KeyValueType<boolean>(
     'boolean',
     (value) => value === 'true' || value === 'false',
-    (value) => value === 'true'
+    (value) => value === 'true',
   ),
   number: new KeyValueType<number>(
     'number',
     (value) => !!value.match(/^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?$/),
-    (value) => parseFloat(value)
+    (value) => parseFloat(value),
   ),
   integer: new KeyValueType<number>(
     'integer',
     (value) => !!value.match(/^[-+]?\d+$/),
-    (value) => parseInt(value)
+    (value) => parseInt(value),
   ),
   string: new KeyValueType<string>(
     'string',
     (_value) => true,
-    (value) => value
+    (value) => value,
   ),
   oneof: (...values: string[]) =>
     new KeyValueType<string>(
       'oneof',
       (value) => values.indexOf(value) >= 0,
-      (value) => value
+      (value) => value,
     ),
   dimen: new KeyValueType<string>(
     'dimen',
     (value) => UnitUtil.matchDimen(value)[0] !== null,
-    (value) => value
+    (value) => value,
   ),
 };
 
@@ -149,7 +149,7 @@ function readValue(
   text: string,
   end: string[],
   l3keys: boolean = false,
-  dropBrace: boolean = false
+  dropBrace: boolean = false,
 ): [string, string, string] {
   let length = text.length;
   let braces = 0;
@@ -195,7 +195,7 @@ function readValue(
   if (braces) {
     throw new TexError(
       'ExtraOpenMissingClose',
-      'Extra open brace or missing close brace'
+      'Extra open brace or missing close brace',
     );
   }
   return dropBrace && start
@@ -235,7 +235,7 @@ export const ParseUtil = {
     mml: MmlNode,
     close: string,
     big: string = '',
-    color: string = ''
+    color: string = '',
   ) {
     // @test Fenced, Fenced3
     let nf = configuration.nodeFactory;
@@ -249,7 +249,7 @@ export const ParseUtil = {
       mo = new TexParser(
         '\\' + big + 'l' + open,
         configuration.parser.stack.env,
-        configuration
+        configuration,
       ).mml();
     } else {
       let openNode = nf.create('text', open);
@@ -263,7 +263,7 @@ export const ParseUtil = {
           symmetric: true,
           texClass: TEXCLASS.OPEN,
         },
-        openNode
+        openNode,
       );
     }
     NodeUtil.appendChildren(mrow, [mo, mml]);
@@ -271,7 +271,7 @@ export const ParseUtil = {
       mo = new TexParser(
         '\\' + big + 'r' + close,
         configuration.parser.stack.env,
-        configuration
+        configuration,
       ).mml();
     } else {
       let closeNode = nf.create('text', close);
@@ -285,7 +285,7 @@ export const ParseUtil = {
           symmetric: true,
           texClass: TEXCLASS.CLOSE,
         },
-        closeNode
+        closeNode,
       );
     }
     color && mo.attributes.set('mathcolor', color);
@@ -305,7 +305,7 @@ export const ParseUtil = {
     configuration: ParseOptions,
     open: string,
     mml: MmlNode,
-    close: string
+    close: string,
   ): MmlNode {
     // @test Choose, Over With Delims, Above with Delims
     let mrow = configuration.nodeFactory.create('node', 'mrow', [], {
@@ -343,7 +343,7 @@ export const ParseUtil = {
   mathPalette(
     configuration: ParseOptions,
     fence: string,
-    side: string
+    side: string,
   ): MmlNode {
     if (fence === '{' || fence === '}') {
       fence = '\\' + fence;
@@ -353,7 +353,7 @@ export const ParseUtil = {
     return new TexParser(
       '\\mathchoice' + D + T + T + T,
       {},
-      configuration
+      configuration,
     ).mml();
   },
 
@@ -400,7 +400,7 @@ export const ParseUtil = {
     parser: TexParser,
     text: string,
     level?: number | string,
-    font?: string
+    font?: string,
   ): MmlNode[] {
     text = text.replace(/ +/g, ' ');
     if (parser.configuration.options.internalMath) {
@@ -408,7 +408,7 @@ export const ParseUtil = {
         parser,
         text,
         level,
-        font
+        font,
       );
     }
     let mathvariant = font || parser.stack.env.font;
@@ -430,7 +430,7 @@ export const ParseUtil = {
               new TexParser(
                 text.slice(k, i - 1),
                 {},
-                parser.configuration
+                parser.configuration,
               ).mml(),
             ]);
             mml.push(node);
@@ -441,7 +441,7 @@ export const ParseUtil = {
             if (k < i - 1) {
               // @test Interspersed Text
               mml.push(
-                ParseUtil.internalText(parser, text.slice(k, i - 1), def)
+                ParseUtil.internalText(parser, text.slice(k, i - 1), def),
               );
             }
             match = '$';
@@ -457,7 +457,7 @@ export const ParseUtil = {
             let atom = new TexParser(
               text.slice(k, i),
               {},
-              parser.configuration
+              parser.configuration,
             ).mml();
             node = parser.create('node', 'TeXAtom', [atom], def);
             mml.push(node);
@@ -478,7 +478,7 @@ export const ParseUtil = {
             if (k < i - 1) {
               // @test Mbox Eqref
               mml.push(
-                ParseUtil.internalText(parser, text.slice(k, i - 1), def)
+                ParseUtil.internalText(parser, text.slice(k, i - 1), def),
               );
             }
             match = '}';
@@ -492,7 +492,7 @@ export const ParseUtil = {
               if (k < i - 2) {
                 // @test Mbox Internal Display
                 mml.push(
-                  ParseUtil.internalText(parser, text.slice(k, i - 2), def)
+                  ParseUtil.internalText(parser, text.slice(k, i - 2), def),
                 );
               }
               match = ')';
@@ -503,7 +503,7 @@ export const ParseUtil = {
                 new TexParser(
                   text.slice(k, i - 2),
                   {},
-                  parser.configuration
+                  parser.configuration,
                 ).mml(),
               ]);
               mml.push(node);
@@ -521,7 +521,7 @@ export const ParseUtil = {
                 throw new TexError(
                   'BadRawUnicode',
                   'Argument to %1 must a hexadecimal number with 1 to 6 digits',
-                  '\\U'
+                  '\\U',
                 );
               }
               //  Replace \U{...} with specified character
@@ -539,7 +539,7 @@ export const ParseUtil = {
         // @test Internal Math Error
         throw new TexError(
           'MathNotTerminated',
-          'Math mode is not properly terminated'
+          'Math mode is not properly terminated',
         );
       }
     }
@@ -593,7 +593,7 @@ export const ParseUtil = {
     base: MmlNode,
     script: MmlNode,
     pos: string,
-    stack: boolean
+    stack: boolean,
   ): MmlNode {
     // @test Overline
     ParseUtil.checkMovableLimits(base);
@@ -646,7 +646,7 @@ export const ParseUtil = {
   setArrayAlign(
     array: ArrayItem,
     align: string,
-    parser?: TexParser
+    parser?: TexParser,
   ): ArrayItem {
     // @test Array1, Array2, Array Test
     if (!parser) {
@@ -692,13 +692,13 @@ export const ParseUtil = {
           if (!c.match(/[1-9]/) || parseInt(c, 10) > args.length) {
             throw new TexError(
               'IllegalMacroParam',
-              'Illegal macro parameter reference'
+              'Illegal macro parameter reference',
             );
           }
           newstring = ParseUtil.addArgs(
             parser,
             ParseUtil.addArgs(parser, newstring, text),
-            args[parseInt(c, 10) - 1]
+            args[parseInt(c, 10) - 1],
           );
           text = '';
         }
@@ -726,7 +726,7 @@ export const ParseUtil = {
       throw new TexError(
         'MaxBufferSize',
         'MathJax internal buffer size exceeded; is there a' +
-          ' recursive macro call?'
+          ' recursive macro call?',
       );
     }
     return s1 + s2;
@@ -745,13 +745,13 @@ export const ParseUtil = {
       throw new TexError(
         'MaxMacroSub1',
         'MathJax maximum macro substitution count exceeded; ' +
-          'is here a recursive macro call?'
+          'is here a recursive macro call?',
       );
     } else {
       throw new TexError(
         'MaxMacroSub2',
         'MathJax maximum substitution count exceeded; ' +
-          'is there a recursive latex environment?'
+          'is there a recursive latex environment?',
       );
     }
   },
@@ -771,7 +771,7 @@ export const ParseUtil = {
     if (!top.isKind('start') || first) {
       throw new TexError(
         'ErroneousNestingEq',
-        'Erroneous nesting of equation structures'
+        'Erroneous nesting of equation structures',
       );
     }
   },
@@ -833,7 +833,7 @@ export const ParseUtil = {
     attrib: string,
     allowed: { [key: string]: number | KeyValueType<any> } = null,
     error: boolean = false,
-    l3keys: boolean = false
+    l3keys: boolean = false,
   ): EnvList {
     let def: EnvList = readKeyval(attrib, l3keys);
     if (allowed) {
@@ -849,7 +849,7 @@ export const ParseUtil = {
               throw new TexError(
                 'InvalidValue',
                 "Value for key '%1' is not of the expected type",
-                key
+                key,
               );
             }
             def[key] = type.convert(value);

--- a/ts/input/tex/Stack.ts
+++ b/ts/input/tex/Stack.ts
@@ -47,7 +47,7 @@ export default class Stack {
   constructor(
     private _factory: StackItemFactory,
     private _env: EnvList,
-    inner: boolean
+    inner: boolean,
   ) {
     this.global = { isInner: inner };
     this.stack = [this._factory.create('start', this.global)];

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -215,7 +215,7 @@ export abstract class MmlStack implements NodeStack {
       'node',
       inferred ? 'inferredMrow' : 'mrow',
       this._nodes,
-      {}
+      {},
     );
   }
 

--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -39,7 +39,7 @@ export class Label {
    */
   constructor(
     public tag: string = '???',
-    public id: string = ''
+    public id: string = '',
   ) {}
 }
 
@@ -69,7 +69,7 @@ export class TagInfo {
     public tagId: string = '',
     public tagFormat: string = '',
     public noTag: boolean = false,
-    public labelId: string = ''
+    public labelId: string = '',
   ) {}
 }
 
@@ -527,7 +527,7 @@ export class AbstractTags implements Tags {
     this.currentTag.tagId = this.formatId(
       this.configuration.options['useLabelIds']
         ? this.label || this.currentTag.tag
-        : this.currentTag.tag
+        : this.currentTag.tag,
     );
   }
 
@@ -539,14 +539,14 @@ export class AbstractTags implements Tags {
     if (this.label) {
       this.labels[this.label] = new Label(
         this.currentTag.tag,
-        this.currentTag.tagId
+        this.currentTag.tagId,
       );
       this.label = '';
     }
     let mml = new TexParser(
       '\\text{' + this.currentTag.tagFormat + '}',
       {},
-      this.configuration
+      this.configuration,
     ).mml();
     return this.configuration.nodeFactory.create('node', 'mtd', [mml], {
       id: this.currentTag.tagId,

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -58,7 +58,7 @@ export default class TexError {
               parseInt(
                 // parts[i] = %{n}
                 parts[i].substring(1, parts[i].length - 1),
-                10
+                10,
               ) - 1
             ];
           if (typeof parts[i] === 'number') {

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -79,7 +79,7 @@ export default class TexParser {
   constructor(
     private _string: string,
     env: EnvList,
-    public configuration: ParseOptions
+    public configuration: ParseOptions,
   ) {
     const inner = env.hasOwnProperty('isInner');
     const isInner = env['isInner'] as boolean;
@@ -311,7 +311,7 @@ export default class TexParser {
           throw new TexError(
             'MissingArgFor',
             'Missing argument for %1',
-            this.currentCS
+            this.currentCS,
           );
         }
         return null;
@@ -320,7 +320,7 @@ export default class TexParser {
           // @test ExtraCloseMissingOpen
           throw new TexError(
             'ExtraCloseMissingOpen',
-            'Extra close brace or missing open brace'
+            'Extra close brace or missing open brace',
           );
         }
         return null;
@@ -363,7 +363,7 @@ export default class TexParser {
   public GetBrackets(
     _name: string,
     def?: string,
-    matchBrackets: boolean = false
+    matchBrackets: boolean = false,
   ): string {
     if (this.GetNext() !== '[') {
       return def;
@@ -385,7 +385,7 @@ export default class TexParser {
             throw new TexError(
               'ExtraCloseLooking',
               'Extra close brace while looking for %1',
-              "']'"
+              "']'",
             );
           }
           break;
@@ -406,7 +406,7 @@ export default class TexParser {
     throw new TexError(
       'MissingCloseBracket',
       "Could not find closing ']' for argument to %1",
-      this.currentCS
+      this.currentCS,
     );
   }
 
@@ -434,7 +434,7 @@ export default class TexParser {
     throw new TexError(
       'MissingOrUnrecognizedDelim',
       'Missing or unrecognized delimiter for %1',
-      this.currentCS
+      this.currentCS,
     );
   }
 
@@ -464,7 +464,7 @@ export default class TexParser {
     throw new TexError(
       'MissingDimOrUnits',
       'Missing dimension or its units for %1',
-      this.currentCS
+      this.currentCS,
     );
   }
 
@@ -497,7 +497,7 @@ export default class TexParser {
             throw new TexError(
               'ExtraCloseLooking',
               'Extra close brace while looking for %1',
-              token
+              token,
             );
           }
           parens--;
@@ -512,7 +512,7 @@ export default class TexParser {
       'TokenNotFoundForCommand',
       'Could not find %1 for %2',
       token,
-      this.currentCS
+      this.currentCS,
     );
   }
 
@@ -525,7 +525,7 @@ export default class TexParser {
     return new TexParser(
       this.GetArgument(name),
       this.stack.env,
-      this.configuration
+      this.configuration,
     ).mml();
   }
 
@@ -539,7 +539,7 @@ export default class TexParser {
     return new TexParser(
       this.GetUpTo(name, token),
       this.stack.env,
-      this.configuration
+      this.configuration,
     ).mml();
   }
 
@@ -560,7 +560,7 @@ export default class TexParser {
     throw new TexError(
       'MissingOrUnrecognizedDelim',
       'Missing or unrecognized delimiter for %1',
-      this.currentCS
+      this.currentCS,
     );
   }
 
@@ -681,7 +681,7 @@ export default class TexParser {
     node: MmlNode,
     comp: string,
     pos1: number,
-    pos2: number
+    pos2: number,
   ) {
     if (!node.childNodes[pos1] || !node.childNodes[pos2]) return;
     const expr =

--- a/ts/input/tex/Token.ts
+++ b/ts/input/tex/Token.ts
@@ -36,7 +36,7 @@ export class Token {
   constructor(
     private _token: string,
     private _char: string,
-    private _attributes: Attributes
+    private _attributes: Attributes,
   ) {}
 
   public get token(): string {
@@ -62,7 +62,7 @@ export class Macro {
   constructor(
     private _token: string,
     private _func: ParseMethod,
-    private _args: Args[] = []
+    private _args: Args[] = [],
   ) {}
 
   public get token(): string {

--- a/ts/input/tex/TokenMap.ts
+++ b/ts/input/tex/TokenMap.ts
@@ -93,7 +93,7 @@ export abstract class AbstractTokenMap<T> implements TokenMap {
    */
   constructor(
     private _name: string,
-    private _parser: ParseMethod
+    private _parser: ParseMethod,
   ) {
     MapHandler.register(this);
   }
@@ -155,7 +155,7 @@ export class RegExpMap extends AbstractTokenMap<string> {
   constructor(
     name: string,
     parser: ParseMethod,
-    private _regExp: RegExp
+    private _regExp: RegExp,
   ) {
     super(name, parser);
   }
@@ -232,7 +232,7 @@ export class CharacterMap extends AbstractParseMap<Token> {
   constructor(
     name: string,
     parser: ParseMethod,
-    json: { [index: string]: string | [string, Attributes] }
+    json: { [index: string]: string | [string, Attributes] },
   ) {
     super(name, parser);
     for (const key of Object.keys(json)) {
@@ -278,7 +278,7 @@ export class MacroMap extends AbstractParseMap<Macro> {
   constructor(
     name: string,
     json: { [index: string]: ParseFunction | [ParseFunction, ...Args[]] },
-    functionMap: { [key: string]: ParseMethod } = {}
+    functionMap: { [key: string]: ParseMethod } = {},
   ) {
     super(name, null);
     const getMethod = (func: ParseFunction) =>
@@ -364,7 +364,7 @@ export class EnvironmentMap extends MacroMap {
     name: string,
     parser: ParseMethod,
     json: { [index: string]: ParseFunction | [ParseFunction, ...Args[]] },
-    functionMap: { [key: string]: ParseMethod } = {}
+    functionMap: { [key: string]: ParseMethod } = {},
   ) {
     super(name, json, functionMap);
     this.parser = parser;

--- a/ts/input/tex/UnitUtil.ts
+++ b/ts/input/tex/UnitUtil.ts
@@ -94,7 +94,7 @@ function muReplace([value, unit, length]: [string, string, number]): [
     return [value, unit, length];
   }
   let em = UnitUtil.em(
-    UnitUtil.UNIT_CASES.get(unit) * parseFloat(value || '1')
+    UnitUtil.UNIT_CASES.get(unit) * parseFloat(value || '1'),
   );
   return [em.slice(0, -2), 'em', length];
 }
@@ -124,7 +124,7 @@ export const UnitUtil = {
    */
   matchDimen(dim: string, rest: boolean = false): [string, string, number] {
     let match = dim.match(
-      rest ? UnitUtil.UNIT_CASES.dimenRest : UnitUtil.UNIT_CASES.dimenEnd
+      rest ? UnitUtil.UNIT_CASES.dimenRest : UnitUtil.UNIT_CASES.dimenEnd,
     );
     return match
       ? muReplace([match[1].replace(/,/, '.'), match[4], match[0].length])

--- a/ts/input/tex/action/ActionConfiguration.ts
+++ b/ts/input/tex/action/ActionConfiguration.ts
@@ -41,11 +41,11 @@ export const ActionMethods: { [key: string]: ParseMethod } = {
     let arg;
     while ((arg = parser.GetArgument(name)) !== '\\endtoggle') {
       children.push(
-        new TexParser(arg, parser.stack.env, parser.configuration).mml()
+        new TexParser(arg, parser.stack.env, parser.configuration).mml(),
       );
     }
     parser.Push(
-      parser.create('node', 'maction', children, { actiontype: 'toggle' })
+      parser.create('node', 'maction', children, { actiontype: 'toggle' }),
     );
   },
 
@@ -59,7 +59,7 @@ export const ActionMethods: { [key: string]: ParseMethod } = {
     const arg = parser.ParseArg(name);
     const tip = parser.ParseArg(name);
     parser.Push(
-      parser.create('node', 'maction', [arg, tip], { actiontype: 'tooltip' })
+      parser.create('node', 'maction', [arg, tip], { actiontype: 'tooltip' }),
     );
   },
 

--- a/ts/input/tex/ams/AmsConfiguration.ts
+++ b/ts/input/tex/ams/AmsConfiguration.ts
@@ -43,7 +43,7 @@ export class AmsTags extends AbstractTags {}
 let init = function (config: ParserConfiguration) {
   new CommandMap(NEW_OPS, {});
   config.append(
-    Configuration.local({ handler: { macro: [NEW_OPS] }, priority: -1 })
+    Configuration.local({ handler: { macro: [NEW_OPS] }, priority: -1 }),
   );
 };
 

--- a/ts/input/tex/ams/AmsItems.ts
+++ b/ts/input/tex/ams/AmsItems.ts
@@ -63,7 +63,7 @@ export class MultlineItem extends ArrayItem {
       'node',
       'mtd',
       this.nodes,
-      shove ? { columnalign: shove } : {}
+      shove ? { columnalign: shove } : {},
     );
     this.setProperty('shove', null);
     this.row.push(mtd);
@@ -79,7 +79,7 @@ export class MultlineItem extends ArrayItem {
       throw new TexError(
         'MultlineRowsOneCol',
         'The rows within the %1 environment must have exactly one column',
-        'multline'
+        'multline',
       );
     }
     let row = this.create('node', 'mtr', this.row);
@@ -98,25 +98,25 @@ export class MultlineItem extends ArrayItem {
       if (
         !NodeUtil.getAttribute(
           NodeUtil.getChildren(this.table[0])[0],
-          'columnalign'
+          'columnalign',
         )
       ) {
         NodeUtil.setAttribute(
           NodeUtil.getChildren(this.table[0])[0],
           'columnalign',
-          TexConstant.Align.LEFT
+          TexConstant.Align.LEFT,
         );
       }
       if (
         !NodeUtil.getAttribute(
           NodeUtil.getChildren(this.table[m])[0],
-          'columnalign'
+          'columnalign',
         )
       ) {
         NodeUtil.setAttribute(
           NodeUtil.getChildren(this.table[m])[0],
           'columnalign',
-          TexConstant.Align.RIGHT
+          TexConstant.Align.RIGHT,
         );
       }
       let tag = this.factory.configuration.tags.getTag();
@@ -129,7 +129,7 @@ export class MultlineItem extends ArrayItem {
         const mlabel = this.create(
           'node',
           'mlabeledtr',
-          [tag].concat(NodeUtil.getChildren(mtr))
+          [tag].concat(NodeUtil.getChildren(mtr)),
         );
         NodeUtil.copyAttributes(mtr, mlabel);
         this.table[label] = mlabel;
@@ -158,7 +158,7 @@ export class FlalignItem extends EqnArrayItem {
     public name: string,
     public numbered: boolean,
     public padded: boolean,
-    public center: boolean
+    public center: boolean,
   ) {
     super(factory);
     this.factory.configuration.tags.start(name, numbered, numbered);
@@ -176,7 +176,7 @@ export class FlalignItem extends EqnArrayItem {
         'XalignOverflow',
         'Extra %1 in row of %2',
         '&',
-        this.name
+        this.name,
       );
     }
   }
@@ -231,7 +231,7 @@ export class FlalignItem extends EqnArrayItem {
         'node',
         'mpadded',
         NodeUtil.getChildren(mtd),
-        def
+        def,
       );
       mtd.setChildren([mpadded]);
     }

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -94,7 +94,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     align: string,
     balign: string,
     spacing: string,
-    style: string
+    style: string,
   ) {
     // @test Aligned, Gathered
     const args = parser.GetBrackets('\\begin{' + begin.getName() + '}');
@@ -106,7 +106,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       align,
       balign,
       spacing,
-      style
+      style,
     );
     return ParseUtil.setArrayAlign(array as ArrayItem, args, parser);
   },
@@ -123,7 +123,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     begin: StackItem,
     numbered: boolean,
-    taggable: boolean
+    taggable: boolean,
   ) {
     const name = begin.getName();
     let n,
@@ -141,7 +141,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'PositiveIntegerArg',
         'Argument to %1 must be a positive integer',
-        '\\begin{' + name + '}'
+        '\\begin{' + name + '}',
       );
     }
     let count = parseInt(n, 10);
@@ -161,7 +161,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
         taggable,
         align,
         balign,
-        spaceStr
+        spaceStr,
       );
     }
     // @test Alignedat
@@ -172,12 +172,12 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       taggable,
       align,
       balign,
-      spaceStr
+      spaceStr,
     );
     return ParseUtil.setArrayAlign(
       array as ArrayItem,
       valign,
-      !taggable ? parser : null
+      !taggable ? parser : null,
     );
   },
 
@@ -195,7 +195,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     const item = parser.itemFactory.create(
       'multline',
       numbered,
-      parser.stack
+      parser.stack,
     ) as ArrayItem;
     item.arraydef = {
       displaystyle: true,
@@ -221,14 +221,14 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     begin: StackItem,
     numbered: boolean,
-    padded: boolean
+    padded: boolean,
   ) {
     let n = parser.GetArgument('\\begin{' + begin.getName() + '}');
     if (n.match(/[^0-9]/)) {
       throw new TexError(
         'PositiveIntegerArg',
         'Argument to %1 must be a positive integer',
-        '\\begin{' + begin.getName() + '}'
+        '\\begin{' + begin.getName() + '}',
       );
     }
     const align = padded ? 'crl' : 'rlc';
@@ -243,7 +243,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       align,
       balign,
       width,
-      true
+      true,
     ) as FlalignItem;
     item.setProperty('xalignat', 2 * parseInt(n));
     return item;
@@ -270,7 +270,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     align: string,
     balign: string,
     width: string,
-    zeroWidthLabel: boolean = false
+    zeroWidthLabel: boolean = false,
   ) {
     ParseUtil.checkEqnEnv(parser);
     parser.Push(begin);
@@ -287,7 +287,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       numbered,
       padded,
       center,
-      parser.stack
+      parser.stack,
     ) as FlalignItem;
     item.arraydef = {
       width: '100%',
@@ -319,7 +319,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     let op = parser.GetArgument(name);
     (parser.configuration.handlers.retrieve(NEW_OPS) as CommandMap).add(
       cs,
-      new Macro(cs, AmsMethods.Macro, [`\\operatorname${star}{${op}}`])
+      new Macro(cs, AmsMethods.Macro, [`\\operatorname${star}{${op}}`]),
     );
     parser.Push(parser.itemFactory.create('null'));
   },
@@ -344,7 +344,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
         multiLetterIdentifiers: parser.options.ams.operatornamePattern,
         operatorLetters: true,
       },
-      parser.configuration
+      parser.configuration,
     ).mml();
     //
     //  If we get something other than a single mi, wrap in a TeXAtom.
@@ -406,10 +406,10 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
               'node',
               'mpadded',
               [ParseUtil.copyNode(base, parser)],
-              { width: 0 }
+              { width: 0 },
             ),
           ]),
-          NodeUtil.getChildAt(preScripts, 0)
+          NodeUtil.getChildAt(preScripts, 0),
         );
       } else {
         //
@@ -527,7 +527,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       'token',
       'mo',
       { stretchy: true, texClass: TEXCLASS.REL },
-      String.fromCodePoint(chr)
+      String.fromCodePoint(chr),
     );
     arrow = parser.create('node', 'mstyle', [arrow], { scriptlevel: 0 });
     let mml = parser.create('node', 'munderover', [arrow]) as MmlMunderover;
@@ -540,7 +540,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       let bottom = new TexParser(
         bot,
         parser.stack.env,
-        parser.configuration
+        parser.configuration,
       ).mml();
       let bstrut = parser.create('node', 'mspace', [], { height: '.75em' });
       mpadded = parser.create('node', 'mpadded', [bottom, bstrut], def);
@@ -569,7 +569,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
         'CommandOnlyAllowedInEnv',
         '%1 only allowed in %2 environment',
         parser.currentCS,
-        'multline'
+        'multline',
       );
     }
     if (top.Size()) {
@@ -577,7 +577,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'CommandAtTheBeginingOfLine',
         '%1 must come at the beginning of the line',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     top.setProperty('shove', shove);
@@ -600,12 +600,12 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     let numNode = new TexParser(
       '\\strut\\textstyle{' + num + '}',
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     ).mml();
     let denNode = new TexParser(
       '\\strut\\textstyle{' + den + '}',
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     ).mml();
     let frac = parser.create('node', 'mfrac', [numNode, denNode]);
     lr = lrMap[lr];
@@ -614,7 +614,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'IllegalAlign',
         'Illegal alignment specified in %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     if (lr) {
@@ -640,7 +640,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
     left: string,
     right: string,
     thick: string,
-    style: string
+    style: string,
   ) {
     if (left == null) {
       // @test Genfrac
@@ -678,7 +678,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'BadMathStyleFor',
           'Bad math style for %1',
-          parser.currentCS
+          parser.currentCS,
         );
       }
       frac = parser.create('node', 'mstyle', [frac]);
@@ -711,7 +711,7 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
         'CommandNotAllowedInEnv',
         '%1 not allowed in %2 environment',
         parser.currentCS,
-        parser.tags.env
+        parser.tags.env,
       );
     }
     if (parser.tags.currentTag.tag) {

--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -127,7 +127,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
             let nodeA = new TexParser(
               a,
               parser.stack.env,
-              parser.configuration
+              parser.configuration,
             ).mml();
             let mpadded = parser.create('node', 'mpadded', [nodeA], pad);
             NodeUtil.setAttribute(mpadded, 'voffset', '.1em');
@@ -137,12 +137,12 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
             let nodeB = new TexParser(
               b,
               parser.stack.env,
-              parser.configuration
+              parser.configuration,
             ).mml();
             NodeUtil.setChild(
               mml,
               mml.under,
-              parser.create('node', 'mpadded', [nodeB], pad)
+              parser.create('node', 'mpadded', [nodeB], pad),
             );
           }
           if (parser.configuration.options.amscd.hideHorizontalLabels) {
@@ -165,7 +165,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
               new TexParser(
                 '\\scriptstyle\\llap{' + a + '}',
                 parser.stack.env,
-                parser.configuration
+                parser.configuration,
               ).mml(),
             ]);
           }
@@ -176,7 +176,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
               new TexParser(
                 '\\scriptstyle\\rlap{' + b + '}',
                 parser.stack.env,
-                parser.configuration
+                parser.configuration,
               ).mml(),
             ]);
           }
@@ -202,13 +202,13 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
       // better spacing of arrow rows.
       //
       parser.Push(
-        parser.create('node', 'mpadded', [], { height: '8.5pt', depth: '2pt' })
+        parser.create('node', 'mpadded', [], { height: '8.5pt', depth: '2pt' }),
       );
     }
     parser.Push(
       parser.itemFactory
         .create('cell')
-        .setProperties({ isEntry: true, name: name })
+        .setProperties({ isEntry: true, name: name }),
     );
   },
 

--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -51,7 +51,7 @@ function Autoload(
   parser: TexParser,
   name: string,
   extension: string,
-  isMacro: boolean
+  isMacro: boolean,
 ) {
   if (Package.packages.has(parser.options.require.prefix + extension)) {
     const def = parser.options.autoload[extension];
@@ -120,7 +120,7 @@ function configAutoload(config: ParserConfiguration, jax: TeX<any, any, any>) {
       if (!environments.lookup(name)) {
         AutoloadEnvironments.add(
           name,
-          new Macro(name, Autoload, [extension, false])
+          new Macro(name, Autoload, [extension, false]),
         );
       }
     }

--- a/ts/input/tex/base/BaseConfiguration.ts
+++ b/ts/input/tex/base/BaseConfiguration.ts
@@ -88,7 +88,7 @@ function csUndefined(_parser: TexParser, name: string) {
   throw new TexError(
     'UndefinedControlSequence',
     'Undefined control sequence %1',
-    '\\' + name
+    '\\' + name,
   );
 }
 

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -48,7 +48,7 @@ export class StartItem extends BaseItem {
    */
   constructor(
     factory: StackItemFactory,
-    public global: EnvList
+    public global: EnvList,
   ) {
     super(factory);
   }
@@ -202,7 +202,7 @@ export class PrimeItem extends BaseItem {
       const node = this.create(
         'node',
         top0.getProperty('movesupsub') ? 'mover' : 'msup',
-        [top0, top1]
+        [top0, top1],
       );
       return [[node, item], true];
     }
@@ -255,7 +255,7 @@ export class SubsupItem extends BaseItem {
           NodeUtil.setProperty(
             this.getProperty('primes') as MmlNode,
             'variantForm',
-            true
+            true,
           );
           const node = this.create('node', 'mrow', [
             this.getProperty('primes') as MmlNode,
@@ -270,7 +270,7 @@ export class SubsupItem extends BaseItem {
         NodeUtil.setProperty(
           top,
           'movesupsub',
-          this.getProperty('movesupsub') as Property
+          this.getProperty('movesupsub') as Property,
         );
       }
       const result = this.factory.create('mml', top);
@@ -320,7 +320,7 @@ export class OverItem extends BaseItem {
       throw new TexError(
         'AmbiguousUseOf',
         'Ambiguous use of %1',
-        item.getName()
+        item.getName(),
       );
     }
     if (item.isClose) {
@@ -334,7 +334,7 @@ export class OverItem extends BaseItem {
         NodeUtil.setAttribute(
           mml,
           'linethickness',
-          this.getProperty('thickness') as string
+          this.getProperty('thickness') as string,
         );
       }
       if (this.getProperty('ldelim') || this.getProperty('rdelim')) {
@@ -344,12 +344,12 @@ export class OverItem extends BaseItem {
           this.factory.configuration,
           this.getProperty('ldelim') as string,
           mml,
-          this.getProperty('rdelim') as string
+          this.getProperty('rdelim') as string,
         );
       }
       mml.attributes.set(
         TexConstant.Attr.LATEXITEM,
-        this.getProperty('name') as string
+        this.getProperty('name') as string,
       );
       return [[this.factory.create('mml', mml), item], true];
     }
@@ -415,7 +415,7 @@ export class LeftItem extends BaseItem {
         this.toMml(),
         item.getProperty('delim') as string,
         '',
-        item.getProperty('color') as string
+        item.getProperty('color') as string,
       );
       let left = fenced.childNodes[0];
       let right = fenced.childNodes[fenced.childNodes.length - 1];
@@ -426,7 +426,7 @@ export class LeftItem extends BaseItem {
         .Peek()[0]
         .attributes.set(
           TexConstant.Attr.LATEXITEM,
-          '\\left' + item.startStr.slice(this.startI, item.stopI)
+          '\\left' + item.startStr.slice(this.startI, item.stopI),
         );
       return [[mrow], true];
     }
@@ -443,7 +443,7 @@ export class LeftItem extends BaseItem {
       this.Push(
         this.create('node', 'TeXAtom', [], { texClass: TEXCLASS.CLOSE }),
         middle,
-        this.create('node', 'TeXAtom', [], { texClass: TEXCLASS.OPEN })
+        this.create('node', 'TeXAtom', [], { texClass: TEXCLASS.OPEN }),
       );
       this.env = {}; // Since \middle closes the group, clear the environment
       return [[this], true]; // this will reset the environment to its initial state
@@ -587,7 +587,7 @@ export class BeginItem extends BaseItem {
           'EnvBadEnd',
           '\\begin{%1} ended with \\end{%2}',
           this.getName(),
-          item.getName()
+          item.getName(),
         );
       }
       if (!this.getProperty('end')) {
@@ -650,7 +650,7 @@ export class StyleItem extends BaseItem {
       'node',
       'mstyle',
       this.nodes,
-      this.getProperty('styles')
+      this.getProperty('styles'),
     );
     return [[this.factory.create('mml', mml), item], true];
   }
@@ -792,7 +792,7 @@ export class FnItem extends BaseItem {
         'token',
         'mo',
         { texClass: TEXCLASS.NONE },
-        entities.ApplyFunction
+        entities.ApplyFunction,
       );
       return [[top, node, item], true];
     }
@@ -1096,7 +1096,7 @@ export class ArrayItem extends BaseItem {
       NodeUtil.setAttribute(
         mml,
         'framespacing',
-        this.getProperty('arrayPadding') as string
+        this.getProperty('arrayPadding') as string,
       );
     }
     mml = this.handleFrame(mml);
@@ -1106,7 +1106,7 @@ export class ArrayItem extends BaseItem {
         this.factory.configuration,
         this.getProperty('open') as string,
         mml,
-        this.getProperty('close') as string
+        this.getProperty('close') as string,
       );
     }
     return mml;
@@ -1128,7 +1128,7 @@ export class ArrayItem extends BaseItem {
     //
     const fstyle = this.frame.reduce(
       (fstyle, [, style]) => (style === fstyle ? style : ''),
-      this.frame[0][1]
+      this.frame[0][1],
     );
     if (fstyle) {
       if (this.frame.length === 4) {
@@ -1253,7 +1253,7 @@ export class ArrayItem extends BaseItem {
           i -= match[2].length;
           let entry = parser.string.slice(parser.i, i).trim();
           const prefix = entry.match(
-            /^(?:\s*\\(?:h(?:dash)?line|hfil{1,3}|rowcolor\s*\{.*?\}))+/
+            /^(?:\s*\\(?:h(?:dash)?line|hfil{1,3}|rowcolor\s*\{.*?\}))+/,
           );
           if (prefix) {
             entry = entry.slice(prefix[0].length);
@@ -1283,7 +1283,7 @@ export class ArrayItem extends BaseItem {
         NodeUtil.setAttribute(
           mtd,
           'columnalign',
-          NodeUtil.getAttribute(mtd, 'columnalign') ? 'center' : 'left'
+          NodeUtil.getAttribute(mtd, 'columnalign') ? 'center' : 'left',
         );
       }
     }
@@ -1397,7 +1397,7 @@ export class ArrayItem extends BaseItem {
         rows.push(UnitUtil.em(rowspacing));
       }
       rows[this.table.length - 1] = UnitUtil.em(
-        Math.max(0, rowspacing + UnitUtil.dimen2em(spacing))
+        Math.max(0, rowspacing + UnitUtil.dimen2em(spacing)),
       );
       this.arraydef['rowspacing'] = rows.join(' ');
     }
@@ -1517,7 +1517,7 @@ export class EqnArrayItem extends ArrayItem {
               'node',
               'mstyle',
               cell.childNodes[0].childNodes,
-              { indentshift }
+              { indentshift },
             );
             cell.childNodes[0].childNodes = [];
             cell.appendChild(mstyle);
@@ -1629,7 +1629,7 @@ function addLatexItem(node: MmlNode, item: StackItem, prefix: string = '') {
   if (str) {
     node.attributes.set(
       TexConstant.Attr.LATEXITEM,
-      prefix ? prefix + str : str
+      prefix ? prefix + str : str,
     );
     node.attributes.set(TexConstant.Attr.LATEX, prefix ? prefix + str : str);
   }

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -72,7 +72,7 @@ export function splitAlignArray(align: string, n: number = Infinity) {
         throw new TexError(
           'BadBreakAlign',
           'Invalid alignment character: %1',
-          s
+          s,
         );
       }
       return name;
@@ -81,7 +81,7 @@ export function splitAlignArray(align: string, n: number = Infinity) {
     throw new TexError(
       'TooManyAligns',
       'Too many alignment characters: %1',
-      align
+      align,
     );
   }
   return n === 1 ? list[0] : list.join(' ');
@@ -151,8 +151,8 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         'token',
         'mo',
         { stretchy: false, texClass: TEXCLASS.ORD },
-        c
-      )
+        c,
+      ),
     );
   },
 
@@ -217,7 +217,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       // @test Double-super-error, Double-over-error
       throw new TexError(
         'DoubleExponent',
-        'Double exponent: use braces to clarify'
+        'Double exponent: use braces to clarify',
       );
     }
     if (!NodeUtil.isType(base, 'msubsup') || NodeUtil.isType(base, 'msup')) {
@@ -245,7 +245,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         position: position,
         primes: primes,
         movesupsub: movesupsub,
-      })
+      }),
     );
   },
 
@@ -291,7 +291,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       // @test Double-sub-error, Double-under-error
       throw new TexError(
         'DoubleSubscripts',
-        'Double subscripts: use braces to clarify'
+        'Double subscripts: use braces to clarify',
       );
     }
     if (!NodeUtil.isType(base, 'msubsup') || NodeUtil.isType(base, 'msup')) {
@@ -319,7 +319,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         position: position,
         primes: primes,
         movesupsub: movesupsub,
-      })
+      }),
     );
   },
 
@@ -347,7 +347,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       // @test Double Prime Error
       throw new TexError(
         'DoubleExponentPrime',
-        'Prime causes double exponent: use braces to clarify'
+        'Prime causes double exponent: use braces to clarify',
       );
     }
     let sup = '';
@@ -385,7 +385,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     // @test Hash Error
     throw new TexError(
       'CantUseHash1',
-      "You can't use 'macro parameter character #' in math mode"
+      "You can't use 'macro parameter character #' in math mode",
     );
   },
 
@@ -396,7 +396,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     name: string,
     variant: string,
-    italic: string = ''
+    italic: string = '',
   ) {
     const text = parser.GetArgument(name);
     let mml = new TexParser(
@@ -408,7 +408,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         italicFont: italic,
         noAutoOP: true,
       },
-      parser.configuration
+      parser.configuration,
     ).mml();
     parser.Push(parser.create('node', 'TeXAtom', [mml]));
   },
@@ -437,14 +437,14 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     _name: string,
     texStyle: string,
     style: boolean,
-    level: string
+    level: string,
   ) {
     parser.stack.env['style'] = texStyle;
     parser.stack.env['level'] = level;
     parser.Push(
       parser.itemFactory
         .create('style')
-        .setProperty('styles', { displaystyle: style, scriptlevel: level })
+        .setProperty('styles', { displaystyle: style, scriptlevel: level }),
     );
   },
 
@@ -459,7 +459,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('style')
-        .setProperty('styles', { mathsize: em(size) })
+        .setProperty('styles', { mathsize: em(size) }),
     );
   },
 
@@ -484,7 +484,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
    */
   DiscretionaryTimes(parser: TexParser, _name: string) {
     parser.Push(
-      parser.create('token', 'mo', { linebreakmultchar: '\u00D7' }, '\u2062')
+      parser.create('token', 'mo', { linebreakmultchar: '\u00D7' }, '\u2062'),
     );
   },
 
@@ -508,7 +508,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.create('token', 'mspace', {
         linebreak: TexConstant.LineBreak.NEWLINE,
-      })
+      }),
     );
   },
 
@@ -546,8 +546,8 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       parser.itemFactory.create(
         first,
         parser.GetDelimiter(name),
-        parser.stack.env.color
-      )
+        parser.stack.env.color,
+      ),
     );
   },
 
@@ -587,7 +587,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         form: TexConstant.Form.PREFIX,
         texClass: TEXCLASS.OP,
       },
-      id
+      id,
     );
     parser.Push(mml);
   },
@@ -611,7 +611,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MisplacedLimits',
         '%1 is allowed only on operators',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     const top = parser.stack.Top();
@@ -731,7 +731,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MisplacedMoveRoot',
         '%1 can appear only within a root',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     if (parser.stack.global[id]) {
@@ -739,7 +739,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MultipleMoveRoot',
         'Multiple use of %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     let n = parser.GetArgument(name);
@@ -748,7 +748,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'IntegerArg',
         'The argument to %1 must be an integer',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     n = parseInt(n, 10) / 15 + 'em';
@@ -809,7 +809,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       'token',
       'mo',
       { stretchy: true, accent: true },
-      entity
+      entity,
     );
     mo.setProperty('mathaccent', false);
     const pos = name.charAt(1) === 'o' ? 'over' : 'under';
@@ -897,7 +897,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         const parsed = new TexParser(
           arg,
           parser.stack.env,
-          parser.configuration
+          parser.configuration,
         ).mml();
         node = parser.create('node', 'TeXAtom', [parsed], def);
       }
@@ -919,7 +919,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     const arg = new TexParser(
       parser.GetArgument(name),
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     );
     const def = {
       'data-vertical-align': align,
@@ -975,7 +975,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BreakNotInArray',
         '%1 must be used in an alignment environment',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     const type = parser.GetArgument(name).trim();
@@ -985,7 +985,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
           throw new TexError(
             'BreakFirstInEntry',
             '%1 must be at the beginning of an alignment entry',
-            parser.currentCS + '{c}'
+            parser.currentCS + '{c}',
           );
         }
         top.breakAlign.cell = splitAlignArray(parser.GetArgument(name), 1);
@@ -995,7 +995,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
           throw new TexError(
             'BreakFirstInRow',
             '%1 must be at the beginning of an alignment row',
-            parser.currentCS + '{r}'
+            parser.currentCS + '{r}',
           );
         }
         top.breakAlign.row = splitAlignArray(parser.GetArgument(name));
@@ -1005,7 +1005,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
           throw new TexError(
             'BreakFirstInTable',
             '%1 must be at the beginning of an alignment',
-            parser.currentCS + '{t}'
+            parser.currentCS + '{t}',
           );
         }
         top.breakAlign.table = splitAlignArray(parser.GetArgument(name));
@@ -1014,7 +1014,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'BreakType',
           'First argument to %1 must be one of c, r, or t',
-          parser.currentCS
+          parser.currentCS,
         );
     }
   },
@@ -1043,14 +1043,14 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     }
     while (attr !== '') {
       const match = attr.match(
-        /^([a-z]+)\s*=\s*('[^']*'|"[^"]*"|[^ ,]*)\s*,?\s*/i
+        /^([a-z]+)\s*=\s*('[^']*'|"[^"]*"|[^ ,]*)\s*,?\s*/i,
       );
       if (!match) {
         // @test Token Invalid Attribute
         throw new TexError(
           'InvalidMathMLAttr',
           'Invalid MathML attribute: %1',
-          attr
+          attr,
         );
       }
       if (!node.attributes.hasDefault(match[1]) && !MmlTokenAllow[match[1]]) {
@@ -1059,13 +1059,13 @@ const BaseMethods: { [key: string]: ParseMethod } = {
           'UnknownAttrForElement',
           '%1 is not a recognized attribute for %2',
           match[1],
-          kind
+          kind,
         );
       }
       let value: string | boolean = ParseUtil.mmlFilterAttribute(
         parser,
         match[1],
-        match[2].replace(/^(['"])(.*)\1$/, '$2')
+        match[2].replace(/^(['"])(.*)\1$/, '$2'),
       );
       if (value) {
         if (value.toLowerCase() === 'true') {
@@ -1222,7 +1222,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         move: 'horizontal',
         left: parser.create('node', 'mspace', [], { width: h }),
         right: parser.create('node', 'mspace', [], { width: nh }),
-      })
+      }),
     );
   },
 
@@ -1317,7 +1317,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         stretchy: true,
         symmetric: true,
       },
-      delim
+      delim,
     );
     const node = parser.create('node', 'TeXAtom', [mo], { texClass: mclass });
     parser.Push(node);
@@ -1353,7 +1353,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
   HBox(parser: TexParser, name: string, style: string, font?: string) {
     // @test Hbox
     parser.PushAll(
-      ParseUtil.internalMath(parser, parser.GetArgument(name), style, font)
+      ParseUtil.internalMath(parser, parser.GetArgument(name), style, font),
     );
   },
 
@@ -1392,7 +1392,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       'node',
       'TeXAtom',
       [parser.create('node', 'menclose', mml, { notation: 'box' })],
-      { texClass: TEXCLASS.ORD }
+      { texClass: TEXCLASS.ORD },
     );
     parser.Push(node);
   },
@@ -1409,7 +1409,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     const mml = parser.create(
       'node',
       'mpadded',
-      ParseUtil.internalMath(parser, parser.GetArgument(name))
+      ParseUtil.internalMath(parser, parser.GetArgument(name)),
     );
     if (width) {
       NodeUtil.setAttribute(mml, 'width', width);
@@ -1447,19 +1447,19 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       'token',
       'mo',
       { stretchy: false },
-      ldotsEntity
+      ldotsEntity,
     );
     const cdots = parser.create(
       'token',
       'mo',
       { stretchy: false },
-      cdotsEntity
+      cdotsEntity,
     );
     parser.Push(
       parser.itemFactory.create('dots').setProperties({
         ldots: ldots,
         cdots: cdots,
-      })
+      }),
     );
   },
 
@@ -1486,7 +1486,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     vspacing: string,
     style: string,
     cases: boolean,
-    numbered: boolean
+    numbered: boolean,
   ) {
     const c = parser.GetNext();
     if (c === '') {
@@ -1494,7 +1494,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MissingArgFor',
         'Missing argument for %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     if (c === '{') {
@@ -1551,7 +1551,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('cell')
-        .setProperties({ isEntry: true, name: name })
+        .setProperties({ isEntry: true, name: name }),
     );
     const top = parser.stack.Top();
     const env = top.getProperty('casesEnv') as string;
@@ -1606,7 +1606,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         // @test ExtraAlignTab
         throw new TexError(
           'ExtraAlignTab',
-          'Extra alignment tab in \\cases text'
+          'Extra alignment tab in \\cases text',
         );
       } else if (c === '\\') {
         //
@@ -1641,7 +1641,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       const internal = ParseUtil.internalMath(
         parser,
         UnitUtil.trimSpaces(text),
-        0
+        0,
       );
       parser.PushAll(internal);
       parser.i = i;
@@ -1658,7 +1658,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('cell')
-        .setProperties({ isCR: true, name: name })
+        .setProperties({ isCR: true, name: name }),
     );
   },
 
@@ -1687,7 +1687,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
           throw new TexError(
             'BracketMustBeDimension',
             'Bracket argument to %1 must be a dimension',
-            parser.currentCS
+            parser.currentCS,
           );
         }
         n = value + unit;
@@ -1696,7 +1696,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('cell')
-        .setProperties({ isCR: true, name: name, linebreak: true })
+        .setProperties({ isCR: true, name: name, linebreak: true }),
     );
     const top = parser.stack.Top();
     let node: MmlNode;
@@ -1764,7 +1764,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'UnsupportedHFill',
         'Unsupported use of %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
   },
@@ -1782,14 +1782,14 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BadColumnName',
         'Column specifier must be exactly one character: %1',
-        c
+        c,
       );
     }
     if (!n.match(/^\d+$/)) {
       throw new TexError(
         'PositiveIntegerArg',
         'Argument to %1 must be a positive integer',
-        n
+        n,
       );
     }
     const cparser = parser.configuration.columnParser;
@@ -1854,7 +1854,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     spacing: string,
     vspacing: string,
     style: string,
-    raggedHeight: boolean
+    raggedHeight: boolean,
   ) {
     if (!align) {
       // @test Array Single
@@ -1918,7 +1918,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       null,
       null,
       null,
-      style
+      style,
     );
     return ParseUtil.setArrayAlign(item as sitem.ArrayItem, align);
   },
@@ -1944,7 +1944,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BracketMustBeDimension',
         'Bracket argument to %1 must be a dimension',
-        name
+        name,
       );
     }
     //
@@ -1954,11 +1954,11 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     if (lcr && !lcr.match(/^([lcr]{1,3})?$/)) {
       throw new TexError(
         'BadAlignment',
-        'Alignment must be one to three copies of l, c, or r'
+        'Alignment must be one to three copies of l, c, or r',
       );
     }
     const align = [...lcr].map(
-      (c) => ({ l: 'left', c: 'center', r: 'right' })[c]
+      (c) => ({ l: 'left', c: 'center', r: 'right' })[c],
     );
     align.length === 1 && align.push(align[0]);
     //
@@ -1994,7 +1994,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     begin: StackItem,
     numbered: boolean,
-    display: boolean = true
+    display: boolean = true,
   ) {
     parser.configuration.mathItem.display = display;
     parser.stack.env.display = display;
@@ -2022,7 +2022,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     taggable: boolean,
     align: string,
     balign: string,
-    spacing: string
+    spacing: string,
   ) {
     // @test The Lorenz Equations, Maxwell's Equations, Cubic Binomial
     let name = begin.getName();
@@ -2045,7 +2045,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       name,
       numbered,
       taggable,
-      parser.stack.global
+      parser.stack.global,
     ) as sitem.ArrayItem;
     newItem.arraydef = {
       displaystyle: true,
@@ -2098,7 +2098,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'MultipleLabel',
           "Label '%1' multiply defined",
-          label
+          label,
         );
       }
       // TODO: This should be set in the tags structure!
@@ -2135,7 +2135,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       {
         href: parser.tags.formatUrl(ref.id, parser.options.baseURL),
         class: 'MathJax_ref',
-      }
+      },
     );
     parser.Push(node);
   },
@@ -2148,7 +2148,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     name: string,
     macro: string,
     argcount: number,
-    def?: string
+    def?: string,
   ) {
     if (argcount) {
       const args: string[] = [];
@@ -2164,7 +2164,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     parser.string = ParseUtil.addArgs(
       parser,
       macro,
-      parser.string.slice(parser.i)
+      parser.string.slice(parser.i),
     );
     parser.i = 0;
     ParseUtil.checkMaxMacros(parser);

--- a/ts/input/tex/bbm/BbmConfiguration.ts
+++ b/ts/input/tex/bbm/BbmConfiguration.ts
@@ -36,7 +36,7 @@ export const BbmMethods: { [key: string]: ParseMethod } = {
     BaseMethods.MathFont(
       parser,
       name,
-      parser.options.bbm.bold ? bold : regular
+      parser.options.bbm.bold ? bold : regular,
     );
   },
 

--- a/ts/input/tex/bboldx/BboldxMappings.ts
+++ b/ts/input/tex/bboldx/BboldxMappings.ts
@@ -201,7 +201,7 @@ new CharacterMap(
     txtbbomega: '\u03C9',
     txtbbdotlessi: '\u0131',
     txtbbdotlessj: '\u0237',
-  }
+  },
 );
 
 /**

--- a/ts/input/tex/bboldx/BboldxMethods.ts
+++ b/ts/input/tex/bboldx/BboldxMethods.ts
@@ -38,7 +38,7 @@ export const BboldxMethods = {
     name: string,
     normal: string,
     light: string,
-    bfbb: string
+    bfbb: string,
   ) {
     const font = getBbxFont(parser, normal, light, bfbb);
     BaseMethods.MathFont(parser, name, font);
@@ -49,7 +49,7 @@ export const BboldxMethods = {
     name: string,
     normal: string,
     light: string,
-    bfbb: string
+    bfbb: string,
   ) {
     const font = getBbxFont(parser, normal, light, bfbb);
     TextMacrosMethods.TextFont(parser, name, font);
@@ -66,7 +66,7 @@ export const BboldxMethods = {
       'token',
       'mi',
       { mathvariant: font },
-      mchar.char
+      mchar.char,
     );
     parser.Push(node);
   },
@@ -94,7 +94,7 @@ export const BboldxMethods = {
       'token',
       'mi',
       { mathvariant: font },
-      mchar.char
+      mchar.char,
     );
     parser.Push(node);
   },
@@ -125,7 +125,7 @@ function getBbxFont(
   parser: TexParser,
   normal: string,
   light: string,
-  bfbb: string
+  bfbb: string,
 ) {
   if (!parser.options?.bboldx) {
     return normal;

--- a/ts/input/tex/bbox/BboxConfiguration.ts
+++ b/ts/input/tex/bbox/BboxConfiguration.ts
@@ -43,7 +43,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
     for (let i = 0, m = parts.length; i < m; i++) {
       const part = parts[i].trim();
       const match = part.match(
-        /^(\.\d+|\d+(\.\d*)?)(pt|em|ex|mu|px|in|cm|mm)$/
+        /^(\.\d+|\d+(\.\d*)?)(pt|em|ex|mu|px|in|cm|mm)$/,
       );
       if (match) {
         // @test Bbox-Padding
@@ -53,7 +53,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
             'MultipleBBoxProperty',
             '%1 specified twice in %2',
             'Padding',
-            name
+            name,
           );
         }
         const pad = BBoxPadding(match[1] + match[3]);
@@ -74,7 +74,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
             'MultipleBBoxProperty',
             '%1 specified twice in %2',
             'Background',
-            name
+            name,
           );
         }
         background = part;
@@ -86,7 +86,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
             'MultipleBBoxProperty',
             '%1 specified twice in %2',
             'Style',
-            name
+            name,
           );
         }
         style = BBoxStyle(part);
@@ -95,7 +95,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'InvalidBBoxProperty',
           '"%1" doesn\'t look like a color, a padding dimension, or a style',
-          part
+          part,
         );
       }
     }

--- a/ts/input/tex/boldsymbol/BoldsymbolConfiguration.ts
+++ b/ts/input/tex/boldsymbol/BoldsymbolConfiguration.ts
@@ -72,7 +72,7 @@ export function createBoldToken(
   factory: NodeFactory,
   kind: string,
   def: any,
-  text: string
+  text: string,
 ): MmlNode {
   let token = NodeFactory.createToken(factory, kind, def, text);
   if (
@@ -99,7 +99,7 @@ export function rewriteBoldTokens(arg: { data: ParseOptions }) {
         NodeUtil.setAttribute(
           node,
           'mathvariant',
-          BOLDVARIANT[variant] || variant
+          BOLDVARIANT[variant] || variant,
         );
       }
       NodeUtil.removeProperties(node, 'fixBold');

--- a/ts/input/tex/braket/BraketMethods.ts
+++ b/ts/input/tex/braket/BraketMethods.ts
@@ -46,14 +46,14 @@ const BraketMethods: { [key: string]: ParseMethod } = {
     close: string,
     stretchy: boolean,
     barmax: number,
-    space: boolean = false
+    space: boolean = false,
   ) {
     let next = parser.GetNext();
     if (next === '') {
       throw new TexError(
         'MissingArgFor',
         'Missing argument for %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     let single = true;
@@ -101,7 +101,7 @@ const BraketMethods: { [key: string]: ParseMethod } = {
         'token',
         'mo',
         { stretchy: false, 'data-braketbar': true, texClass: TEXCLASS.ORD },
-        c
+        c,
       );
       parser.Push(node);
       return;
@@ -124,9 +124,9 @@ const BraketMethods: { [key: string]: ParseMethod } = {
         'token',
         'mo',
         { stretchy: true, 'data-braketbar': true, texClass: TEXCLASS.BIN },
-        c
+        c,
       ),
-      parser.create('node', 'TeXAtom', [], { texClass: TEXCLASS.OPEN })
+      parser.create('node', 'TeXAtom', [], { texClass: TEXCLASS.OPEN }),
     );
     top.setProperty('barcount', (top.getProperty('barcount') as number) + 1);
   },

--- a/ts/input/tex/bussproofs/BussproofsMethods.ts
+++ b/ts/input/tex/bussproofs/BussproofsMethods.ts
@@ -64,25 +64,25 @@ function createRule(
   left: MmlNode | null,
   right: MmlNode | null,
   style: string,
-  rootAtTop: boolean
+  rootAtTop: boolean,
 ) {
   const upper = parser.create(
     'node',
     'mtr',
     [parser.create('node', 'mtd', [premise], {})],
-    {}
+    {},
   );
   const lower = parser.create(
     'node',
     'mtr',
     [parser.create('node', 'mtd', conclusions, {})],
-    {}
+    {},
   );
   let rule = parser.create(
     'node',
     'mtable',
     rootAtTop ? [lower, upper] : [upper, lower],
-    { align: 'top 2', rowlines: style, framespacing: '0 0' }
+    { align: 'top 2', rowlines: style, framespacing: '0 0' },
   );
   BussproofsUtil.setProperty(rule, 'inferenceRule', rootAtTop ? 'up' : 'down');
   let leftLabel, rightLabel;
@@ -135,7 +135,7 @@ function parseFCenterLine(parser: TexParser, name: string): MmlNode {
     throw new TexError(
       'IllegalUseOfCommand',
       'Use of %1 does not match its definition.',
-      name
+      name,
     );
   }
   parser.i++;
@@ -145,7 +145,7 @@ function parseFCenterLine(parser: TexParser, name: string): MmlNode {
       'MissingProofCommand',
       'Missing %1 in %2.',
       '\\fCenter',
-      name
+      name,
     );
   }
   // Check for fCenter and throw error?
@@ -153,17 +153,17 @@ function parseFCenterLine(parser: TexParser, name: string): MmlNode {
   let premise = new TexParser(
     prem,
     parser.stack.env,
-    parser.configuration
+    parser.configuration,
   ).mml();
   let conclusion = new TexParser(
     conc,
     parser.stack.env,
-    parser.configuration
+    parser.configuration,
   ).mml();
   let fcenter = new TexParser(
     '\\fCenter',
     parser.stack.env,
-    parser.configuration
+    parser.configuration,
   ).mml();
   const left = parser.create('node', 'mtd', [premise], {});
   const middle = parser.create('node', 'mtd', [fcenter], {});
@@ -212,7 +212,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     let content = paddedContent(parser, parser.GetArgument(name));
@@ -231,7 +231,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     if (top.Size() < n) {
@@ -247,7 +247,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
       children.unshift(
         parser.create('node', 'mtd', [top.Pop()], {
           rowalign: rootAtTop ? 'top' : 'bottom',
-        })
+        }),
       );
       n--;
     } while (n > 0);
@@ -265,7 +265,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
       top.getProperty('left') as MmlNode,
       top.getProperty('right') as MmlNode,
       style,
-      rootAtTop
+      rootAtTop,
     );
     top.setProperty('left', null);
     top.setProperty('right', null);
@@ -286,7 +286,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     let content = ParseUtil.internalMath(parser, parser.GetArgument(name), 0);
@@ -310,7 +310,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     top.setProperty('currentLine', style);
@@ -330,7 +330,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     top.setProperty('rootAtTop', where);
@@ -346,7 +346,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     let line = parseFCenterLine(parser, name);
@@ -372,7 +372,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
     if (top.kind !== 'proofTree') {
       throw new TexError(
         'IllegalProofCommand',
-        'Proof commands only allowed in prooftree environment.'
+        'Proof commands only allowed in prooftree environment.',
       );
     }
     if (top.Size() < n) {
@@ -388,7 +388,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
       children.unshift(
         parser.create('node', 'mtd', [top.Pop()], {
           rowalign: rootAtTop ? 'top' : 'bottom',
-        })
+        }),
       );
       n--;
     } while (n > 0);
@@ -407,7 +407,7 @@ const BussproofsMethods: { [key: string]: ParseMethod } = {
       top.getProperty('left') as MmlNode,
       top.getProperty('right') as MmlNode,
       style,
-      rootAtTop
+      rootAtTop,
     );
     top.setProperty('left', null);
     top.setProperty('right', null);

--- a/ts/input/tex/bussproofs/BussproofsUtil.ts
+++ b/ts/input/tex/bussproofs/BussproofsUtil.ts
@@ -194,7 +194,7 @@ let getParentInf = function (inf: MmlNode): MmlNode {
 let getSpaces = function (
   inf: MmlNode,
   rule: MmlNode,
-  right: boolean = false
+  right: boolean = false,
 ): number {
   let result = 0;
   if (inf === rule) {
@@ -250,7 +250,7 @@ let addSpace = function (
   config: ParseOptions,
   inf: MmlNode,
   space: number,
-  right: boolean = false
+  right: boolean = false,
 ) {
   if (space === 0) return;
   if (getProperty(inf, 'inferenceRule') || getProperty(inf, 'labelledRule')) {
@@ -269,8 +269,8 @@ let addSpace = function (
       'width',
       UnitUtil.em(
         UnitUtil.dimen2em(NodeUtil.getAttribute(mspace, 'width') as string) +
-          space
-      )
+          space,
+      ),
     );
     return;
   }
@@ -332,13 +332,13 @@ let adjustSequents = function (config: ParseOptions) {
       // In case we have a table with a label.
       inf = getRule(inf);
       let premise = firstPremise(
-        getPremises(inf, getProperty(inf, 'inferenceRule') as string)
+        getPremises(inf, getProperty(inf, 'inferenceRule') as string),
       );
       let sequent = getProperty(premise, 'inferenceRule')
         ? // If the first premise is an inference rule, check the conclusions for a sequent.
           getConclusion(
             premise,
-            getProperty(premise, 'inferenceRule') as string
+            getProperty(premise, 'inferenceRule') as string,
           )
         : // Otherwise it is a hyp and we have to check the formula itself.
           premise;
@@ -366,7 +366,7 @@ const addSequentSpace = function (
   sequent: MmlNode,
   position: number,
   direction: string,
-  width: number
+  width: number,
 ) {
   let mspace = config.nodeFactory.create('node', 'mspace', [], {
     width: UnitUtil.em(width),
@@ -399,7 +399,7 @@ const addSequentSpace = function (
  */
 const adjustSequentPairwise = function (
   config: ParseOptions,
-  sequents: MmlNode[]
+  sequents: MmlNode[],
 ) {
   let top = sequents.pop();
   while (sequents.length) {
@@ -411,14 +411,14 @@ const adjustSequentPairwise = function (
         left < 0 ? top : bottom,
         0,
         'left',
-        Math.abs(left)
+        Math.abs(left),
       );
       addSequentSpace(
         config,
         right < 0 ? top : bottom,
         2,
         'right',
-        Math.abs(right)
+        Math.abs(right),
       );
     }
     top = bottom;
@@ -437,7 +437,7 @@ const adjustSequentPairwise = function (
  */
 const compareSequents = function (
   top: MmlNode,
-  bottom: MmlNode
+  bottom: MmlNode,
 ): [number, number] {
   const tr = getBBox(top.childNodes[2]);
   const br = getBBox(bottom.childNodes[2]);
@@ -516,7 +516,7 @@ export let balanceRules = function (arg: FilterData) {
     let rule = getRule(inf);
     let premises = getPremises(
       rule,
-      getProperty(rule, 'inferenceRule') as string
+      getProperty(rule, 'inferenceRule') as string,
     );
     let premiseF = firstPremise(premises);
     let leftAdjust = 0;
@@ -550,7 +550,7 @@ export let balanceRules = function (arg: FilterData) {
         // in case the rule has been moved into an mrow in Left Adjust.
         getProperty(inf, 'proof') ? inf : inf.parent,
         maxAdjust,
-        true
+        true,
       );
       continue;
     }
@@ -588,7 +588,7 @@ const prefix_pattern = RegExp('^' + property_prefix);
 export let setProperty = function (
   node: MmlNode,
   property: string,
-  value: Property
+  value: Property,
 ) {
   NodeUtil.setProperty(node, property_prefix + property, value);
 };
@@ -638,7 +638,7 @@ export let saveDocument = function (arg: FilterData) {
   doc = arg.document;
   if (!('getBBox' in doc.outputJax)) {
     throw Error(
-      'The bussproofs extension requires an output jax with a getBBox() method'
+      'The bussproofs extension requires an output jax with a getBBox() method',
     );
   }
 };

--- a/ts/input/tex/cancel/CancelConfiguration.ts
+++ b/ts/input/tex/cancel/CancelConfiguration.ts
@@ -71,7 +71,7 @@ export const CancelMethods: { [key: string]: ParseMethod } = {
       parser.create('node', 'msup', [
         parser.create('node', 'menclose', [math], def),
         value,
-      ])
+      ]),
     );
   },
 };

--- a/ts/input/tex/cases/CasesConfiguration.ts
+++ b/ts/input/tex/cases/CasesConfiguration.ts
@@ -88,7 +88,7 @@ export const CasesMethods = {
     if (parser.stack.env.closing === begin.getName()) {
       delete parser.stack.env.closing;
       parser.Push(
-        parser.itemFactory.create('end').setProperty('name', begin.getName())
+        parser.itemFactory.create('end').setProperty('name', begin.getName()),
       ); // finish eqnarray
       const cases = parser.stack.Top();
       const table = cases.Last as MmlMtable;
@@ -99,10 +99,10 @@ export const CasesMethods = {
         original,
         left + '\\empheqlbrace\\,',
         parser,
-        'numcases-left'
+        'numcases-left',
       );
       parser.Push(
-        parser.itemFactory.create('end').setProperty('name', begin.getName())
+        parser.itemFactory.create('end').setProperty('name', begin.getName()),
       );
       return null;
     } else {
@@ -114,7 +114,7 @@ export const CasesMethods = {
         true,
         true,
         'll',
-        'tt'
+        'tt',
       ) as EqnArrayItem;
       array.arraydef.displaystyle = false;
       array.arraydef.rowspacing = '.2em';
@@ -134,7 +134,7 @@ export const CasesMethods = {
     parser.Push(
       parser.itemFactory
         .create('cell')
-        .setProperties({ isEntry: true, name: name })
+        .setProperties({ isEntry: true, name: name }),
     );
     //
     //  Make second column be in \text{...}
@@ -174,7 +174,7 @@ export const CasesMethods = {
         //
         throw new TexError(
           'ExtraCasesAlignTab',
-          'Extra alignment tab in text for numcase environment'
+          'Extra alignment tab in text for numcase environment',
         );
       } else if (c === '\\' && braces === 0) {
         //

--- a/ts/input/tex/centernot/CenternotConfiguration.ts
+++ b/ts/input/tex/centernot/CenternotConfiguration.ts
@@ -51,7 +51,7 @@ function CenterOver(parser: TexParser, name: string) {
         }),
         parser.create('node', 'mphantom', [base]),
       ],
-      { width: 0, lspace: '-.5width' }
+      { width: 0, lspace: '-.5width' },
     ),
   ]);
   parser.configuration.addNode('centerOver', base);

--- a/ts/input/tex/color/ColorConfiguration.ts
+++ b/ts/input/tex/color/ColorConfiguration.ts
@@ -47,7 +47,7 @@ new CommandMap('color', {
  */
 const config = function (
   _config: ParserConfiguration,
-  jax: TeX<any, any, any>
+  jax: TeX<any, any, any>,
 ) {
   jax.parseOptions.packageData.set('color', { model: new ColorModel() });
 };

--- a/ts/input/tex/color/ColorUtil.ts
+++ b/ts/input/tex/color/ColorUtil.ts
@@ -60,7 +60,7 @@ export class ColorModel {
     throw new TexError(
       'UndefinedColorModel',
       "Color model '%1' not defined",
-      model
+      model,
     );
   }
 
@@ -135,7 +135,7 @@ ColorModelProcessors.set('rgb', function (rgb: string): string {
     throw new TexError(
       'ModelArg1',
       'Color values for the %1 model require 3 numbers',
-      'rgb'
+      'rgb',
     );
   }
 
@@ -151,7 +151,7 @@ ColorModelProcessors.set('rgb', function (rgb: string): string {
         'Color values for the %1 model must be between %2 and %3',
         'rgb',
         '0',
-        '1'
+        '1',
       );
     }
 
@@ -181,7 +181,7 @@ ColorModelProcessors.set('RGB', function (rgb: string): string {
     throw new TexError(
       'ModelArg1',
       'Color values for the %1 model require 3 numbers',
-      'RGB'
+      'RGB',
     );
   }
 
@@ -197,7 +197,7 @@ ColorModelProcessors.set('RGB', function (rgb: string): string {
         'Color values for the %1 model must be between %2 and %3',
         'RGB',
         '0',
-        '255'
+        '255',
       );
     }
 
@@ -229,7 +229,7 @@ ColorModelProcessors.set('gray', function (gray: string): string {
       'Color values for the %1 model must be between %2 and %3',
       'gray',
       '0',
-      '1'
+      '1',
     );
   }
   let pn = Math.floor(n * 255).toString(16);

--- a/ts/input/tex/colortbl/ColortblConfiguration.ts
+++ b/ts/input/tex/colortbl/ColortblConfiguration.ts
@@ -130,7 +130,7 @@ function TableColor(parser: TexParser, name: string, type: keyof ColorData) {
     throw new TexError(
       'UnsupportedTableColor',
       'Unsupported use of %1',
-      parser.currentCS
+      parser.currentCS,
     );
   }
   //
@@ -141,7 +141,7 @@ function TableColor(parser: TexParser, name: string, type: keyof ColorData) {
       throw new TexError(
         'ColumnColorNotTop',
         '%1 must be in the top row or preamble',
-        name
+        name,
       );
     }
     top.color.col[top.row.length] = color;
@@ -157,7 +157,7 @@ function TableColor(parser: TexParser, name: string, type: keyof ColorData) {
       throw new TexError(
         'RowColorNotFirst',
         '%1 must be at the beginning of a row',
-        name
+        name,
       );
     }
   }

--- a/ts/input/tex/configmacros/ConfigMacrosConfiguration.ts
+++ b/ts/input/tex/configmacros/ConfigMacrosConfiguration.ts
@@ -65,7 +65,7 @@ function configmacrosInit(config: ParserConfiguration) {
         [HandlerType.ENVIRONMENT]: [ENVIRONMENTMAP],
       },
       priority: 3,
-    })
+    }),
   );
 }
 
@@ -97,7 +97,7 @@ function setMacros(name: string, map: string, jax: TEX) {
       ? new Macro(
           cs,
           NewcommandMethods.MacroWithTemplate,
-          def.slice(0, 2).concat(def[2])
+          def.slice(0, 2).concat(def[2]),
         )
       : new Macro(cs, NewcommandMethods.Macro, def);
     handler.add(cs, macro);
@@ -129,7 +129,7 @@ function configMacros(jax: TEX) {
  */
 function configEnvironments(jax: TEX) {
   const handler = jax.parseOptions.handlers.retrieve(
-    ENVIRONMENTMAP
+    ENVIRONMENTMAP,
   ) as EnvironmentMap;
   const environments = jax.parseOptions.options.environments;
   for (const env of Object.keys(environments)) {
@@ -138,8 +138,8 @@ function configEnvironments(jax: TEX) {
       new Macro(
         env,
         NewcommandMethods.BeginEnv,
-        [true].concat(environments[env])
-      )
+        [true].concat(environments[env]),
+      ),
     );
   }
 }

--- a/ts/input/tex/dsfont/DsfontConfiguration.ts
+++ b/ts/input/tex/dsfont/DsfontConfiguration.ts
@@ -34,7 +34,7 @@ function ChooseFont(parser: TexParser, name: string) {
   BaseMethods.MathFont(
     parser,
     name,
-    parser.options.dsfont.sans ? '-ds-ss' : '-ds-rm'
+    parser.options.dsfont.sans ? '-ds-ss' : '-ds-rm',
   );
 }
 

--- a/ts/input/tex/empheq/EmpheqConfiguration.ts
+++ b/ts/input/tex/empheq/EmpheqConfiguration.ts
@@ -69,13 +69,13 @@ export const EmpheqMethods = {
       parser.Push(
         parser.itemFactory
           .create('end')
-          .setProperty('name', parser.stack.global.empheq)
+          .setProperty('name', parser.stack.global.empheq),
       );
       parser.stack.global.empheq = '';
       const empheq = parser.stack.Top() as EmpheqBeginItem;
       EmpheqUtil.adjustTable(empheq, parser);
       parser.Push(
-        parser.itemFactory.create('end').setProperty('name', 'empheq')
+        parser.itemFactory.create('end').setProperty('name', 'empheq'),
       );
     } else {
       ParseUtil.checkEqnEnv(parser);
@@ -89,7 +89,7 @@ export const EmpheqMethods = {
       begin.setProperty('nestable', true);
       if (opts) {
         begin.setProperties(
-          EmpheqUtil.splitOptions(opts, { left: 1, right: 1 })
+          EmpheqUtil.splitOptions(opts, { left: 1, right: 1 }),
         );
       }
       parser.stack.global.empheq = env;
@@ -124,7 +124,7 @@ export const EmpheqMethods = {
   EmpheqDelim(parser: TexParser, name: string) {
     const c = parser.GetDelimiter(name);
     parser.Push(
-      parser.create('token', 'mo', { stretchy: true, symmetric: true }, c)
+      parser.create('token', 'mo', { stretchy: true, symmetric: true }, c),
     );
   },
 };

--- a/ts/input/tex/empheq/EmpheqUtil.ts
+++ b/ts/input/tex/empheq/EmpheqUtil.ts
@@ -56,7 +56,7 @@ export const EmpheqUtil = {
    */
   splitOptions(
     text: string,
-    allowed: { [key: string]: number } = null
+    allowed: { [key: string]: number } = null,
   ): EnvList {
     return ParseUtil.keyvalOptions(text, allowed, true);
   },
@@ -91,7 +91,7 @@ export const EmpheqUtil = {
     tex: string,
     table: MmlMtable,
     parser: TexParser,
-    env: string
+    env: string,
   ): MmlNode {
     const mpadded = parser.create('node', 'mpadded', [], {
       height: 0,
@@ -110,7 +110,7 @@ export const EmpheqUtil = {
     mpadded.appendChild(
       parser.create('node', 'mphantom', [
         parser.create('node', 'mpadded', [table], { width: 0 }),
-      ])
+      ]),
     );
     return mpadded;
   },
@@ -147,7 +147,7 @@ export const EmpheqUtil = {
     tex: string,
     table: MmlMtable,
     parser: TexParser,
-    env: string
+    env: string,
   ) {
     mtd.appendChild(
       parser.create(
@@ -157,8 +157,8 @@ export const EmpheqUtil = {
           this.cellBlock(tex, ParseUtil.copyNode(table, parser), parser, env),
           this.topRowTable(table, parser),
         ],
-        { height: 0, depth: 0, voffset: 'height' }
-      )
+        { height: 0, depth: 0, voffset: 'height' },
+      ),
     );
   },
 
@@ -176,15 +176,15 @@ export const EmpheqUtil = {
     original: MmlMtable,
     left: string,
     parser: TexParser,
-    env: string = ''
+    env: string = '',
   ) {
     table.attributes.set(
       'columnalign',
-      'right ' + (table.attributes.get('columnalign') || '')
+      'right ' + (table.attributes.get('columnalign') || ''),
     );
     table.attributes.set(
       'columnspacing',
-      '0em ' + (table.attributes.get('columnspacing') || '')
+      '0em ' + (table.attributes.get('columnspacing') || ''),
     );
     let mtd;
     for (const row of table.childNodes.slice(0).reverse()) {
@@ -213,7 +213,7 @@ export const EmpheqUtil = {
     original: MmlMtable,
     right: string,
     parser: TexParser,
-    env: string = ''
+    env: string = '',
   ) {
     if (table.childNodes.length === 0) {
       table.appendChild(parser.create('node', 'mtr'));
@@ -229,14 +229,14 @@ export const EmpheqUtil = {
       ((table.attributes.get('columnalign') as string) || '')
         .split(/ /)
         .slice(0, m)
-        .join(' ') + ' left'
+        .join(' ') + ' left',
     );
     table.attributes.set(
       'columnspacing',
       ((table.attributes.get('columnspacing') as string) || '')
         .split(/ /)
         .slice(0, m - 1)
-        .join(' ') + ' 0em'
+        .join(' ') + ' 0em',
     );
   },
 

--- a/ts/input/tex/extpfeil/ExtpfeilConfiguration.ts
+++ b/ts/input/tex/extpfeil/ExtpfeilConfiguration.ts
@@ -47,21 +47,21 @@ const ExtpfeilMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'NewextarrowArg1',
         'First argument to %1 must be a control sequence name',
-        name
+        name,
       );
     }
     if (!space.match(/^(\d+),(\d+)$/)) {
       throw new TexError(
         'NewextarrowArg2',
         'Second argument to %1 must be two integers separated by a comma',
-        name
+        name,
       );
     }
     if (!chr.match(/^(\d+|0x[0-9A-F]+)$/i)) {
       throw new TexError(
         'NewextarrowArg3',
         'Third argument to %1 must be a unicode character number',
-        name
+        name,
       );
     }
     cs = cs.substring(1);

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -59,7 +59,7 @@ const HtmlMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'InvalidHTMLAttr',
           'Invalid HTML attribute: %1',
-          `data-${key}`
+          `data-${key}`,
         );
       }
       NodeUtil.setAttribute(arg, `data-${key}`, data[key]);

--- a/ts/input/tex/mathtools/MathtoolsConfiguration.ts
+++ b/ts/input/tex/mathtools/MathtoolsConfiguration.ts
@@ -50,7 +50,7 @@ function initMathtools(config: ParserConfiguration) {
     Configuration.local({
       [ConfigurationType.HANDLER]: { [HandlerType.MACRO]: [PAIREDDELIMS] },
       priority: -5,
-    })
+    }),
   );
 }
 

--- a/ts/input/tex/mathtools/MathtoolsItems.ts
+++ b/ts/input/tex/mathtools/MathtoolsItems.ts
@@ -54,7 +54,7 @@ export class MultlinedItem extends MultlineItem {
         NodeUtil.getAttribute(first, 'columnalign') !== TexConstant.Align.RIGHT
       ) {
         first.appendChild(
-          this.create('node', 'mspace', [], { width: firstskip })
+          this.create('node', 'mspace', [], { width: firstskip }),
         );
       }
       const last = NodeUtil.getChildren(this.table[this.table.length - 1])[0];

--- a/ts/input/tex/mathtools/MathtoolsMethods.ts
+++ b/ts/input/tex/mathtools/MathtoolsMethods.ts
@@ -57,7 +57,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     begin: StackItem,
     open: string,
-    close: string
+    close: string,
   ): ParseResult {
     const align = parser.GetBrackets(`\\begin{${begin.getName()}}`, 'c');
     return MathtoolsMethods.Array(parser, begin, open, close, align);
@@ -78,12 +78,12 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     begin: StackItem,
     open: string,
     close: string,
-    align?: string
+    align?: string,
   ): ParseResult {
     if (!align) {
       align = parser.GetBrackets(
         `\\begin{${begin.getName()}}`,
-        parser.options.mathtools['smallmatrix-align']
+        parser.options.mathtools['smallmatrix-align'],
       );
     }
     return MathtoolsMethods.Array(
@@ -95,7 +95,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       UnitUtil.em(1 / 3),
       '.2em',
       'S',
-      1
+      1,
     );
   },
 
@@ -117,7 +117,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     if (!parser.nextIsSpace()) {
       const arg = parser.GetBrackets(
         name,
-        parser.options.mathtools['multlined-pos'] || 'c'
+        parser.options.mathtools['multlined-pos'] || 'c',
       );
       if (arg.match(/^[ctb]$/)) {
         pos = arg;
@@ -129,7 +129,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'BadWidth',
           'Width for %1 must be a dimension',
-          name
+          name,
         );
       }
     }
@@ -137,7 +137,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const item = parser.itemFactory.create(
       'multlined',
       parser,
-      begin
+      begin,
     ) as ArrayItem;
     item.arraydef = {
       displaystyle: true,
@@ -161,14 +161,14 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'CommandInMultlined',
         '%1 can only appear within the multline or multlined environments',
-        name
+        name,
       );
     }
     if (top.Size()) {
       throw new TexError(
         'CommandAtTheBeginingOfLine',
         '%1 must come at the beginning of the line',
-        name
+        name,
       );
     }
     top.setProperty('shove', shove);
@@ -239,7 +239,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     begin: StackItem,
     open: string,
     close: string,
-    style: string
+    style: string,
   ): ArrayItem {
     const array = parser.itemFactory
       .create('array')
@@ -278,7 +278,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
             : { lspace: pos === 'l' ? '-1width' : '-.5width' }),
         }),
       ],
-      { 'data-cramped': cramped }
+      { 'data-cramped': cramped },
     );
     MathtoolsUtil.setDisplayLevel(mml, style);
     parser.Push(parser.create('node', 'TeXAtom', [mml]));
@@ -314,7 +314,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       NodeUtil.setAttribute(
         mml,
         'lspace',
-        pos === 'l' ? '-1width' : '-.5width'
+        pos === 'l' ? '-1width' : '-.5width',
       );
     }
     parser.Push(mml);
@@ -371,12 +371,12 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const base = new TexParser(
       arg,
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     ).mml();
     const copy = new TexParser(
       arg,
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     ).mml();
     const script = parser.create(
       'node',
@@ -386,7 +386,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
         style: `border: ${t} solid; border-${border}: none`,
         height: height,
         depth: 0,
-      }
+      },
     );
     const node = ParseUtil.underOver(parser, base, script, pos, true);
     const munderover = NodeUtil.getChildAt(NodeUtil.getChildAt(node, 0), 0); // TeXAtom.inferredMrow child 0
@@ -431,7 +431,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const tex = ParseUtil.substituteArgs(
       parser,
       [left, right],
-      '\\rlap{\\boxed{#1{}#2}}\\kern.267em\\phantom{#1}&\\phantom{{}#2}\\kern.267em'
+      '\\rlap{\\boxed{#1{}#2}}\\kern.267em\\phantom{#1}&\\phantom{{}#2}\\kern.267em',
     );
     parser.string = tex + rest;
     parser.i = 0;
@@ -458,7 +458,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const mml = new TexParser(
       tex,
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     ).mml();
     parser.Push(mml);
     top.EndEntry();
@@ -480,7 +480,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const base = new TexParser(
       arg,
       parser.stack.env,
-      parser.configuration
+      parser.configuration,
     ).mml();
     let mml = parser.create(
       'node',
@@ -494,13 +494,13 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
             width: 0,
             lspace: '-.5width',
             ...(isFlush ? { height: '-.6em', voffset: '-.18em' } : {}),
-          }
+          },
         ),
         parser.create('node', 'mphantom', [base]),
       ],
       {
         lspace: '.5width',
-      }
+      },
     );
     parser.Push(mml);
   },
@@ -536,7 +536,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     if (top.table) {
       top.setProperty('flushspaceabove', top.table.length); // marker so \vdotswithin can shorten its height
       top.addRowSpacing(
-        '-' + parser.options.mathtools['shortvdotsadjustabove']
+        '-' + parser.options.mathtools['shortvdotsadjustabove'],
       );
     }
   },
@@ -553,7 +553,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       top.Size() && top.EndEntry();
       top.EndRow();
       top.addRowSpacing(
-        '-' + parser.options.mathtools['shortvdotsadjustbelow']
+        '-' + parser.options.mathtools['shortvdotsadjustbelow'],
       );
     }
   },
@@ -578,7 +578,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     body: string = '#1',
     n: number = 1,
     pre: string = '',
-    post: string = ''
+    post: string = '',
   ) {
     const star = parser.GetStar();
     const size = star ? '' : parser.GetBrackets(name);
@@ -687,7 +687,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     _name: string,
     center: boolean,
     force: boolean = false,
-    thin: boolean = false
+    thin: boolean = false,
   ) {
     const options = parser.options.mathtools;
     let mml = parser.create('token', 'mo', {}, ':');
@@ -717,7 +717,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const options = parser.options.mathtools;
     if (options['use-unicode'] && unicode) {
       parser.Push(
-        parser.create('token', 'mo', { texClass: TEXCLASS.REL }, unicode)
+        parser.create('token', 'mo', { texClass: TEXCLASS.REL }, unicode),
       );
     } else {
       tex =
@@ -727,7 +727,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       parser.string = ParseUtil.addArgs(
         parser,
         tex,
-        parser.string.substring(parser.i)
+        parser.string.substring(parser.i),
       );
       parser.i = 0;
     }
@@ -770,20 +770,20 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
                       notation: 'updiagonalstrike',
                       'data-thickness': '.05em',
                       'data-padding': 0,
-                    }
+                    },
                   ),
                 ],
-                { width: 0, lspace: '-.5width', voffset: dy }
+                { width: 0, lspace: '-.5width', voffset: dy },
               ),
               parser.create('node', 'mphantom', [
                 parser.create('token', 'mtext', {}, c),
               ]),
             ],
-            { width: 0, lspace: '-.5width' }
+            { width: 0, lspace: '-.5width' },
           ),
         ],
-        { texClass: TEXCLASS.REL }
-      )
+        { texClass: TEXCLASS.REL },
+      ),
     );
   },
 
@@ -814,7 +814,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
                   parser.create('token', 'mi'),
                   parser.create('token', 'mspace', { width: '1em' }), // no parameter for this in mathtools.  Should we add one?
                 ],
-                { scriptlevel: 0 }
+                { scriptlevel: 0 },
               ),
               parser.create(
                 'node',
@@ -824,14 +824,14 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
                   parser.create('token', 'mi'),
                   den,
                 ],
-                { scriptlevel: 0 }
+                { scriptlevel: 0 },
               ),
             ],
-            { linethickness: 0, numalign: 'left', denomalign: 'right' }
+            { linethickness: 0, numalign: 'left', denomalign: 'right' },
           ),
         ],
-        { displaystyle: display, scriptlevel: 0 }
-      )
+        { displaystyle: display, scriptlevel: 0 },
+      ),
     );
   },
 
@@ -859,11 +859,11 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
                 parser.create('token', 'mo', { stretchy: false }, '('),
               ]),
             ],
-            { width: 0, height: dh + 'height', depth: dd + 'depth' }
+            { width: 0, height: dh + 'height', depth: dd + 'depth' },
           ),
         ],
-        { texClass: TEXCLASS.ORD }
-      )
+        { texClass: TEXCLASS.ORD },
+      ),
     );
   },
 
@@ -905,7 +905,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'TagsNotMT',
         '%1 can only be used with ams or mathtools tags',
-        name
+        name,
       );
     }
     const id = parser.GetArgument(name).trim();
@@ -934,7 +934,7 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'TagsNotMT',
         '%1 can only be used with ams or mathtools tags',
-        name
+        name,
       );
     }
     const id = parser.GetArgument(name).trim();

--- a/ts/input/tex/mathtools/MathtoolsTags.ts
+++ b/ts/input/tex/mathtools/MathtoolsTags.ts
@@ -45,7 +45,7 @@ let tagID = 0;
  */
 export function MathtoolsTagFormat(
   config: ParserConfiguration,
-  jax: TeX<any, any, any>
+  jax: TeX<any, any, any>,
 ) {
   /**
    * If the tag format is being added by one of the other extensions,
@@ -88,7 +88,7 @@ export function MathtoolsTagFormat(
           throw new TexError(
             'InvalidTagFormDef',
             'The tag form definition for "%1" should be an array fo three strings',
-            form
+            form,
           );
         }
         this.mtFormats.set(form, forms[form]);

--- a/ts/input/tex/mathtools/MathtoolsUtil.ts
+++ b/ts/input/tex/mathtools/MathtoolsUtil.ts
@@ -53,7 +53,7 @@ export const MathtoolsUtil = {
         '\\scriptstyle': [false, 1],
         '\\scriptscriptstyle': [false, 2],
       },
-      [null, null]
+      [null, null],
     );
     if (display !== null) {
       mml.attributes.set('displaystyle', display);
@@ -74,7 +74,7 @@ export const MathtoolsUtil = {
       throw new TexError(
         'NotInAlignment',
         '%1 can only be used in aligment environments',
-        name
+        name,
       );
     }
     return top;

--- a/ts/input/tex/newcommand/NewcommandConfiguration.ts
+++ b/ts/input/tex/newcommand/NewcommandConfiguration.ts
@@ -39,7 +39,7 @@ let init = function (config: ParserConfiguration) {
   new sm.EnvironmentMap(
     NewcommandUtil.NEW_ENVIRONMENT,
     ParseMethods.environment,
-    {}
+    {},
   );
   config.append(
     Configuration.local({
@@ -53,7 +53,7 @@ let init = function (config: ParserConfiguration) {
         [HandlerType.ENVIRONMENT]: [NewcommandUtil.NEW_ENVIRONMENT],
       },
       [ConfigurationType.PRIORITY]: -1,
-    })
+    }),
   );
 };
 

--- a/ts/input/tex/newcommand/NewcommandItems.ts
+++ b/ts/input/tex/newcommand/NewcommandItems.ts
@@ -56,7 +56,7 @@ export class BeginEnvItem extends BaseItem {
           'EnvBadEnd',
           '\\begin{%1} ended with \\end{%2}',
           this.getName(),
-          item.getName()
+          item.getName(),
         );
       }
       return [[this.factory.create('mml', this.toMml())], true];

--- a/ts/input/tex/newcommand/NewcommandMethods.ts
+++ b/ts/input/tex/newcommand/NewcommandMethods.ts
@@ -93,7 +93,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
           parser,
           cs,
           NewcommandMethods.MacroWithTemplate,
-          [def].concat(params)
+          [def].concat(params),
         );
     parser.Push(parser.itemFactory.create('null'));
   },
@@ -137,7 +137,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
           parser,
           '\\' + cs,
           macro.char,
-          macro.attributes
+          macro.attributes,
         );
         return;
       }
@@ -154,7 +154,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
           cs,
           macro.func,
           macro.args,
-          macro.token
+          macro.token,
         );
         return;
       }
@@ -173,7 +173,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
         parser,
         '\\' + cs,
         macro.char,
-        macro.attributes
+        macro.attributes,
       );
       return;
     }
@@ -208,7 +208,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'MismatchUseDef',
           "Use of %1 doesn't match its definition",
-          name
+          name,
         );
       }
       if (argCount) {
@@ -222,7 +222,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
     parser.string = ParseUtil.addArgs(
       parser,
       text,
-      parser.string.slice(parser.i)
+      parser.string.slice(parser.i),
     );
     parser.i = 0;
     ParseUtil.checkMaxMacros(parser);
@@ -243,7 +243,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
     bdef: string,
     edef: string,
     n: number,
-    def: string
+    def: string,
   ) {
     // @test Newenvironment Empty, Newenvironment Content
     // We have an end item, and we are supposed to close this environment.
@@ -257,7 +257,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
         parser.string = ParseUtil.addArgs(
           parser,
           `${edef}\\end{${begin.getName()}}`,
-          parser.string.slice(parser.i)
+          parser.string.slice(parser.i),
         );
         parser.i = 0;
         return null;
@@ -284,7 +284,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
     parser.string = ParseUtil.addArgs(
       parser,
       bdef,
-      parser.string.slice(parser.i)
+      parser.string.slice(parser.i),
     );
     parser.i = 0;
     return parser.itemFactory

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -43,7 +43,7 @@ namespace NewcommandUtil {
       throw new TexError(
         'MissingCS',
         '%1 must be followed by a control sequence',
-        cmd
+        cmd,
       );
     }
     let cs = UnitUtil.trimSpaces(parser.GetArgument(cmd));
@@ -67,7 +67,7 @@ namespace NewcommandUtil {
       throw new TexError(
         'IllegalControlSequenceName',
         'Illegal control sequence name for %1',
-        name
+        name,
       );
     }
     return cs;
@@ -90,7 +90,7 @@ namespace NewcommandUtil {
         throw new TexError(
           'IllegalParamNumber',
           'Illegal number of parameters specified in %1',
-          name
+          name,
         );
       }
     }
@@ -108,7 +108,7 @@ namespace NewcommandUtil {
   export function GetTemplate(
     parser: TexParser,
     cmd: string,
-    cs: string
+    cs: string,
   ): number | string[] {
     // @test Def Double Let, Def ReDef, Def Let
     let c = parser.GetNext();
@@ -130,7 +130,7 @@ namespace NewcommandUtil {
           throw new TexError(
             'CantUseHash2',
             'Illegal use of # in template for %1',
-            cs
+            cs,
           );
         }
         if (parseInt(c) !== ++n) {
@@ -138,7 +138,7 @@ namespace NewcommandUtil {
           throw new TexError(
             'SequentialParam',
             'Parameters for %1 must be numbered sequentially',
-            cs
+            cs,
           );
         }
         i = parser.i + 1;
@@ -163,7 +163,7 @@ namespace NewcommandUtil {
     throw new TexError(
       'MissingReplacementString',
       'Missing replacement string for definition of %1',
-      cmd
+      cmd,
     );
   }
 
@@ -259,7 +259,7 @@ namespace NewcommandUtil {
     parser: TexParser,
     cs: string,
     char: string,
-    attr: Attributes
+    attr: Attributes,
   ) {
     const handlers = parser.configuration.handlers;
     const handler = handlers.retrieve(NEW_DELIMITER) as sm.DelimiterMap;
@@ -280,7 +280,7 @@ namespace NewcommandUtil {
     cs: string,
     func: ParseMethod,
     attr: Args[],
-    token: string = ''
+    token: string = '',
   ) {
     const handlers = parser.configuration.handlers;
     const handler = handlers.retrieve(NEW_COMMAND) as sm.CommandMap;
@@ -298,7 +298,7 @@ namespace NewcommandUtil {
     parser: TexParser,
     env: string,
     func: ParseMethod,
-    attr: Args[]
+    attr: Args[],
   ) {
     const handlers = parser.configuration.handlers;
     const handler = handlers.retrieve(NEW_ENVIRONMENT) as sm.EnvironmentMap;

--- a/ts/input/tex/noerrors/NoErrorsConfiguration.ts
+++ b/ts/input/tex/noerrors/NoErrorsConfiguration.ts
@@ -36,7 +36,7 @@ function noErrors(
   factory: NodeFactory,
   message: string,
   _id: string,
-  expr: string
+  expr: string,
 ) {
   let mtext = factory.create('token', 'mtext', {}, expr.replace(/\n/g, ' '));
   let error = factory.create('node', 'merror', [mtext], {

--- a/ts/input/tex/physics/PhysicsItems.ts
+++ b/ts/input/tex/physics/PhysicsItems.ts
@@ -80,7 +80,7 @@ export class AutoOpen extends BaseItem {
     }
     if (right) {
       this.Push(
-        new TexParser(right, parser.stack.env, parser.configuration).mml()
+        new TexParser(right, parser.stack.env, parser.configuration).mml(),
       );
     }
     let mml = ParseUtil.fenced(
@@ -88,7 +88,7 @@ export class AutoOpen extends BaseItem {
       this.getProperty('open') as string,
       super.toMml(),
       this.getProperty('close') as string,
-      this.getProperty('big') as string
+      this.getProperty('big') as string,
     );
     //
     //  Remove fence markers that would cause it to be TeX class INNER,

--- a/ts/input/tex/physics/PhysicsMethods.ts
+++ b/ts/input/tex/physics/PhysicsMethods.ts
@@ -80,7 +80,7 @@ function createVectorToken(
   factory: NodeFactory,
   kind: string,
   def: any,
-  text: string
+  text: string,
 ): MmlNode {
   let parser = factory.configuration.parser;
   let token = NodeFactory.createToken(factory, kind, def, text);
@@ -115,12 +115,12 @@ function vectorApplication(
   kind: string,
   name: string,
   operator: string,
-  fences: string[]
+  fences: string[],
 ) {
   let op = new TexParser(
     operator,
     parser.stack.env,
-    parser.configuration
+    parser.configuration,
   ).mml();
   parser.Push(parser.itemFactory.create(kind, op));
   let left = parser.GetNext();
@@ -148,7 +148,7 @@ function vectorApplication(
   parser.Push(
     parser.itemFactory
       .create('auto open')
-      .setProperties({ open: left, close: right })
+      .setProperties({ open: left, close: right }),
   );
 }
 
@@ -162,7 +162,7 @@ function vectorApplication(
 function outputBraket(
   [arg1, arg2, arg3]: [string, string, string],
   star1: boolean,
-  star2: boolean
+  star2: boolean,
 ) {
   return star1 && star2
     ? `\\left\\langle{${arg1}}\\middle\\vert{${arg2}}\\middle\\vert{${arg3}}\\right\\rangle`
@@ -181,7 +181,10 @@ function makeDiagMatrix(elements: string[], anti: boolean) {
   let matrix = [];
   for (let i = 0; i < length; i++) {
     matrix.push(
-      Array(anti ? length - i : i + 1).join('&') + '\\mqty{' + elements[i] + '}'
+      Array(anti ? length - i : i + 1).join('&') +
+        '\\mqty{' +
+        elements[i] +
+        '}',
     );
   }
   return matrix.join('\\\\ ');
@@ -210,7 +213,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     close: string = ')',
     arg: boolean = false,
     named: string = '',
-    variant: string = ''
+    variant: string = '',
   ) {
     let star = arg ? parser.GetStar() : false;
     let next = parser.GetNext();
@@ -233,7 +236,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MissingArgFor',
         'Missing argument for %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     if (!right) {
@@ -248,7 +251,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
         'token',
         'mi',
         { texClass: TEXCLASS.OP },
-        named
+        named,
       );
       if (variant) {
         NodeUtil.setAttribute(mml, 'mathvariant', variant);
@@ -276,7 +279,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
             right
           : '\\left' + next + ' ' + argument + ' ' + '\\right' + right;
       parser.Push(
-        new TexParser(argument, parser.stack.env, parser.configuration).mml()
+        new TexParser(argument, parser.stack.env, parser.configuration).mml(),
       );
       return;
     }
@@ -288,7 +291,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('auto open')
-        .setProperties({ open: next, close: right, big: big })
+        .setProperties({ open: next, close: right, big: big }),
     );
   },
 
@@ -321,14 +324,14 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
           close: '|',
           smash: star,
           right: '\\vphantom{\\int}',
-        })
+        }),
       );
       return;
     }
     throw new TexError(
       'MissingArgFor',
       'Missing argument for %1',
-      parser.currentCS
+      parser.currentCS,
     );
   },
 
@@ -343,7 +346,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     name: string,
     open: string = '[',
-    close: string = ']'
+    close: string = ']',
   ) {
     let star = parser.GetStar();
     let next = parser.GetNext();
@@ -356,7 +359,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
         throw new TexError(
           'MissingArgFor',
           'Missing argument for %1',
-          parser.currentCS
+          parser.currentCS,
         );
       }
       next = parser.GetNext();
@@ -365,7 +368,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MissingArgFor',
         'Missing argument for %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     let arg1 = parser.GetArgument(name);
@@ -387,7 +390,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
           close
         : '\\left' + open + ' ' + argument + ' ' + '\\right' + close;
     parser.Push(
-      new TexParser(argument, parser.stack.env, parser.configuration).mml()
+      new TexParser(argument, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -446,7 +449,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     parser.string = ParseUtil.addArgs(
       parser,
       macro,
-      parser.string.slice(parser.i)
+      parser.string.slice(parser.i),
     );
     parser.i = 0;
     ParseUtil.checkMaxMacros(parser);
@@ -506,7 +509,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     parser: TexParser,
     name: string,
     opt: boolean = true,
-    id: string = ''
+    id: string = '',
   ) {
     id = id || name.slice(1);
     const exp = opt ? parser.GetBrackets(name) : null;
@@ -515,7 +518,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       const sup = new TexParser(
         exp,
         parser.stack.env,
-        parser.configuration
+        parser.configuration,
       ).mml();
       mml = parser.create('node', 'msup', [mml, sup]);
     }
@@ -527,7 +530,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('auto open')
-        .setProperties({ open: '(', close: ')' })
+        .setProperties({ open: '(', close: ')' }),
     );
   },
 
@@ -574,7 +577,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       let mml = new TexParser(
         macro,
         parser.stack.env,
-        parser.configuration
+        parser.configuration,
       ).mml();
       parser.Push(mml);
       return;
@@ -584,21 +587,21 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       const mml = new TexParser(
         macro,
         parser.stack.env,
-        parser.configuration
+        parser.configuration,
       ).mml();
       parser.Push(
-        parser.create('node', 'TeXAtom', [mml], { texClass: TEXCLASS.OP })
+        parser.create('node', 'TeXAtom', [mml], { texClass: TEXCLASS.OP }),
       );
       return;
     }
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
     parser.i++;
     parser.Push(
       parser.itemFactory
         .create('auto open')
-        .setProperties({ open: '(', close: ')' })
+        .setProperties({ open: '(', close: ')' }),
     );
   },
 
@@ -661,14 +664,14 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       rest +
       '}';
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
     if (parser.GetNext() === '(') {
       parser.i++;
       parser.Push(
         parser.itemFactory
           .create('auto open')
-          .setProperties({ open: '(', close: ')', ignore: ignore })
+          .setProperties({ open: '(', close: ')', ignore: ignore }),
       );
     }
   },
@@ -722,7 +725,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
           : `\\left\\langle{${bra}}\\right\\vert{${ket}}`;
     }
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -738,7 +741,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       ? `\\vert{${ket}}\\rangle`
       : `\\left\\vert{${ket}}\\right\\rangle`;
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -765,7 +768,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
         : `\\left\\langle{${bra}}\\middle\\vert{${ket}}\\right\\rangle`;
     }
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -792,7 +795,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
         : `\\left\\vert{${ket}}\\middle\\rangle\\!\\middle\\langle{${bra}}\\right\\vert`;
     }
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -817,7 +820,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
           ? `\\langle {${arg1}} \\rangle`
           : `\\left\\langle {${arg1}} \\right\\rangle`;
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -834,7 +837,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     const arg3 = parser.GetArgument(name);
     const macro = outputBraket([arg1, arg2, arg3], star1, star2);
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -895,7 +898,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       (open ? '\\right' : '') +
       close;
     parser.Push(
-      new TexParser(macro, parser.stack.env, parser.configuration).mml()
+      new TexParser(macro, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -1085,10 +1088,10 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
     parser.Push(
       parser.itemFactory
         .create('close')
-        .setProperties({ 'pre-autoclose': true })
+        .setProperties({ 'pre-autoclose': true }),
     );
     parser.Push(
-      parser.itemFactory.create('mml', mo).setProperties({ autoclose: true })
+      parser.itemFactory.create('mml', mo).setProperties({ autoclose: true }),
     );
   },
 
@@ -1102,7 +1105,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
       ? '\\vec{\\gradientnabla}'
       : '{\\gradientnabla}';
     return parser.Push(
-      new TexParser(argument, parser.stack.env, parser.configuration).mml()
+      new TexParser(argument, parser.stack.env, parser.configuration).mml(),
     );
   },
 
@@ -1114,7 +1117,7 @@ const PhysicsMethods: { [key: string]: ParseMethod } = {
   DiffD(parser: TexParser, _name: string) {
     let argument = parser.options.physics.italicdiff ? 'd' : '{\\rm d}';
     return parser.Push(
-      new TexParser(argument, parser.stack.env, parser.configuration).mml()
+      new TexParser(argument, parser.stack.env, parser.configuration).mml(),
     );
   },
 

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -71,7 +71,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
     //
     if (retry) {
       mathjax.retryAfter(
-        retry.then(() => ProcessExtension(jax, name, extension))
+        retry.then(() => ProcessExtension(jax, name, extension)),
       );
     } else {
       ProcessExtension(jax, name, extension);
@@ -88,7 +88,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
 function ProcessExtension(
   jax: TeX<any, any, any>,
   name: string,
-  extension: string
+  extension: string,
 ) {
   //
   //  If the required file loaded an extension...
@@ -134,7 +134,7 @@ function ProcessExtension(
  */
 function RegisterDependencies(
   jax: TeX<any, any, any>,
-  names: string[] = []
+  names: string[] = [],
 ): Promise<any> {
   const prefix = jax.parseOptions.options.require.prefix;
   const retries = [];
@@ -170,7 +170,7 @@ export function RequireLoad(parser: TexParser, name: string) {
     throw new TexError(
       'BadRequire',
       'Extension "%1" is not allowed to be loaded',
-      extension
+      extension,
     );
   }
   if (!Package.packages.has(extension)) {
@@ -178,11 +178,11 @@ export function RequireLoad(parser: TexParser, name: string) {
   }
   const require = LOADERCONFIG[extension]?.rendererExtensions;
   (MathJax.startup.document as MenuMathDocument)?.menu?.addRequiredExtensions?.(
-    require
+    require,
   );
   RegisterExtension(
     parser.configuration.packageData.get('require').jax,
-    extension
+    extension,
   );
 }
 
@@ -223,7 +223,7 @@ export const RequireMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BadPackageName',
         'Argument for %1 is not a valid package name',
-        name
+        name,
       );
     }
     RequireLoad(parser, required);

--- a/ts/input/tex/setoptions/SetOptionsConfiguration.ts
+++ b/ts/input/tex/setoptions/SetOptionsConfiguration.ts
@@ -57,7 +57,7 @@ export const SetOptionsUtil = {
       throw new TexError(
         'PackageNotSettable',
         'Options can\'t be set for package "%1"',
-        extension
+        extension,
       );
     }
     return true;
@@ -82,7 +82,7 @@ export const SetOptionsUtil = {
       throw new TexError(
         'OptionNotSettable',
         'Option "%1" is not allowed to be set',
-        option
+        option,
       );
     }
     if (
@@ -94,14 +94,14 @@ export const SetOptionsUtil = {
         throw new TexError(
           'InvalidTexOption',
           'Invalid TeX option "%1"',
-          option
+          option,
         );
       } else {
         throw new TexError(
           'InvalidOptionKey',
           'Invalid option "%1" for package "%2"',
           option,
-          extension
+          extension,
         );
       }
     }
@@ -121,7 +121,7 @@ export const SetOptionsUtil = {
     _parser: TexParser,
     _extension: string,
     _option: string,
-    value: string
+    value: string,
   ): string {
     return value;
   },
@@ -161,7 +161,7 @@ const setOptionsMap = new CommandMap('setoptions', {
  */
 function setoptionsConfig(
   _config: ParserConfiguration,
-  jax: TeX<any, any, any>
+  jax: TeX<any, any, any>,
 ) {
   const require = jax.parseOptions.handlers
     .get(HandlerType.MACRO)
@@ -174,7 +174,7 @@ function setoptionsConfig(
         '\\Require{#2}\\setOptions[#2]{#1}',
         2,
         '',
-      ])
+      ]),
     );
   }
 }

--- a/ts/input/tex/tagformat/TagFormatConfiguration.ts
+++ b/ts/input/tex/tagformat/TagFormatConfiguration.ts
@@ -40,7 +40,7 @@ let tagID = 0;
  */
 export function tagformatConfig(
   config: ParserConfiguration,
-  jax: TeX<any, any, any>
+  jax: TeX<any, any, any>,
 ) {
   /**
    * If the tag format is being added by one of the other extensions,

--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -62,7 +62,7 @@ export const HtmlNodeMethods: { [key: string]: ParseMethod } = {
         'TokenNotFoundForCommand',
         'Could not find %1 for %2',
         end,
-        '<' + match[0]
+        '<' + match[0],
       );
     }
     const html = parser.string.substring(parser.i, parser.i + i).trim();
@@ -79,7 +79,7 @@ export const HtmlNodeMethods: { [key: string]: ParseMethod } = {
     const DOM = nodes.length === 1 ? nodes[0] : adaptor.node('div', {}, nodes);
     const node = (parser.create('node', 'html') as HtmlNode<any>).setHTML(
       DOM,
-      adaptor
+      adaptor,
     );
     parser.Push(parser.create('node', 'mtext', [node]));
     return true;
@@ -104,7 +104,7 @@ export const TexHtmlConfiguration = Configuration.create('texhtml', {
       if (!include['tex-html']) {
         include['tex-html'] = (
           node: any,
-          adaptor: DOMAdaptor<any, any, any>
+          adaptor: DOMAdaptor<any, any, any>,
         ) => {
           //
           // Use the node's serialized contents, and check if there are

--- a/ts/input/tex/textcomp/TextcompMappings.ts
+++ b/ts/input/tex/textcomp/TextcompMappings.ts
@@ -37,7 +37,7 @@ function Insert(parser: TexParser, name: string, c: string, font: string) {
     parser.saveText();
   }
   parser.Push(
-    ParseUtil.internalText(parser, c, font ? { mathvariant: font } : {})
+    ParseUtil.internalText(parser, c, font ? { mathvariant: font } : {}),
   );
 }
 

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -65,7 +65,7 @@ export const TextBaseConfiguration = Configuration.create('text-base', {
         parser.Error(
           'MathMacro',
           '%1 is only supported in math mode',
-          '\\' + name
+          '\\' + name,
         );
       }
       texParser.parse('macro', [parser, name]);
@@ -92,7 +92,7 @@ function internalMath(
   parser: TexParser,
   text: string,
   level?: number | string,
-  mathvariant?: string
+  mathvariant?: string,
 ): MmlNode[] {
   const config = parser.configuration.packageData.get('textmacros');
   if (!(parser instanceof TextParser)) {
@@ -104,7 +104,7 @@ function internalMath(
       text,
       mathvariant ? { mathvariant } : {},
       config.parseOptions,
-      level
+      level,
     ).mml(),
   ];
 }
@@ -125,7 +125,7 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
     //
     const textConf = new ParserConfiguration(
       jax.parseOptions.options.textmacros.packages,
-      ['tex', 'text']
+      ['tex', 'text'],
     );
     textConf.init();
     const parseOptions = new ParseOptions(textConf, []);

--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -73,7 +73,7 @@ export const TextMacrosMethods = {
             const mml = new TexParser(
               parser.string.substring(i, j),
               parser.stack.env,
-              config
+              config,
             ).mml();
             parser.PushMath(mml);
             return;
@@ -88,7 +88,7 @@ export const TextMacrosMethods = {
           if (braces === 0) {
             parser.Error(
               'ExtraCloseMissingOpen',
-              'Extra close brace or missing open brace'
+              'Extra close brace or missing open brace',
             );
           }
           braces--;
@@ -142,7 +142,7 @@ export const TextMacrosMethods = {
     } else {
       parser.Error(
         'ExtraCloseMissingOpen',
-        'Extra close brace or missing open brace'
+        'Extra close brace or missing open brace',
       );
     }
   },

--- a/ts/input/tex/textmacros/TextParser.ts
+++ b/ts/input/tex/textmacros/TextParser.ts
@@ -77,7 +77,7 @@ export class TextParser extends TexParser {
     text: string,
     env: EnvList,
     configuration: ParseOptions,
-    level?: number | string
+    level?: number | string,
   ) {
     super(text, env, configuration);
     this.level = level;
@@ -133,7 +133,7 @@ export class TextParser extends TexParser {
       const text = ParseUtil.internalText(
         this,
         this.text,
-        mathvariant ? { mathvariant } : {}
+        mathvariant ? { mathvariant } : {},
       );
       this.text = '';
       this.Push(text);
@@ -222,7 +222,7 @@ export class TextParser extends TexParser {
     return new TextParser(
       this.GetArgument(name),
       this.stack.env,
-      this.configuration
+      this.configuration,
     ).mml();
   }
 

--- a/ts/input/tex/unicode/UnicodeConfiguration.ts
+++ b/ts/input/tex/unicode/UnicodeConfiguration.ts
@@ -60,7 +60,7 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BadFont',
         "Font name for %1 can't contain semicolons",
-        parser.currentCS
+        parser.currentCS,
       );
     }
     let n = UnitUtil.trimSpaces(parser.GetArgument(name)).replace(/^0x/, 'x');
@@ -68,7 +68,7 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BadUnicode',
         'Argument to %1 must be a number',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     let N = parseInt(n.match(/^x/) ? '0' + n : n);
@@ -113,7 +113,7 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'BadRawUnicode',
         'Argument to %1 must a hexadecimal number with 1 to 6 digits',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     const n = parseInt(hex, 16);
@@ -146,7 +146,7 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
             throw new TexError(
               'InvalidAlphanumeric',
               'Invalid alphanumeric constant for %1',
-              parser.currentCS
+              parser.currentCS,
             );
           }
           c = cs[0];
@@ -168,7 +168,7 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'MissingNumber',
         'Missing numeric constant for %1',
-        parser.currentCS
+        parser.currentCS,
       );
     }
     parser.i += match[0].length;

--- a/ts/input/tex/units/UnitsConfiguration.ts
+++ b/ts/input/tex/units/UnitsConfiguration.ts
@@ -74,12 +74,12 @@ export let UnitsMethods: { [key: string]: ParseMethod } = {
     let numMml = new TexParser(
       `${font}{${num}}`,
       { ...parser.stack.env },
-      parser.configuration
+      parser.configuration,
     ).mml();
     let denMml = new TexParser(
       `${font}{${den}}`,
       { ...parser.stack.env },
-      parser.configuration
+      parser.configuration,
     ).mml();
     const def = parser.options.units.ugly ? {} : { bevelled: true };
     const node = parser.create('node', 'mfrac', [numMml, denMml], def);

--- a/ts/input/tex/verb/VerbConfiguration.ts
+++ b/ts/input/tex/verb/VerbConfiguration.ts
@@ -52,7 +52,7 @@ const VerbMethods: { [key: string]: ParseMethod } = {
       throw new TexError(
         'NoClosingDelim',
         "Can't find closing delimiter for %1",
-        parser.currentCS
+        parser.currentCS,
       );
     }
     const text = parser.string.slice(start, parser.i).replace(/ /g, '\u00A0');
@@ -62,8 +62,8 @@ const VerbMethods: { [key: string]: ParseMethod } = {
         'token',
         'mtext',
         { mathvariant: TexConstant.Variant.MONOSPACE },
-        text
-      )
+        text,
+      ),
     );
   },
 };

--- a/ts/mathjax.ts
+++ b/ts/mathjax.ts
@@ -51,7 +51,7 @@ export const mathjax = {
    */
   document: function (
     document: any,
-    options: OptionList
+    options: OptionList,
   ): MathDocument<any, any, any> {
     return mathjax.handlers.document(document, options);
   },

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -179,7 +179,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
    */
   public addExtension(
     font: FontExtensionData<ChtmlCharOptions, ChtmlDelimiterData>,
-    prefix: string = ''
+    prefix: string = '',
   ): string[] {
     const css = super.addExtension(font, prefix);
     if (css.length && this.options.adaptiveCSS && this.chtmlStyles) {
@@ -236,7 +236,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
     }
     for (const kind of this.wrapperUsage.update()) {
       const wrapper = this.factory.getNodeClass(
-        kind
+        kind,
       ) as any as typeof CommonWrapper;
       wrapper && this.addClassStyles(wrapper, styles);
     }
@@ -333,7 +333,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
     adaptor.setStyle(
       text,
       'font-family',
-      adaptor.getStyle(text, 'font-family').replace(/MJXZERO, /g, '')
+      adaptor.getStyle(text, 'font-family').replace(/MJXZERO, /g, ''),
     );
     //
     const em = this.math.metrics.em;

--- a/ts/output/chtml/DynamicFonts.ts
+++ b/ts/output/chtml/DynamicFonts.ts
@@ -31,7 +31,7 @@ import { ChtmlCharMap, ChtmlCharData } from './FontData.js';
  */
 export function AddFontIds(
   ranges: { [variant: string]: { [id: string]: ChtmlCharMap } },
-  prefix?: string
+  prefix?: string,
 ) {
   const variants: { [variant: string]: ChtmlCharMap } = {};
   for (const id of Object.keys(ranges)) {

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -179,7 +179,7 @@ export class ChtmlFontData extends FontData<
   public static addDynamicFontCss(
     styles: StyleList,
     fonts: string[],
-    root: string
+    root: string,
   ) {
     const fontStyles: StyleList = {};
     for (const font of fonts) {
@@ -200,7 +200,7 @@ export class ChtmlFontData extends FontData<
    */
   public static addExtension(
     data: ChtmlFontExtensionData<ChtmlCharOptions, ChtmlDelimiterData>,
-    prefix: string = ''
+    prefix: string = '',
   ) {
     super.addExtension(data, prefix);
     data.fonts &&
@@ -212,7 +212,7 @@ export class ChtmlFontData extends FontData<
    */
   public addExtension(
     data: ChtmlFontExtensionData<ChtmlCharOptions, ChtmlDelimiterData>,
-    prefix: string = ''
+    prefix: string = '',
   ): string[] {
     super.addExtension(data, prefix);
     if (!data.fonts || !this.options.adaptiveCSS) {
@@ -223,7 +223,7 @@ export class ChtmlFontData extends FontData<
     (this.constructor as typeof ChtmlFontData).addDynamicFontCss(
       css,
       data.fonts,
-      data.fontURL
+      data.fontURL,
     );
     styles.addStyles(css);
     return styles.getStyleRules();
@@ -254,7 +254,7 @@ export class ChtmlFontData extends FontData<
   public createVariant(
     name: string,
     inherit: string = null,
-    link: string = null
+    link: string = null,
   ) {
     super.createVariant(name, inherit, link);
     this.variant[name].letter = (
@@ -290,12 +290,12 @@ export class ChtmlFontData extends FontData<
    */
   public addDynamicFontCss(
     fonts: string[],
-    root: string = this.options.fontURL
+    root: string = this.options.fontURL,
   ) {
     (this.constructor as typeof ChtmlFontData).addDynamicFontCss(
       this.fontUsage,
       fonts,
-      root
+      root,
     );
   }
 
@@ -354,7 +354,7 @@ export class ChtmlFontData extends FontData<
         styles,
         variant.letter,
         N,
-        variant.chars[N] as ChtmlCharData
+        variant.chars[N] as ChtmlCharData,
       );
     }
     return styles;
@@ -372,7 +372,7 @@ export class ChtmlFontData extends FontData<
       this.addDelimiterStyles(
         styles,
         N,
-        this.delimiters[N] as ChtmlDelimiterData
+        this.delimiters[N] as ChtmlDelimiterData,
       );
     }
     //
@@ -403,7 +403,7 @@ export class ChtmlFontData extends FontData<
   protected addDelimiterStyles(
     styles: StyleList,
     n: number,
-    data: ChtmlDelimiterData
+    data: ChtmlDelimiterData,
   ) {
     if (!data.stretch) return;
     const c =
@@ -427,7 +427,7 @@ export class ChtmlFontData extends FontData<
     styles: StyleList,
     n: number,
     c: string,
-    data: ChtmlDelimiterData
+    data: ChtmlDelimiterData,
   ) {
     const HDW = data.HDW as ChtmlCharData;
     const [beg, ext, end, mid] = data.stretch;
@@ -468,7 +468,7 @@ export class ChtmlFontData extends FontData<
     part: string,
     n: number,
     v: string,
-    HDW: ChtmlCharData
+    HDW: ChtmlCharData,
   ): number {
     if (!n) return 0;
     const [h, d, w] = this.getChar(v, n);
@@ -515,7 +515,7 @@ export class ChtmlFontData extends FontData<
     styles: StyleList,
     n: number,
     c: string,
-    data: ChtmlDelimiterData
+    data: ChtmlDelimiterData,
   ) {
     const HDW = [...data.HDW] as ChtmlCharData;
     const [beg, ext, end, mid] = data.stretch;
@@ -566,7 +566,7 @@ export class ChtmlFontData extends FontData<
     part: string,
     n: number,
     v: string,
-    HDW: ChtmlCharData
+    HDW: ChtmlCharData,
   ) {
     if (!n) return 0;
     const [, , w, options] = this.getChar(v, n);
@@ -595,7 +595,7 @@ export class ChtmlFontData extends FontData<
     styles: StyleList,
     vletter: string,
     n: number,
-    data: ChtmlCharData
+    data: ChtmlCharData,
   ) {
     const options = data[3] as ChtmlCharOptions;
     const letter = options.f !== undefined ? options.f : vletter;
@@ -686,14 +686,14 @@ export type CssMap = { [name: number]: number };
  */
 export function AddCSS(
   font: ChtmlCharMap,
-  options: CharOptionsMap
+  options: CharOptionsMap,
 ): ChtmlCharMap {
   for (const c of Object.keys(options)) {
     const n = parseInt(c);
     const data = options[n];
     if (data.c) {
       data.c = data.c.replace(/\\[0-9A-F]+/gi, (x) =>
-        String.fromCodePoint(parseInt(x.substring(1), 16))
+        String.fromCodePoint(parseInt(x.substring(1), 16)),
       );
     }
     Object.assign(FontData.charOptions(font, n), data);

--- a/ts/output/chtml/Notation.ts
+++ b/ts/output/chtml/Notation.ts
@@ -40,7 +40,7 @@ export type DEFPAIR<N, T, D> = Notation.DefPair<ChtmlMencloseNTD<N, T, D>, N>;
  */
 export const RenderElement = function <N, T, D>(
   name: string,
-  offset: string = ''
+  offset: string = '',
 ): RENDERER<N, T, D> {
   return ((node, _child) => {
     const shape = node.adjustBorder(node.html('mjx-' + name));
@@ -60,13 +60,13 @@ export const RenderElement = function <N, T, D>(
  * @return {DEFPAIR}      The notation definition for the notation having a line on the given side
  */
 export const Border = function <N, T, D>(
-  side: Notation.Side
+  side: Notation.Side,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonBorder<ChtmlMencloseNTD<N, T, D>, N>((node, child) => {
     node.adaptor.setStyle(
       child,
       'border-' + side,
-      node.Em(node.thickness) + ' solid'
+      node.Em(node.thickness) + ' solid',
     );
   })(side);
 };
@@ -80,7 +80,7 @@ export const Border = function <N, T, D>(
 export const Border2 = function <N, T, D>(
   name: string,
   side1: Notation.Side,
-  side2: Notation.Side
+  side2: Notation.Side,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonBorder2<ChtmlMencloseNTD<N, T, D>, N>((node, child) => {
     const border = node.Em(node.thickness) + ' solid';
@@ -96,7 +96,7 @@ export const Border2 = function <N, T, D>(
  */
 export const DiagonalStrike = function <N, T, D>(
   name: string,
-  neg: number
+  neg: number,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalStrike<ChtmlMencloseNTD<N, T, D>, N>(
     (cname: string) => (node, _child) => {
@@ -110,10 +110,10 @@ export const DiagonalStrike = function <N, T, D>(
             transform:
               'rotate(' + node.fixed(-neg * a) + 'rad) translateY(' + t + 'em)',
           },
-        })
+        }),
       );
       node.adaptor.append(node.dom[0], strike);
-    }
+    },
   )(name);
 };
 
@@ -122,12 +122,12 @@ export const DiagonalStrike = function <N, T, D>(
  * @return {DEFPAIR}      The notation definition for the diagonal arrow
  */
 export const DiagonalArrow = function <N, T, D>(
-  name: string
+  name: string,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalArrow<ChtmlMencloseNTD<N, T, D>, N>(
     (node, arrow) => {
       node.adaptor.append(node.dom[0], arrow);
-    }
+    },
   )(name);
 };
 

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -242,7 +242,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
     if (!href) return parents;
     return parents.map(
       (parent) =>
-        this.adaptor.append(parent, this.html('a', { href: href })) as N
+        this.adaptor.append(parent, this.html('a', { href: href })) as N,
     );
   }
 
@@ -261,8 +261,8 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
           adaptor.setStyle(
             dom,
             'font-family',
-            this.font.cssFamilyPrefix + ', ' + family
-          )
+            this.font.cssFamilyPrefix + ', ' + family,
+          ),
         );
       }
     }
@@ -313,7 +313,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
           SPACE[space]
             ? { size: SPACE[space] }
             : { style: `letter-spacing: ${this.em(dimen - 1)}` },
-          [adaptor.text(' ')]
+          [adaptor.text(' ')],
         );
         adaptor.insert(node, this.dom[i]);
       } else if (dimen) {
@@ -374,7 +374,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
     }
     if (background) {
       this.dom.forEach((dom) =>
-        adaptor.setStyle(dom, 'backgroundColor', background)
+        adaptor.setStyle(dom, 'backgroundColor', background),
       );
     }
   }
@@ -410,7 +410,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
     }
     if (this.node.getProperty('inline-breaks')) {
       this.dom.forEach((dom) =>
-        adaptor.setAttribute(dom, 'inline-breaks', 'true')
+        adaptor.setAttribute(dom, 'inline-breaks', 'true'),
       );
     }
   }
@@ -425,7 +425,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
         this.dom.forEach((dom) => adaptor.setAttribute(dom, 'width', 'full'));
       } else {
         this.dom.forEach((dom) =>
-          adaptor.setStyle(dom, 'width', this.bbox.pwidth)
+          adaptor.setStyle(dom, 'width', this.bbox.pwidth),
         );
       }
     }
@@ -482,7 +482,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
             'background-color': 'green',
           },
         }),
-      ] as N[]
+      ] as N[],
     );
     const node = this.dom[0] || this.parent.dom[0];
     const size = this.adaptor.getAttribute(node, 'size');

--- a/ts/output/chtml/Wrappers/HtmlNode.ts
+++ b/ts/output/chtml/Wrappers/HtmlNode.ts
@@ -53,7 +53,7 @@ export interface ChtmlHtmlNodeClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlHtmlNodeNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/ts/output/chtml/Wrappers/TeXAtom.ts
@@ -90,7 +90,7 @@ export interface ChtmlTeXAtomClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlTeXAtomNTD<N, T, D>;
 }
 
@@ -134,8 +134,8 @@ export const ChtmlTeXAtom = (function <N, T, D>(): ChtmlTeXAtomClass<N, T, D> {
         this.adaptor.setAttribute(
           dom,
           'texclass',
-          TEXCLASSNAMES[this.node.texClass]
-        )
+          TEXCLASSNAMES[this.node.texClass],
+        ),
       );
     }
   };

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -92,7 +92,7 @@ export interface ChtmlTextNodeClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlTextNodeNTD<N, T, D>;
 }
 
@@ -183,8 +183,8 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<
               this.html(
                 'mjx-c',
                 { class: this.char(n) + (font ? ' ' + font : '') },
-                [this.text(data.c || String.fromCodePoint(n))]
-              )
+                [this.text(data.c || String.fromCodePoint(n))],
+              ),
             );
             if (i < m - 1 || bbox.oc) {
               adaptor.setAttribute(node as N, 'noic', 'true');

--- a/ts/output/chtml/Wrappers/maction.ts
+++ b/ts/output/chtml/Wrappers/maction.ts
@@ -108,7 +108,7 @@ export interface ChtmlMactionClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMactionNTD<N, T, D>;
 }
 
@@ -200,7 +200,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
               node.adaptor.setAttribute(
                 dom,
                 'toggle',
-                node.node.attributes.get('selection') as string
+                node.node.attributes.get('selection') as string,
               );
             });
             //
@@ -226,7 +226,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
                 document,
                 mml.attributes.get('data-maction-id')
                   ? STATE.ENRICHED
-                  : STATE.RERENDER
+                  : STATE.RERENDER,
               );
               event.stopPropagation();
             });
@@ -247,7 +247,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
               //
               const text = (tip.node as TextNode).getText();
               node.dom.forEach((dom) =>
-                node.adaptor.setAttribute(dom, 'title', text)
+                node.adaptor.setAttribute(dom, 'title', text),
               );
             } else {
               //
@@ -265,8 +265,8 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
                         right: node.Em(-node.tipDx),
                       },
                     },
-                    [node.html('mjx-tip')]
-                  )
+                    [node.html('mjx-tip')],
+                  ),
                 ) as N;
                 tip.toCHTML([adaptor.firstChild(tool) as N]);
                 //
@@ -278,12 +278,12 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
                     data.stopTimers(dom, data);
                     const timeout = setTimeout(
                       () => adaptor.setStyle(tool, 'display', 'block'),
-                      data.postDelay
+                      data.postDelay,
                     );
                     data.hoverTimer.set(dom, timeout);
                     event.stopPropagation();
                   },
-                  dom
+                  dom,
                 );
                 node.setEventHandler(
                   'mouseout',
@@ -291,12 +291,12 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
                     data.stopTimers(dom, data);
                     const timeout = setTimeout(
                       () => adaptor.setStyle(tool, 'display', ''),
-                      data.clearDelay
+                      data.clearDelay,
                     );
                     data.clearTimer.set(dom, timeout);
                     event.stopPropagation();
                   },
-                  dom
+                  dom,
                 );
               }
             }
@@ -315,7 +315,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
               const adaptor = node.adaptor;
               const text = (tip.node as TextNode).getText();
               node.dom.forEach((dom) =>
-                adaptor.setAttribute(dom, 'statusline', text)
+                adaptor.setAttribute(dom, 'statusline', text),
               );
               //
               // Set up event handlers to change the status window
@@ -325,7 +325,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
                   const body = adaptor.body(adaptor.document);
                   data.status = adaptor.append(
                     body,
-                    node.html('mjx-status', {}, [node.text(text)])
+                    node.html('mjx-status', {}, [node.text(text)]),
                   );
                 }
                 event.stopPropagation();
@@ -367,7 +367,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
      */
     public setEventHandler(type: string, handler: EventHandler, dom: N = null) {
       (dom ? [dom] : this.dom).forEach((node) =>
-        (node as any).addEventListener(type, handler)
+        (node as any).addEventListener(type, handler),
       );
     }
 

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -92,7 +92,7 @@ export interface ChtmlMathClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMathNTD<N, T, D>;
 }
 
@@ -267,7 +267,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
     public setChildPWidths(
       recompute: boolean,
       w: number = null,
-      clear: boolean = true
+      clear: boolean = true,
     ) {
       return this.parent ? super.setChildPWidths(recompute, w, clear) : false;
     }
@@ -280,7 +280,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
       const adaptor = this.adaptor;
       if (this.node.getProperty('process-breaks')) {
         this.dom.forEach((dom) =>
-          adaptor.setAttribute(dom, 'breakable', 'true')
+          adaptor.setAttribute(dom, 'breakable', 'true'),
         );
       }
     }

--- a/ts/output/chtml/Wrappers/menclose.ts
+++ b/ts/output/chtml/Wrappers/menclose.ts
@@ -138,7 +138,7 @@ export interface ChtmlMencloseClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMencloseNTD<N, T, D>;
 }
 
@@ -363,7 +363,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
               node.adaptor.setStyle(
                 child,
                 'border',
-                node.Em(node.thickness) + ' solid'
+                node.Em(node.thickness) + ' solid',
               );
             },
             bbox: Notation.fullBBox,
@@ -401,7 +401,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
               node.adaptor.setStyle(
                 child,
                 'border-bottom',
-                node.Em(node.thickness) + ' solid'
+                node.Em(node.thickness) + ' solid',
               );
               const strike = node.adjustBorder(
                 node.html('mjx-ustrike', {
@@ -414,7 +414,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
                       node.fixed(-a) +
                       'rad)',
                   },
-                })
+                }),
               );
               node.adaptor.append(node.dom[0], strike);
             },
@@ -456,15 +456,15 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
               adaptor.setStyle(
                 child,
                 'border-top',
-                node.Em(node.thickness) + ' solid'
+                node.Em(node.thickness) + ' solid',
               );
               const arc1 = adaptor.append(
                 node.dom[0],
-                node.html('mjx-dbox-top')
+                node.html('mjx-dbox-top'),
               ) as N;
               const arc2 = adaptor.append(
                 node.dom[0],
-                node.html('mjx-dbox-bot')
+                node.html('mjx-dbox-bot'),
               ) as N;
               const t = node.thickness;
               const p = node.padding;
@@ -498,7 +498,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
               node.adaptor.setStyle(
                 node.msqrt.dom[0],
                 'margin',
-                TRBL.map((x) => node.Em(-x)).join(' ')
+                TRBL.map((x) => node.Em(-x)).join(' '),
               );
             },
             //
@@ -538,7 +538,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       const [x, y] = [t * head.x, t * head.y].map((x) => this.em(x));
       const a = Angle(head.dx, head.y);
       const [line, rthead, rbhead, lthead, lbhead] = this.adaptor.childNodes(
-        arrow
+        arrow,
       ) as N[];
       this.adjustHead(rthead, [y, '0', '1px', x], a);
       this.adjustHead(rbhead, ['1px', '0', y, x], '-' + a);
@@ -585,7 +585,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       this.adaptor.setStyle(
         arrow,
         'transform',
-        `translate${offset}(${this.em(-d)})${transform ? ' ' + transform : ''}`
+        `translate${offset}(${this.em(-d)})${transform ? ' ' + transform : ''}`,
       );
     }
 
@@ -675,7 +675,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       a: number,
       double: boolean,
       offset: string = '',
-      dist: number = 0
+      dist: number = 0,
     ): N {
       const W = this.getBBox().w;
       const style = { width: this.em(w) } as OptionList;

--- a/ts/output/chtml/Wrappers/mfenced.ts
+++ b/ts/output/chtml/Wrappers/mfenced.ts
@@ -91,7 +91,7 @@ export interface ChtmlMfencedClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMfencedNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mfrac.ts
+++ b/ts/output/chtml/Wrappers/mfrac.ts
@@ -93,7 +93,7 @@ export interface ChtmlMfracClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMfracNTD<N, T, D>;
 }
 
@@ -232,7 +232,7 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
       this.standardChtmlNodes(parents);
       const { linethickness, bevelled } = this.node.attributes.getList(
         'linethickness',
-        'bevelled'
+        'bevelled',
       );
       const display = this.isDisplay();
       if (bevelled) {
@@ -256,7 +256,7 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
     protected makeFraction(display: boolean, t: number) {
       const { numalign, denomalign } = this.node.attributes.getList(
         'numalign',
-        'denomalign'
+        'denomalign',
       );
       const withDelims = this.node.getProperty('withDelims');
       //
@@ -314,7 +314,7 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
               ]),
             ]),
           ]),
-        ])
+        ]),
       );
       this.childNodes[0].toCHTML([num]);
       this.childNodes[1].toCHTML([den]);
@@ -328,7 +328,7 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
     protected makeAtop(display: boolean) {
       const { numalign, denomalign } = this.node.attributes.getList(
         'numalign',
-        'denomalign'
+        'denomalign',
       );
       const withDelims = this.node.getProperty('withDelims');
       //
@@ -361,7 +361,7 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
         this.html('mjx-frac', fattr, [
           (num = this.html('mjx-num', nattr)),
           (den = this.html('mjx-den', dattr)),
-        ])
+        ]),
       );
       this.childNodes[0].toCHTML([num]);
       this.childNodes[1].toCHTML([den]);

--- a/ts/output/chtml/Wrappers/mglyph.ts
+++ b/ts/output/chtml/Wrappers/mglyph.ts
@@ -92,7 +92,7 @@ export interface ChtmlMglyphClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMglyphNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mi.ts
+++ b/ts/output/chtml/Wrappers/mi.ts
@@ -90,7 +90,7 @@ export interface ChtmlMiClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMiNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -94,7 +94,7 @@ export interface ChtmlMmultiscriptsClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMmultiscriptsNTD<N, T, D>;
 }
 
@@ -193,7 +193,7 @@ export const ChtmlMmultiscripts = (function <
           data.psub,
           data.psup,
           this.firstPrescript,
-          data.numPrescripts
+          data.numPrescripts,
         );
         preAlign !== 'right' &&
           this.adaptor.setAttribute(scripts, 'script-align', preAlign);
@@ -208,7 +208,7 @@ export const ChtmlMmultiscripts = (function <
           data.sub,
           data.sup,
           1,
-          data.numScripts
+          data.numScripts,
         );
         postAlign !== 'left' &&
           this.adaptor.setAttribute(scripts, 'script-align', postAlign);
@@ -236,7 +236,7 @@ export const ChtmlMmultiscripts = (function <
       sub: BBox,
       sup: BBox,
       i: number,
-      n: number
+      n: number,
     ): N {
       const adaptor = this.adaptor;
       const q = u - sup.d + (v - sub.h); // separation of scripts
@@ -258,7 +258,7 @@ export const ChtmlMmultiscripts = (function <
       }
       return adaptor.append(
         dom,
-        this.html(name, tabledef, [supRow, sepRow, subRow])
+        this.html(name, tabledef, [supRow, sepRow, subRow]),
       ) as N;
     }
   };

--- a/ts/output/chtml/Wrappers/mn.ts
+++ b/ts/output/chtml/Wrappers/mn.ts
@@ -90,7 +90,7 @@ export interface ChtmlMnClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMnNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -92,7 +92,7 @@ export interface ChtmlMoClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMoNTD<N, T, D>;
 }
 
@@ -187,7 +187,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       }
       parents.length > 1 &&
         parents.forEach((dom) =>
-          adaptor.append(dom, this.html('mjx-linestrut'))
+          adaptor.append(dom, this.html('mjx-linestrut')),
         );
       let chtml = this.standardChtmlNodes(parents);
       if (chtml.length > 1 && this.breakStyle !== 'duplicate') {
@@ -202,7 +202,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
           const u = this.em(this.getCenterOffset());
           if (u !== '0') {
             chtml.forEach(
-              (dom) => dom && adaptor.setStyle(dom, 'verticalAlign', u)
+              (dom) => dom && adaptor.setStyle(dom, 'verticalAlign', u),
             );
           }
         }
@@ -212,7 +212,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
             adaptor.setStyle(
               dom,
               'margin-left',
-              this.em(this.getAccentOffset())
+              this.em(this.getAccentOffset()),
             );
           });
         }
@@ -289,12 +289,12 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
           options.ff || (letter ? `${this.font.cssFontPrefix}-${letter}` : '');
         let c = ((options.c as string) || String.fromCodePoint(n)).replace(
           /\\[0-9A-F]+/gi,
-          (x) => String.fromCodePoint(parseInt(x.substring(1), 16))
+          (x) => String.fromCodePoint(parseInt(x.substring(1), 16)),
         );
         content.push(
           this.html(part, {}, [
             this.html('mjx-c', font ? { class: font } : {}, [this.text(c)]),
-          ])
+          ]),
         );
       }
     }

--- a/ts/output/chtml/Wrappers/mpadded.ts
+++ b/ts/output/chtml/Wrappers/mpadded.ts
@@ -91,7 +91,7 @@ export interface ChtmlMpaddedClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMpaddedNTD<N, T, D>;
 }
 
@@ -185,7 +185,7 @@ export const ChtmlMpadded = (function <N, T, D>(): ChtmlMpaddedClass<N, T, D> {
       chtml = [
         this.adaptor.append(
           chtml[0],
-          this.html('mjx-block', { style: style }, content)
+          this.html('mjx-block', { style: style }, content),
         ) as N,
       ];
       if (this.childNodes[0].childNodes.length) {

--- a/ts/output/chtml/Wrappers/mroot.ts
+++ b/ts/output/chtml/Wrappers/mroot.ts
@@ -92,7 +92,7 @@ export interface ChtmlMrootClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMrootNTD<N, T, D>;
 }
 
@@ -134,7 +134,7 @@ export const ChtmlMroot = (function <N, T, D>(): ChtmlMrootClass<N, T, D> {
       ROOT: N,
       root: ChtmlWrapper<N, T, D>,
       sbox: BBox,
-      H: number
+      H: number,
     ) {
       root.toCHTML([ROOT]);
       const adaptor = this.adaptor;
@@ -145,7 +145,7 @@ export const ChtmlMroot = (function <N, T, D>(): ChtmlMrootClass<N, T, D> {
         adaptor.setStyle(
           adaptor.firstChild(ROOT) as N,
           'paddingLeft',
-          this.em(dx)
+          this.em(dx),
         );
       }
     }

--- a/ts/output/chtml/Wrappers/mrow.ts
+++ b/ts/output/chtml/Wrappers/mrow.ts
@@ -99,7 +99,7 @@ export interface ChtmlMrowClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMrowNTD<N, T, D>;
 }
 
@@ -242,7 +242,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
           indentalign,
           indentshift,
           alignfirst,
-          shiftfirst
+          shiftfirst,
         );
         adaptor.setAttribute(parents[i], 'align', align);
         if (shift) {
@@ -253,7 +253,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
           adaptor.setStyle(
             parents[i],
             'margin-bottom',
-            this.em(bbox.lineLeading)
+            this.em(bbox.lineLeading),
           );
         }
       }
@@ -267,7 +267,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
         this.adaptor.setStyle(
           this.adaptor.parent(dom),
           'vertical-align',
-          this.em(this.dh)
+          this.em(this.dh),
         );
       }
     }
@@ -305,7 +305,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       }
       if (this.node.isInferred || !this.isStack) {
         const valign = this.parent.node.attributes.get(
-          'data-vertical-align'
+          'data-vertical-align',
         ) as string;
         if (valign === 'middle' || valign === 'center' || valign === 'bottom') {
           adaptor.setAttribute(this.dom[0], 'break-align', valign);
@@ -324,7 +324,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       for (let i = 0; i <= n; i++) {
         chtml[i] = adaptor.append(
           this.dom[0],
-          this.html('mjx-linebox', { lineno: i })
+          this.html('mjx-linebox', { lineno: i }),
         ) as N;
       }
       //
@@ -400,7 +400,7 @@ export interface ChtmlInferredMrowClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlInferredMrowNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/ms.ts
+++ b/ts/output/chtml/Wrappers/ms.ts
@@ -90,7 +90,7 @@ export interface ChtmlMsClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMsNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mspace.ts
+++ b/ts/output/chtml/Wrappers/mspace.ts
@@ -90,7 +90,7 @@ export interface ChtmlMspaceClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMspaceNTD<N, T, D>;
 }
 
@@ -131,7 +131,7 @@ export const ChtmlMspace = (function <N, T, D>(): ChtmlMspaceClass<N, T, D> {
     public toCHTML(parents: N[]) {
       parents.length > 1 &&
         parents.forEach((dom) =>
-          this.adaptor.append(dom, this.html('mjx-linestrut'))
+          this.adaptor.append(dom, this.html('mjx-linestrut')),
         );
       let chtml = this.standardChtmlNodes(parents);
       let { w, h, d } = this.getBBox();

--- a/ts/output/chtml/Wrappers/msqrt.ts
+++ b/ts/output/chtml/Wrappers/msqrt.ts
@@ -93,7 +93,7 @@ export interface ChtmlMsqrtClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMsqrtNTD<N, T, D>;
 }
 
@@ -184,13 +184,13 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
         this.html('mjx-sqrt', {}, [
           (SURD = this.html('mjx-surd')),
           (BASE = this.html('mjx-box', { style: { paddingTop: this.em(q) } })),
-        ])
+        ]),
       ) as N;
       if (t !== 0.06) {
         adaptor.setStyle(
           BASE,
           'border-top-width',
-          this.em(t * this.font.params.rule_factor)
+          this.em(t * this.font.params.rule_factor),
         );
       }
       //
@@ -221,7 +221,7 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
       _ROOT: N,
       _root: ChtmlWrapper<N, T, D>,
       _sbox: BBox,
-      _H: number
+      _H: number,
     ) {}
   };
 })<any, any, any>();

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -107,7 +107,7 @@ export interface ChtmlMsubClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMsubNTD<N, T, D>;
 }
 
@@ -197,7 +197,7 @@ export interface ChtmlMsupClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMsupNTD<N, T, D>;
 }
 
@@ -287,7 +287,7 @@ export interface ChtmlMsubsupClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMsubsupNTD<N, T, D>;
 }
 
@@ -349,12 +349,12 @@ export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
       base.toCHTML(chtml);
       const stack = adaptor.append(
         chtml[chtml.length - 1],
-        this.html('mjx-script', { style })
+        this.html('mjx-script', { style }),
       ) as N;
       sup.toCHTML([stack]);
       adaptor.append(
         stack,
-        this.html('mjx-spacer', { style: { 'margin-top': this.em(q) } })
+        this.html('mjx-spacer', { style: { 'margin-top': this.em(q) } }),
       );
       sub.toCHTML([stack]);
       const ic = this.getAdjustedIc();
@@ -362,13 +362,13 @@ export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
         adaptor.setStyle(
           sup.dom[0],
           'marginLeft',
-          this.em(ic / sup.bbox.rscale)
+          this.em(ic / sup.bbox.rscale),
         );
         if (!this.baseIsChar) {
           adaptor.setStyle(
             sub.dom[0],
             'marginLeft',
-            this.em(ic / sup.bbox.rscale)
+            this.em(ic / sup.bbox.rscale),
           );
         }
       }

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -105,7 +105,7 @@ export interface ChtmlMtableClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMtableNTD<N, T, D>;
 }
 
@@ -225,7 +225,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     constructor(
       factory: ChtmlWrapperFactory<N, T, D>,
       node: MmlNode,
-      parent: ChtmlWrapper<N, T, D> = null
+      parent: ChtmlWrapper<N, T, D> = null,
     ) {
       super(factory, node, parent);
       this.itable = this.html('mjx-itable');
@@ -315,7 +315,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       const spacing = this.getEmHalfSpacing(
         [this.fSpace[0], this.fSpace[2]],
         this.cSpace,
-        scale
+        scale,
       );
       //
       //  For each row...
@@ -400,7 +400,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       const spacing = this.getEmHalfSpacing(
         [this.fSpace[1], this.fSpace[1]],
         this.rSpace,
-        scale
+        scale,
       );
       const frame = this.fframe;
       //
@@ -498,7 +498,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     protected setRowBaseline(
       row: ChtmlWrapper<N, T, D>,
       HD: number,
-      D: number
+      D: number,
     ) {
       const ralign = row.node.attributes.get('rowalign') as string;
       //
@@ -523,7 +523,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       cell: ChtmlWrapper<N, T, D>,
       ralign: string,
       HD: number,
-      D: number
+      D: number,
     ): boolean {
       const calign = cell.node.attributes.get('rowalign');
       if (calign === 'baseline' || calign === 'axis') {
@@ -551,7 +551,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
         this.adaptor.setStyle(
           this.itable,
           'border',
-          `${this.em(this.fLine)} ${frame}`
+          `${this.em(this.fLine)} ${frame}`,
         );
       }
     }
@@ -586,7 +586,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
           adaptor.setStyle(
             table,
             style,
-            '0 ' + this.em(R) + ' 0 ' + this.em(L)
+            '0 ' + this.em(R) + ' 0 ' + this.em(L),
           );
         }
       }
@@ -676,7 +676,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       }
       this.adaptor.append(
         this.dom[0],
-        this.html('mjx-labels', styles, [this.labels])
+        this.html('mjx-labels', styles, [this.labels]),
       );
       return [align, shift] as [string, number];
     }
@@ -692,7 +692,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
         const row = this.childNodes[i];
         this.setRowHeight(
           row,
-          H[i] + D[i] + space[i] + space[i + 1] + this.rLines[i]
+          H[i] + D[i] + space[i] + space[i + 1] + this.rLines[i],
         );
         if (H[i] !== NH[i] || D[i] !== ND[i]) {
           this.setRowBaseline(row, H[i] + D[i], D[i]);
@@ -723,12 +723,12 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
           h &&
             adaptor.insert(
               this.html('mjx-mtr', { style: { height: this.em(h) } }),
-              current
+              current,
             );
           adaptor.setStyle(
             current,
             'height',
-            this.em((equal ? HD : H[i] + D[i]) + space[i] + space[i + 1])
+            this.em((equal ? HD : H[i] + D[i]) + space[i] + space[i + 1]),
           );
           current = adaptor.next(current) as N;
           h = this.rLines[i];

--- a/ts/output/chtml/Wrappers/mtd.ts
+++ b/ts/output/chtml/Wrappers/mtd.ts
@@ -91,7 +91,7 @@ export interface ChtmlMtdClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMtdNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mtext.ts
+++ b/ts/output/chtml/Wrappers/mtext.ts
@@ -90,7 +90,7 @@ export interface ChtmlMtextClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMtextNTD<N, T, D>;
 }
 

--- a/ts/output/chtml/Wrappers/mtr.ts
+++ b/ts/output/chtml/Wrappers/mtr.ts
@@ -96,7 +96,7 @@ export interface ChtmlMtrClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMtrNTD<N, T, D>;
 }
 
@@ -219,7 +219,7 @@ export interface ChtmlMlabeledtrClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMlabeledtrNTD<N, T, D>;
 }
 
@@ -302,7 +302,7 @@ export const ChtmlMlabeledtr = (function <N, T, D>(): ChtmlMlabeledtrClass<
         const row = this.html('mjx-mtr', attr, [child]);
         this.adaptor.append(
           (this.parent as ChtmlMtableNTD<N, T, D>).labels,
-          row
+          row,
         );
       }
     }

--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -113,7 +113,7 @@ export interface ChtmlMunderClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMunderNTD<N, T, D>;
 }
 
@@ -179,11 +179,11 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
       this.dom = this.standardChtmlNodes(parents);
       const base = this.adaptor.append(
         this.adaptor.append(this.dom[0], this.html('mjx-row')) as N,
-        this.html('mjx-base')
+        this.html('mjx-base'),
       ) as N;
       const under = this.adaptor.append(
         this.adaptor.append(this.dom[0], this.html('mjx-row')) as N,
-        this.html('mjx-under')
+        this.html('mjx-under'),
       ) as N;
       this.baseChild.toCHTML([base]);
       this.scriptChild.toCHTML([under]);
@@ -196,7 +196,7 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
       this.adaptor.setStyle(under, 'paddingTop', this.em(k));
       this.setDeltaW(
         [base, under],
-        this.getDeltaW([basebox, underbox], [0, -delta])
+        this.getDeltaW([basebox, underbox], [0, -delta]),
       );
       this.adjustUnderDepth(under, underbox);
     }
@@ -256,7 +256,7 @@ export interface ChtmlMoverClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMoverNTD<N, T, D>;
 }
 
@@ -327,7 +327,7 @@ export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
       this.adaptor.setStyle(over, 'paddingBottom', this.em(k));
       this.setDeltaW(
         [base, over],
-        this.getDeltaW([basebox, overbox], [0, delta])
+        this.getDeltaW([basebox, overbox], [0, delta]),
       );
       this.adjustOverDepth(over, overbox);
     }
@@ -387,7 +387,7 @@ export interface ChtmlMunderoverClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlMunderoverNTD<N, T, D>;
 }
 
@@ -455,15 +455,15 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<
       const over = this.adaptor.append(this.dom[0], this.html('mjx-over')) as N;
       const table = this.adaptor.append(
         this.adaptor.append(this.dom[0], this.html('mjx-box')) as N,
-        this.html('mjx-munder')
+        this.html('mjx-munder'),
       ) as N;
       const base = this.adaptor.append(
         this.adaptor.append(table, this.html('mjx-row')) as N,
-        this.html('mjx-base')
+        this.html('mjx-base'),
       ) as N;
       const under = this.adaptor.append(
         this.adaptor.append(table, this.html('mjx-row')) as N,
-        this.html('mjx-under')
+        this.html('mjx-under'),
       ) as N;
       this.overChild.toCHTML([over]);
       this.baseChild.toCHTML([base]);
@@ -482,8 +482,8 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<
         [base, under, over],
         this.getDeltaW(
           [basebox, underbox, overbox],
-          [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta]
-        )
+          [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta],
+        ),
       );
       this.adjustOverDepth(over, overbox);
       this.adjustUnderDepth(under, underbox);

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -119,7 +119,7 @@ export interface ChtmlScriptbaseClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlScriptbaseNTD<N, T, D>;
 }
 
@@ -214,7 +214,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
       this.adaptor.setStyle(
         over,
         'marginBottom',
-        this.em(overbox.d * overbox.rscale)
+        this.em(overbox.d * overbox.rscale),
       );
     }
 
@@ -230,7 +230,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
         style: { 'margin-bottom': v, 'vertical-align': v },
       });
       for (const child of adaptor.childNodes(
-        adaptor.firstChild(under) as N
+        adaptor.firstChild(under) as N,
       ) as N[]) {
         adaptor.append(box, child);
       }

--- a/ts/output/chtml/Wrappers/semantics.ts
+++ b/ts/output/chtml/Wrappers/semantics.ts
@@ -103,7 +103,7 @@ export interface ChtmlSemanticsClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlSemanticsNTD<N, T, D>;
 }
 
@@ -269,7 +269,7 @@ export interface ChtmlXmlNodeClass<N, T, D>
   new (
     factory: ChtmlWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
+    parent?: ChtmlWrapper<N, T, D>,
   ): ChtmlXmlNodeNTD<N, T, D>;
 }
 
@@ -329,7 +329,7 @@ export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
             'transform-origin': 'top left',
           },
         },
-        [html]
+        [html],
       );
     }
   };

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -261,7 +261,7 @@ export abstract class CommonOutputJax<
   constructor(
     options: OptionList = {},
     defaultFactory: typeof CommonWrapperFactory = null,
-    defaultFont: FC = null
+    defaultFont: FC = null,
   ) {
     const [fontClass, font] =
       options.fontData instanceof FontData
@@ -269,7 +269,7 @@ export abstract class CommonOutputJax<
         : [options.fontData || defaultFont, null];
     const [jaxOptions, fontOptions] = separateOptions(
       options,
-      fontClass.OPTIONS
+      fontClass.OPTIONS,
     );
     super(jaxOptions);
     this.factory =
@@ -312,7 +312,7 @@ export abstract class CommonOutputJax<
    */
   public addExtension(
     font: FontExtensionData<CC, DD>,
-    prefix: string = ''
+    prefix: string = '',
   ): string[] {
     return this.font.addExtension(font, prefix);
   }
@@ -387,7 +387,7 @@ export abstract class CommonOutputJax<
   public toDOM(
     math: MathItem<N, T, D>,
     node: N,
-    html: MathDocument<N, T, D> = null
+    html: MathDocument<N, T, D> = null,
   ) {
     this.setDocument(html);
     this.math = math;
@@ -469,7 +469,7 @@ export abstract class CommonOutputJax<
           forcebreak,
           markNext,
           node,
-          child
+          child,
         );
         markNext = '';
         postbreak = false;
@@ -496,7 +496,7 @@ export abstract class CommonOutputJax<
                 linebreak,
                 node,
                 child,
-                mo
+                mo,
               );
             }
           } else {
@@ -512,7 +512,7 @@ export abstract class CommonOutputJax<
             forcebreak,
             linebreak,
             node,
-            child
+            child,
           );
         }
         postbreak = linebreak === 'newline';
@@ -559,7 +559,7 @@ export abstract class CommonOutputJax<
     linebreak: string,
     node: MmlNode,
     child: MmlNode,
-    mo: MmlNode = null
+    mo: MmlNode = null,
   ): boolean {
     child.setProperty('breakable', true);
     if (forcebreak && linebreak !== 'newline') {
@@ -720,7 +720,7 @@ export abstract class CommonOutputJax<
               float: 'right',
             },
           }),
-        ]
+        ],
       );
       this.testDisplay = adaptor.clone(this.testInline);
       adaptor.setStyle(this.testDisplay, 'display', 'table');
@@ -728,7 +728,7 @@ export abstract class CommonOutputJax<
       adaptor.setStyle(
         adaptor.firstChild(this.testDisplay) as N,
         'display',
-        'none'
+        'none',
       );
       const right = adaptor.lastChild(this.testDisplay) as N;
       adaptor.setStyle(right, 'display', 'table-cell');
@@ -737,7 +737,7 @@ export abstract class CommonOutputJax<
     }
     return adaptor.append(
       node,
-      adaptor.clone(display ? this.testDisplay : this.testInline) as N
+      adaptor.clone(display ? this.testDisplay : this.testInline) as N,
     ) as N;
   }
 
@@ -761,7 +761,7 @@ export abstract class CommonOutputJax<
           2;
     const scale = Math.max(
       this.options.minScale,
-      this.options.matchFontHeight ? ex / this.font.params.x_height / em : 1
+      this.options.matchFontHeight ? ex / this.font.params.x_height / em : 1,
     );
     return { em, ex, containerWidth, scale, family };
   }
@@ -778,7 +778,7 @@ export abstract class CommonOutputJax<
     //
     this.cssStyles.clear();
     this.cssStyles.addStyles(
-      (this.constructor as typeof CommonOutputJax).commonStyles
+      (this.constructor as typeof CommonOutputJax).commonStyles,
     );
     //
     // Add document-specific styles
@@ -825,7 +825,7 @@ export abstract class CommonOutputJax<
   protected addClassStyles(CLASS: typeof CommonWrapper, styles: CssStyles) {
     CLASS.addStyles<CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>>(
       styles,
-      this
+      this,
     );
   }
 
@@ -852,7 +852,7 @@ export abstract class CommonOutputJax<
     type: string,
     def: OptionList = {},
     content: (N | T)[] = [],
-    ns?: string
+    ns?: string,
   ): N {
     return this.adaptor.node(type, def, content, ns);
   }
@@ -904,7 +904,7 @@ export abstract class CommonOutputJax<
   public measureText(
     text: string,
     variant: string,
-    font: CssFontData = ['', false, false]
+    font: CssFontData = ['', false, false],
   ): UnknownBBox {
     const node = this.unknownText(text, variant);
     if (variant === '-explicitFont') {
@@ -928,11 +928,11 @@ export abstract class CommonOutputJax<
     text: N,
     chars: string,
     variant: string,
-    font: CssFontData = ['', false, false]
+    font: CssFontData = ['', false, false],
   ): UnknownBBox {
     if (variant === '-explicitFont') {
       variant = [font[0], font[1] ? 'T' : 'F', font[2] ? 'T' : 'F', ''].join(
-        '-'
+        '-',
       );
     }
     if (!this.unknownCache.has(variant)) {

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -730,12 +730,12 @@ export class FontData<
    */
   public static charOptions(
     font: CharMap<CharOptions>,
-    n: number
+    n: number,
   ): CharOptions {
     const char = font[n];
     if (!Array.isArray(char)) {
       throw Error(
-        `Character data hasn't been loaded for 0x${n.toString(16).toUpperCase()}`
+        `Character data hasn't been loaded for 0x${n.toString(16).toUpperCase()}`,
       );
     }
     if (char.length === 3) {
@@ -753,7 +753,7 @@ export class FontData<
    */
   public static defineDynamicFiles(
     dynamicFiles: DynamicFileDef[],
-    extension: string = ''
+    extension: string = '',
   ): DynamicFileList {
     const list: DynamicFileList = {};
     (dynamicFiles || []).forEach(([file, variants, delimiters]) => {
@@ -787,13 +787,13 @@ export class FontData<
     file: string,
     variants: CharMapMap<C>,
     delimiters: DelimiterMap<D> = {},
-    fonts: string[] = null
+    fonts: string[] = null,
   ) {
     const data = extension ? this.dynamicExtensions.get(extension) : null;
     const files = extension ? data.files : this.dynamicFiles;
     files[file].setup = (font) => {
       Object.keys(variants).forEach((name) =>
-        font.defineChars(name, variants[name])
+        font.defineChars(name, variants[name]),
       );
       font.defineDelimiters(delimiters);
       extension &&
@@ -801,7 +801,7 @@ export class FontData<
           font.delimiters,
           Object.keys(delimiters),
           data.sizeN,
-          data.stretchN
+          data.stretchN,
         );
       fonts && font.addDynamicFontCss(fonts);
     };
@@ -817,7 +817,7 @@ export class FontData<
     delimiters: DelimiterMap<DelimiterData>,
     keys: string[],
     sizeN: number,
-    stretchN: number
+    stretchN: number,
   ) {
     keys.forEach((id) => {
       const delim = delimiters[parseInt(id)];
@@ -848,7 +848,7 @@ export class FontData<
    */
   public static addExtension(
     data: FontExtensionData<CharOptions, DelimiterData>,
-    prefix: string = ''
+    prefix: string = '',
   ) {
     const extension = {
       name: data.name,
@@ -883,7 +883,7 @@ export class FontData<
         this.defaultDelimiters,
         Object.keys(data.delimiters),
         extension.sizeN,
-        extension.stretchN
+        extension.stretchN,
       );
     }
   }
@@ -906,14 +906,14 @@ export class FontData<
     this.createVariants(CLASS.defaultVariants);
     this.defineDelimiters(CLASS.defaultDelimiters as DelimiterMap<D>);
     Object.keys(CLASS.defaultChars).forEach((name) =>
-      this.defineChars(name, CLASS.defaultChars[name] as CharMap<C>)
+      this.defineChars(name, CLASS.defaultChars[name] as CharMap<C>),
     );
     this.defineRemap('accent', CLASS.defaultAccentMap);
     this.defineRemap('mo', CLASS.defaultMoMap);
     this.defineRemap('mn', CLASS.defaultMnMap);
     this.defineDynamicCharacters(CLASS.dynamicFiles);
     CLASS.dynamicExtensions.forEach((data) =>
-      this.defineDynamicCharacters(data.files)
+      this.defineDynamicCharacters(data.files),
     );
   }
 
@@ -933,7 +933,7 @@ export class FontData<
    */
   public addExtension(
     data: FontExtensionData<C, D>,
-    prefix: string = ''
+    prefix: string = '',
   ): string[] {
     const jax = (
       this.constructor as typeof FontData<C, V, D>
@@ -953,20 +953,20 @@ export class FontData<
     mergeOptions(this, 'stretchVariants', data.stretchVariants);
     mergeOptions(this.constructor, 'VariantSmp', data.variantSmp);
     this.defineCssFonts(
-      mergeOptions({ cssFonts: {} }, 'cssFonts', data.cssFonts)
+      mergeOptions({ cssFonts: {} }, 'cssFonts', data.cssFonts),
     );
     this.createVariants(
-      mergeOptions({ variants: [] }, 'variants', data.variants)
+      mergeOptions({ variants: [] }, 'variants', data.variants),
     );
     if (data.delimiters) {
       this.defineDelimiters(
-        mergeOptions({ delimiters: {} }, 'delimiters', data.delimiters)
+        mergeOptions({ delimiters: {} }, 'delimiters', data.delimiters),
       );
       this.CLASS.adjustDelimiters(
         this.delimiters,
         Object.keys(data.delimiters),
         dynamicFont.sizeN,
-        dynamicFont.stretchN
+        dynamicFont.stretchN,
       );
     }
     for (const name of Object.keys(data.chars || {})) {
@@ -1029,12 +1029,12 @@ export class FontData<
   public createVariant(
     name: string,
     inherit: string = null,
-    link: string = null
+    link: string = null,
   ) {
     let variant = {
       linked: [] as CharMap<C>[],
       chars: Object.create(
-        inherit ? this.variant[inherit].chars : {}
+        inherit ? this.variant[inherit].chars : {},
       ) as CharMap<C>,
     } as unknown as V;
     if (this.variant[link]) {
@@ -1165,7 +1165,7 @@ export class FontData<
       for (const name of Object.keys(dynamic.variants)) {
         this.defineChars(
           name,
-          this.flattenRanges(dynamic.variants[name], dynamic)
+          this.flattenRanges(dynamic.variants[name], dynamic),
         );
       }
       this.defineDelimiters(this.flattenRanges(dynamic.delimiters, dynamic));
@@ -1181,7 +1181,7 @@ export class FontData<
    */
   protected flattenRanges(
     ranges: DynamicRanges,
-    dynamic: DynamicFile
+    dynamic: DynamicFile,
   ): DynamicCharMap {
     const chars: DynamicCharMap = {};
     for (const n of ranges) {
@@ -1219,14 +1219,14 @@ export class FontData<
   public async loadDynamicFile(dynamic: DynamicFile): Promise<void> {
     if (dynamic.failed)
       return Promise.reject(
-        new Error(`dynamic file '${dynamic.file}' failed to load`)
+        new Error(`dynamic file '${dynamic.file}' failed to load`),
       );
     if (!dynamic.promise) {
       dynamic.promise = asyncLoad(this.dynamicFileName(dynamic)).catch(
         (err) => {
           dynamic.failed = true;
           console.warn(err);
-        }
+        },
       );
     }
     return dynamic.promise.then(() => dynamic.setup(this));
@@ -1240,13 +1240,13 @@ export class FontData<
   public loadDynamicFiles(): Promise<void[]> {
     const dynamicFiles = this.CLASS.dynamicFiles;
     const promises = Object.keys(dynamicFiles).map((name) =>
-      this.loadDynamicFile(dynamicFiles[name])
+      this.loadDynamicFile(dynamicFiles[name]),
     );
     for (const data of this.CLASS.dynamicExtensions.values()) {
       promises.push(
         ...Object.keys(data.files).map((name) =>
-          this.loadDynamicFile(data.files[name])
-        )
+          this.loadDynamicFile(data.files[name]),
+        ),
       );
     }
     return Promise.all(promises);
@@ -1260,16 +1260,16 @@ export class FontData<
     if (!mathjax.asyncIsSynchronous) {
       throw Error(
         'MathJax(loadDynamicFilesSync): mathjax.asyncLoad must be specified and synchronous\n' +
-          '    Try importing #js/../components/require.mjs and #js/util/asyncLoad/node.js'
+          '    Try importing #js/../components/require.mjs and #js/util/asyncLoad/node.js',
       );
     }
     const dynamicFiles = this.CLASS.dynamicFiles;
     Object.keys(dynamicFiles).forEach((name) =>
-      this.loadDynamicFileSync(dynamicFiles[name])
+      this.loadDynamicFileSync(dynamicFiles[name]),
     );
     for (const data of this.CLASS.dynamicExtensions.values()) {
       Object.keys(data.files).forEach((name) =>
-        this.loadDynamicFileSync(data.files[name])
+        this.loadDynamicFileSync(data.files[name]),
       );
     }
   }
@@ -1417,7 +1417,7 @@ export interface FontDataClass<
   /* tslint:disable-next-line:jsdoc-require */
   defineDynamicFiles(
     dynamicFiles: DynamicFileDef[],
-    prefix?: string
+    prefix?: string,
   ): DynamicFileList;
   /* tslint:disable-next-line:jsdoc-require */
   dynamicSetup<C extends CharOptions, D extends DelimiterData>(
@@ -1425,7 +1425,7 @@ export interface FontDataClass<
     file: string,
     variants: CharMapMap<C>,
     delimiters?: DelimiterMap<D>,
-    fonts?: string[]
+    fonts?: string[],
   ): void;
   /* tslint:disable-next-line:jsdoc-require */
   addExtension(data: FontExtensionData<C, D>, prefix?: string): void;

--- a/ts/output/common/LineBBox.ts
+++ b/ts/output/common/LineBBox.ts
@@ -74,7 +74,7 @@ export class LineBBox extends BBox {
   public static from(
     bbox: BBox,
     leading: number,
-    indent: IndentData[] = null
+    indent: IndentData[] = null,
   ): LineBBox {
     const nbox = new this();
     Object.assign(nbox, bbox);

--- a/ts/output/common/LinebreakVisitor.ts
+++ b/ts/output/common/LinebreakVisitor.ts
@@ -173,7 +173,7 @@ export class LinebreakVisitor<
   protected FACTORS: {
     [key: string]: (
       p: number,
-      mo?: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+      mo?: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
     ) => number;
   } = {
     //
@@ -194,7 +194,7 @@ export class LinebreakVisitor<
       Math.floor(
         (this.state.width /
           Math.max(0.0001, this.state.mathLeft - this.state.w)) *
-          500
+          500,
       ),
     //
     // Adjust for an open fence
@@ -222,7 +222,7 @@ export class LinebreakVisitor<
         mo.node === this.getFirstToken(parent)
       ) {
         const prescripts = !!parent.childNodes.filter((node) =>
-          node.isKind('mprescripts')
+          node.isKind('mprescripts'),
         ).length;
         if (prescripts) return NOBREAK;
       }
@@ -484,18 +484,18 @@ export class LinebreakVisitor<
     const mo = wrapper.coreMO();
     const bbox = LineBBox.from(
       wrapper.getOuterBBox(),
-      wrapper.linebreakOptions.lineleading
+      wrapper.linebreakOptions.lineleading,
     );
     bbox.getIndentData(mo.node);
     const style = mo.getBreakStyle(
-      mo.node.attributes.get('linebreakstyle') as string
+      mo.node.attributes.get('linebreakstyle') as string,
     );
     const dw = mo.processIndent(
       '',
       bbox.indentData[1][1],
       '',
       bbox.indentData[0][1],
-      this.state.width
+      this.state.width,
     )[1];
     const penalty = this.moPenalty(mo);
     if (style === 'before') {
@@ -526,18 +526,18 @@ export class LinebreakVisitor<
     >;
     const bbox = LineBBox.from(
       mo.getOuterBBox(),
-      mo.linebreakOptions.lineleading
+      mo.linebreakOptions.lineleading,
     );
     bbox.getIndentData(mo.node);
     const style = mo.getBreakStyle(
-      mo.node.attributes.get('linebreakstyle') as string
+      mo.node.attributes.get('linebreakstyle') as string,
     );
     const dw = mo.processIndent(
       '',
       bbox.indentData[1][1],
       '',
       bbox.indentData[0][1],
-      this.state.width
+      this.state.width,
     )[1];
     const penalty = this.moPenalty(mo);
     if (style === 'before') {
@@ -560,12 +560,12 @@ export class LinebreakVisitor<
    * @return {number}        The computed penalty
    */
   protected moPenalty(
-    mo: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    mo: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
   ): number {
     const { linebreak, fence, form } = mo.node.attributes.getList(
       'linebreak',
       'fence',
-      'form'
+      'form',
     );
     const FACTORS = this.FACTORS;
     let penalty = FACTORS.tail(FACTORS.width(0));
@@ -583,7 +583,7 @@ export class LinebreakVisitor<
     }
     penalty = (this.TEXCLASS[mo.node.texClass] || ((p) => p))(penalty);
     return (this.PENALTY[linebreak as string] || ((p) => p))(
-      FACTORS.depth(penalty)
+      FACTORS.depth(penalty),
     );
   }
 
@@ -591,7 +591,7 @@ export class LinebreakVisitor<
    * @param {CommonMo} mo   The mo whose preceeding mo node is needed
    */
   protected getPrevious(
-    mo: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    mo: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
   ): MmlNode | null {
     let child = mo.node;
     let parent = child.parent;
@@ -626,7 +626,7 @@ export class LinebreakVisitor<
         bbox.indentData[1][1],
         '',
         bbox.indentData[0][1],
-        this.state.width
+        this.state.width,
       )[1];
       this.pushBreak(wrapper, penalty, dw - bbox.w, null);
     }
@@ -638,13 +638,13 @@ export class LinebreakVisitor<
    * @return {number}               The computed penalty
    */
   protected mspacePenalty(
-    mspace: CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    mspace: CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
   ): number {
     const linebreak = mspace.node.attributes.get('linebreak');
     const FACTORS = this.FACTORS;
     let penalty = FACTORS.space(FACTORS.tail(FACTORS.width(0)), mspace as any);
     return (this.PENALTY[linebreak as string] || ((p) => p))(
-      FACTORS.depth(penalty)
+      FACTORS.depth(penalty),
     );
   }
 
@@ -720,7 +720,7 @@ export class LinebreakVisitor<
     for (let i = start; i <= end; i++) {
       this.visitNode(
         wrapper.childNodes[i],
-        i === start ? startL : i === end ? endL : 0
+        i === start ? startL : i === end ? endL : 0,
       );
     }
     this.addWidth(line, line.R + R);
@@ -801,7 +801,7 @@ export class LinebreakVisitor<
     const [L, R] = this.getBorderLR(wrapper);
     this.addWidth(
       msub.getLineBBox(i),
-      x + L + sbox.rscale * sbox.w + msub.font.params.scriptspace + R
+      x + L + sbox.rscale * sbox.w + msub.font.params.scriptspace + R,
     );
   }
 
@@ -820,7 +820,7 @@ export class LinebreakVisitor<
     const [L, R] = this.getBorderLR(wrapper);
     this.addWidth(
       msup.getLineBBox(i),
-      x + L + sbox.rscale * sbox.w + msup.font.params.scriptspace + R
+      x + L + sbox.rscale * sbox.w + msup.font.params.scriptspace + R,
     );
   }
 
@@ -857,22 +857,22 @@ export class LinebreakVisitor<
     if (data.numPrescripts) {
       const w = Math.max(
         data.psup.rscale * data.psup.w,
-        data.psub.rscale * data.psub.w
+        data.psub.rscale * data.psub.w,
       );
       this.addWidth(
         wrapper.getLineBBox(i),
-        w + mmultiscripts.font.params.scriptspace
+        w + mmultiscripts.font.params.scriptspace,
       );
     }
     this.visitDefault(wrapper, i);
     if (data.numScripts) {
       const w = Math.max(
         data.sup.rscale * data.sup.w,
-        data.sub.rscale * data.sub.w
+        data.sub.rscale * data.sub.w,
       );
       this.addWidth(
         wrapper.getLineBBox(i),
-        w + mmultiscripts.font.params.scriptspace
+        w + mmultiscripts.font.params.scriptspace,
       );
     }
   }

--- a/ts/output/common/Notation.ts
+++ b/ts/output/common/Notation.ts
@@ -153,7 +153,7 @@ export const fullBorder = ((node) =>
 export const arrowHead = (node: Menclose) => {
   return Math.max(
     node.padding,
-    node.thickness * (node.arrowhead.x + node.arrowhead.dx + 1)
+    node.thickness * (node.arrowhead.x + node.arrowhead.dx + 1),
   );
 };
 
@@ -165,7 +165,7 @@ export const arrowBBoxHD = (node: Menclose, TRBL: PaddingData) => {
     const { h, d } = node.childNodes[0].getBBox();
     TRBL[0] = TRBL[2] = Math.max(
       0,
-      node.thickness * node.arrowhead.y - (h + d) / 2
+      node.thickness * node.arrowhead.y - (h + d) / 2,
     );
   }
   return TRBL;
@@ -240,7 +240,7 @@ export const arrowBBox = {
  *                              for the notation having a line on the given side
  */
 export const CommonBorder = function <W extends Menclose, N>(
-  render: Renderer<W, N>
+  render: Renderer<W, N>,
 ): DefPairF<Side, W, N> {
   /**
    * @param {string} side   The side on which a border should appear
@@ -282,7 +282,7 @@ export const CommonBorder = function <W extends Menclose, N>(
  *                                             for the notation having lines on two sides
  */
 export const CommonBorder2 = function <W extends Menclose, N>(
-  render: Renderer<W, N>
+  render: Renderer<W, N>,
 ): (name: string, side1: Side, side2: Side) => DefPair<W, N> {
   /**
    * @param {string} name    The name of the notation to define
@@ -333,7 +333,7 @@ export const CommonBorder2 = function <W extends Menclose, N>(
  * @return {string => DefPair}   The function returning the notation definition for the diagonal strike
  */
 export const CommonDiagonalStrike = function <W extends Menclose, N>(
-  render: (sname: string) => Renderer<W, N>
+  render: (sname: string) => Renderer<W, N>,
 ): DefPairF<string, W, N> {
   /**
    * @param {string} name  The name of the diagonal strike to define
@@ -364,7 +364,7 @@ export const CommonDiagonalStrike = function <W extends Menclose, N>(
  * @return {string => DefPair}  The funciton returning the notation definition for the diagonal arrow
  */
 export const CommonDiagonalArrow = function <W extends Menclose, N>(
-  render: Renderer<W, N>
+  render: Renderer<W, N>,
 ): DefPairF<string, W, N> {
   /**
    * @param {string} name   The name of the diagonal arrow to define
@@ -417,7 +417,7 @@ export const CommonDiagonalArrow = function <W extends Menclose, N>(
  * @return {string => DefPair}  The function returning the notation definition for the arrow
  */
 export const CommonArrow = function <W extends Menclose, N>(
-  render: Renderer<W, N>
+  render: Renderer<W, N>,
 ): DefPairF<string, W, N> {
   /**
    * @param {string} name   The name of the horizontal or vertical arrow to define

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -628,7 +628,7 @@ export class CommonWrapper<
         const obox = this.getOuterBBox();
         this.lineBBox[i] = LineBBox.from(
           obox,
-          this.linebreakOptions.lineleading
+          this.linebreakOptions.lineleading,
         );
       }
     }
@@ -743,7 +743,7 @@ export class CommonWrapper<
   public setChildPWidths(
     recompute: boolean,
     w: number | null = null,
-    clear: boolean = true
+    clear: boolean = true,
   ): boolean {
     if (recompute) {
       return false;
@@ -878,7 +878,7 @@ export class CommonWrapper<
       const values = attributes.getList(
         'fontfamily',
         'fontweight',
-        'fontstyle'
+        'fontstyle',
       ) as StringMap;
       if (this.removedStyles) {
         const style = this.removedStyles;
@@ -896,7 +896,7 @@ export class CommonWrapper<
         variant = this.explicitVariant(
           values.family,
           values.weight,
-          values.style
+          values.style,
         );
       } else {
         if (this.node.getProperty('variantForm')) variant = '-tex-variant';
@@ -920,7 +920,7 @@ export class CommonWrapper<
   protected explicitVariant(
     fontFamily: string,
     fontWeight: string,
-    fontStyle: string
+    fontStyle: string,
   ) {
     let style = this.styles;
     if (!style) style = this.styles = new Styles();
@@ -950,7 +950,7 @@ export class CommonWrapper<
     if (scriptlevel !== 0) {
       scale = Math.pow(
         attributes.get('scriptsizemultiplier') as number,
-        scriptlevel
+        scriptlevel,
       );
     }
     //
@@ -978,7 +978,7 @@ export class CommonWrapper<
       let scriptminsize = this.length2em(
         attributes.get('scriptminsize'),
         0.4,
-        1
+        1,
       );
       if (scale < scriptminsize) scale = scriptminsize;
     }
@@ -1179,7 +1179,7 @@ export class CommonWrapper<
     indentshift: string,
     align: string = '',
     shift: string = '',
-    width: number = this.metrics.containerWidth
+    width: number = this.metrics.containerWidth,
   ): [string, number] {
     if (!this.jax.math.display) {
       return ['left', 0];
@@ -1234,7 +1234,7 @@ export class CommonWrapper<
     D: number,
     h: number,
     d: number,
-    align: string
+    align: string,
   ): number {
     return align === 'top'
       ? H - h
@@ -1300,7 +1300,7 @@ export class CommonWrapper<
   protected length2em(
     length: Property,
     size: number = 1,
-    scale: number = null
+    scale: number = null,
   ): number {
     if (scale === null) {
       scale = this.bbox.scale;
@@ -1309,7 +1309,7 @@ export class CommonWrapper<
     const factor = lookup(
       length as string,
       { medium: 1, thin: 2 / 3, thick: 5 / 3 },
-      0
+      0,
     );
     return factor
       ? factor * t
@@ -1368,12 +1368,12 @@ export class CommonWrapper<
   public mmlNode(
     kind: string,
     properties: PropertyList = {},
-    children: MmlNode[] = []
+    children: MmlNode[] = [],
   ): MmlNode {
     return (this.node as AbstractMmlNode).factory.create(
       kind,
       properties,
-      children
+      children,
     );
   }
 
@@ -1385,7 +1385,7 @@ export class CommonWrapper<
    * @return {CommonMO}     The wrapped MmlMo node
    */
   protected createMo(
-    text: string
+    text: string,
   ): CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
     const mmlFactory = (this.node as AbstractMmlNode).factory;
     const textNode = (mmlFactory.create('text') as TextNode).setText(text);

--- a/ts/output/common/Wrappers/TeXAtom.ts
+++ b/ts/output/common/Wrappers/TeXAtom.ts
@@ -134,7 +134,7 @@ export function CommonTeXAtomMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonTeXAtomMixin
     extends Base

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -143,7 +143,7 @@ export function CommonTextNodeMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonTextNodeMixin
     extends Base

--- a/ts/output/common/Wrappers/XmlNode.ts
+++ b/ts/output/common/Wrappers/XmlNode.ts
@@ -168,7 +168,7 @@ export function CommonXmlNodeMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   abstract class CommonXmlNodeMixin
     extends Base
@@ -246,7 +246,7 @@ export function CommonXmlNodeMixin<
       return this.html(
         'mjx-html',
         { variant: this.parent.variant, style: styles },
-        [html]
+        [html],
       );
     }
 
@@ -300,7 +300,7 @@ export function CommonXmlNodeMixin<
       const content = this.html(
         'mjx-xml-block',
         { style: { display: 'inline-block' } },
-        [adaptor.clone(xml)]
+        [adaptor.clone(xml)],
       );
       const base = this.html('mjx-baseline', {
         style: { display: 'inline-block', width: 0, height: 0 },

--- a/ts/output/common/Wrappers/maction.ts
+++ b/ts/output/common/Wrappers/maction.ts
@@ -299,7 +299,7 @@ export function CommonMactionMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMactionMixin
     extends Base

--- a/ts/output/common/Wrappers/math.ts
+++ b/ts/output/common/Wrappers/math.ts
@@ -134,7 +134,7 @@ export function CommonMathMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMathMixin
     extends Base

--- a/ts/output/common/Wrappers/menclose.ts
+++ b/ts/output/common/Wrappers/menclose.ts
@@ -176,7 +176,7 @@ export interface CommonMenclose<
     a: number,
     double: boolean,
     offset?: string,
-    trans?: number
+    trans?: number,
   ): N;
 
   /**
@@ -283,7 +283,7 @@ export function CommonMencloseMixin<
   S extends CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMencloseMixin
     extends Base
@@ -361,7 +361,7 @@ export function CommonMencloseMixin<
         >
       ).notations;
       for (const name of split(
-        this.node.attributes.get('notation') as string
+        this.node.attributes.get('notation') as string,
       )) {
         const notation = Notations.get(name);
         if (notation) {
@@ -422,7 +422,7 @@ export function CommonMencloseMixin<
         }
       }
       return [0, 1, 2, 3].map(
-        (i) => this.TRBL[i] - BTRBL[i]
+        (i) => this.TRBL[i] - BTRBL[i],
       ) as Notation.PaddingData;
     }
 
@@ -463,7 +463,7 @@ export function CommonMencloseMixin<
       _a: number,
       _double: boolean,
       _offset: string = '',
-      _dist: number = 0
+      _dist: number = 0,
     ): N {
       return null as N;
     }

--- a/ts/output/common/Wrappers/mfenced.ts
+++ b/ts/output/common/Wrappers/mfenced.ts
@@ -161,7 +161,7 @@ export function CommonMfencedMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMfencedMixin
     extends Base

--- a/ts/output/common/Wrappers/mfrac.ts
+++ b/ts/output/common/Wrappers/mfrac.ts
@@ -208,7 +208,7 @@ export function CommonMfracMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMfracMixin
     extends Base
@@ -245,7 +245,7 @@ export function CommonMfracMixin<
      */
     public getTUV(
       display: boolean,
-      t: number
+      t: number,
     ): { T: number; u: number; v: number } {
       const tex = this.font.params;
       const a = tex.axis_height;
@@ -331,7 +331,7 @@ export function CommonMfracMixin<
       const H =
         Math.max(
           nbox.scale * (nbox.h + nbox.d),
-          dbox.scale * (dbox.h + dbox.d)
+          dbox.scale * (dbox.h + dbox.d),
         ) +
         2 * delta;
       const a = this.font.params.axis_height;
@@ -348,7 +348,7 @@ export function CommonMfracMixin<
     public isDisplay(): boolean {
       const { displaystyle, scriptlevel } = this.node.attributes.getList(
         'displaystyle',
-        'scriptlevel'
+        'scriptlevel',
       );
       return displaystyle && scriptlevel === 0;
     }
@@ -383,7 +383,7 @@ export function CommonMfracMixin<
       bbox.empty();
       const { linethickness, bevelled } = this.node.attributes.getList(
         'linethickness',
-        'bevelled'
+        'bevelled',
       );
       const display = this.isDisplay();
       let w = null as number | null;

--- a/ts/output/common/Wrappers/mglyph.ts
+++ b/ts/output/common/Wrappers/mglyph.ts
@@ -163,7 +163,7 @@ export function CommonMglyphMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMglyphMixin
     extends Base
@@ -208,7 +208,7 @@ export function CommonMglyphMixin<
           'height',
           'valign',
           'src',
-          'index'
+          'index',
         );
       if (src) {
         this.width = width === 'auto' ? 1 : this.length2em(width);
@@ -218,7 +218,7 @@ export function CommonMglyphMixin<
         const text = String.fromCodePoint(parseInt(index as string));
         const mmlFactory = this.node.factory;
         this.charWrapper = this.wrap(
-          (mmlFactory.create('text') as TextNode).setText(text)
+          (mmlFactory.create('text') as TextNode).setText(text),
         );
         this.charWrapper.parent = this as any as WW;
       }

--- a/ts/output/common/Wrappers/mi.ts
+++ b/ts/output/common/Wrappers/mi.ts
@@ -134,7 +134,7 @@ export function CommonMiMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMiMixin
     extends Base

--- a/ts/output/common/Wrappers/mmultiscripts.ts
+++ b/ts/output/common/Wrappers/mmultiscripts.ts
@@ -156,7 +156,7 @@ export interface CommonMmultiscripts<
     bbox1: BBox,
     bbox2: BBox,
     list1: BBox[],
-    list2: BBox[]
+    list2: BBox[],
   ): void;
 
   /**
@@ -243,7 +243,7 @@ export function CommonMmultiscriptsMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonMsubsupClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: Constructor<CommonMsubsup<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>
+  Base: Constructor<CommonMsubsup<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>,
 ): B {
   return class CommonMmultiscriptsMixin
     extends Base
@@ -297,7 +297,7 @@ export function CommonMmultiscriptsMixin<
         data.psub,
         data.psup,
         lists.psubList,
-        lists.psupList
+        lists.psupList,
       );
       data.base = lists.base[0];
       //
@@ -359,7 +359,7 @@ export function CommonMmultiscriptsMixin<
       bbox1: BBox,
       bbox2: BBox,
       list1: BBox[],
-      list2: BBox[]
+      list2: BBox[],
     ) {
       for (let i = 0; i < list1.length; i++) {
         const [w1, h1, d1] = this.getScaledWHD(list1[i]);
@@ -460,7 +460,7 @@ export function CommonMmultiscriptsMixin<
       if (i === 0) {
         bbox = LineBBox.from(
           this.addPrescripts(BBox.zero(), u, v),
-          this.linebreakOptions.lineleading
+          this.linebreakOptions.lineleading,
         );
         bbox.append(cbox);
         this.addLeftBorders(bbox);

--- a/ts/output/common/Wrappers/mn.ts
+++ b/ts/output/common/Wrappers/mn.ts
@@ -133,7 +133,7 @@ export function CommonMnMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMnMixin
     extends Base

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -260,7 +260,7 @@ export function CommonMoMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMoMixin
     extends Base
@@ -481,7 +481,7 @@ export function CommonMoMixin<
     public getBaseline(
       WHD: number[],
       HD: number,
-      C: DelimiterData
+      C: DelimiterData,
     ): [number, number] {
       const hasWHD = WHD.length === 2 && WHD[0] + WHD[1] === HD;
       const symmetric = this.node.attributes.get('symmetric');
@@ -617,7 +617,7 @@ export function CommonMoMixin<
       const leadingString = this.node.attributes.get('lineleading') as string;
       const leading = this.length2em(
         leadingString,
-        this.linebreakOptions.lineleading
+        this.linebreakOptions.lineleading,
       );
       if (i === 0 && style === 'before') {
         const bbox = LineBBox.from(BBox.zero(), leading);

--- a/ts/output/common/Wrappers/mpadded.ts
+++ b/ts/output/common/Wrappers/mpadded.ts
@@ -163,7 +163,7 @@ export function CommonMpaddedMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMpaddedMixin
     extends Base
@@ -178,7 +178,7 @@ export function CommonMpaddedMixin<
         'height',
         'depth',
         'lspace',
-        'voffset'
+        'voffset',
       );
       const bbox = this.childNodes[0].getOuterBBox(); // get unmodified bbox of children
       let { w, h, d } = bbox;
@@ -207,7 +207,7 @@ export function CommonMpaddedMixin<
       length: Property,
       bbox: BBox,
       d: string = '',
-      m: number = null
+      m: number = null,
     ): number {
       length = String(length);
       const match = length.match(/width|height|depth/);

--- a/ts/output/common/Wrappers/mroot.ts
+++ b/ts/output/common/Wrappers/mroot.ts
@@ -131,7 +131,7 @@ export function CommonMrootMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonMsqrtClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: Constructor<CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>
+  Base: Constructor<CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>,
 ): B {
   return class CommonMrootMixin
     extends Base

--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -153,7 +153,7 @@ export function CommonMrowMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMrowMixin
     extends Base
@@ -403,7 +403,7 @@ export function CommonMrowMixin<
           indentshift,
           alignfirst,
           shiftfirst,
-          W
+          W,
         );
         bbox.L = 0;
         bbox.L = this.getAlignX(W, bbox, align) + shift;
@@ -416,7 +416,7 @@ export function CommonMrowMixin<
     public setChildPWidths(
       recompute: boolean,
       w: number | null = null,
-      clear: boolean = true
+      clear: boolean = true,
     ): boolean {
       if (!this.breakCount) return super.setChildPWidths(recompute, w, clear);
       if (recompute) return false;
@@ -538,7 +538,7 @@ export function CommonInferredMrowMixin<
   Base: CommonWrapperConstructor<
     N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
     CommonMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-  >
+  >,
 ): B {
   return class CommonInferredMrowMixin
     extends Base

--- a/ts/output/common/Wrappers/ms.ts
+++ b/ts/output/common/Wrappers/ms.ts
@@ -142,7 +142,7 @@ export function CommonMsMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMsMixin
     extends Base

--- a/ts/output/common/Wrappers/mspace.ts
+++ b/ts/output/common/Wrappers/mspace.ts
@@ -154,7 +154,7 @@ export function CommonMspaceMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMspaceMixin
     extends Base
@@ -216,11 +216,11 @@ export function CommonMspaceMixin<
      */
     public computeLineBBox(i: number): LineBBox {
       const leadingString = this.node.attributes.get(
-        'data-lineleading'
+        'data-lineleading',
       ) as string;
       const leading = this.length2em(
         leadingString,
-        this.linebreakOptions.lineleading
+        this.linebreakOptions.lineleading,
       );
       const bbox = LineBBox.from(BBox.zero(), leading);
       if (i === 1) {

--- a/ts/output/common/Wrappers/msqrt.ts
+++ b/ts/output/common/Wrappers/msqrt.ts
@@ -189,7 +189,7 @@ export function CommonMsqrtMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMsqrtMixin
     extends Base
@@ -245,7 +245,7 @@ export function CommonMsqrtMixin<
      */
     public getRootDimens(
       _sbox: BBox,
-      _H: number
+      _H: number,
     ): [number, number, number, number] {
       return [0, 0, 0, 0];
     }

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -141,7 +141,20 @@ export function CommonMsubMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonScriptbaseConstructor<
+    N,
+    T,
+    D,
+    JX,
+    WW,
+    WF,
+    WC,
+    CC,
+    VV,
+    DD,
+    FD,
+    FC
+  >,
 ): B {
   return class CommonMsubMixin
     extends Base
@@ -268,7 +281,20 @@ export function CommonMsupMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonScriptbaseConstructor<
+    N,
+    T,
+    D,
+    JX,
+    WW,
+    WF,
+    WC,
+    CC,
+    VV,
+    DD,
+    FD,
+    FC
+  >,
 ): B {
   return class CommonMsupMixin
     extends Base
@@ -415,7 +441,20 @@ export function CommonMsubsupMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonScriptbaseConstructor<
+    N,
+    T,
+    D,
+    JX,
+    WW,
+    WF,
+    WC,
+    CC,
+    VV,
+    DD,
+    FD,
+    FC
+  >,
 ): B {
   return class CommonMsubsupMixin
     extends Base
@@ -457,7 +496,7 @@ export function CommonMsubsupMixin<
      */
     public getUVQ(
       subbox: BBox = this.subChild.getOuterBBox(),
-      supbox: BBox = this.supChild.getOuterBBox()
+      supbox: BBox = this.supChild.getOuterBBox(),
     ): number[] {
       const base = this.baseCore;
       const bbox = base.getLineBBox(base.breakCount);
@@ -466,10 +505,10 @@ export function CommonMsubsupMixin<
       const t = 3 * tex.rule_thickness;
       const subscriptshift = this.length2em(
         this.node.attributes.get('subscriptshift'),
-        tex.sub2
+        tex.sub2,
       );
       const drop = this.baseCharZero(
-        bbox.d * this.baseScale + tex.sub_drop * subbox.rscale
+        bbox.d * this.baseScale + tex.sub_drop * subbox.rscale,
       );
       const supd = supbox.d * supbox.rscale;
       const subh = subbox.h * subbox.rscale;
@@ -502,11 +541,11 @@ export function CommonMsubsupMixin<
       //
       u = Math.max(
         this.length2em(this.node.attributes.get('superscriptshift'), u),
-        u
+        u,
       );
       v = Math.max(
         this.length2em(this.node.attributes.get('subscriptshift'), v),
-        v
+        v,
       );
       q = u - supd - (subh - v);
       this.UVQ = [u, -v, q];

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -253,7 +253,7 @@ export interface CommonMtable<
     H: number[],
     D: number[],
     W: number[],
-    M: number
+    M: number,
   ): number;
 
   /**
@@ -522,7 +522,7 @@ export function CommonMtableMixin<
   R extends CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMtableMixin
     extends Base
@@ -819,7 +819,7 @@ export function CommonMtableMixin<
       H: number[],
       D: number[],
       W: number[],
-      M: number
+      M: number,
     ): number {
       let { h, d, w } = cell.getBBox();
       const scale = cell.parent.bbox.rscale;
@@ -946,7 +946,7 @@ export function CommonMtableMixin<
         pad = Math.max(
           pad,
           this.length2em(lpad || '0'),
-          this.length2em(rpad || '0')
+          this.length2em(rpad || '0'),
         );
       }
       //
@@ -978,11 +978,11 @@ export function CommonMtableMixin<
       const attributes = this.node.attributes;
       if (attributes.get('width') !== 'auto') return;
       const [pad, align] = this.getPadAlignShift(
-        attributes.get('side') as string
+        attributes.get('side') as string,
       );
       const W = Math.max(
         this.containerWidth / 10,
-        this.containerWidth - pad - (align === 'center' ? pad : 0)
+        this.containerWidth - pad - (align === 'center' ? pad : 0),
       );
       this.naturalWidth() > W && this.adjustColumnWidths(W);
     }
@@ -1095,7 +1095,7 @@ export function CommonMtableMixin<
      */
     public getColumnWidthsFixed(
       swidths: string[],
-      width: number
+      width: number,
     ): ColumnWidths {
       //
       // Get the indices of the fit and auto columns, and the number of fit or auto entries.
@@ -1164,7 +1164,7 @@ export function CommonMtableMixin<
           (i) =>
             swidths[i] !== 'fit' &&
             swidths[i] !== 'auto' &&
-            !isPercent(swidths[i])
+            !isPercent(swidths[i]),
         )
         .sort((a, b) => W[b] - W[a]);
       const columns = [...fit, ...auto, ...percent, ...fixed];
@@ -1173,7 +1173,9 @@ export function CommonMtableMixin<
       //  Get the current widths of all the columns
       //
       this.cWidths = indices.map((i) =>
-        typeof this.cWidths[i] === 'number' ? (this.cWidths[i] as number) : W[i]
+        typeof this.cWidths[i] === 'number'
+          ? (this.cWidths[i] as number)
+          : W[i],
       );
       //
       // Determine the space remaining from the fixed width after the
@@ -1267,7 +1269,7 @@ export function CommonMtableMixin<
     public getEmHalfSpacing(
       fspace: number[],
       space: number[],
-      scale: number = 1
+      scale: number = 1,
     ): string[] {
       //
       //  Get the column spacing values, and add the frame spacing values at the left and right
@@ -1381,7 +1383,7 @@ export function CommonMtableMixin<
       this.numRows = this.childNodes.length;
       this.hasLabels = this.childNodes.reduce(
         (value, row) => value || row.node.isKind('mlabeledtr'),
-        false
+        false,
       );
       this.findContainer();
       this.isTop =
@@ -1402,14 +1404,14 @@ export function CommonMtableMixin<
       this.fLine = this.frame ? 0.07 : 0;
       this.fSpace = this.getFrameSpacing();
       this.cSpace = this.convertLengths(
-        this.getColumnAttributes('columnspacing')
+        this.getColumnAttributes('columnspacing'),
       );
       this.rSpace = this.convertLengths(this.getRowAttributes('rowspacing'));
       this.cLines = this.getColumnAttributes('columnlines').map((x) =>
-        x === 'none' ? 0 : 0.07
+        x === 'none' ? 0 : 0.07,
       );
       this.rLines = this.getRowAttributes('rowlines').map((x) =>
-        x === 'none' ? 0 : 0.07
+        x === 'none' ? 0 : 0.07,
       );
       this.cWidths = this.getColumnWidths();
       this.adjustWideTable();
@@ -1494,7 +1496,7 @@ export function CommonMtableMixin<
     public setChildPWidths(
       _recompute: boolean,
       cwidth: number,
-      _clear: boolean
+      _clear: boolean,
     ) {
       const width = this.node.attributes.get('width') as string;
       if (!isPercent(width)) return false;
@@ -1504,7 +1506,7 @@ export function CommonMtableMixin<
       }
       const { w, L, R } = this.bbox;
       const labelInWidth = this.node.attributes.get(
-        'data-width-includes-label'
+        'data-width-includes-label',
       ) as boolean;
       const W =
         Math.max(w, this.length2em(width, Math.max(cwidth, L + w + R))) -

--- a/ts/output/common/Wrappers/mtd.ts
+++ b/ts/output/common/Wrappers/mtd.ts
@@ -135,7 +135,7 @@ export function CommonMtdMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMtdMixin
     extends Base

--- a/ts/output/common/Wrappers/mtext.ts
+++ b/ts/output/common/Wrappers/mtext.ts
@@ -176,7 +176,7 @@ export function CommonMtextMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMtextMixin
     extends Base
@@ -253,7 +253,7 @@ export function CommonMtextMixin<
         this.variant = this.explicitVariant(
           family,
           font[2] ? 'bold' : '',
-          font[1] ? 'italic' : ''
+          font[1] ? 'italic' : '',
         );
         return;
       }
@@ -280,7 +280,7 @@ export function CommonMtextMixin<
     public computeLineBBox(i: number): LineBBox {
       const bbox = LineBBox.from(
         this.getOuterBBox(),
-        this.linebreakOptions.lineleading
+        this.linebreakOptions.lineleading,
       );
       if (!this.breakCount) return bbox;
       bbox.w = this.getBreakWidth(i);

--- a/ts/output/common/Wrappers/mtr.ts
+++ b/ts/output/common/Wrappers/mtr.ts
@@ -173,7 +173,7 @@ export function CommonMtrMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonMtrMixin
     extends Base
@@ -374,7 +374,7 @@ export function CommonMlabeledtrMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonMtrClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: Constructor<CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>
+  Base: Constructor<CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>,
 ): B {
   return class CommonMlabeledtrMixin
     extends Base

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -141,7 +141,20 @@ export function CommonMunderMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonScriptbaseConstructor<
+    N,
+    T,
+    D,
+    JX,
+    WW,
+    WF,
+    WC,
+    CC,
+    VV,
+    DD,
+    FD,
+    FC
+  >,
 ): B {
   return class CommonMunderMixin
     extends Base
@@ -284,7 +297,20 @@ export function CommonMoverMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonScriptbaseConstructor<
+    N,
+    T,
+    D,
+    JX,
+    WW,
+    WF,
+    WC,
+    CC,
+    VV,
+    DD,
+    FD,
+    FC
+  >,
 ): B {
   return class CommonMoverMixin
     extends Base
@@ -320,7 +346,7 @@ export function CommonMoverMixin<
       if (this.node.attributes.get('accent')) {
         basebox.h = Math.max(
           basebox.h,
-          this.font.params.x_height * this.baseScale
+          this.font.params.x_height * this.baseScale,
         );
       }
       const u = this.getOverKU(basebox, overbox)[1];
@@ -441,7 +467,20 @@ export function CommonMunderoverMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonScriptbaseConstructor<
+    N,
+    T,
+    D,
+    JX,
+    WW,
+    WF,
+    WC,
+    CC,
+    VV,
+    DD,
+    FD,
+    FC
+  >,
 ): B {
   return class CommonMunderoverMixin
     extends Base
@@ -505,7 +544,7 @@ export function CommonMunderoverMixin<
       if (this.node.attributes.get('accent')) {
         basebox.h = Math.max(
           basebox.h,
-          this.font.params.x_height * this.baseScale
+          this.font.params.x_height * this.baseScale,
         );
       }
       const u = this.getOverKU(basebox, overbox)[1];
@@ -514,7 +553,7 @@ export function CommonMunderoverMixin<
       const udelta = this.getDelta(this.underChild, true);
       const [bw, uw, ow] = this.getDeltaW(
         [basebox, underbox, overbox],
-        [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta]
+        [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta],
       );
       bbox.combine(basebox, bw, 0);
       bbox.combine(overbox, ow, u);

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -396,7 +396,7 @@ export function CommonScriptbaseMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonScriptbaseMixin
     extends Base
@@ -525,7 +525,7 @@ export function CommonScriptbaseMixin<
      */
     public getSemanticBase(): WW {
       let fence = this.node.attributes.getExplicit(
-        'data-semantic-fencepointer'
+        'data-semantic-fencepointer',
       ) as string;
       return this.getBaseFence(this.baseChild, fence);
     }
@@ -666,12 +666,12 @@ export function CommonScriptbaseMixin<
       const tex = this.font.params;
       const subscriptshift = this.length2em(
         this.node.attributes.get('subscriptshift'),
-        tex.sub1
+        tex.sub1,
       );
       return Math.max(
         this.baseCharZero(bbox.d * this.baseScale + tex.sub_drop * sbox.rscale),
         subscriptshift,
-        sbox.h * sbox.rscale - (4 / 5) * tex.x_height
+        sbox.h * sbox.rscale - (4 / 5) * tex.x_height,
       );
     }
 
@@ -685,7 +685,7 @@ export function CommonScriptbaseMixin<
       const tex = this.font.params;
       const attr = this.node.attributes.getList(
         'displaystyle',
-        'superscriptshift'
+        'superscriptshift',
       );
       const prime = this.node.getProperty('texprimestyle');
       const p = prime ? tex.sup3 : attr.displaystyle ? tex.sup1 : tex.sup2;
@@ -693,7 +693,7 @@ export function CommonScriptbaseMixin<
       return Math.max(
         this.baseCharZero(bbox.h * this.baseScale - tex.sup_drop * sbox.rscale),
         superscriptshift,
-        sbox.d * sbox.rscale + (1 / 4) * tex.x_height
+        sbox.d * sbox.rscale + (1 / 4) * tex.x_height,
       );
     }
 
@@ -726,7 +726,7 @@ export function CommonScriptbaseMixin<
           ? T
           : Math.max(
               tex.big_op_spacing1,
-              tex.big_op_spacing3 - Math.max(0, d)
+              tex.big_op_spacing3 - Math.max(0, d),
             )) - delta;
       return [k, basebox.h * basebox.rscale + k + d];
     }
@@ -777,7 +777,7 @@ export function CommonScriptbaseMixin<
         }
       }
       [1, 2].map(
-        (i) => (dw[i] += boxes[i] ? boxes[i].dx * boxes[0].rscale : 0)
+        (i) => (dw[i] += boxes[i] ? boxes[i].dx * boxes[0].rscale : 0),
       );
       return dw;
     }
@@ -944,7 +944,7 @@ export function CommonScriptbaseMixin<
       if (!n)
         return LineBBox.from(
           this.getOuterBBox(),
-          this.linebreakOptions.lineleading
+          this.linebreakOptions.lineleading,
         );
       const bbox = this.baseChild.getLineBBox(i).copy();
       if (i < n) {

--- a/ts/output/common/Wrappers/semantics.ts
+++ b/ts/output/common/Wrappers/semantics.ts
@@ -134,7 +134,7 @@ export function CommonSemanticsMixin<
   FC extends FontDataClass<CC, VV, DD>,
   B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 >(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
 ): B {
   return class CommonSemanticsMixin
     extends Base

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -219,7 +219,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
           id: SVG.FONTCACHEID,
           style: { display: 'none' },
         },
-        [this.fontCache.getCache()]
+        [this.fontCache.getCache()],
       );
     }
     return null as N;
@@ -291,12 +291,12 @@ export class SVG<N, T, D> extends CommonOutputJax<
       adaptor.removeAttribute(svg, 'viewBox');
       const scale = this.fixed(
         wrapper.metrics.ex / (this.font.params.x_height * 1000),
-        6
+        6,
       );
       adaptor.setAttribute(
         g,
         'transform',
-        `scale(${scale},-${scale}) translate(0, ${this.fixed(-h * 1000, 1)})`
+        `scale(${scale},-${scale}) translate(0, ${this.fixed(-h * 1000, 1)})`,
       );
     }
     return [svg, g];
@@ -343,8 +343,8 @@ export class SVG<N, T, D> extends CommonOutputJax<
             this.fixed(H * 1000, 1),
           ].join(' '),
         },
-        [g]
-      )
+        [g],
+      ),
     ) as N;
     if (W === 0.001) {
       adaptor.setAttribute(svg, 'preserveAspectRatio', 'xMidYMid slice');
@@ -453,7 +453,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
           this.addInlineBreak(
             nsvg,
             dimen,
-            forced || !!mml.node.getProperty('forcebreak')
+            forced || !!mml.node.getProperty('forcebreak'),
           );
         }
       }
@@ -464,7 +464,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
     if (adaptor.childNodes(svg).length) {
       adaptor.append(
         adaptor.firstChild(adaptor.parent(svg)) as N,
-        adaptor.firstChild(svg)
+        adaptor.firstChild(svg),
       );
     }
     adaptor.remove(svg);
@@ -481,7 +481,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
     if (!forced) {
       adaptor.insert(
         adaptor.node('mjx-break', { prebreak: true }, [adaptor.text(' ')]),
-        nsvg
+        nsvg,
       );
     }
     adaptor.insert(
@@ -492,9 +492,9 @@ export class SVG<N, T, D> extends CommonOutputJax<
           : SPACE[space]
             ? { size: SPACE[space] }
             : { style: `letter-spacing: ${LENGTHS.em(dimen - 1)}` },
-        [adaptor.text(' ')]
+        [adaptor.text(' ')],
       ),
-      nsvg
+      nsvg,
     );
   }
 
@@ -518,7 +518,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
   public svg(
     kind: string,
     properties: OptionList = {},
-    children: (N | T)[] = []
+    children: (N | T)[] = [],
   ): N {
     return this.html(kind, properties, children, SVGNS);
   }
@@ -538,7 +538,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
         transform: 'scale(1,-1)',
         'font-size': this.fixed(scale, 1) + 'px',
       },
-      [this.text(text)]
+      [this.text(text)],
     );
     const adaptor = this.adaptor;
     if (variant !== '-explicitFont') {
@@ -580,7 +580,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
         left: 0,
         viewBox: [0, 0, ex, ex].join(' '),
       },
-      [text]
+      [text],
     );
     adaptor.append(adaptor.body(adaptor.document), svg);
     let w = adaptor.nodeSize(text, 1000, true)[0];

--- a/ts/output/svg/FontCache.ts
+++ b/ts/output/svg/FontCache.ts
@@ -75,7 +75,7 @@ export class FontCache<N, T, D> {
       this.cache.set(id, path);
       this.jax.adaptor.append(
         this.defs,
-        this.jax.svg('path', { id: id, d: path })
+        this.jax.svg('path', { id: id, d: path }),
       );
     }
     return id;

--- a/ts/output/svg/FontData.ts
+++ b/ts/output/svg/FontData.ts
@@ -106,7 +106,7 @@ export class SvgFontData extends FontData<
    */
   public static addExtension(
     data: SvgFontExtensionData<SvgCharOptions, SvgDelimiterData>,
-    prefix: string = ''
+    prefix: string = '',
   ) {
     super.addExtension(data, prefix);
     mergeOptions(this, 'variantCacheIds', data.cacheIds);
@@ -126,7 +126,7 @@ export type SvgFontDataClass = typeof SvgFontData;
 export function AddPaths(
   font: SvgCharMap,
   paths: CharStringMap,
-  content: CharStringMap
+  content: CharStringMap,
 ): SvgCharMap {
   for (const c of Object.keys(paths)) {
     const n = parseInt(c);

--- a/ts/output/svg/Notation.ts
+++ b/ts/output/svg/Notation.ts
@@ -77,7 +77,7 @@ export const computeLineData = {
 export const lineData = function (
   node: Menclose,
   kind: LineName,
-  offset: string = ''
+  offset: string = '',
 ): LineData {
   const { h, d, w } = node.getBBox();
   const t = node.thickness / 2;
@@ -94,7 +94,7 @@ export const lineData = function (
 export const lineOffset = function (
   data: LineData,
   node: Menclose,
-  offset: string
+  offset: string,
 ): LineData {
   if (offset) {
     const d = node.getOffset(offset);
@@ -119,7 +119,7 @@ export const lineOffset = function (
  */
 export const RenderLine = function <N, T, D>(
   line: LineName,
-  offset: string = ''
+  offset: string = '',
 ): RENDERER<N, T, D> {
   return (node, _child) => {
     const L = node.line(lineData(node, line, offset));
@@ -134,7 +134,7 @@ export const RenderLine = function <N, T, D>(
  * @return {DEFPAIR}      The notation definition for the notation having a line on the given side
  */
 export const Border = function <N, T, D>(
-  side: Notation.Side
+  side: Notation.Side,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonBorder<SvgMencloseNTD<N, T, D>, N>((node, _child) => {
     node.adaptor.append(node.dom[0], node.line(lineData(node, side)));
@@ -150,7 +150,7 @@ export const Border = function <N, T, D>(
 export const Border2 = function <N, T, D>(
   name: string,
   side1: Notation.Side,
-  side2: Notation.Side
+  side2: Notation.Side,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonBorder2<SvgMencloseNTD<N, T, D>, N>((node, _child) => {
     node.adaptor.append(node.dom[0], node.line(lineData(node, side1)));
@@ -165,12 +165,12 @@ export const Border2 = function <N, T, D>(
  * @return {DEFPAIR}       The notation definition for the diagonal strike
  */
 export const DiagonalStrike = function <N, T, D>(
-  name: LineName
+  name: LineName,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalStrike<SvgMencloseNTD<N, T, D>, N>(
     (_cname: string) => (node, _child) => {
       node.adaptor.append(node.dom[0], node.line(lineData(node, name)));
-    }
+    },
   )(name);
 };
 
@@ -181,12 +181,12 @@ export const DiagonalStrike = function <N, T, D>(
  * @return {DEFPAIR}      The notation definition for the diagonal arrow
  */
 export const DiagonalArrow = function <N, T, D>(
-  name: string
+  name: string,
 ): DEFPAIR<N, T, D> {
   return Notation.CommonDiagonalArrow<SvgMencloseNTD<N, T, D>, N>(
     (node, arrow) => {
       node.adaptor.append(node.dom[0], arrow);
-    }
+    },
   )(name);
 };
 

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -219,7 +219,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    */
   protected createSvgNodes(parents: N[]): N[] {
     this.dom = parents.map((_parent) =>
-      this.svg('g', { 'data-mml-node': this.node.kind })
+      this.svg('g', { 'data-mml-node': this.node.kind }),
     ); // FIXME: add segment id
     parents = this.handleHref(parents);
     for (const i of parents.keys()) {
@@ -255,7 +255,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
           height: this.fixed(h + d),
           x: i === 1 || isEmbellished ? this.fixed(-this.dx) : 0,
           y: this.fixed(-d),
-        })
+        }),
       );
       return parent;
     });
@@ -269,7 +269,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     const styles = this.styles.cssText;
     if (styles) {
       this.dom.forEach((node) =>
-        this.adaptor.setAttribute(node, 'style', styles)
+        this.adaptor.setAttribute(node, 'style', styles),
       );
     }
     const padding = (this.styleData?.padding || [0, 0, 0, 0])[3];
@@ -286,7 +286,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     if (this.bbox.rscale !== 1) {
       const scale = 'scale(' + this.fixed(this.bbox.rscale / 1000, 3) + ')';
       this.dom.forEach((node) =>
-        this.adaptor.setAttribute(node, 'transform', scale)
+        this.adaptor.setAttribute(node, 'transform', scale),
       );
     }
   }
@@ -378,7 +378,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
             border.width[i],
             i,
             dom,
-            dx
+            dx,
           );
         } else {
           this.addBorderSolid(path, border.color[i], child, dom, dx);
@@ -401,7 +401,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     color: string,
     child: N,
     parent: N,
-    dx: number
+    dx: number,
   ) {
     const border = this.svg('polygon', {
       points: path
@@ -437,7 +437,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     t: number,
     i: number,
     parent: N,
-    dx: number
+    dx: number,
   ) {
     const dot = style === 'dotted';
     const t2 = t / 2;
@@ -499,8 +499,8 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
           adaptor.setAttribute(
             dom,
             name,
-            attributes.getExplicit(name) as string
-          )
+            attributes.getExplicit(name) as string,
+          ),
         );
       }
     }
@@ -532,7 +532,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     this.adaptor.setAttribute(
       element,
       'transform',
-      translate + (transform ? ' ' + transform : '')
+      translate + (transform ? ' ' + transform : ''),
     );
   }
 
@@ -560,14 +560,14 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     const g = this.svg(
       'g',
       { 'data-idbox': true, transform: `translate(0,${this.fixed(-h)})` },
-      children
+      children,
     );
     //
     //  Add the text element (not transformed) and the transformed <g>
     //
     adaptor.append(
       this.dom[0],
-      this.svg('text', { 'data-id-align': true }, [this.text('')])
+      this.svg('text', { 'data-id-align': true }, [this.text('')]),
     );
     adaptor.append(this.dom[0], g);
     return y + h;
@@ -613,7 +613,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     y: number,
     parent: N,
     variant: string = null,
-    buffer: boolean = false
+    buffer: boolean = false,
   ): number {
     if (variant === null) {
       variant = this.variant;
@@ -631,14 +631,14 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       this.place(
         x,
         y,
-        this.adaptor.append(parent, this.charNode(variant, C, path)) as N
+        this.adaptor.append(parent, this.charNode(variant, C, path)) as N,
       );
       return w + dx;
     }
     if ('c' in data) {
       const g = this.adaptor.append(
         parent,
-        this.svg('g', { 'data-c': C })
+        this.svg('g', { 'data-c': C }),
       ) as N;
       this.place(x + dx, y, g);
       x = 0;
@@ -664,7 +664,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     this.utext = '';
     const text = this.adaptor.append(
       parent,
-      this.jax.unknownText(c, variant)
+      this.jax.unknownText(c, variant),
     ) as N;
     this.place(x, y, text);
     return this.jax.measureTextNodeWithCache(text, c, variant).w;
@@ -705,7 +705,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       use,
       'href',
       id,
-      this.jax.options.useXlink ? XLINKNS : null
+      this.jax.options.useXlink ? XLINKNS : null,
     );
     return use;
   }

--- a/ts/output/svg/Wrappers/HtmlNode.ts
+++ b/ts/output/svg/Wrappers/HtmlNode.ts
@@ -48,7 +48,7 @@ export interface SvgHtmlNodeClass<N, T, D> extends SvgXmlNodeClass<N, T, D> {
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgHtmlNodeNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/TeXAtom.ts
+++ b/ts/output/svg/Wrappers/TeXAtom.ts
@@ -90,7 +90,7 @@ export interface SvgTeXAtomClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgTeXAtomNTD<N, T, D>;
 }
 
@@ -133,7 +133,7 @@ export const SvgTeXAtom = (function <N, T, D>(): SvgTeXAtomClass<N, T, D> {
       this.adaptor.setAttribute(
         this.dom[0],
         'data-mjx-texclass',
-        TEXCLASSNAMES[this.node.texClass]
+        TEXCLASSNAMES[this.node.texClass],
       );
     }
   } as any as SvgTeXAtomClass<N, T, D>;

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -90,7 +90,7 @@ export interface SvgTextNodeClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgTextNodeNTD<N, T, D>;
 }
 
@@ -130,7 +130,7 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
      */
     public static addStyles<JX extends SVG<any, any, any>>(
       styles: CssStyles,
-      jax: JX
+      jax: JX,
     ) {
       styles.addStyles({
         'mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c]':
@@ -158,7 +158,7 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
           parents = this.dom = [
             adaptor.append(
               parents[0],
-              this.svg('g', { 'data-mml-node': 'text' })
+              this.svg('g', { 'data-mml-node': 'text' }),
             ) as N,
           ];
         } else {

--- a/ts/output/svg/Wrappers/maction.ts
+++ b/ts/output/svg/Wrappers/maction.ts
@@ -109,7 +109,7 @@ export interface SvgMactionClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMactionNTD<N, T, D>;
 }
 
@@ -200,7 +200,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
               node.adaptor.setAttribute(
                 dom,
                 'data-toggle',
-                node.node.attributes.get('selection') as string
+                node.node.attributes.get('selection') as string,
               );
             });
             //
@@ -226,7 +226,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                 document,
                 mml.attributes.get('data-maction-id')
                   ? STATE.ENRICHED
-                  : STATE.RERENDER
+                  : STATE.RERENDER,
               );
               event.stopPropagation();
             });
@@ -250,7 +250,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                 const text = (tip.node as TextNode).getText();
                 node.adaptor.insert(
                   node.svg('title', {}, [node.text(text)]),
-                  rect
+                  rect,
                 );
               } else {
                 //
@@ -261,18 +261,18 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                 const math = (node.node as AbstractMmlNode).factory.create(
                   'math',
                   {},
-                  [node.childNodes[1].node]
+                  [node.childNodes[1].node],
                 );
                 const tool = node.html('mjx-tool', {}, [node.html('mjx-tip')]);
                 const hidden = adaptor.append(
                   rect,
                   node.svg('foreignObject', { style: { display: 'none' } }, [
                     tool,
-                  ])
+                  ]),
                 ) as N;
                 node.jax.processMath(
                   node.jax.factory.wrap(math),
-                  adaptor.firstChild(tool) as N
+                  adaptor.firstChild(tool) as N,
                 );
                 node.childNodes[1].node.parent = node.node;
                 //
@@ -298,11 +298,11 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                           node.tipDy;
                         adaptor.setStyle(tool, 'left', node.Px(dx));
                         adaptor.setStyle(tool, 'top', node.Px(dy));
-                      }, data.postDelay)
+                      }, data.postDelay),
                     );
                     event.stopPropagation();
                   },
-                  dom
+                  dom,
                 );
                 node.setEventHandler(
                   'mouseout',
@@ -310,12 +310,12 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                     data.stopTimers(dom, data);
                     const timer = setTimeout(
                       () => adaptor.append(hidden, tool),
-                      data.clearDelay
+                      data.clearDelay,
                     );
                     data.clearTimer.set(dom, timer);
                     event.stopPropagation();
                   },
-                  dom
+                  dom,
                 );
               }
             }
@@ -334,7 +334,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
               const adaptor = node.adaptor;
               const text = (tip.node as TextNode).getText();
               node.dom.forEach((dom) =>
-                adaptor.setAttribute(dom, 'data-statusline', text)
+                adaptor.setAttribute(dom, 'data-statusline', text),
               );
               //
               // Set up event handlers to change the status window
@@ -344,7 +344,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                   const body = adaptor.body(adaptor.document);
                   data.status = adaptor.append(
                     body,
-                    node.html('mjx-status', {}, [node.text(text)])
+                    node.html('mjx-status', {}, [node.text(text)]),
                   );
                 }
                 event.stopPropagation();
@@ -386,7 +386,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
      */
     public setEventHandler(type: string, handler: EventHandler, dom: N = null) {
       (dom ? [dom] : this.dom).forEach((node) =>
-        (node as any).addEventListener(type, handler)
+        (node as any).addEventListener(type, handler),
       );
     }
 
@@ -418,7 +418,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
             y: this.fixed(-d),
             fill: 'none',
             'pointer-events': 'all',
-          })
+          }),
         );
       });
       child.toSVG(svg);

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -93,7 +93,7 @@ export interface SvgMathClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMathNTD<N, T, D>;
 }
 
@@ -237,7 +237,7 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
         adaptor.removeAttribute(this.dom[0], 'aria-label');
         for (const child of this.childNodes[0].childNodes) {
           child.dom.forEach((node) =>
-            adaptor.setAttribute(node, 'aria-hidden', 'true')
+            adaptor.setAttribute(node, 'aria-hidden', 'true'),
           );
         }
       }
@@ -274,12 +274,12 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
     public setChildPWidths(
       recompute: boolean,
       w: number = null,
-      _clear: boolean = true
+      _clear: boolean = true,
     ) {
       return super.setChildPWidths(
         recompute,
         this.parent ? w : this.metrics.containerWidth / this.jax.pxPerEm,
-        false
+        false,
       );
     }
   };

--- a/ts/output/svg/Wrappers/menclose.ts
+++ b/ts/output/svg/Wrappers/menclose.ts
@@ -141,7 +141,7 @@ export interface SvgMencloseClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMencloseNTD<N, T, D>;
 }
 
@@ -268,8 +268,8 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
                 t - d,
                 'L',
                 cos * HD + t,
-                HD - d - t
-              )
+                HD - d - t,
+              ),
             );
           },
           bbox: (node) => {
@@ -325,8 +325,8 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
                 h + d - 2 * t,
                 'L',
                 w - t,
-                h - t
-              )
+                h - t,
+              ),
             );
           },
           bbox: (node) => {

--- a/ts/output/svg/Wrappers/merror.ts
+++ b/ts/output/svg/Wrappers/merror.ts
@@ -48,7 +48,7 @@ export interface SvgMerrorClass<N, T, D> extends SvgWrapperClass<N, T, D> {
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMerrorNTD<N, T, D>;
 }
 
@@ -94,13 +94,13 @@ export const SvgMerror = (function <N, T, D>(): SvgMerrorClass<N, T, D> {
           width: this.fixed(w),
           height: this.fixed(h + d),
           y: this.fixed(-d),
-        })
+        }),
       );
       const title = this.node.attributes.get('title') as string;
       if (title) {
         this.adaptor.append(
           this.dom[0],
-          this.svg('title', {}, [this.adaptor.text(title)])
+          this.svg('title', {}, [this.adaptor.text(title)]),
         );
       }
       this.addChildren(svg);

--- a/ts/output/svg/Wrappers/mfenced.ts
+++ b/ts/output/svg/Wrappers/mfenced.ts
@@ -91,7 +91,7 @@ export interface SvgMfencedClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMfencedNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mfrac.ts
+++ b/ts/output/svg/Wrappers/mfrac.ts
@@ -91,7 +91,7 @@ export interface SvgMfracClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMfracNTD<N, T, D>;
 }
 
@@ -141,7 +141,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
       this.standardSvgNodes(parents);
       const { linethickness, bevelled } = this.node.attributes.getList(
         'linethickness',
-        'bevelled'
+        'bevelled',
       );
       const display = this.isDisplay();
       if (bevelled) {
@@ -166,7 +166,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
       const svg = this.dom;
       const { numalign, denomalign } = this.node.attributes.getList(
         'numalign',
-        'denomalign'
+        'denomalign',
       );
       const [num, den] = this.childNodes;
       const nbox = num.getOuterBBox();
@@ -180,7 +180,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
         : tex.nulldelimiterspace;
       const W = Math.max(
         (nbox.L + nbox.w + nbox.R) * nbox.rscale,
-        (dbox.L + dbox.w + dbox.R) * dbox.rscale
+        (dbox.L + dbox.w + dbox.R) * dbox.rscale,
       );
       const nx = this.getAlignX(W, nbox, numalign as string) + d + pad;
       const dx = this.getAlignX(W, dbox, denomalign as string) + d + pad;
@@ -198,7 +198,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
           height: this.fixed(t),
           x: this.fixed(pad),
           y: this.fixed(a - t / 2),
-        })
+        }),
       );
     }
 
@@ -211,7 +211,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
       const svg = this.dom;
       const { numalign, denomalign } = this.node.attributes.getList(
         'numalign',
-        'denomalign'
+        'denomalign',
       );
       const [num, den] = this.childNodes;
       const nbox = num.getOuterBBox();
@@ -223,7 +223,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
         : tex.nulldelimiterspace;
       const W = Math.max(
         (nbox.L + nbox.w + nbox.R) * nbox.rscale,
-        (dbox.L + dbox.w + dbox.R) * dbox.rscale
+        (dbox.L + dbox.w + dbox.R) * dbox.rscale,
       );
       const nx = this.getAlignX(W, nbox, numalign as string) + pad;
       const dx = this.getAlignX(W, dbox, denomalign as string) + pad;
@@ -254,7 +254,7 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
       this.bevel.place(w - delta / 2, 0);
       den.place(
         w + this.bevel.getOuterBBox().w + dbox.L * dbox.rscale - delta,
-        v
+        v,
       );
     }
   };

--- a/ts/output/svg/Wrappers/mglyph.ts
+++ b/ts/output/svg/Wrappers/mglyph.ts
@@ -92,7 +92,7 @@ export interface SvgMglyphClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMglyphNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mi.ts
+++ b/ts/output/svg/Wrappers/mi.ts
@@ -90,7 +90,7 @@ export interface SvgMiClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMiNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mmultiscripts.ts
+++ b/ts/output/svg/Wrappers/mmultiscripts.ts
@@ -114,7 +114,7 @@ export interface SvgMmultiscriptsClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMmultiscriptsNTD<N, T, D>;
 }
 
@@ -181,7 +181,7 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
           v,
           this.firstPrescript,
           data.numPrescripts,
-          preAlign
+          preAlign,
         );
       }
       const base = this.baseChild;
@@ -197,7 +197,7 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
           v,
           1,
           data.numScripts,
-          postAlign
+          postAlign,
         );
       }
     }
@@ -220,7 +220,7 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
       v: number,
       i: number,
       n: number,
-      align: string
+      align: string,
     ): number {
       const adaptor = this.adaptor;
       const alignX = AlignX(align);

--- a/ts/output/svg/Wrappers/mn.ts
+++ b/ts/output/svg/Wrappers/mn.ts
@@ -90,7 +90,7 @@ export interface SvgMnClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMnNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -97,7 +97,7 @@ export interface SvgMoClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMoNTD<N, T, D>;
 }
 
@@ -165,13 +165,13 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
             this.adaptor.setAttribute(
               svg[0],
               'transform',
-              `translate(${v} ${u})`
+              `translate(${v} ${u})`,
             );
           svg[1] &&
             this.adaptor.setAttribute(
               svg[1],
               'transform',
-              `translate(${v} ${u})`
+              `translate(${v} ${u})`,
             );
         }
         svg[0] && this.addChildren([svg[0]]);
@@ -213,7 +213,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
     protected stretchVertical(
       stretch: number[],
       variant: string[],
-      bbox: BBox
+      bbox: BBox,
     ) {
       const { h, d, w } = bbox;
       const T = this.addTop(stretch[0], variant[0], h, w);
@@ -235,7 +235,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
     protected stretchHorizontal(
       stretch: number[],
       variant: string[],
-      bbox: BBox
+      bbox: BBox,
     ) {
       const w = bbox.w;
       const L = this.addLeft(stretch[0], variant[0]);
@@ -280,7 +280,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       variant: string,
       x: number,
       y: number,
-      parent: N = null
+      parent: N = null,
     ): number {
       if (parent) {
         return this.placeChar(n, x, y, parent, variant);
@@ -401,7 +401,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       W: number,
       L: number,
       R: number,
-      x: number = 0
+      x: number = 0,
     ) {
       if (!n) return;
       R = Math.max(0, R - HFUZZ); // A little less than the width of the right glyph
@@ -425,7 +425,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       adaptor.setAttribute(
         glyph as N,
         'transform',
-        'scale(' + this.jax.fixed(s) + ',1)'
+        'scale(' + this.jax.fixed(s) + ',1)',
       );
       if (this.dom[0]) {
         adaptor.append(this.dom[0], svg);

--- a/ts/output/svg/Wrappers/mpadded.ts
+++ b/ts/output/svg/Wrappers/mpadded.ts
@@ -90,7 +90,7 @@ export interface SvgMpaddedClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMpaddedNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mphantom.ts
+++ b/ts/output/svg/Wrappers/mphantom.ts
@@ -47,7 +47,7 @@ export interface SvgMphantomClass<N, T, D> extends SvgWrapperClass<N, T, D> {
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMphantomNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mroot.ts
+++ b/ts/output/svg/Wrappers/mroot.ts
@@ -92,7 +92,7 @@ export interface SvgMrootClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMrootNTD<N, T, D>;
 }
 
@@ -134,7 +134,7 @@ export const SvgMroot = (function <N, T, D>(): SvgMrootClass<N, T, D> {
       ROOT: N[],
       root: SvgWrapper<N, T, D>,
       sbox: BBox,
-      H: number
+      H: number,
     ) {
       root.toSVG(ROOT);
       const [x, h, dx] = this.getRootDimens(sbox, H);

--- a/ts/output/svg/Wrappers/mrow.ts
+++ b/ts/output/svg/Wrappers/mrow.ts
@@ -96,7 +96,7 @@ export interface SvgMrowClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMrowNTD<N, T, D>;
 }
 
@@ -211,7 +211,7 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
       for (let i = 0; i <= n; i++) {
         svg[i] = adaptor.append(
           this.dom[0],
-          this.svg('g', { 'data-mjx-linebox': true, 'data-mjx-lineno': i })
+          this.svg('g', { 'data-mjx-linebox': true, 'data-mjx-lineno': i }),
         ) as N;
       }
       //
@@ -307,7 +307,7 @@ export interface SvgInferredMrowClass<N, T, D>
   new (
     factory: SvgWrapper<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgInferredMrowNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/ms.ts
+++ b/ts/output/svg/Wrappers/ms.ts
@@ -90,7 +90,7 @@ export interface SvgMsClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMsNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mspace.ts
+++ b/ts/output/svg/Wrappers/mspace.ts
@@ -90,7 +90,7 @@ export interface SvgMspaceClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMspaceNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/msqrt.ts
+++ b/ts/output/svg/Wrappers/msqrt.ts
@@ -97,7 +97,7 @@ export interface SvgMsqrtClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMsqrtNTD<N, T, D>;
 }
 
@@ -150,7 +150,7 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
       _ROOT: N[],
       _root: SvgWrapper<N, T, D>,
       _sbox: BBox,
-      _H: number
+      _H: number,
     ): number {
       return 0;
     }
@@ -192,7 +192,7 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
           height: this.fixed(t),
           x: this.fixed(dx + sbox.w),
           y: this.fixed(H - t),
-        })
+        }),
       );
     }
   };

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -106,7 +106,7 @@ export interface SvgMsubClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMsubNTD<N, T, D>;
 }
 
@@ -194,7 +194,7 @@ export interface SvgMsupClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMsupNTD<N, T, D>;
 }
 
@@ -282,7 +282,7 @@ export interface SvgMsubsupClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMsubsupNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mtable.ts
+++ b/ts/output/svg/Wrappers/mtable.ts
@@ -102,7 +102,7 @@ export interface SvgMtableClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMtableNTD<N, T, D>;
 }
 
@@ -205,7 +205,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
       equal: boolean,
       HD: number,
       H: number,
-      D: number
+      D: number,
     ): [number, number] {
       return equal ? [(HD + H - D) / 2, (HD - H + D) / 2] : [H, D];
     }
@@ -296,7 +296,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
       const CW =
         Math.max(
           this.isTop ? W : 0,
-          this.container.getWrapWidth(this.containerI)
+          this.container.getWrapWidth(this.containerI),
         ) -
         L -
         R;
@@ -338,7 +338,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
           height: this.fixed(h + d - t),
           x: this.fixed(t / 2),
           y: this.fixed(t / 2 - d),
-        })
+        }),
       );
     }
 
@@ -361,7 +361,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
           y1: this.fixed(dt - d),
           x2: X,
           y2: this.fixed(h - dt),
-        })
+        }),
       );
     }
 
@@ -384,7 +384,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
           y1: Y,
           x2: this.fixed(w - dt),
           y2: Y,
-        })
+        }),
       );
     }
 
@@ -397,7 +397,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
     protected setLineThickness(
       t: number,
       style: string,
-      properties: OptionList
+      properties: OptionList,
     ) {
       if (t !== 0.07) {
         properties['stroke-thickness'] = this.fixed(t);
@@ -504,10 +504,10 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
                 ? 'xMaxYMid'
                 : 'xMidYMid',
           viewBox: [this.fixed(-dx), this.fixed(-h), 1, this.fixed(h + d)].join(
-            ' '
+            ' ',
           ),
         },
-        [this.svg('g', { transform: matrix }, adaptor.childNodes(svg))]
+        [this.svg('g', { transform: matrix }, adaptor.childNodes(svg))],
       );
       labels = this.svg(
         'svg',
@@ -521,11 +521,11 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
             this.fixed(h + d),
           ].join(' '),
         },
-        [labels]
+        [labels],
       );
       adaptor.append(
         svg,
-        this.svg('g', { transform: transform }, [table, labels])
+        this.svg('g', { transform: transform }, [table, labels]),
       );
       this.place(-L, 0, svg); // remove spacing for L, which is added by the parent during appending
     }
@@ -558,7 +558,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
               L -
               labelW,
         0,
-        labels
+        labels,
       );
       adaptor.append(svg, labels);
     }
@@ -569,7 +569,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
     constructor(
       factory: SvgWrapperFactory<N, T, D>,
       node: MmlNode,
-      parent: SvgWrapper<N, T, D> = null
+      parent: SvgWrapper<N, T, D> = null,
     ) {
       super(factory, node, parent);
       const def: OptionList = { 'data-labels': true };

--- a/ts/output/svg/Wrappers/mtd.ts
+++ b/ts/output/svg/Wrappers/mtd.ts
@@ -76,7 +76,7 @@ export interface SvgMtdNTD<N, T, D>
     y: number,
     W: number,
     H: number,
-    D: number
+    D: number,
   ): [number, number];
 
   /**
@@ -114,7 +114,7 @@ export interface SvgMtdClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMtdNTD<N, T, D>;
 }
 
@@ -157,7 +157,7 @@ export const SvgMtd = (function <N, T, D>(): SvgMtdClass<N, T, D> {
       y: number,
       W: number,
       H: number,
-      D: number
+      D: number,
     ): [number, number] {
       const bbox = this.getBBox();
       const h = Math.max(bbox.h, 0.75);

--- a/ts/output/svg/Wrappers/mtext.ts
+++ b/ts/output/svg/Wrappers/mtext.ts
@@ -90,7 +90,7 @@ export interface SvgMtextClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMtextNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/mtr.ts
+++ b/ts/output/svg/Wrappers/mtr.ts
@@ -141,7 +141,7 @@ export interface SvgMtrClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMtrNTD<N, T, D>;
 }
 
@@ -215,7 +215,7 @@ export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
         -(dx + lSpace + lLine / 2),
         -(d + b + dy),
         W + (lLine + rLine) / 2,
-        h + d + t + b
+        h + d + t + b,
       );
       return W + rLine;
     }
@@ -266,12 +266,12 @@ export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
         adaptor.setAttribute(
           child,
           'width',
-          this.fixed((this.parent as SvgMtableNTD<N, T, D>).getWidth() * scale)
+          this.fixed((this.parent as SvgMtableNTD<N, T, D>).getWidth() * scale),
         );
         adaptor.setAttribute(
           child,
           'height',
-          this.fixed(TL + TS + H + D + BS + BL)
+          this.fixed(TL + TS + H + D + BS + BL),
         );
       }
     }
@@ -340,7 +340,7 @@ export interface SvgMlabeledtrClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMlabeledtrNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/munderover.ts
+++ b/ts/output/svg/Wrappers/munderover.ts
@@ -112,7 +112,7 @@ export interface SvgMunderClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMunderNTD<N, T, D>;
 }
 
@@ -229,7 +229,7 @@ export interface SvgMoverClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMoverNTD<N, T, D>;
 }
 
@@ -343,7 +343,7 @@ export interface SvgMunderoverClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgMunderoverNTD<N, T, D>;
 }
 
@@ -413,7 +413,7 @@ export const SvgMunderover = (function <N, T, D>(): SvgMunderoverClass<
       const v = this.getUnderKV(bbox, ubox)[1];
       const [bx, ux, ox] = this.getDeltaW(
         [bbox, ubox, obox],
-        [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta]
+        [0, this.isLineBelow ? 0 : -udelta, this.isLineAbove ? 0 : odelta],
       );
 
       base.place(bx, 0);

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -92,7 +92,7 @@ export interface SvgScriptbaseClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgScriptbaseNTD<N, T, D>;
 }
 

--- a/ts/output/svg/Wrappers/semantics.ts
+++ b/ts/output/svg/Wrappers/semantics.ts
@@ -103,7 +103,7 @@ export interface SvgSemanticsClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgSemanticsNTD<N, T, D>;
 }
 
@@ -259,7 +259,7 @@ export interface SvgXmlNodeClass<N, T, D>
   new (
     factory: SvgWrapperFactory<N, T, D>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
+    parent?: SvgWrapper<N, T, D>,
   ): SvgXmlNodeNTD<N, T, D>;
 }
 
@@ -323,8 +323,8 @@ export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
               height: this.jax.fixed((h + d) * em) + 'px',
               transform: `scale(${scale}) matrix(1 0 0 -1 0 0)`,
             },
-            [this.getHTML()]
-          )
+            [this.getHTML()],
+          ),
         ) as N,
       ];
     }

--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -422,7 +422,7 @@ export function LazyMathDocumentMixin<
       //
       this.lazyObserver = new IntersectionObserver(
         this.lazyObserve.bind(this),
-        { rootMargin: this.options.lazyMargin }
+        { rootMargin: this.options.lazyMargin },
       );
       this.lazyList = new LazyList<N, T, D>();
       const callback = this.lazyHandleSet.bind(this);
@@ -723,7 +723,7 @@ export function LazyMathDocumentMixin<
         ? null
         : this.adaptor.getElements(
             Array.isArray(always) ? always : [always],
-            this.document
+            this.document,
           );
       this.lazyAlwaysIndex = 0;
       super.render();
@@ -745,7 +745,7 @@ export function LazyMathDocumentMixin<
  * @template D  The Document class
  */
 export function LazyHandler<N, T, D>(
-  handler: HTMLHandler<N, T, D>
+  handler: HTMLHandler<N, T, D>,
 ): HTMLHandler<N, T, D> {
   //
   // Only update the document class if we can handle IntersectionObservers

--- a/ts/ui/menu/AnnotationMenu.ts
+++ b/ts/ui/menu/AnnotationMenu.ts
@@ -47,7 +47,7 @@ type AnnotationTypes = { [type: string]: string[] };
 export function showAnnotations(
   box: SelectableInfo,
   types: AnnotationTypes,
-  cache: [string, string][]
+  cache: [string, string][],
 ) {
   return (menu: MJContextMenu, sub: Submenu) => {
     getAnnotation(getSemanticNode(menu), types, cache);
@@ -67,7 +67,7 @@ export function copyAnnotations(cache: [string, string][]) {
     const annotations = cache.slice();
     cache.length = 0;
     return createAnnotationMenu(menu, sub, annotations, () =>
-      MenuUtil.copyToClipboard(annotation.trim())
+      MenuUtil.copyToClipboard(annotation.trim()),
     );
   };
 }
@@ -98,7 +98,7 @@ function getSemanticNode(menu: MJContextMenu): MmlNode | null {
 function getAnnotation(
   node: MmlNode,
   types: AnnotationTypes,
-  annotations: [string, string][]
+  annotations: [string, string][],
 ) {
   if (!node) return;
   for (const child of node.childNodes) {
@@ -107,7 +107,7 @@ function getAnnotation(
       if (match) {
         const value = child.childNodes.reduce(
           (text, chars) => text + chars.toString(),
-          ''
+          '',
         );
         annotations.push([match, value]);
       }
@@ -122,7 +122,7 @@ function getAnnotation(
  */
 function annotationMatch(
   child: MmlNode,
-  types: AnnotationTypes
+  types: AnnotationTypes,
 ): string | null {
   const encoding = child.attributes.get('encoding') as string;
   for (const type of Object.keys(types)) {
@@ -152,7 +152,7 @@ function createAnnotationMenu(
   menu: MJContextMenu,
   submenu: Submenu,
   annotations: [string, string][],
-  action: () => void
+  action: () => void,
 ): SubMenu {
   return menu.factory.get('subMenu')(
     menu.factory,
@@ -170,6 +170,6 @@ function createAnnotationMenu(
       }),
       id: 'annotations',
     },
-    submenu
+    submenu,
   );
 }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -284,13 +284,14 @@ export class Menu {
     () => {
       const lines = [] as string[];
       lines.push(
-        'Input Jax: ' + this.document.inputJax.map((jax) => jax.name).join(', ')
+        'Input Jax: ' +
+          this.document.inputJax.map((jax) => jax.name).join(', '),
       );
       lines.push('Output Jax: ' + this.document.outputJax.name);
       lines.push('Document Type: ' + this.document.kind);
       return lines.join('<br/>');
     },
-    '<a href="https://www.mathjax.org">www.mathjax.org</a>'
+    '<a href="https://www.mathjax.org">www.mathjax.org</a>',
   );
 
   /**
@@ -334,7 +335,7 @@ export class Menu {
         ' MathJax in any way.</p>',
       ].join('\n');
     },
-    '<a href="https://www.mathjax.org">www.mathjax.org</a>'
+    '<a href="https://www.mathjax.org">www.mathjax.org</a>',
   );
 
   /**
@@ -347,7 +348,7 @@ export class Menu {
       const text = this.toMML(this.menu.mathItem);
       return '<pre>' + this.formatSource(text) + '</pre>';
     },
-    ''
+    '',
   );
 
   /**
@@ -364,7 +365,7 @@ export class Menu {
         '</pre>'
       );
     },
-    ''
+    '',
   );
 
   /**
@@ -380,7 +381,7 @@ export class Menu {
         '</pre>'
       );
     },
-    ''
+    '',
   );
 
   /**
@@ -397,7 +398,7 @@ export class Menu {
         'Generative SVG Image...</div>'
       );
     },
-    ''
+    '',
   );
 
   /**
@@ -413,7 +414,7 @@ export class Menu {
         '</div>'
       );
     },
-    ''
+    '',
   );
 
   /**
@@ -429,7 +430,7 @@ export class Menu {
         '</div>'
       );
     },
-    ''
+    '',
   );
 
   /**
@@ -445,7 +446,7 @@ export class Menu {
         '</pre>'
       );
     },
-    ''
+    '',
   );
 
   /**
@@ -456,7 +457,7 @@ export class Menu {
     () => {
       if (!this.menu.mathItem) return '';
       const element = (this.menu.mathItem.typesetRoot as any).cloneNode(
-        true
+        true,
       ) as HTMLElement;
       element.style.margin = '0';
       const scale = 1.25 * parseFloat(this.settings.zscale); // 1.25 is to reverse the default 80% font-size
@@ -464,7 +465,7 @@ export class Menu {
         '<div style="font-size: ' + scale + '%">' + element.outerHTML + '</div>'
       );
     },
-    ''
+    '',
   );
 
   /*======================================================================*/
@@ -481,7 +482,7 @@ export class Menu {
     this.document = document;
     this.options = userOptions(
       defaultOptions({}, (this.constructor as typeof Menu).OPTIONS),
-      options
+      options,
     );
     this.initSettings();
     this.mergeUserSettings();
@@ -526,10 +527,10 @@ export class Menu {
         this.variable<string>('zscale'),
         this.variable<string>('renderer', (jax) => this.setRenderer(jax)),
         this.variable<string>('overflow', (overflow) =>
-          this.setOverflow(overflow)
+          this.setOverflow(overflow),
         ),
         this.variable<boolean>('breakInline', (breaks) =>
-          this.setInlineBreaks(breaks)
+          this.setInlineBreaks(breaks),
         ),
         this.variable<boolean>('alt'),
         this.variable<boolean>('cmd'),
@@ -539,7 +540,7 @@ export class Menu {
         this.a11yVar<boolean>('speech', (speech) => this.setSpeech(speech)),
         this.a11yVar<boolean>('braille', (braille) => this.setBraille(braille)),
         this.variable<string>('brailleCode', (code) =>
-          this.setBrailleCode(code)
+          this.setBrailleCode(code),
         ),
         this.a11yVar<string>('highlight', (value) => this.setHighlight(value)),
         this.a11yVar<string>('backgroundColor'),
@@ -564,23 +565,23 @@ export class Menu {
         this.a11yVar<boolean>('infoPrefix'),
         this.variable<boolean>('autocollapse'),
         this.variable<boolean>('collapsible', (collapse) =>
-          this.setCollapsible(collapse)
+          this.setCollapsible(collapse),
         ),
         this.variable<boolean>('enrich', (enrich) =>
-          this.setEnrichment(enrich)
+          this.setEnrichment(enrich),
         ),
         this.variable<boolean>('inTabOrder', (tab) => this.setTabOrder(tab)),
         this.variable<boolean>('assistiveMml', (mml) =>
-          this.setAssistiveMml(mml)
+          this.setAssistiveMml(mml),
         ),
       ],
       items: [
         this.submenu('Show', 'Show Math As', [
           this.command('MathMLcode', 'MathML Code', () =>
-            this.mathmlCode.post()
+            this.mathmlCode.post(),
           ),
           this.command('Original', 'Original Form', () =>
-            this.originalText.post()
+            this.originalText.post(),
           ),
           this.rule(),
           this.command('Speech', 'Speech Text', () => this.speechText.post(), {
@@ -590,7 +591,7 @@ export class Menu {
             'Braille',
             'Braille Code',
             () => this.brailleText.post(),
-            { disabled: true }
+            { disabled: true },
           ),
           this.command('SVG', 'SVG Image', () => this.postSvgImage(), {
             disabled: true,
@@ -601,7 +602,7 @@ export class Menu {
             'Error',
             'Error Message',
             () => this.errorMessage.post(),
-            { disabled: true }
+            { disabled: true },
           ),
         ]),
         this.submenu('Copy', 'Copy to Clipboard', [
@@ -615,7 +616,7 @@ export class Menu {
             'Braille',
             'Braille Code',
             () => this.copyBrailleText(),
-            { disabled: true }
+            { disabled: true },
           ),
           this.command('SVG', 'SVG Image', () => this.copySvgImage(), {
             disabled: true,
@@ -626,7 +627,7 @@ export class Menu {
             'Error',
             'Error Message',
             () => this.copyErrorMessage(),
-            { disabled: true }
+            { disabled: true },
           ),
         ]),
         this.rule(),
@@ -634,7 +635,7 @@ export class Menu {
           this.submenu(
             'Renderer',
             'Math Renderer',
-            this.radioGroup('renderer', [['CHTML'], ['SVG']])
+            this.radioGroup('renderer', [['CHTML'], ['SVG']]),
           ),
           this.submenu('Overflow', 'Wide Expressions', [
             this.radioGroup('overflow', [
@@ -659,7 +660,7 @@ export class Menu {
           this.rule(),
           this.submenu('ZoomTrigger', 'Zoom Trigger', [
             this.command('ZoomNow', 'Zoom Once Now', () =>
-              this.zoom(null, '', this.menu.mathItem)
+              this.zoom(null, '', this.menu.mathItem),
             ),
             this.rule(),
             this.radioGroup('zoom', [
@@ -672,7 +673,7 @@ export class Menu {
             this.checkbox(
               MenuUtil.isMac ? 'Option' : 'Alt',
               MenuUtil.isMac ? 'Option' : 'Alt',
-              'alt'
+              'alt',
             ),
             this.checkbox('Command', 'Command', 'cmd', {
               hidden: !MenuUtil.isMac,
@@ -692,13 +693,13 @@ export class Menu {
               ['250%'],
               ['300%'],
               ['400%'],
-            ])
+            ]),
           ),
           this.rule(),
           this.command('Scale', 'Scale All Math...', () => this.scaleAllMath()),
           this.rule(),
           this.command('Reset', 'Reset to defaults', () =>
-            this.resetDefaults()
+            this.resetDefaults(),
           ),
         ]),
         this.rule(),
@@ -716,12 +717,12 @@ export class Menu {
               ['mathspeak-default', 'Verbose'],
               ['mathspeak-brief', 'Brief'],
               ['mathspeak-sbrief', 'Superbrief'],
-            ])
+            ]),
           ),
           this.submenu(
             'Clearspeak',
             'Clearspeak',
-            this.radioGroup('speechRules', [['clearspeak-default', 'Auto']])
+            this.radioGroup('speechRules', [['clearspeak-default', 'Auto']]),
           ),
           this.submenu(
             'ChromeVox',
@@ -729,7 +730,7 @@ export class Menu {
             this.radioGroup('speechRules', [
               ['chromevox-default', 'Standard'],
               ['chromevox-alternative', 'Alternative'],
-            ])
+            ]),
           ),
           this.rule(),
           this.submenu('A11yLanguage', 'Language'),
@@ -759,7 +760,7 @@ export class Menu {
                 ['Magenta'],
                 ['White'],
                 ['Black'],
-              ])
+              ]),
             ),
             { type: 'slider', variable: 'backgroundOpacity', content: ' ' },
             this.submenu(
@@ -774,7 +775,7 @@ export class Menu {
                 ['Green'],
                 ['Red'],
                 ['Blue'],
-              ])
+              ]),
             ),
             { type: 'slider', variable: 'foregroundOpacity', content: ' ' },
             this.rule(),
@@ -804,7 +805,7 @@ export class Menu {
               this.checkbox('Role', 'Role', 'infoRole'),
               this.checkbox('Prefix', 'Prefix', 'infoPrefix'),
             ],
-            true
+            true,
           ),
         ]),
         this.submenu('Options', '\xA0 \xA0 Options', [
@@ -818,7 +819,7 @@ export class Menu {
           this.checkbox(
             'AssistiveMml',
             'Include Hidden MathML',
-            'assistiveMml'
+            'assistiveMml',
           ),
         ]),
         this.rule(),
@@ -838,7 +839,7 @@ export class Menu {
       AnnotationMenu.showAnnotations(
         this.annotationBox,
         this.options.annotationTypes,
-        cache
+        cache,
       ),
       '',
     ]);
@@ -996,7 +997,7 @@ export class Menu {
     const promise = (Menu._loadingPromise || Promise.resolve()).then(() =>
       renderer !== this.defaultSettings.renderer
         ? this.setRenderer(renderer, false)
-        : Promise.resolve()
+        : Promise.resolve(),
     );
     promise.then(() => {
       const settings = this.settings;
@@ -1133,7 +1134,7 @@ export class Menu {
     const enable = this.settings.enrich;
     const method = enable ? 'enable' : 'disable';
     ['Speech', 'Braille', 'Explorer'].forEach((id) =>
-      this.menu.findID(id)[method]()
+      this.menu.findID(id)[method](),
     );
     const options = this.document.options;
     options.enableSpeech =
@@ -1247,7 +1248,7 @@ export class Menu {
       .replace(/.0$/, '');
     const percent = prompt(
       'Scale all mathematics (compared to surrounding text) by',
-      scale + '%'
+      scale + '%',
     );
     if (percent) {
       if (percent.match(/^\s*\d+(\.\d*)?\s*%?\s*$/)) {
@@ -1365,7 +1366,7 @@ export class Menu {
           this.rerender(
             component === 'complexity' || noEnrich
               ? STATE.COMPILED
-              : STATE.TYPESET
+              : STATE.TYPESET,
           );
         });
       }
@@ -1417,7 +1418,7 @@ export class Menu {
     const jax = this.jax.SVG;
     if (!jax)
       return Promise.resolve(
-        "SVG can't be produced.<br>Try switching to SVG output first."
+        "SVG can't be produced.<br>Try switching to SVG output first.",
       );
     const adaptor = jax.adaptor;
     const cache = jax.options.fontCache;
@@ -1430,7 +1431,7 @@ export class Menu {
       for (const child of adaptor.childNodes(math.typesetRoot)) {
         if (adaptor.kind(child) === 'svg') {
           return Promise.resolve(
-            this.formatSvg(adaptor.serializeXML(child as HTMLElement))
+            this.formatSvg(adaptor.serializeXML(child as HTMLElement)),
           );
         }
       }
@@ -1447,7 +1448,7 @@ export class Menu {
   protected async typesetSVG(
     math: HTMLMATHITEM,
     cache: string,
-    breaks: boolean
+    breaks: boolean,
   ): Promise<string> {
     const jax = this.jax.SVG as SVG<HTMLElement, Text, Document>;
     const div = jax.html('div');
@@ -1554,7 +1555,7 @@ export class Menu {
             }
             this.document.rerender(this.rerenderStart);
             this.rerenderStart = STATE.LAST;
-          })
+          }),
       );
     }
   }
@@ -1613,22 +1614,22 @@ export class Menu {
     element.addEventListener(
       'contextmenu',
       () => (this.menu.mathItem = math),
-      true
+      true,
     );
     element.addEventListener(
       'keydown',
       () => (this.menu.mathItem = math),
-      true
+      true,
     );
     element.addEventListener(
       'click',
       (event) => this.zoom(event, 'Click', math),
-      true
+      true,
     );
     element.addEventListener(
       'dblclick',
       (event) => this.zoom(event, 'DoubleClick', math),
-      true
+      true,
     );
     this.menu.store.insert(element);
   }
@@ -1653,7 +1654,7 @@ export class Menu {
    */
   public variable<T extends string | boolean>(
     name: keyof MenuSettings,
-    action?: (value: T) => void
+    action?: (value: T) => void,
   ): Object {
     return {
       name: name,
@@ -1676,7 +1677,7 @@ export class Menu {
    */
   public a11yVar<T extends string | boolean>(
     name: keyof MenuSettings,
-    action?: (value: T) => void
+    action?: (value: T) => void,
   ): Object {
     return {
       name: name,
@@ -1703,7 +1704,7 @@ export class Menu {
     id: string,
     content: string,
     entries: any[] = [],
-    disabled: boolean = false
+    disabled: boolean = false,
   ): Object {
     let items = [] as Array<Object>;
     for (const entry of entries) {
@@ -1735,7 +1736,7 @@ export class Menu {
     id: string,
     content: string,
     action: () => void,
-    other: Object = {}
+    other: Object = {},
   ): Object {
     return Object.assign({ type: 'command', id, content, action }, other);
   }
@@ -1753,7 +1754,7 @@ export class Menu {
     id: string,
     content: string,
     variable: string,
-    other: Object = {}
+    other: Object = {},
   ): Object {
     return Object.assign({ type: 'checkbox', id, content, variable }, other);
   }
@@ -1783,7 +1784,7 @@ export class Menu {
     id: string,
     content: string,
     variable: string,
-    other: Object = {}
+    other: Object = {},
   ): Object {
     return Object.assign({ type: 'radio', id, content, variable }, other);
   }

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -100,7 +100,7 @@ export interface MenuMathItem
  * @template B  The MathItem class to extend
  */
 export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
-  BaseMathItem: B
+  BaseMathItem: B,
 ): Constructor<MenuMathItem> & B {
   return class extends BaseMathItem {
     /**
@@ -160,7 +160,7 @@ export interface MenuMathDocument
  * @template B  The MathDocument class to extend
  */
 export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
-  BaseDocument: B
+  BaseDocument: B,
 ): Constructor<MenuMathDocument> & B {
   return class extends BaseDocument {
     /**
@@ -215,7 +215,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
         ProcessBits.allocate('context-menu');
       }
       this.options.MathItem = MenuMathItemMixin<A11yMathItemConstructor>(
-        this.options.MathItem
+        this.options.MathItem,
       );
 
       const settings = this.menu.settings;
@@ -250,7 +250,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
     public checkLoading(): MenuMathDocument {
       if (this.menu.isLoading) {
         mathjax.retryAfter(
-          this.menu.loadingPromise.catch((err) => console.log(err))
+          this.menu.loadingPromise.catch((err) => console.log(err)),
         );
       }
       if (this.options.enableComplexity) {
@@ -293,10 +293,10 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
  * @return {Handler}          The handler that was modified (for purposes of chaining extensions)
  */
 export function MenuHandler(
-  handler: Handler<HTMLElement, Text, Document>
+  handler: Handler<HTMLElement, Text, Document>,
 ): Handler<HTMLElement, Text, Document> {
   handler.documentClass = MenuMathDocumentMixin<A11yDocumentConstructor>(
-    handler.documentClass as any
+    handler.documentClass as any,
   );
   return handler;
 }

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -61,7 +61,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
   public visitTree(
     node: MmlNode,
     math: MathItem<N, T, D> = null,
-    options: OptionList = {}
+    options: OptionList = {},
   ) {
     this.mathItem = math;
     userOptions(this.options, options);
@@ -133,8 +133,8 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
     if (this.options.filterSRE) {
       const keys = Object.keys(list).filter((id) =>
         id.match(
-          /^(?:data-semantic-.*?|role|aria-(?:level|posinset|setsize|owns))$/
-        )
+          /^(?:data-semantic-.*?|role|aria-(?:level|posinset|setsize|owns))$/,
+        ),
       );
       for (const key of keys) {
         delete list[key];

--- a/ts/ui/menu/RadioCompare.ts
+++ b/ts/ui/menu/RadioCompare.ts
@@ -47,7 +47,7 @@ export class RadioCompare extends Radio {
       id: string;
       comparator: (variable: string, id: string) => boolean;
     },
-    menu: Menu
+    menu: Menu,
   ): Radio {
     return new this(menu, content, variable, id, comparator);
   }
@@ -60,7 +60,7 @@ export class RadioCompare extends Radio {
     content: string,
     variable: string,
     id: string,
-    private comparator: (variable: string, id: string) => boolean
+    private comparator: (variable: string, id: string) => boolean,
   ) {
     super(menu, content, variable, id);
   }
@@ -72,7 +72,7 @@ export class RadioCompare extends Radio {
   protected updateAria() {
     this.html.setAttribute(
       'aria-checked',
-      this.comparator(this.variable.getValue(), this.id) ? 'true' : 'false'
+      this.comparator(this.variable.getValue(), this.id) ? 'true' : 'false',
     );
   }
 

--- a/ts/ui/menu/SelectableInfo.ts
+++ b/ts/ui/menu/SelectableInfo.ts
@@ -50,7 +50,7 @@ export class SelectableInfo extends Info {
   public selectAll() {
     const selection = document.getSelection();
     selection.selectAllChildren(
-      this.html.querySelector('.CtxtMenu_InfoContent').firstChild
+      this.html.querySelector('.CtxtMenu_InfoContent').firstChild,
     );
   }
 
@@ -73,13 +73,13 @@ export class SelectableInfo extends Info {
   public generateHtml() {
     super.generateHtml();
     const footer = this.html.querySelector(
-      'span.' + HtmlClasses['INFOSIGNATURE']
+      'span.' + HtmlClasses['INFOSIGNATURE'],
     );
     const button = footer.appendChild(document.createElement('input'));
     button.type = 'button';
     button.value = 'Copy to Clipboard';
     button.addEventListener('click', (_event: MouseEvent) =>
-      this.copyToClipboard()
+      this.copyToClipboard(),
     );
   }
 }

--- a/ts/ui/safe/SafeHandler.ts
+++ b/ts/ui/safe/SafeHandler.ts
@@ -90,10 +90,10 @@ export function SafeMathDocumentMixin<
       for (const jax of this.inputJax) {
         if (jax.name.match(/MathML/)) {
           (jax as any).mathml.filterAttribute = this.safe.mmlAttribute.bind(
-            this.safe
+            this.safe,
           );
           (jax as any).mathml.filterClassList = this.safe.mmlClassList.bind(
-            this.safe
+            this.safe,
           );
         } else if (jax.name.match(/TeX/)) {
           jax.postFilters.add(this.sanitize.bind(jax), -5.5);
@@ -124,7 +124,7 @@ export function SafeMathDocumentMixin<
  * @return {Handler}          The handler that was modified (for purposes of chaining extensions)
  */
 export function SafeHandler<N, T, D>(
-  handler: Handler<N, T, D>
+  handler: Handler<N, T, D>,
 ): Handler<N, T, D> {
   handler.documentClass = SafeMathDocumentMixin(handler.documentClass);
   return handler;

--- a/ts/ui/safe/SafeMethods.ts
+++ b/ts/ui/safe/SafeMethods.ts
@@ -175,7 +175,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   filterStyle<N, T, D>(
     safe: Safe<N, T, D>,
     style: string,
-    div: N
+    div: N,
   ): string | null {
     const value = safe.adaptor.getStyle(div, style);
     if (
@@ -211,7 +211,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
     safe: Safe<N, T, D>,
     style: string,
     value: string,
-    div: N
+    div: N,
   ): string | null {
     const name = safe.options.styleLengths[style];
     if (!name) {
@@ -223,7 +223,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
     const length = this.filterStyleLength(
       safe,
       name,
-      safe.adaptor.getStyle(div, name)
+      safe.adaptor.getStyle(div, name),
     );
     if (!length) {
       return null;
@@ -247,7 +247,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   filterStyleLength<N, T, D>(
     safe: Safe<N, T, D>,
     style: string,
-    value: string
+    value: string,
   ): string | null {
     if (!value.match(/^(.+)(em|ex|ch|rem|px|mm|cm|in|pt|pc|%)$/)) return null;
     const em = length2em(value, 1);
@@ -307,7 +307,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
    */
   filterScriptLevel<N, T, D>(
     safe: Safe<N, T, D>,
-    level: string
+    level: string,
   ): string | null {
     const [m, M] = safe.options.scriptlevelRange || [-Infinity, Infinity];
     return Math.min(M, Math.max(m, parseInt(level))).toString();
@@ -328,7 +328,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   filterData<N, T, D>(
     safe: Safe<N, T, D>,
     value: string,
-    id: string
+    id: string,
   ): string | null {
     return id.match(safe.options.dataPattern) ? value : null;
   },

--- a/ts/util/AsyncLoad.ts
+++ b/ts/util/AsyncLoad.ts
@@ -32,7 +32,7 @@ import { mathjax } from '../mathjax.js';
 export function asyncLoad(name: string): Promise<any> {
   if (!mathjax.asyncLoad) {
     return Promise.reject(
-      `Can't load '${name}': No mathjax.asyncLoad method specified`
+      `Can't load '${name}': No mathjax.asyncLoad method specified`,
     );
   }
   return new Promise((ok, fail) => {

--- a/ts/util/LinkedList.ts
+++ b/ts/util/LinkedList.ts
@@ -311,7 +311,7 @@ export class LinkedList<DataClass> {
    */
   public merge(
     list: LinkedList<DataClass>,
-    isBefore: SortFn<DataClass> = null
+    isBefore: SortFn<DataClass> = null,
   ): LinkedList<DataClass> {
     if (isBefore === null) {
       isBefore = this.isBefore.bind(this);

--- a/ts/util/Options.ts
+++ b/ts/util/Options.ts
@@ -139,7 +139,7 @@ export function keys(def: OptionList): (string | symbol)[] {
     return [];
   }
   return (Object.keys(def) as (string | symbol)[]).concat(
-    Object.getOwnPropertySymbols(def)
+    Object.getOwnPropertySymbols(def),
   );
 }
 
@@ -166,7 +166,7 @@ export function copy(def: OptionList): OptionList {
   }
   return Object.defineProperties(
     def.constructor === Expandable ? expandable({}) : {},
-    props
+    props,
   );
 }
 
@@ -183,7 +183,7 @@ export function copy(def: OptionList): OptionList {
 export function insert(
   dst: OptionList,
   src: OptionList,
-  warn: boolean = true
+  warn: boolean = true,
 ): OptionList {
   for (let key of keys(src) as string[]) {
     //
@@ -340,7 +340,7 @@ export function selectOptions(
  */
 export function selectOptionsFromKeys(
   options: OptionList,
-  object: OptionList
+  object: OptionList,
 ): OptionList {
   return selectOptions(options, ...Object.keys(object));
 }

--- a/ts/util/PrioritizedList.ts
+++ b/ts/util/PrioritizedList.ts
@@ -90,7 +90,7 @@ export class PrioritizedList<DataClass> {
    */
   public add(
     item: DataClass,
-    priority: number = PrioritizedList.DEFAULTPRIORITY
+    priority: number = PrioritizedList.DEFAULTPRIORITY,
   ): DataClass {
     let i = this.items.length;
     do {

--- a/ts/util/Styles.ts
+++ b/ts/util/Styles.ts
@@ -230,7 +230,7 @@ const FONT: { [name: string]: RegExp } = {
         'full-width|proportional-width',
         'ruby',
       ].join('|') +
-      ')$'
+      ')$',
   ),
   weight: /^(?:normal|bold|bolder|lighter|[1-9]00|inherit|initial|unset)$/,
   stretch: new RegExp(
@@ -240,7 +240,7 @@ const FONT: { [name: string]: RegExp } = {
         '(?:(?:ultra|extra|semi)-)?(?:condensed|expanded)',
         'inherit|initial|unset',
       ].join('|') +
-      ')$'
+      ')$',
   ),
   size: new RegExp(
     '^(?:' +
@@ -250,7 +250,7 @@ const FONT: { [name: string]: RegExp } = {
         'inherit|initial|unset',
       ].join('|') +
       ')' +
-      '(?:/(?:normal|[\\d.]+(?:%|[a-z]+)?))?$'
+      '(?:/(?:normal|[\\d.]+(?:%|[a-z]+)?))?$',
   ),
 };
 
@@ -317,7 +317,7 @@ function splitFont(name: string) {
  */
 function saveFontParts(
   name: string,
-  value: { [name: string]: string | string[] }
+  value: { [name: string]: string | string[] },
 ) {
   for (const child of Styles.connect[name].children) {
     const cname = this.childName(name, child);

--- a/ts/util/asyncLoad/esm.ts
+++ b/ts/util/asyncLoad/esm.ts
@@ -25,7 +25,7 @@ import { mathjax } from '../../mathjax.js';
 
 let root = new URL(import.meta.url).href.replace(
   /\/util\/asyncLoad\/esm.js$/,
-  '/'
+  '/',
 );
 
 if (!mathjax.asyncLoad) {

--- a/ts/util/entities/a.ts
+++ b/ts/util/entities/a.ts
@@ -82,5 +82,5 @@ Entities.add(
     awconint: '\u2233',
     awint: '\u2A11',
   },
-  'a'
+  'a',
 );

--- a/ts/util/entities/b.ts
+++ b/ts/util/entities/b.ts
@@ -109,5 +109,5 @@ Entities.add(
     bumpe: '\u224F',
     bumpeq: '\u224F',
   },
-  'b'
+  'b',
 );

--- a/ts/util/entities/c.ts
+++ b/ts/util/entities/c.ts
@@ -107,5 +107,5 @@ Entities.add(
     cwint: '\u2231',
     cylcty: '\u232D',
   },
-  'c'
+  'c',
 );

--- a/ts/util/entities/d.ts
+++ b/ts/util/entities/d.ts
@@ -105,5 +105,5 @@ Entities.add(
     dzcy: '\u045F',
     dzigrarr: '\u27FF',
   },
-  'd'
+  'd',
 );

--- a/ts/util/entities/e.ts
+++ b/ts/util/entities/e.ts
@@ -85,5 +85,5 @@ Entities.add(
     expectation: '\u2130',
     exponentiale: '\u2147',
   },
-  'e'
+  'e',
 );

--- a/ts/util/entities/f.ts
+++ b/ts/util/entities/f.ts
@@ -53,5 +53,5 @@ Entities.add(
     frac78: '\u215E',
     frasl: '\u2044',
   },
-  'f'
+  'f',
 );

--- a/ts/util/entities/fr.ts
+++ b/ts/util/entities/fr.ts
@@ -72,5 +72,5 @@ Entities.add(
     yfr: '\uD835\uDD36',
     zfr: '\uD835\uDD37',
   },
-  'fr'
+  'fr',
 );

--- a/ts/util/entities/g.ts
+++ b/ts/util/entities/g.ts
@@ -76,5 +76,5 @@ Entities.add(
     gvertneqq: '\u2269\uFE00',
     gvnE: '\u2269\uFE00',
   },
-  'g'
+  'g',
 );

--- a/ts/util/entities/h.ts
+++ b/ts/util/entities/h.ts
@@ -45,5 +45,5 @@ Entities.add(
     hybull: '\u2043',
     hyphen: '\u2010',
   },
-  'h'
+  'h',
 );

--- a/ts/util/entities/i.ts
+++ b/ts/util/entities/i.ts
@@ -79,5 +79,5 @@ Entities.add(
     iukcy: '\u0456',
     iuml: '\u00EF',
   },
-  'i'
+  'i',
 );

--- a/ts/util/entities/j.ts
+++ b/ts/util/entities/j.ts
@@ -28,5 +28,5 @@ Entities.add(
     jsercy: '\u0458',
     jukcy: '\u0454',
   },
-  'j'
+  'j',
 );

--- a/ts/util/entities/k.ts
+++ b/ts/util/entities/k.ts
@@ -30,5 +30,5 @@ Entities.add(
     khcy: '\u0445',
     kjcy: '\u045C',
   },
-  'k'
+  'k',
 );

--- a/ts/util/entities/l.ts
+++ b/ts/util/entities/l.ts
@@ -172,5 +172,5 @@ Entities.add(
     lvertneqq: '\u2268\uFE00',
     lvnE: '\u2268\uFE00',
   },
-  'l'
+  'l',
 );

--- a/ts/util/entities/m.ts
+++ b/ts/util/entities/m.ts
@@ -54,5 +54,5 @@ Entities.add(
     mstpos: '\u223E',
     mumap: '\u22B8',
   },
-  'm'
+  'm',
 );

--- a/ts/util/entities/n.ts
+++ b/ts/util/entities/n.ts
@@ -213,5 +213,5 @@ Entities.add(
     nwarrow: '\u2196',
     nwnear: '\u2927',
   },
-  'n'
+  'n',
 );

--- a/ts/util/entities/o.ts
+++ b/ts/util/entities/o.ts
@@ -83,5 +83,5 @@ Entities.add(
     ouml: '\u00F6',
     ovbar: '\u233D',
   },
-  'o'
+  'o',
 );

--- a/ts/util/entities/opf.ts
+++ b/ts/util/entities/opf.ts
@@ -72,5 +72,5 @@ Entities.add(
     yopf: '\uD835\uDD6A',
     zopf: '\uD835\uDD6B',
   },
-  'opf'
+  'opf',
 );

--- a/ts/util/entities/p.ts
+++ b/ts/util/entities/p.ts
@@ -77,5 +77,5 @@ Entities.add(
     prurel: '\u22B0',
     puncsp: '\u2008',
   },
-  'p'
+  'p',
 );

--- a/ts/util/entities/q.ts
+++ b/ts/util/entities/q.ts
@@ -27,5 +27,5 @@ Entities.add(
     quest: '\u003F',
     questeq: '\u225F',
   },
-  'q'
+  'q',
 );

--- a/ts/util/entities/r.ts
+++ b/ts/util/entities/r.ts
@@ -131,5 +131,5 @@ Entities.add(
     ruluhar: '\u2968',
     rx: '\u211E',
   },
-  'r'
+  'r',
 );

--- a/ts/util/entities/s.ts
+++ b/ts/util/entities/s.ts
@@ -163,5 +163,5 @@ Entities.add(
     swnwar: '\u292A',
     szlig: '\u00DF',
   },
-  's'
+  's',
 );

--- a/ts/util/entities/scr.ts
+++ b/ts/util/entities/scr.ts
@@ -72,5 +72,5 @@ Entities.add(
     yscr: '\uD835\uDCCE',
     zscr: '\uD835\uDCCF',
   },
-  'scr'
+  'scr',
 );

--- a/ts/util/entities/t.ts
+++ b/ts/util/entities/t.ts
@@ -79,5 +79,5 @@ Entities.add(
     twoheadleftarrow: '\u219E',
     twoheadrightarrow: '\u21A0',
   },
-  't'
+  't',
 );

--- a/ts/util/entities/u.ts
+++ b/ts/util/entities/u.ts
@@ -85,5 +85,5 @@ Entities.add(
     uuml: '\u00FC',
     uwangle: '\u29A7',
   },
-  'u'
+  'u',
 );

--- a/ts/util/entities/v.ts
+++ b/ts/util/entities/v.ts
@@ -66,5 +66,5 @@ Entities.add(
     vsupne: '\u228B\uFE00',
     vzigzag: '\u299A',
   },
-  'v'
+  'v',
 );

--- a/ts/util/entities/w.ts
+++ b/ts/util/entities/w.ts
@@ -28,5 +28,5 @@ Entities.add(
     wr: '\u2240',
     wreath: '\u2240',
   },
-  'w'
+  'w',
 );

--- a/ts/util/entities/x.ts
+++ b/ts/util/entities/x.ts
@@ -40,5 +40,5 @@ Entities.add(
     xvee: '\u22C1',
     xwedge: '\u22C0',
   },
-  'x'
+  'x',
 );

--- a/ts/util/entities/y.ts
+++ b/ts/util/entities/y.ts
@@ -34,5 +34,5 @@ Entities.add(
     yucy: '\u044E',
     yuml: '\u00FF',
   },
-  'y'
+  'y',
 );

--- a/ts/util/entities/z.ts
+++ b/ts/util/entities/z.ts
@@ -35,5 +35,5 @@ Entities.add(
     zwj: '\u200D',
     zwnj: '\u200C',
   },
-  'z'
+  'z',
 );

--- a/ts/util/lengths.ts
+++ b/ts/util/lengths.ts
@@ -91,7 +91,7 @@ export function length2em(
   length: string | number,
   size: number = 0,
   scale: number = 1,
-  em: number = 16
+  em: number = 16,
 ): number {
   if (typeof length !== 'string') {
     length = String(length);
@@ -103,7 +103,7 @@ export function length2em(
     return MATHSPACE[length];
   }
   let match = length.match(
-    /^\s*([-+]?(?:\.\d+|\d+(?:\.\d*)?))?(pt|em|ex|mu|px|pc|in|mm|cm|%)?/
+    /^\s*([-+]?(?:\.\d+|\d+(?:\.\d*)?))?(pt|em|ex|mu|px|pc|in|mm|cm|%)?/,
   );
   if (!match || match[0] === '') {
     return size;

--- a/ts/util/string.ts
+++ b/ts/util/string.ts
@@ -97,6 +97,6 @@ export function split(x: string): string[] {
 export function replaceUnicode(text: string): string {
   return text.replace(
     /((?:^|[^\\])(?:\\\\)*)\\U(?:([0-9A-Fa-f]{4})|\{\s*([0-9A-Fa-f]{1,6})\s*\})/g,
-    (_m, pre, h1, h2) => pre + String.fromCodePoint(parseInt(h1 || h2, 16))
+    (_m, pre, h1, h2) => pre + String.fromCodePoint(parseInt(h1 || h2, 16)),
   );
 }


### PR DESCRIPTION
For comparison, `prettier` with the `trailing-commas: "all"` option. 

Personally, I don't think it is a good idea to have trailing commas at every, single parameter list. If we change parameter lists, we need to go through a proper review anyway, so a single comma will not make such a difference.