### PR TITLE
Improve merging of math lists (mathjax/MathJax#3301).

### DIFF
--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -124,14 +124,16 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     nodes: HTMLNodeArray<N, T>
   ): Location<N, T> {
     const adaptor = this.adaptor;
-    for (const list of nodes[N]) {
-      const [node, n] = list;
+    const inc = 1 / (nodes[N].length || 1);
+    let i = N;
+    for (const [node, n] of nodes[N]) {
       if (index <= n && adaptor.kind(node) === '#text') {
-        return { node: node, n: Math.max(index, 0), delim: delim };
+        return { i, node, n: Math.max(index, 0), delim };
       }
       index -= n;
+      i += inc;
     }
-    return { node: null, n: 0, delim: delim };
+    return { node: null, n: 0, delim };
   }
 
   /**


### PR DESCRIPTION
This PR fixes a problem with the merging of MathLists when multiple input jax are used.  The index for the location (`start` and `end` objects of the `MathItem` object) were not being set, and so the sorting of math items was not being done properly.  This could lead to the indices within the text nodes containing the math being off when the DOM is updated, as the math is handled in the wrong order, and the text nodes are broken up, changing the character indices of the math that is out of order.

This PR includes indices that can be used to sort the lists properly, and resolves issue mathjax/MathJax#3301.