### PR TITLE
Change default font to mathjax-newcm

### DIFF
--- a/components/bin/package.json
+++ b/components/bin/package.json
@@ -7,6 +7,6 @@
     "#menu/*": "mj-context-menu/cjs/*",
     "#sre/*": "speech-rule-engine/cjs/*",
     "#mhchem/*": "mhchemparser/dist/*",
-    "#default-font/*": "mathjax-modern-font/cjs/*"
+    "#default-font/*": "mathjax-newcm-font/cjs/*"
   }
 }

--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -34,11 +34,11 @@ const dir = global.MathJax.config.__dirname;   // set up by node-main.mjs or nod
  * Set up the initial configuration
  */
 combineDefaults(MathJax.config, 'loader', {
-  paths: {'mathjax-modern': 'mathjax-modern-font'},
+  paths: {'mathjax-newcm': 'mathjax-newcm-font'},
   require: eval("(file) => import(file)"),   // use dynamic imports
   failed: (err) => {throw err}               // pass on error message to init()'s catch function
 });
-combineDefaults(MathJax.config, 'output', {font: 'mathjax-modern'});
+combineDefaults(MathJax.config, 'output', {font: 'mathjax-newcm'});
 
 /*
  * Mark the preloaded components

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "#menu/*": "mj-context-menu/js/*",
     "#sre/*": "speech-rule-engine/js/*",
     "#mhchem/*": "mhchemparser/esm/*",
-    "#default-font/*": "mathjax-modern-font/mjs/*"
+    "#default-font/*": "mathjax-newcm-font/mjs/*"
   },
   "files": [
     "/bundle",
@@ -146,7 +146,7 @@
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.8.10",
-    "mathjax-modern-font": "^4.0.0-beta.7",
+    "mathjax-newcm-font": "^4.0.0-beta.7",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
     "speech-rule-engine": "^4.1.0-beta.11",

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -499,7 +499,7 @@ export class FontData<
   ];
 
   /**
-   * Characters to map back top other Unicode positions
+   * Characters to map back to other Unicode positions
    * (holes in the Math Alphanumeric ranges)
    */
   /* prettier-ignore */


### PR DESCRIPTION
This PR changes the default front from mathjax-modern to mathjax-newcm, which has more coverage and is slightly darker.  The lightness of mathjax-modern was one of the complaints with v4.

You need to do `pnpm install` to get the new font installed, and need the `lab-extension-update` branch in the `MathJax-dev` repository, and do `npm install` there as well, then relink `node_modules/mathjax-full` to your current `MathJax-src` repository.