### PR TITLE
Have \let look up macros first then delimiters, and removes \\ delimiter

### DIFF
--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -348,7 +348,6 @@ new sm.DelimiterMap('delimiter', ParseMethods.delimiter, {
   '/': '/',
   '|': ['|', { texClass: TEXCLASS.ORD }],
   '.': '',
-  '\\\\': '\\',
   '\\lmoustache': '\u23B0', // non-standard
   '\\rmoustache': '\u23B1', // non-standard
   '\\lgroup': '\u27EE', // non-standard

--- a/ts/input/tex/newcommand/NewcommandMethods.ts
+++ b/ts/input/tex/newcommand/NewcommandMethods.ts
@@ -131,19 +131,6 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
     if (c === '\\') {
       // @test Let Bar, Let Brace Equal Stretchy
       name = NewcommandUtil.GetCSname(parser, name);
-      let macro = handlers
-        .get(HandlerType.DELIMITER)
-        .lookup('\\' + name) as Token;
-      if (macro) {
-        // @test Let Bar, Let Brace Equal Stretchy
-        NewcommandUtil.addDelimiter(
-          parser,
-          '\\' + cs,
-          macro.char,
-          macro.attributes
-        );
-        return;
-      }
       const map = handlers.get(HandlerType.MACRO).applicable(name);
       if (!map) {
         // @test Let Undefined CS
@@ -158,6 +145,19 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
           macro.func,
           macro.args,
           macro.token
+        );
+        return;
+      }
+      let macro = handlers
+        .get(HandlerType.DELIMITER)
+        .lookup('\\' + name) as Token;
+      if (macro) {
+        // @test Let Bar, Let Brace Equal Stretchy
+        NewcommandUtil.addDelimiter(
+          parser,
+          '\\' + cs,
+          macro.char,
+          macro.attributes
         );
         return;
       }


### PR DESCRIPTION
This PR switches the order in which the `\let` command looks up macros and delimiters, so that something like `\let\xyz=\\` will make `\xyz` work as `\\` rather than produce a backslash (which is the delimiter tied to `\\`).  Also removes `\\` as a delimiter, as LaTeX doesn't actually allow that.
