### PR TITLE
Fix processing of latex attributes for user-defined environments thatwas broken by #1139

### DIFF
--- a/ts/input/tex/newcommand/NewcommandMethods.ts
+++ b/ts/input/tex/newcommand/NewcommandMethods.ts
@@ -263,8 +263,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
         if (edef) {
           // Parse the commands in the end environment definition.
           let rest = parser.string.slice(parser.i);
-          parser.string = edef;
-          parser.i = 0;
+          parser.string = ParseUtil.addArgs(parser, parser.string.substring(0, parser.i), edef);
           parser.Parse();
           // Reset to parsing the remainder of the expression.
           parser.string = rest;


### PR DESCRIPTION
This PR fixes a problem where the `data-latex` attributes were missing or incomplete when a user-defined macro was used.  This caused some tests to fail (so kudos for the tests).

All the tests should pass with this update.