### PR TITLE
Update explorer to allow drag selection, handle menu tab-order settings better, and a few other fixes

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -216,9 +216,9 @@ export function ExplorerMathDocumentMixin<
         magnification: 'None',             // type of magnification
         magnify: '400%',                   // percentage of magnification of zoomed expressions
         mouseMagnifier: false,             // switch on magnification via mouse hovering
-        subtitles: true,                   // show speech as a subtitle
+        subtitles: false,                  // show speech as a subtitle
         treeColoring: false,               // tree color expression
-        viewBraille: true,                 // display Braille output as subtitles
+        viewBraille: false,                // display Braille output as subtitles
         voicing: false,                    // switch on speech output
       }
     };

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -166,14 +166,26 @@ export class SpeechExplorer
   ]);
 
   /**
+   * Test of an event has any modifier keys
+   *
+   * @param {MouseEvent} event   The event to check
+   * @returns {boolean}          True if shift, ctrl, alt, or meta key is pressed
+   */
+  protected hasModifiers(event: MouseEvent): boolean {
+    return event.shiftKey || event.metaKey || event.altKey || event.ctrlKey;
+  }
+
+  /**
    * Records a mouse down event on the element. This ensures that focus events
    * only fire if they were not triggered by a mouse click.
    *
    * @param {MouseEvent} e The mouse event.
    */
   private MouseDown(e: MouseEvent) {
+    this.FocusOut(null);
     this.mousedown = true;
-    e.preventDefault();
+    if (this.hasModifiers(e)) return;
+    document.getSelection()?.removeAllRanges();
   }
 
   /**
@@ -183,6 +195,11 @@ export class SpeechExplorer
    */
   public Click(event: MouseEvent) {
     const clicked = (event.target as HTMLElement).closest(nav) as HTMLElement;
+    if (this.hasModifiers(event) || document.getSelection().type === 'Range') {
+      this.FocusOut(null);
+      return;
+    }
+    if (this.node.getAttribute('tabIndex') === '-1') return;
     if (!this.node.contains(clicked)) {
       // In case the mjx-container is in a div, we get the click, although it is outside.
       this.mousedown = false;
@@ -218,7 +235,8 @@ export class SpeechExplorer
    * @override
    */
   public FocusOut(_event: FocusEvent) {
-    // This guard is to FF and Safari, where focus in fires only once on
+    (document.activeElement as HTMLElement)?.blur();
+    // This guard is to FF and Safari, where focus in fired only once on
     // keyboard.
     if (!this.active) return;
     this.generators.CleanUp(this.current);
@@ -268,6 +286,9 @@ export class SpeechExplorer
    * @returns {HTMLElement} The next element.
    */
   protected nextSibling(el: HTMLElement): HTMLElement {
+    if (!this.current.getAttribute('data-semantic-parent')) {
+      return null;
+    }
     const sib = el.nextElementSibling as HTMLElement;
     if (sib) {
       if (sib.matches(nav)) {
@@ -289,6 +310,9 @@ export class SpeechExplorer
    * @returns {HTMLElement} The next element.
    */
   protected prevSibling(el: HTMLElement): HTMLElement {
+    if (!this.current.getAttribute('data-semantic-parent')) {
+      return null;
+    }
     const sib = el.previousElementSibling as HTMLElement;
     if (sib) {
       if (sib.matches(nav)) {

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -349,7 +349,7 @@ export class LiveRegion extends StringRegion {
     ['.' + LiveRegion.className]: {
       position: 'absolute',
       top: 0,
-      display: 'block',
+      display: 'none',
       width: 'auto',
       height: 'auto',
       padding: 0,
@@ -361,6 +361,9 @@ export class LiveRegion extends StringRegion {
       'background-color': 'white',
       'box-shadow': '0px 5px 20px #888',
       border: '2px solid #CCCCCC',
+    },
+    ['.' + LiveRegion.className + '_Show']: {
+      display: 'block'
     },
   });
 }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1639,6 +1639,7 @@ export class Menu {
       true
     );
     this.menu.store.insert(element);
+    element.tabIndex = this.settings.inTabOrder ? 0 : -1;
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bunch of small issues with the explorer interface.

* It turns off the subtitles and Braille subtitles by default.  Currently, since the assistive tools are on by default, anyone clicking on an expression will get these showing up, and that will be a cause of confusion and questions about how to turn it off.  Since they are mostly for debugging and demonstration purposes, we can turn them on if we want them.

* There were a number of issues centered around the `tabIndex` handling.  For one, if the user turns off the "in tab order" option, reloading the page would cause the expression to get `tabIndex="0"` even though the menu item was still unchecked.  This is due to the fact that the mj-context-menu code doesn't know about the menu setting controlling this, so always sets the `tabIndex` to 0, and is resolved in the menu code when elements are added to the menu store.

* Currently, even when `tabIndex` is set to `-1`, you can still click on the equation to focus it.  Is that how it is supposed to be?  I'm thinking that the "in tab order" menu item would be an easy way to disable the explorer without losing the enrichment and even still allowing the speech to be attached.  So The click handler exits if `tabIndex` is `-1`.  If you don't like that, new line 202 can be removed.

* When subtitles or Braille subtitles are turned off, the changes I made to the handling of the regions for these allow them to remain visible anyway.  So I've added back some of the CSS that was removed in order to get the display of these regions to be handled properly.

* The problem we discussed in our meeting a few weeks ago concerning arrow keys moving from one expression to the next is resolved here in the `nextSibling()` and `prevSibling()` methods.  If the current expression is the top-level `math` element, then these currently move you to the next or previous expression (and don't properly remove highlighting).  The fist here is to check that the current node has a `data-semantic-parent` before looking for a sibling.

* In `FocusOut()` we blur the current item, which avoids some unexpected focusing in some circumstances (such as when the window is no longer focused and then gets focus again).

* The remaining changes have to do with better handling of clicks so that you can drag-select portions of the output for example, or shift-click to extend a selection, etc.  Here, the mouse-down handler clears any selection unless one of the modifier keys (shift, alt, meta, control) is pressed, which might be used to extend selections, etc.  Then in the click handler, if there is now a selection, that must have come from dragging the mouse to cause that selection, so we don't do the usual click action in that case.  We also skip it if any modifier key is down (e.g., if we are extending the selection).
