### PR TITLE
Remove need for 'end' property in handling of environments, and refactor numcases and empheq items

### DIFF
--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -203,14 +203,14 @@ const ParseMethods = {
    *
    * @param {TexParser} parser The current tex parser.
    * @param {string} env The name of the environment.
-   * @param {Function} func The parse method for the environment.
+   * @param {ParseMethod} func The parse method for the environment.
    * @param {any[]} args A list of additional arguments.
    */
   environment(parser: TexParser, env: string, func: ParseMethod, args: any[]) {
     const mml = parser.itemFactory
       .create('begin')
       .setProperty('name', env);
-    parser.Push(func(parser, mml, ...args.slice(1)));
+    parser.Push(func(parser, mml, ...args.slice(1)) as StackItem);
   },
 };
 

--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -210,12 +210,10 @@ namespace ParseMethods {
     func: Function,
     args: any[]
   ) {
-    const end = args[0];
-    let mml = parser.itemFactory
+    const mml = parser.itemFactory
       .create('begin')
-      .setProperties({ name: env, end: end });
-    mml = func(parser, mml, ...args.slice(1));
-    parser.Push(mml);
+      .setProperty('name', env);
+    parser.Push(func(parser, mml, ...args.slice(1)));
   }
 }
 

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -591,13 +591,10 @@ export class BeginItem extends BaseItem {
           item.getName()
         );
       }
