### PR TITLE
Remove superfluous slashes in reg exps

### DIFF
--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -151,7 +151,7 @@ function getProsody(element: Element, prosody: ProsodyElement): ProsodyElement {
 /**
  * Extracts the prosody value from an attribute.
  */
-const prosodyRegexp = /([\+-]?)([0-9]+)%/;
+const prosodyRegexp = /([+-]?)([0-9]+)%/;
 
 /**
  * Extracts the prosody value from an attribute.

--- a/ts/adaptors/NodeMixin.ts
+++ b/ts/adaptors/NodeMixin.ts
@@ -55,6 +55,7 @@ export const NodeMixinOptions: OptionList = {
  * @template N  The HTMLElement node class
  * @template T  The Text node class
  * @template D  The Document class
+ * @template A  Extension of AdaptorConstructor
  */
 export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
   Base: A,

--- a/ts/adaptors/lite/Document.ts
+++ b/ts/adaptors/lite/Document.ts
@@ -48,6 +48,7 @@ export class LiteDocument {
 
   /**
    * The kind is always #document
+   *
    * @returns {string} The document string.
    */
   public get kind(): string {

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -196,7 +196,7 @@ export class LiteParser implements MinDOMParser<LiteDocument> {
     //
     // Get the child to be added to the node
     //
-    const kind = tag.match(/<(.*?)[\s\n>\/]/)[1].toLowerCase();
+    const kind = tag.match(/<(.*?)[\s\n>/]/)[1].toLowerCase();
     const child = adaptor.node(kind) as LiteElement;
     //
     // Split out the tag attributes as an array of space, name, value1, value3, value3,

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -127,7 +127,7 @@ export const PathFilters: { [name: string]: PathFilterFunction } = {
     if (!name.match(/^(?:[a-z]+:\/)?\/|[a-z]:\\|\[/i)) {
       data.name = '[mathjax]/' + name.replace(/^\.\//, '');
     }
-    if (data.addExtension && !name.match(/\.[^\/]+$/)) {
+    if (data.addExtension && !name.match(/\.[^/]+$/)) {
       data.name += '.js';
     }
     return true;
@@ -273,7 +273,7 @@ export namespace Loader {
       const script =
         document.currentScript || document.getElementById('MathJax-script');
       if (script) {
-        return (script as HTMLScriptElement).src.replace(/\/[^\/]*$/, '');
+        return (script as HTMLScriptElement).src.replace(/\/[^/]*$/, '');
       }
     }
     return mjxRoot();

--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -160,7 +160,7 @@ export class SerializedMmlVisitor extends MmlVisitor {
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
-      .replace(/\"/g, '&quot;')
+      .replace(/"/g, '&quot;')
       .replace(/[\uD800-\uDBFF]./g, toEntity)
       .replace(/[\u0080-\uD7FF\uE000-\uFFFF]/g, toEntity);
   }

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -23,7 +23,7 @@
 
 export default class TexError {
   private static pattern =
-    /%(\d+|\{\d+\}|\{[a-z]+:\%\d+(?:\|(?:%\{\d+\}|%.|[^\}])*)+\}|.)/g;
+    /%(\d+|\{\d+\}|\{[a-z]+:%\d+(?:\|(?:%\{\d+\}|%.|[^}])*)+\}|.)/g;
 
   /**
    * Default error message.

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1338,7 +1338,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     });
     if (v) {
       mml = parser.create('node', 'mpadded', [mml], { voffset: v });
-      if (v.match(/^\-/)) {
+      if (v.match(/^-/)) {
         NodeUtil.setAttribute(mml, 'height', v);
         NodeUtil.setAttribute(mml, 'depth', '+' + v.substring(1));
       } else {

--- a/ts/input/tex/bbox/BboxConfiguration.ts
+++ b/ts/input/tex/bbox/BboxConfiguration.ts
@@ -67,7 +67,7 @@ const BboxMethods: { [key: string]: ParseMethod } = {
             width: '+' + 2 * parseInt(match[1], 10) + match[3],
           };
         }
-      } else if (part.match(/^([a-z0-9]+|\#[0-9a-f]{6}|\#[0-9a-f]{3})$/i)) {
+      } else if (part.match(/^([a-z0-9]+|#[0-9a-f]{6}|#[0-9a-f]{3})$/i)) {
         // @test Bbox-Background
         if (background) {
           // @test Bbox-Background-Error

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -39,7 +39,7 @@ const nonCharacterRegexp =
  */
 function isLegalAttributeName(name: string): boolean {
   return !(
-    name.match(/[\x00-\x1f\x7f-\x9f "'>\/=]/) || name.match(nonCharacterRegexp)
+    name.match(/[\x00-\x1f\x7f-\x9f "'>/=]/) || name.match(nonCharacterRegexp)
   );
 }
 

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -348,9 +348,10 @@ export interface FontExtensionData<
 /**
  * Merge options into an object or array.
  *
- * @param obj
- * @param dst
- * @param src
+ * @param {OptionList} obj The target options list.
+ * @param {string} dst Name of the option to merge into.
+ * @param {OptionList} src The options to be merged.
+ * @returns The options for `dst`.
  */
 export function mergeOptions(obj: OptionList, dst: string, src: OptionList) {
   return src ? defaultOptions(obj, { [dst]: src })[dst] : obj[dst];
@@ -1213,7 +1214,7 @@ export class FontData<
     const prefix = !dynamic.extension
       ? this.options.dynamicPrefix
       : this.CLASS.dynamicExtensions.get(dynamic.extension).prefix;
-    return dynamic.file.match(/^(?:[\/\[]|[a-z]+:\/\/|[a-z]:)/i)
+    return dynamic.file.match(/^(?:[/[]|[a-z]+:\/\/|[a-z]:)/i)
       ? dynamic.file
       : prefix + '/' + dynamic.file.replace(/(?<!\.js)$/, '.js');
   }

--- a/ts/util/asyncLoad/system.ts
+++ b/ts/util/asyncLoad/system.ts
@@ -26,7 +26,7 @@ import { mathjax } from '../../mathjax.js';
 declare const System: { import: (name: string, url?: string) => any };
 declare const __dirname: string;
 
-let root = 'file://' + __dirname.replace(/\/[^\/]*\/[^\/]*$/, '/');
+let root = 'file://' + __dirname.replace(/\/[^/]*\/[^/]*$/, '/');
 
 if (!mathjax.asyncLoad && typeof System !== 'undefined' && System.import) {
   mathjax.asyncLoad = (name: string) => {

--- a/ts/util/string.ts
+++ b/ts/util/string.ts
@@ -45,7 +45,7 @@ export function sortLength(a: string, b: string): number {
  * @returns {string}  The quoted string
  */
 export function quotePattern(text: string): string {
-  return text.replace(/([\^$(){}.+*?\-|\[\]\:\\])/g, '\\$1');
+  return text.replace(/([\^$(){}.+*?\-|[\]:\\])/g, '\\$1');
 }
 
 /**


### PR DESCRIPTION
Remove superfluous slashes from all regular expressions. There is still one bizarre `escape character` error here:

```
ts/input/mathml/mml3/mml3.ts:691:13: Unnecessary escape character: \<. [Error/no-useless-escape]
```