### PR TITLE
Prevent attempts to set aria-hidden attributes on text nodes

### DIFF
--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -319,8 +319,10 @@ export function EnrichedMathItemMixin<
         adaptor.setAttribute(node, 'aria-braillelabel', braille as string);
         this.root.attributes.set('aria-braillelabel', braille);
       }
-      for (const child of adaptor.childNodes(node) as N[]) {
-        adaptor.setAttribute(child, 'aria-hidden', 'true');
+      for (const child of adaptor.childNodes(node)) {
+        if (adaptor.kind(child) !== '#text') {
+          adaptor.setAttribute(child as N, 'aria-hidden', 'true');
+        }
       }
       this.outputData.speech = speech;
       this.outputData.braille = braille;


### PR DESCRIPTION
Puts in a test to see if the child element of the container node is not a text node. This prevents issues, when a render actions inserts some spaces, as in the Euro Braille example for selecting and copying:
https://mathjax.github.io/MathJax-demos-web/euro-braille/