### PR TITLE
Add a template substitution count to avoid infinite loop (#1142)

### DIFF
--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -72,6 +72,8 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     digits: /^(?:[0-9]+(?:\{,\}[0-9]{3})*(?:\.[0-9]*)?|\.[0-9]+)/,
     // Maximum size of TeX string to process.
     maxBuffer: 5 * 1024,
+    // Maximum number of array template substitutions (avoids infinite loop from @{\\} for example)
+    maxTemplateSubtitutions: 10000,
     // math-style to use for Latin and Greek letters
     mathStyle: 'TeX', // one of TeX, ISO, French, or upright
     formatError: (jax: TeX<any, any, any>, err: TexError) =>

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -1214,7 +1214,10 @@ export class ArrayItem extends BaseItem {
         entry = '\\text{' + entry.trim() + '}';
       }
       if (start || end || ralign) {
-        if (++this.templateSubs > parser.configuration.options.maxTemplateSubtitutions) {
+        if (
+          ++this.templateSubs >
+          parser.configuration.options.maxTemplateSubtitutions
+        ) {
           throw new TexError(
             'MaxTemplateSubs',
             'Maximum template substitutions exceeded; ' +

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -1018,6 +1018,11 @@ export class ArrayItem extends BaseItem {
   };
 
   /**
+   * Substitution count for template substitutions (to avoid infinite loops)
+   */
+  public templateSubs: number = 0;
+
+  /**
    * The TeX parser that created this item
    */
   public parser: TexParser;
@@ -1207,6 +1212,15 @@ export class ArrayItem extends BaseItem {
       //
       if (ralign) {
         entry = '\\text{' + entry.trim() + '}';
+      }
+      if (start || end || ralign) {
+        if (++this.templateSubs > parser.configuration.options.maxTemplateSubtitutions) {
+          throw new TexError(
+            'MaxTemplateSubs',
+            'Maximum template substitutions exceeded; ' +
+              'is there an invalid use of \\\\ in the template?'
+          );
+        }
       }
     }
     //


### PR DESCRIPTION
This PR adds a counter to record array template substitutions and an option `maxTemplateSubtitutions` that is used to detect an infinite loop due to a template that includes something like `@{\\}`.  Because the count is incremented for any cell in a column that has a `@` or other similar substitution, the maximum count is set pretty high to accommodate large arrays, but can be configured to be larger in the document options if necessary.  I would have liked to have been able to detect this more directly, but I wasn't able to come up with another reliable method.

Resolves issue #1142.