### PR TITLE
Rewrite general Function type to concrete types

### DIFF
--- a/ts/core/Tree/Factory.ts
+++ b/ts/core/Tree/Factory.ts
@@ -106,8 +106,8 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
 interface AbstractFactoryClass<
   N extends FactoryNode,
   C extends FactoryNodeClass<N>,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 > extends Function {
-  // eslint-disable-line
   defaultNodes: { [kind: string]: C };
 }
 

--- a/ts/core/Tree/Factory.ts
+++ b/ts/core/Tree/Factory.ts
@@ -107,6 +107,7 @@ interface AbstractFactoryClass<
   N extends FactoryNode,
   C extends FactoryNodeClass<N>,
 > extends Function {
+  // eslint-disable-line
   defaultNodes: { [kind: string]: C };
 }
 

--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -28,6 +28,8 @@ import NodeUtil from './NodeUtil.js';
 import { TexConstant } from './TexConstants.js';
 import { MmlNode } from '../../core/MmlTree/MmlNode.js';
 import { ParseUtil } from './ParseUtil.js';
+import { ParseMethod } from './Types.js';
+import { StackItem } from './StackItem.js';
 
 const MATHVARIANT = TexConstant.Variant;
 
@@ -207,14 +209,14 @@ namespace ParseMethods {
   export function environment(
     parser: TexParser,
     env: string,
-    func: Function,
+    func: ParseMethod,
     args: any[]
   ) {
     const end = args[0];
     let mml = parser.itemFactory
       .create('begin')
       .setProperties({ name: env, end: end });
-    mml = func(parser, mml, ...args.slice(1));
+    mml = func(parser, mml, ...args.slice(1)) as StackItem;
     parser.Push(mml);
   }
 }

--- a/ts/input/tex/empheq/EmpheqUtil.ts
+++ b/ts/input/tex/empheq/EmpheqUtil.ts
@@ -22,9 +22,11 @@
  */
 
 import { ParseUtil } from '../ParseUtil.js';
+import { StackItem } from '../StackItem.js';
 import TexParser from '../TexParser.js';
 import { EnvList } from '../StackItem.js';
 import { AbstractTags } from '../Tags.js';
+import { ParseMethod } from '../Types.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtable } from '../../../core/MmlTree/MmlNodes/mtable.js';
 import { MmlMtd } from '../../../core/MmlTree/MmlNodes/mtd.js';
@@ -36,15 +38,15 @@ export const EmpheqUtil = {
    *
    * @param {TexParser} parser   The active tex parser.
    * @param {string} env         The environment to create.
-   * @param {Function} func      A function to process the environment.
+   * @param {ParseMethod} func   A function to process the environment.
    * @param {any[]} args         The arguments for func.
    */
-  environment(parser: TexParser, env: string, func: Function, args: any[]) {
+  environment(parser: TexParser, env: string, func: ParseMethod, args: any[]) {
     const name = args[0];
     const item = parser.itemFactory
       .create(name + '-begin')
       .setProperties({ name: env, end: name });
-    parser.Push(func(parser, item, ...args.slice(1)));
+    parser.Push(func(parser, item, ...args.slice(1)) as MmlNode | StackItem);
   },
 
   /**

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -197,11 +197,11 @@ export class Menu {
   /**
    * Function used to resolve the _loadingPromise
    */
-  protected static _loadingOK: Function = null;
+  protected static _loadingOK: () => void = null;
   /**
    * Function used to reject the _loadingPromise
    */
-  protected static _loadingFailed: Function = null;
+  protected static _loadingFailed: (err: Error) => void = null;
 
   /**
    * The options for this menu

--- a/ts/util/FunctionList.ts
+++ b/ts/util/FunctionList.ts
@@ -23,19 +23,21 @@
 
 import { PrioritizedList, PrioritizedListItem } from './PrioritizedList.js';
 
+type AnyFunction = (...args: any[]) => any;
+
 /*****************************************************************/
 /**
  *  The FunctionListItem interface (extends PrioritizedListItem<Function>)
  */
 
-export interface FunctionListItem extends PrioritizedListItem<Function> {}
+export interface FunctionListItem extends PrioritizedListItem<AnyFunction> {}
 
 /*****************************************************************/
 /**
  *  Implements the FunctionList class (extends PrioritizedList<Function>)
  */
 
-export class FunctionList extends PrioritizedList<Function> {
+export class FunctionList extends PrioritizedList<AnyFunction> {
   /**
    * Executes the functions in the list (in prioritized order),
    *   passing the given data to the functions.  If any return

--- a/ts/util/FunctionList.ts
+++ b/ts/util/FunctionList.ts
@@ -23,7 +23,7 @@
 
 import { PrioritizedList, PrioritizedListItem } from './PrioritizedList.js';
 
-type AnyFunction = (...args: any[]) => any;
+type AnyFunction = (...args: unknown[]) => unknown;
 
 /*****************************************************************/
 /**

--- a/ts/util/Retries.ts
+++ b/ts/util/Retries.ts
@@ -26,7 +26,11 @@
  *  The legacy MathJax object  (FIXME: remove this after all v2 code is gone)
  */
 
-declare const MathJax: { Callback: { After: Function } };
+declare const MathJax: {
+  Callback: {
+    After: (cb1: () => void, cb2: () => void) => Promise<any>;
+  };
+};
 
 /*****************************************************************/
 /**


### PR DESCRIPTION
Rewrites all (but one) occurrences of the `Function` type to the correct types to resolve the [no-unsafe-function-type](https://typescript-eslint.io/rules/no-unsafe-function-type) error. Some of them are a catch all function types, of course.