### PR TITLE
Linting of "expected assignments" error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default tseslint.config({
                                             "caughtErrorsIgnorePattern": "^_" }
                                          ],
     "@typescript-eslint/no-empty-object-type": ["error", {"allowInterfaces": "with-single-extends"}],
+    "@typescript-eslint/no-unused-expressions": ["error", { "allowTernary": true }],
     "prefer-const": ["error", {"destructuring": "all"}],
     "jsdoc/tag-lines": ["warn", "always", {"count": 0, "startLines": 1}]
   }

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -4436,6 +4436,15 @@ describe('Environments', () => {
       </mstyle>
     </math>`
     ));
+  it('IndentAlign Single', () =>
+    toXmlMatch(
+      tex2mml('\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}'),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}\" display=\"block\">
+      <mstyle indentshiftfirst=\"10cm\" indentshift=\"20cm\" indentshiftlast=\"30cm\" indentalignfirst=\"center\" indentalign=\"center\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}\">
+        <mi data-latex=\"a\">a</mi>
+      </mstyle>
+    </math>`
+    ));
 });
 
 describe('Environment Errors', () => {
@@ -7890,6 +7899,15 @@ describe('Boxes', () => {
       </mpadded>
     </math>`
     ));
+  it('Vtop Hsize =', () =>
+    toXmlMatch(
+      tex2mml('\\hsize=2cm\\vtop{x}'),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hsize=2cm\\vtop{x}\" display=\"block\" maxwidth=\"2cm\" overflow=\"linebreak\">
+      <mpadded data-mjx-vbox=\"top\" data-mjx-texclass=\"ORD\" data-vertical-align=\"top\" width=\"2cm\" data-overflow=\"linebreak\" data-latex=\"\\hsize=2cm\\vtop{x}\">
+        <mi data-latex=\"x\">x</mi>
+      </mpadded>
+    </math>`
+    ));
   it('Vcenter', () =>
     toXmlMatch(
       tex2mml('\\vcenter{x}'),
@@ -8010,6 +8028,15 @@ describe('Boxes', () => {
       tex2mml('\\makebox[2cm][c]{x}'),
       `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\makebox[2cm][c]{x}\" display=\"block\">
       <mpadded width=\"2cm\" data-align=\"center\" data-latex=\"\\makebox[2cm][c]{x}\">
+        <mtext>x</mtext>
+      </mpadded>
+    </math>`
+    ));
+  it('Makebox Cap position', () =>
+    toXmlMatch(
+      tex2mml('\\makebox[2cm][C]{x}'),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\makebox[2cm][C]{x}\" display=\"block\">
+      <mpadded width=\"2cm\" data-align=\"center\" data-overflow=\"linebreak\" data-latex=\"\\makebox[2cm][C]{x}\">
         <mtext>x</mtext>
       </mpadded>
     </math>`
@@ -10206,6 +10233,22 @@ describe('User Defined Macros', () => {
       <mi data-latex=\"\\label{A}\">a</mi>
       <mrow href=\"#\" class=\"MathJax_ref\" data-latex=\"\\eqref{A}\">
         <mtext>(???)</mtext>
+      </mrow>
+    </math>`
+    ));
+  it('Right Color', () =>
+    toXmlMatch(
+      tex2mml('\\left(A\\middle|B\\color{red}\\right)'),
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left(A\\middle|B\\color{red}\\right)\" display=\"block\">
+      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left(A\\middle|B\\color{red}\\right)\" data-latex=\"\\left(A\\middle|B\\color{red}\\right)\">
+        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
+        <mi data-latex=\"A\">A</mi>
+        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
+        <mo data-latex-item=\"\\middle|\" data-latex=\"\\middle|\">|</mo>
+        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle|\"></mrow>
+        <mi data-latex=\"B\">B</mi>
+        <mstyle mathcolor=\"red\"></mstyle>
+        <mo data-mjx-texclass=\"CLOSE\" mathcolor=\"red\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
       </mrow>
     </math>`
     ));

--- a/ts/adaptors/chooseAdaptor.ts
+++ b/ts/adaptors/chooseAdaptor.ts
@@ -27,7 +27,8 @@ import { browserAdaptor } from './browserAdaptor.js';
 let choose;
 
 try {
-  document; // errors if not in browser
+  // errors if not in browser
+  document; // eslint-disable-line @typescript-eslint/no-unused-expressions
   choose = browserAdaptor;
 } catch (_e) {
   choose = liteAdaptor;

--- a/ts/components/latest.ts
+++ b/ts/components/latest.ts
@@ -379,7 +379,9 @@ function requestXML(
     request.onreadystatechange = function () {
       if (request.readyState === 4) {
         if (request.status === 200) {
-          !action(JSON.parse(request.responseText)) && failure();
+          if (!action(JSON.parse(request.responseText))) {
+            failure();
+          }
         } else {
           Error(
             'Problem acquiring MathJax version: status = ' + request.status

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -149,19 +149,27 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
     let convert = true;
     const priority = action[0];
     if (action.length === 1 || typeof action[1] === 'boolean') {
-      action.length === 2 && (convert = action[1] as boolean);
+      if (action.length === 2) {
+        convert = action[1] as boolean;
+      }
       [renderDoc, renderMath] = this.methodActions(id);
     } else if (typeof action[1] === 'string') {
       if (typeof action[2] === 'string') {
-        action.length === 4 && (convert = action[3] as boolean);
+        if (action.length === 4) {
+          convert = action[3] as boolean;
+        }
         const [method1, method2] = action.slice(1) as [string, string];
         [renderDoc, renderMath] = this.methodActions(method1, method2);
       } else {
-        action.length === 3 && (convert = action[2] as boolean);
+        if (action.length === 3) {
+          convert = action[2] as boolean;
+        }
         [renderDoc, renderMath] = this.methodActions(action[1] as string);
       }
     } else {
-      action.length === 4 && (convert = action[3] as boolean);
+      if (action.length === 4) {
+        convert = action[3] as boolean;
+      }
       [renderDoc, renderMath] = action.slice(1) as [
         RenderDoc<N, T, D>,
         RenderMath<N, T, D>,
@@ -189,11 +197,15 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
   ): [(document: any) => boolean, (math: any, document: any) => boolean] {
     return [
       (document: any) => {
-        method1 && document[method1]();
+        if (method1) {
+          document[method1]();
+        }
         return false;
       },
       (math: any, document: any) => {
-        method2 && math[method2](document);
+        if (method2) {
+          math[method2](document);
+        }
         return false;
       },
     ];
@@ -1020,11 +1032,18 @@ export abstract class AbstractMathDocument<N, T, D>
    */
   public reset(options: ResetList = { processed: true }) {
     options = userOptions(Object.assign({}, resetOptions), options);
-    options.all && Object.assign(options, resetAllOptions);
-    options.processed && this.processed.reset();
-    options.inputJax &&
+    if (options.all) {
+      Object.assign(options, resetAllOptions);
+    }
+    if (options.processed) {
+      this.processed.reset();
+    }
+    if (options.inputJax) {
       this.inputJax.forEach((jax) => jax.reset(...options.inputJax));
-    options.outputJax && this.outputJax.reset(...options.outputJax);
+    }
+    if (options.outputJax) {
+      this.outputJax.reset(...options.outputJax);
+    }
     return this;
   }
 

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -763,8 +763,9 @@ export abstract class AbstractMmlNode
         Object.hasOwn(AbstractMmlNode.alwaysInherit, key)
       ) {
         const [node, value] = attributes[key];
-        !AbstractMmlNode.noInherit[node]?.[this.kind]?.[key] &&
+        if (!AbstractMmlNode.noInherit[node]?.[this.kind]?.[key]) {
           this.attributes.setInherited(key, value);
+        }
       }
       if (AbstractMmlNode.stopInherit[this.kind]?.[key]) {
         attributes = { ...attributes };
@@ -1482,7 +1483,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
    * @returns {XMLNode}  The XML node (for chaining of method calls)
    */
   public setXML(
-    xml: Object, // eslint-disable-line
+    xml: Object, // eslint-disable-line @typescript-eslint/no-wrapper-object-types
     adaptor: DOMAdaptor<any, any, any> = null
   ): XMLNode {
     this.xml = xml;

--- a/ts/core/MmlTree/MmlNodes/mtable.ts
+++ b/ts/core/MmlTree/MmlNodes/mtable.ts
@@ -188,7 +188,10 @@ export class MmlMtable extends AbstractMmlNode {
         if (!options['fixMtables']) {
           child.parent.removeChild(child); // remove the child from its mtd or mtr
           child.parent = this; // ... and make it think it is a child of the table again
-          isMtd && mtr.appendChild(factory.create('mtd')); // child will be replaced, so make sure there is an mtd
+          if (isMtd) {
+            // child will be replaced, so make sure there is an mtd
+            mtr.appendChild(factory.create('mtd'));
+          }
           const merror = child.mError(
             'Children of ' + this.kind + ' must be mtr or mlabeledtr',
             options,

--- a/ts/core/MmlTree/MmlVisitor.ts
+++ b/ts/core/MmlTree/MmlVisitor.ts
@@ -164,20 +164,29 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
     const data = {} as PropertyList;
     const variant = node.attributes.getExplicit('mathvariant') as string;
     const variants = (this.constructor as typeof MmlVisitor).variants;
-    variant &&
-      (node.getProperty('ignore-variant') ||
-        Object.hasOwn(variants, variant)) &&
+    if (
+      variant &&
+      (node.getProperty('ignore-variant') || Object.hasOwn(variants, variant))
+    ) {
       this.setDataAttribute(data, 'variant', variant);
-    node.getProperty('variantForm') &&
+    }
+    if (node.getProperty('variantForm')) {
       this.setDataAttribute(data, 'alternate', '1');
-    node.getProperty('pseudoscript') &&
+    }
+    if (node.getProperty('pseudoscript')) {
       this.setDataAttribute(data, 'pseudoscript', 'true');
-    node.getProperty('autoOP') === false &&
+    }
+    if (node.getProperty('autoOP') === false) {
       this.setDataAttribute(data, 'auto-op', 'false');
+    }
     const vbox = node.getProperty('vbox') as string;
-    vbox && this.setDataAttribute(data, 'vbox', vbox);
+    if (vbox) {
+      this.setDataAttribute(data, 'vbox', vbox);
+    }
     const scriptalign = node.getProperty('scriptalign') as string;
-    scriptalign && this.setDataAttribute(data, 'script-align', scriptalign);
+    if (scriptalign) {
+      this.setDataAttribute(data, 'script-align', scriptalign);
+    }
     const accent = node.getProperty('mathaccent') as boolean;
     if (accent !== undefined) {
       if (
@@ -194,16 +203,20 @@ export class MmlVisitor extends AbstractVisitor<MmlNode> {
         const name = (node as MmlMi).getText();
         setclass = !(name.length > 1 && name.match(MmlMi.operatorName));
       }
-      setclass &&
+      if (setclass) {
         this.setDataAttribute(
           data,
           'texclass',
           texclass < 0 ? 'NONE' : TEXCLASSNAMES[texclass]
         );
+      }
     }
-    node.getProperty('scriptlevel') &&
-      node.getProperty('useHeight') === false &&
+    if (
+      node.getProperty('scriptlevel') &&
+      node.getProperty('useHeight') === false
+    ) {
       this.setDataAttribute(data, 'smallmatrix', 'true');
+    }
     return data;
   }
 

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -304,7 +304,9 @@ export class MathMLCompile<N, T, D> {
         }
       }
     }
-    mml.isToken && this.trimSpace(mml);
+    if (mml.isToken) {
+      this.trimSpace(mml);
+    }
   }
 
   /**
@@ -406,9 +408,13 @@ export class MathMLCompile<N, T, D> {
   protected trimSpace(mml: MmlNode) {
     let child = mml.childNodes[0] as TextNode;
     if (!child) return;
-    child.isKind('text') && child.setText(child.getText().replace(/^ +/, ''));
+    if (child.isKind('text')) {
+      child.setText(child.getText().replace(/^ +/, ''));
+    }
     child = mml.childNodes[mml.childNodes.length - 1] as TextNode;
-    child.isKind('text') && child.setText(child.getText().replace(/ +$/, ''));
+    if (child.isKind('text')) {
+      child.setText(child.getText().replace(/ +$/, ''));
+    }
   }
   /**
    * @param {string} message  The error message to produce

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -352,7 +352,9 @@ export class ColumnParser {
    * @param {string} rule         The type of rule to add (solid or dashed)
    */
   public addRule(state: ColumnState, rule: string) {
-    state.clines[state.j] && this.addAt(state, '\\,');
+    if (state.clines[state.j]) {
+      this.addAt(state, '\\,');
+    }
     state.clines[state.j] = rule;
     if (state.cspace[state.j] === '0') {
       state.cstart[state.j] = '\\hspace{.5em}';

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -393,11 +393,12 @@ export class ParserConfiguration {
   public addPackage(pkg: string | [string, number]) {
     const name = typeof pkg === 'string' ? pkg : pkg[0];
     const conf = this.getPackage(name);
-    conf &&
+    if (conf) {
       this.configurations.add(
         conf,
         typeof pkg === 'string' ? conf.priority : pkg[1]
       );
+    }
   }
 
   /**

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -307,7 +307,9 @@ export const ParseUtil = {
         closeNode
       );
     }
-    color && mo.attributes.set('mathcolor', color);
+    if (color) {
+      mo.attributes.set('mathcolor', color);
+    }
     NodeUtil.appendChildren(mrow, [mo]);
     return mrow;
   },
@@ -823,7 +825,9 @@ export const ParseUtil = {
       options.addNode(n.kind, n);
       const lists = ((n.getProperty('in-lists') as string) || '').split(/,/);
       for (const list of lists) {
-        list && options.addNode(list, n);
+        if (list) {
+          options.addNode(list, n);
+        }
       }
     });
     return tree;

--- a/ts/input/tex/ams/AmsMethods.ts
+++ b/ts/input/tex/ams/AmsMethods.ts
@@ -488,11 +488,15 @@ export const AmsMethods: { [key: string]: ParseMethod } = {
       movablelimits: true,
     });
     if (preRest) {
-      preScripts && mrow.appendChild(preScripts);
+      if (preScripts) {
+        mrow.appendChild(preScripts);
+      }
       mrow.appendChild(preRest);
     }
     mrow.appendChild(mml);
-    postRest && mrow.appendChild(postRest);
+    if (postRest) {
+      mrow.appendChild(postRest);
+    }
     parser.Push(mrow);
   },
 

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -463,7 +463,9 @@ export class Middle extends BaseItem {
   constructor(factory: StackItemFactory, delim: string, color: string) {
     super(factory);
     this.setProperty('delim', delim);
-    color && this.setProperty('color', color);
+    if (color) {
+      this.setProperty('color', color);
+    }
   }
 
   /**
@@ -492,7 +494,9 @@ export class RightItem extends BaseItem {
   constructor(factory: StackItemFactory, delim: string, color: string) {
     super(factory);
     this.setProperty('delim', delim);
-    color && this.setProperty('color', color);
+    if (color) {
+      this.setProperty('color', color);
+    }
   }
 
   /**
@@ -1250,7 +1254,9 @@ export class ArrayItem extends BaseItem {
           braces--;
           break;
         case '\\begin{array}':
-          !braces && envs++;
+          if (!braces) {
+            envs++;
+          }
           break;
         case '\\end{array}':
           if (!braces && envs) {

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -366,7 +366,8 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     do {
       // @test Prime, PrimeSup, Double Prime, PrePrime
       sup += entities.prime;
-      parser.i++, (c = parser.GetNext());
+      parser.i++;
+      c = parser.GetNext();
     } while (c === "'" || c === entities.rsquo);
     sup = ['', '\u2032', '\u2033', '\u2034', '\u2057'][sup.length] || sup;
     const node = parser.create('token', 'mo', { variantForm: true }, sup);
@@ -979,7 +980,9 @@ const BaseMethods: { [key: string]: ParseMethod } = {
    * @param {string} name The macro name.
    */
   Hsize(parser: TexParser, name: string) {
-    parser.GetNext() === '=' && parser.i++;
+    if (parser.GetNext() === '=') {
+      parser.i++;
+    }
     parser.stack.env.hsize = parser.GetDimen(name);
     parser.Push(parser.itemFactory.create('null'));
   },
@@ -1286,7 +1289,9 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     const node = parser.create('node', 'mspace', [], {
       width: parser.GetDimen(name),
     });
-    nobreak && NodeUtil.setAttribute(node, 'linebreak', 'nobreak');
+    if (nobreak) {
+      NodeUtil.setAttribute(node, 'linebreak', 'nobreak');
+    }
     parser.Push(node);
   },
 
@@ -1476,8 +1481,9 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     if (align) {
       NodeUtil.setAttribute(mml, 'data-align', align);
     }
-    pos.toLowerCase() !== pos &&
+    if (pos.toLowerCase() !== pos) {
       NodeUtil.setAttribute(mml, 'data-overflow', 'linebreak');
+    }
     parser.Push(mml);
   },
 
@@ -1931,8 +1937,9 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       align = parser.GetArgument('\\begin{' + begin.getName() + '}');
     }
     const array = parser.itemFactory.create('array') as sitem.ArrayItem;
-    begin.getName() === 'array' &&
+    if (begin.getName() === 'array') {
       array.setProperty('arrayPadding', '.5em .125em');
+    }
     array.parser = parser;
     array.arraydef = {
       columnspacing: spacing || '1em',
@@ -2037,7 +2044,9 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     const align = [...lcr].map(
       (c) => ({ l: 'left', c: 'center', r: 'right' })[c]
     );
-    align.length === 1 && align.push(align[0]);
+    if (align.length === 1) {
+      align.push(align[0]);
+    }
     //
     // Set the properties for the mstyle
     //

--- a/ts/input/tex/mathtools/MathtoolsMethods.ts
+++ b/ts/input/tex/mathtools/MathtoolsMethods.ts
@@ -516,11 +516,15 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
     const star = parser.GetStar();
     if (top.EndEntry) {
       MathtoolsMethods.FlushSpaceAbove(parser, '\\MTFlushSpaceAbove');
-      !star && top.EndEntry();
+      if (!star) {
+        top.EndEntry();
+      }
     }
     MathtoolsMethods.VDotsWithin(parser, '\\vdotswithin');
     if (top.EndEntry) {
-      star && top.EndEntry();
+      if (star) {
+        top.EndEntry();
+      }
       MathtoolsMethods.FlushSpaceBelow(parser, '\\MTFlushSpaceBelow');
     }
   },
@@ -550,7 +554,9 @@ export const MathtoolsMethods: { [key: string]: ParseMethod } = {
   FlushSpaceBelow(parser: TexParser, name: string) {
     const top = MathtoolsUtil.checkAlignment(parser, name);
     if (top.table) {
-      top.Size() && top.EndEntry();
+      if (top.Size()) {
+        top.EndEntry();
+      }
       top.EndRow();
       top.addRowSpacing(
         '-' + parser.options.mathtools['shortvdotsadjustbelow']

--- a/ts/input/tex/mathtools/MathtoolsUtil.ts
+++ b/ts/input/tex/mathtools/MathtoolsUtil.ts
@@ -145,7 +145,9 @@ export const MathtoolsUtil = {
       return parser.create('node', 'none');
     }
     const format = parser.options.mathtools[`prescript-${pos}-format`];
-    format && (arg = `${format}{${arg}}`);
+    if (format) {
+      arg = `${format}{${arg}}`;
+    }
     return new TexParser(arg, parser.stack.env, parser.configuration).mml();
   },
 };

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -238,7 +238,9 @@ export class CHTML<N, T, D> extends CommonOutputJax<
       const wrapper = this.factory.getNodeClass(
         kind
       ) as any as typeof _CommonWrapper;
-      wrapper && this.addClassStyles(wrapper, styles);
+      if (wrapper) {
+        this.addClassStyles(wrapper, styles);
+      }
     }
   }
 

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -203,8 +203,9 @@ export class ChtmlFontData extends FontData<
     prefix: string = ''
   ) {
     super.addExtension(data, prefix);
-    data.fonts &&
+    if (data.fonts) {
       this.addDynamicFontCss(this.defaultStyles, data.fonts, data.fontURL);
+    }
   }
 
   /**
@@ -307,7 +308,9 @@ export class ChtmlFontData extends FontData<
   public updateDynamicStyles(): StyleList {
     const styles = this.fontUsage;
     this.fontUsage = {};
-    !this.options.adaptiveCSS && this.updateStyles(styles);
+    if (!this.options.adaptiveCSS) {
+      this.updateStyles(styles);
+    }
     return styles;
   }
 

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -172,7 +172,9 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
       if (style !== STYLE) {
         this.toCHTML([parent]);
         dom.push(this.dom[0]);
-        STYLE === 'after' && adaptor.removeAttribute(this.dom[0], 'space');
+        if (STYLE === 'after') {
+          adaptor.removeAttribute(this.dom[0], 'space');
+        }
       } else {
         dom.push(this.createChtmlNodes([parent])[0]);
       }

--- a/ts/output/chtml/Wrappers/menclose.ts
+++ b/ts/output/chtml/Wrappers/menclose.ts
@@ -657,7 +657,9 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       //
       for (const name of Object.keys(this.notations)) {
         const notation = this.notations[name];
-        !notation.renderChild && notation.renderer(this, block);
+        if (!notation.renderChild) {
+          notation.renderer(this, block);
+        }
       }
       //
       //  Add the needed padding, if any
@@ -665,8 +667,9 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       const pbox = this.getPadding();
       for (const name of Notation.sideNames) {
         const i = Notation.sideIndex[name];
-        pbox[i] > 0 &&
+        if (pbox[i] > 0) {
           adaptor.setStyle(block, 'padding-' + name, this.em(pbox[i]));
+        }
       }
     }
 

--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -199,8 +199,9 @@ export const ChtmlMmultiscripts = (function <
           this.firstPrescript,
           data.numPrescripts
         );
-        preAlign !== 'right' &&
+        if (preAlign !== 'right') {
           this.adaptor.setAttribute(scripts, 'script-align', preAlign);
+        }
       }
       this.childNodes[0].toCHTML(chtml);
       if (data.numScripts) {
@@ -214,8 +215,9 @@ export const ChtmlMmultiscripts = (function <
           1,
           data.numScripts
         );
-        postAlign !== 'left' &&
+        if (postAlign !== 'left') {
           this.adaptor.setAttribute(scripts, 'script-align', postAlign);
+        }
       }
     }
 

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -189,10 +189,11 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       if (stretchy && this.size === null) {
         this.getStretchedVariant([]);
       }
-      parents.length > 1 &&
+      if (parents.length > 1) {
         parents.forEach((dom) =>
           adaptor.append(dom, this.html('mjx-linestrut'))
         );
+      }
       const chtml = this.standardChtmlNodes(parents);
       if (chtml.length > 1 && this.breakStyle !== 'duplicate') {
         const i = this.breakStyle === 'after' ? 1 : 0;
@@ -220,9 +221,12 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
             );
           });
         }
-        chtml[0] && this.addChildren([chtml[0]]);
-        chtml[1] &&
+        if (chtml[0]) {
+          this.addChildren([chtml[0]]);
+        }
+        if (chtml[1]) {
           ((this.multChar || this) as ChtmlMo).addChildren([chtml[1]]);
+        }
       }
     }
 
@@ -271,9 +275,12 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       const properties = { class: this.char(delim.c || c), style: styles };
       const html = this.html('mjx-stretchy-' + delim.dir, properties, content);
       const adaptor = this.adaptor;
-      chtml[0] && adaptor.append(chtml[0], html);
-      chtml[1] &&
+      if (chtml[0]) {
+        adaptor.append(chtml[0], html);
+      }
+      if (chtml[1]) {
         adaptor.append(chtml[1], chtml[0] ? adaptor.clone(html) : html);
+      }
     }
 
     /**

--- a/ts/output/chtml/Wrappers/mspace.ts
+++ b/ts/output/chtml/Wrappers/mspace.ts
@@ -129,10 +129,11 @@ export const ChtmlMspace = (function <N, T, D>(): ChtmlMspaceClass<N, T, D> {
      * @override
      */
     public toCHTML(parents: N[]) {
-      parents.length > 1 &&
+      if (parents.length > 1) {
         parents.forEach((dom) =>
           this.adaptor.append(dom, this.html('mjx-linestrut'))
         );
+      }
       const chtml = this.standardChtmlNodes(parents);
       let { w, h, d } = this.getBBox();
       if (w < 0) {

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -719,11 +719,12 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       for (let i = 0; i < this.numRows; i++) {
         const row = this.childNodes[i];
         if (row.node.isKind('mlabeledtr')) {
-          h &&
+          if (h) {
             adaptor.insert(
               this.html('mjx-mtr', { style: { height: this.em(h) } }),
               current
             );
+          }
           adaptor.setStyle(
             current,
             'height',

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -401,7 +401,9 @@ export abstract class CommonOutputJax<
     const overflow = math.root.attributes.get('overflow') as string;
     this.adaptor.setAttribute(node, 'overflow', overflow);
     const linebreak = overflow === 'linebreak';
-    linebreak && this.getLinebreakWidth();
+    if (linebreak) {
+      this.getLinebreakWidth();
+    }
     if (
       this.options.linebreaks.inline &&
       !math.display &&

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -802,14 +802,17 @@ export class FontData<
         font.defineChars(name, variants[name])
       );
       font.defineDelimiters(delimiters);
-      extension &&
+      if (extension) {
         this.adjustDelimiters(
           font.delimiters,
           Object.keys(delimiters),
           data.sizeN,
           data.stretchN
         );
-      fonts && font.addDynamicFontCss(fonts);
+      }
+      if (fonts) {
+        font.addDynamicFontCss(fonts);
+      }
     };
   }
 

--- a/ts/output/common/LinebreakVisitor.ts
+++ b/ts/output/common/LinebreakVisitor.ts
@@ -294,7 +294,9 @@ export class LinebreakVisitor<
     const n = wrapper.breakCount;
     for (let i = 0; i <= n; i++) {
       const line = wrapper.lineBBox[i] || wrapper.getLineBBox(i);
-      line.w > W && this.breakLineToWidth(wrapper, i);
+      if (line.w > W) {
+        this.breakLineToWidth(wrapper, i);
+      }
     }
     for (const [ww, ij] of this.state.breaks) {
       if (ij === null) {
@@ -476,9 +478,13 @@ export class LinebreakVisitor<
       this.addWidth(bbox);
     } else {
       const [L, R] = this.getBorderLR(wrapper);
-      i === 0 && this.addWidth(bbox, bbox.L + L);
+      if (i === 0) {
+        this.addWidth(bbox, bbox.L + L);
+      }
       this.visitNode(wrapper.childNodes[0], i);
-      i === wrapper.breakCount && this.addWidth(bbox, bbox.R + R);
+      if (i === wrapper.breakCount) {
+        this.addWidth(bbox, bbox.R + R);
+      }
     }
   }
 
@@ -896,9 +902,13 @@ export class LinebreakVisitor<
     >;
     const bbox = wrapper.getLineBBox(i);
     const [L, R] = this.getBorderLR(wrapper);
-    i === 0 && this.addWidth(bbox, bbox.L + L);
+    if (i === 0) {
+      this.addWidth(bbox, bbox.L + L);
+    }
     this.visitNode(mfenced.mrow as any as WW, i);
-    i === wrapper.breakCount && this.addWidth(bbox, bbox.R + R);
+    if (i === wrapper.breakCount) {
+      this.addWidth(bbox, bbox.R + R);
+    }
   }
 
   /******************************************************************************/
@@ -914,9 +924,13 @@ export class LinebreakVisitor<
     >;
     const bbox = wrapper.getLineBBox(i);
     const [L, R] = this.getBorderLR(wrapper);
-    i === 0 && this.addWidth(bbox, bbox.L + L);
+    if (i === 0) {
+      this.addWidth(bbox, bbox.L + L);
+    }
     this.visitNode(maction.selected, i);
-    i === wrapper.breakCount && this.addWidth(bbox, bbox.R + R);
+    if (i === wrapper.breakCount) {
+      this.addWidth(bbox, bbox.R + R);
+    }
   }
 }
 

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1013,7 +1013,9 @@ export class CommonWrapper<
     const isTop = this.isTopEmbellished();
     const hasSpacing = this.node.hasSpacingAttributes();
     if (this.jax.options.mathmlSpacing || hasSpacing) {
-      isTop && this.getMathMLSpacing();
+      if (isTop) {
+        this.getMathMLSpacing();
+      }
     } else {
       this.getTeXSpacing(isTop, hasSpacing);
     }

--- a/ts/output/common/Wrappers/math.ts
+++ b/ts/output/common/Wrappers/math.ts
@@ -163,7 +163,9 @@ export function CommonMathMixin<
         attributes.get('overflow') === 'linebreak'
       ) {
         const W = this.containerWidth;
-        bbox.w > W && this.childNodes[0].breakToWidth(W);
+        if (bbox.w > W) {
+          this.childNodes[0].breakToWidth(W);
+        }
         bbox.updateFrom(this.childNodes[0].getBBox());
       }
     }

--- a/ts/output/common/Wrappers/menclose.ts
+++ b/ts/output/common/Wrappers/menclose.ts
@@ -395,7 +395,9 @@ export function CommonMencloseMixin<
     public initializeNotations() {
       for (const name of Object.keys(this.notations)) {
         const init = this.notations[name].init;
-        init && init(this as any);
+        if (init) {
+          init(this as any);
+        }
       }
     }
 

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -541,7 +541,9 @@ export function CommonMoMixin<
         //
         const i = this.parent.node.childIndex(this.node);
         const next = this.parent.node.childNodes[i + 1];
-        next && next.setTeXclass(this.multChar.node);
+        if (next) {
+          next.setTeXclass(this.multChar.node);
+        }
       }
     }
 

--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -277,7 +277,9 @@ export function CommonMrowMixin<
       for (const i of this.childNodes.keys()) {
         const child = this.childNodes[i];
         bbox.append(child.getOuterBBox());
-        breaks && this.computeChildLineBBox(child, i);
+        if (breaks) {
+          this.computeChildLineBBox(child, i);
+        }
       }
       bbox.clean();
       if (breaks && !this.coreMO().node.isEmbellished) {
@@ -303,8 +305,12 @@ export function CommonMrowMixin<
         for (const k of lines.keys()) {
           const line = lines[k];
           this.addMiddleBorders(line);
-          k === 0 && this.addLeftBorders(line);
-          k === n && this.addRightBorders(line);
+          if (k === 0) {
+            this.addLeftBorders(line);
+          }
+          if (k === n) {
+            this.addRightBorders(line);
+          }
         }
       }
       let y = 0;

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -674,7 +674,9 @@ export function CommonMtableMixin<
             ? (this.cWidths[i] as number)
             : null;
         this.stretchColumn(i, width);
-        width !== null && this.breakColumn(i, width, swidths[i]);
+        if (width !== null) {
+          this.breakColumn(i, width, swidths[i]);
+        }
       }
     }
 
@@ -986,7 +988,9 @@ export function CommonMtableMixin<
         this.containerWidth / 10,
         this.containerWidth - pad - (align === 'center' ? pad : 0)
       );
-      this.naturalWidth() > W && this.adjustColumnWidths(W);
+      if (this.naturalWidth() > W) {
+        this.adjustColumnWidths(W);
+      }
     }
 
     /**

--- a/ts/output/common/Wrappers/mtext.ts
+++ b/ts/output/common/Wrappers/mtext.ts
@@ -296,7 +296,9 @@ export function CommonMtextMixin<
           ['left', '0'],
           ['left', '0'],
         ]; // FIXME: do something better, here
-        i === this.breakCount && this.addRightBorders(bbox);
+        if (i === this.breakCount) {
+          this.addRightBorders(bbox);
+        }
       }
       return bbox;
     }

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -950,7 +950,9 @@ export function CommonScriptbaseMixin<
         );
       const bbox = this.baseChild.getLineBBox(i).copy();
       if (i < n) {
-        i === 0 && this.addLeftBorders(bbox);
+        if (i === 0) {
+          this.addLeftBorders(bbox);
+        }
         this.addMiddleBorders(bbox);
       } else {
         this.appendScripts(bbox);

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -266,8 +266,9 @@ export class SVG<N, T, D> extends CommonOutputJax<
     //
     const [svg, g] = this.createRoot(wrapper);
     this.typesetSvg(wrapper, svg, g);
-    wrapper.node.getProperty('process-breaks') &&
+    if (wrapper.node.getProperty('process-breaks')) {
       this.handleInlineBreaks(wrapper, svg, g);
+    }
     //
     //  Put back the original container
     //

--- a/ts/output/svg/Wrappers/menclose.ts
+++ b/ts/output/svg/Wrappers/menclose.ts
@@ -490,7 +490,9 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
       //
       for (const name of Object.keys(this.notations)) {
         const notation = this.notations[name];
-        !notation.renderChild && notation.renderer(this, svg[0]);
+        if (!notation.renderChild) {
+          notation.renderer(this, svg[0]);
+        }
       }
     }
   };

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -165,21 +165,27 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
           ? this.fixed(this.getAccentOffset())
           : '0';
         if (u !== '0' || v !== '0') {
-          svg[0] &&
+          if (svg[0]) {
             this.adaptor.setAttribute(
               svg[0],
               'transform',
               `translate(${v} ${u})`
             );
-          svg[1] &&
+          }
+          if (svg[1]) {
             this.adaptor.setAttribute(
               svg[1],
               'transform',
               `translate(${v} ${u})`
             );
+          }
         }
-        svg[0] && this.addChildren([svg[0]]);
-        svg[1] && ((this.multChar || this) as SvgMo).addChildren([svg[1]]);
+        if (svg[0]) {
+          this.addChildren([svg[0]]);
+        }
+        if (svg[1]) {
+          ((this.multChar || this) as SvgMo).addChildren([svg[1]]);
+        }
       }
     }
 

--- a/ts/output/svg/Wrappers/mtext.ts
+++ b/ts/output/svg/Wrappers/mtext.ts
@@ -171,7 +171,9 @@ export const SvgMtext = (function <N, T, D>(): SvgMtextClass<N, T, D> {
         while (++si < ei && si < childNodes.length) {
           const child = childNodes[si];
           child.toSVG(DOM);
-          child.dom && child.place(x, 0);
+          if (child.dom) {
+            child.place(x, 0);
+          }
           x += child.getBBox().w;
         }
         //

--- a/ts/output/svg/Wrappers/semantics.ts
+++ b/ts/output/svg/Wrappers/semantics.ts
@@ -338,7 +338,8 @@ export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
       styles.height = this.em((h + d) * scale);
       styles.width = this.em(w * scale);
       styles['vertical-align'] = this.em(-d * scale);
-      delete styles['font-size'], styles['font-family'];
+      delete styles['font-size'];
+      delete styles['font-family'];
       return html;
     }
   };

--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -418,7 +418,9 @@ export function LazyMathDocumentMixin<
       //  Allocate a process bit for lazyAlways
       //
       const ProcessBits = (this.constructor as typeof HTMLDocument).ProcessBits;
-      !ProcessBits.has('lazyAlways') && ProcessBits.allocate('lazyAlways');
+      if (!ProcessBits.has('lazyAlways')) {
+        ProcessBits.allocate('lazyAlways');
+      }
       //
       //  Set up the lazy observer and other needed data
       //
@@ -438,7 +440,9 @@ export function LazyMathDocumentMixin<
       if (window) {
         let done = false;
         const handler = () => {
-          !done && this.lazyTypesetAll();
+          if (!done) {
+            this.lazyTypesetAll();
+          }
           done = true;
         };
         window.matchMedia('print').addListener(handler); // for Safari
@@ -531,8 +535,9 @@ export function LazyMathDocumentMixin<
         // Mark it as not lazy and remove it from the observer.
         //
         math.lazyCompile = math.lazyTypeset = false;
-        math.lazyMarker &&
+        if (math.lazyMarker) {
           this.lazyObserver.unobserve(math.lazyMarker as any as Element);
+        }
       }
       //
       // If something needs updating
@@ -642,8 +647,9 @@ export function LazyMathDocumentMixin<
           math.state(STATE.TYPESET - 1);
         }
         math.lazyCompile = math.lazyTypeset = false;
-        math.lazyMarker &&
+        if (math.lazyMarker) {
           this.lazyObserver.unobserve(math.lazyMarker as any as Element);
+        }
       }
       return state;
     }
@@ -664,8 +670,9 @@ export function LazyMathDocumentMixin<
           break;
         }
         earlier.lazyCompile = false;
-        earlier.lazyMarker &&
+        if (earlier.lazyMarker) {
           this.lazyObserver.unobserve(earlier.lazyMarker as any as Element);
+        }
         earlier.state(STATE.COMPILED - 1);
         compile = true;
       }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1671,7 +1671,9 @@ export class Menu {
       getter: () => this.settings[name],
       setter: (value: T) => {
         (this.settings as any)[name] = value;
-        action && action(value);
+        if (action) {
+          action(value);
+        }
         this.saveUserSettings();
       },
     };
@@ -1697,7 +1699,9 @@ export class Menu {
       setter: (value: T) => {
         (this.settings as any)[name] = value;
         this.setA11y({ [name]: value });
-        action && action(value);
+        if (action) {
+          action(value);
+        }
         this.saveUserSettings();
       },
     };


### PR DESCRIPTION
PR rewrites all expressions that use an implicit condition of the form `P && f(a)` and rewrites them into explicit conditional of the for `if (P) { f(a); }`.
However, we do allow for standalone ternary expressions as in `C ? f(a) : f(b);` and add a rule to `esllint.conf.mjs` for that.

While this adds somewhat to the length of code it should make the conditions somewhat more readable. (As an old LISP hacker I never had an issue with conjunctive side effects...). But the real advantage is that those lines are now actually testable and produce useful coverage information, as previously the line would be considered as covered, even if the first condition never evaluated to `true`. As a consequence, some addition tests are added to `Base.test.ts`.