-      if (!this.getProperty('end')) {
-        // @test Hfill
-        const node = this.toMml();
-        addLatexItem(node, item);
-        return [[this.factory.create('mml', node)], true];
-      }
-      return BaseItem.fail; // TODO: This case could probably go!
+      // @test Hfill
+      const node = this.toMml();
+      addLatexItem(node, item);
+      return [[this.factory.create('mml', node)], true];
     }
     if (item.isKind('stop')) {
       // @test EnvMissingEnd Array

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1885,7 +1885,6 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     const macro = parser.configuration.handlers
       .get(HandlerType.ENVIRONMENT)
       .lookup(env) as Macro;
-
     if (macro && name === '\\end') {
       // If the first argument is true, we have some sort of user defined
       // environment. Otherwise we have a standard LaTeX environment that is

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -1885,6 +1885,7 @@ const BaseMethods: { [key: string]: ParseMethod } = {
     const macro = parser.configuration.handlers
       .get(HandlerType.ENVIRONMENT)
       .lookup(env) as Macro;
+
     if (macro && name === '\\end') {
       // If the first argument is true, we have some sort of user defined
       // environment. Otherwise we have a standard LaTeX environment that is

--- a/ts/input/tex/cases/CasesConfiguration.ts
+++ b/ts/input/tex/cases/CasesConfiguration.ts
@@ -137,7 +137,7 @@ export const CasesMethods = {
    */
   Entry(parser: TexParser, name: string): ParseResult {
     if (!parser.stack.Top().getProperty('numCases')) {
-      BaseMethods.Entry(parser, name);
+      return BaseMethods.Entry(parser, name);
     }
     parser.Push(
       parser.itemFactory
@@ -211,12 +211,27 @@ export const CasesMethods = {
     parser.PushAll(ParseUtil.internalMath(parser, text, 0));
     parser.i = i;
   },
+
+  /**
+   * Create the needed envinronment and process it by the give function.
+   *
+   * @param {TexParser} parser   The active tex parser.
+   * @param {string} env         The environment to create.
+   * @param {Function} func      A function to process the environment.
+   * @param {any[]} args         The arguments for func.
+   */
+  environment(parser: TexParser, env: string, func: Function, args: any[]) {
+    const item = parser.itemFactory
+      .create('cases-begin')
+      .setProperties({ name: env, end: true });
+    parser.Push(func(parser, item, ...args));
+  },
 };
 
 /**
  * The environments for this package
  */
-new EnvironmentMap('cases-env', EmpheqUtil.environment, {
+new EnvironmentMap('cases-env', CasesMethods.environment, {
   numcases: [CasesMethods.NumCases, 'cases'],
   subnumcases: [CasesMethods.NumCases, 'cases'],
 });

--- a/ts/input/tex/cases/CasesConfiguration.ts
+++ b/ts/input/tex/cases/CasesConfiguration.ts
@@ -1,7 +1,7 @@
 import { HandlerType, ConfigurationType } from '../HandlerTypes.js';
 import { Configuration } from '../Configuration.js';
 import { EnvironmentMap, MacroMap } from '../TokenMap.js';
-import { ParseResult } from '../Types.js';
+import { ParseResult, ParseMethod } from '../Types.js';
 import { ParseUtil } from '../ParseUtil.js';
 import BaseMethods from '../base/BaseMethods.js';
 import TexParser from '../TexParser.js';
@@ -217,14 +217,14 @@ export const CasesMethods = {
    *
    * @param {TexParser} parser   The active tex parser.
    * @param {string} env         The environment to create.
-   * @param {Function} func      A function to process the environment.
+   * @param {ParseMethod} func      A function to process the environment.
    * @param {any[]} args         The arguments for func.
    */
-  environment(parser: TexParser, env: string, func: Function, args: any[]) {
+  environment(parser: TexParser, env: string, func: ParseMethod, args: any[]) {
     const item = parser.itemFactory
       .create('cases-begin')
       .setProperties({ name: env, end: true });
-    parser.Push(func(parser, item, ...args));
+    parser.Push(func(parser, item, ...args) as StackItem);
   },
 };
 

--- a/ts/input/tex/empheq/EmpheqConfiguration.ts
+++ b/ts/input/tex/empheq/EmpheqConfiguration.ts
@@ -28,30 +28,8 @@ import { ParseUtil } from '../ParseUtil.js';
 import TexParser from '../TexParser.js';
 import TexError from '../TexError.js';
 import { BeginItem } from '../base/BaseItems.js';
-import { StackItem } from '../StackItem.js';
 import { EmpheqUtil } from './EmpheqUtil.js';
-
-/**
- * A StackItem for empheq environments.
- */
-export class EmpheqBeginItem extends BeginItem {
-  /**
-   * @override
-   */
-  public get kind() {
-    return 'empheq-begin';
-  }
-
-  /**
-   * @override
-   */
-  public checkItem(item: StackItem) {
-    if (item.isKind('end') && item.getName() === this.getName()) {
-      this.setProperty('end', false);
-    }
-    return super.checkItem(item);
-  }
-}
+import ParseMethods from '../ParseMethods.js';
 
 /**
  * The methods that implement the empheq package.
@@ -63,7 +41,7 @@ export const EmpheqMethods = {
    * @param {TexParser} parser        The active tex parser.
    * @param {EmpheqBeginItem} begin   The begin item for this environment.
    */
-  Empheq(parser: TexParser, begin: EmpheqBeginItem) {
+  Empheq(parser: TexParser, begin: BeginItem) {
     if (parser.stack.env.closing === begin.getName()) {
       delete parser.stack.env.closing;
       parser.Push(
@@ -72,7 +50,7 @@ export const EmpheqMethods = {
           .setProperty('name', parser.stack.global.empheq)
       );
       parser.stack.global.empheq = '';
-      const empheq = parser.stack.Top() as EmpheqBeginItem;
+      const empheq = parser.stack.Top() as BeginItem;
       EmpheqUtil.adjustTable(empheq, parser);
       parser.Push(
         parser.itemFactory.create('end').setProperty('name', 'empheq')
@@ -132,7 +110,7 @@ export const EmpheqMethods = {
 //
 //  Define an environment map to add the new empheq environment
 //
-new EnvironmentMap('empheq-env', EmpheqUtil.environment, {
+new EnvironmentMap('empheq-env', ParseMethods.environment, {
   empheq: [EmpheqMethods.Empheq, 'empheq'],
 });
 
@@ -185,8 +163,5 @@ export const EmpheqConfiguration = Configuration.create('empheq', {
   [ConfigurationType.HANDLER]: {
     [HandlerType.MACRO]: ['empheq-macros'],
     [HandlerType.ENVIRONMENT]: ['empheq-env'],
-  },
-  [ConfigurationType.ITEMS]: {
-    [EmpheqBeginItem.prototype.kind]: EmpheqBeginItem,
   },
 });

--- a/ts/input/tex/empheq/EmpheqUtil.ts
+++ b/ts/input/tex/empheq/EmpheqUtil.ts
@@ -22,11 +22,9 @@
  */
 
 import { ParseUtil } from '../ParseUtil.js';
-import { StackItem } from '../StackItem.js';
 import TexParser from '../TexParser.js';
 import { EnvList } from '../StackItem.js';
 import { AbstractTags } from '../Tags.js';
-import { ParseMethod } from '../Types.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtable } from '../../../core/MmlTree/MmlNodes/mtable.js';
 import { MmlMtd } from '../../../core/MmlTree/MmlNodes/mtd.js';

--- a/ts/input/tex/empheq/EmpheqUtil.ts
+++ b/ts/input/tex/empheq/EmpheqUtil.ts
@@ -28,25 +28,9 @@ import { AbstractTags } from '../Tags.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtable } from '../../../core/MmlTree/MmlNodes/mtable.js';
 import { MmlMtd } from '../../../core/MmlTree/MmlNodes/mtd.js';
-import { EmpheqBeginItem } from './EmpheqConfiguration.js';
+import { BeginItem } from '../base/BaseItems.js';
 
 export const EmpheqUtil = {
-  /**
-   * Create the needed envinronment and process it by the give function.
-   *
-   * @param {TexParser} parser   The active tex parser.
-   * @param {string} env         The environment to create.
-   * @param {Function} func      A function to process the environment.
-   * @param {any[]} args         The arguments for func.
-   */
-  environment(parser: TexParser, env: string, func: Function, args: any[]) {
-    const name = args[0];
-    const item = parser.itemFactory
-      .create(name + '-begin')
-      .setProperties({ name: env, end: name });
-    parser.Push(func(parser, item, ...args.slice(1)));
-  },
-
   /**
    * Parse an options string.
    *
@@ -243,10 +227,10 @@ export const EmpheqUtil = {
   /**
    * Add the left- and right-hand material to the table.
    *
-   * @param {EmpheqBeginItem} empheq The Empheq begin item.
+   * @param {BeginItem} empheq The Empheq begin item.
    * @param {TexParser} parser The calling parser.
    */
-  adjustTable(empheq: EmpheqBeginItem, parser: TexParser) {
+  adjustTable(empheq: BeginItem, parser: TexParser) {
     const left = empheq.getProperty('left');
     const right = empheq.getProperty('right');
     if (left || right) {

--- a/ts/input/tex/newcommand/NewcommandMethods.ts
+++ b/ts/input/tex/newcommand/NewcommandMethods.ts
@@ -254,7 +254,7 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
     // @test Newenvironment Empty, Newenvironment Content
     // We have an end item, and we are supposed to close this environment.
     const name = begin.getName();
-    if (begin.getProperty('end') && parser.stack.env['closing'] === name) {
+    if (parser.stack.env['closing'] === name) {
       // @test Newenvironment Empty, Newenvironment Content
       delete parser.stack.env['closing'];
       const beginN = parser.stack.global['beginEnv'] as number;


### PR DESCRIPTION
This PR was started as a way to remove the original line 600 from `BaseItems.ts`, but includes changes to `empheq` and `cases` as well.

The changes to `ParseMethods.ts` are because the `end` property is no longer needed (and never really was).  The `BaseItem.ts` changes remove the test for `end` that isn't needed.

The `EmpheqBeginItem` subclass of `BeginItem` is not needed, as it doesn't actually do anything, and so it is removed, as is the `environment()` function in `EmpheqIUtil` that was used to create it.  The latter has been moved to the `CasesConfiguration.ts` environment, where it is still used.  The `end` property is used in `numcases` environments because it wraps the `empheq` environment, and `end` its used to properly handle producing the end for both environments.  A missing `return` was added to `CasesConfiguration.ts` as well.

Finally, the `end` property was removed from `NewcommandMethods.ts`, as it is no longer used.