### PR TITLE
Make a require configuration to include require.mjs in the bundle (so it will be in the mathjax npm package)

### DIFF
--- a/components/mjs/require/config.json
+++ b/components/mjs/require/config.json
@@ -1,0 +1,9 @@
+{
+  "copy": {
+    "to": "../../../bundle",
+    "from": "../..",
+    "copy": [
+      "require.mjs"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "import": "./components/mjs/*",
       "require": "./components/cjs/*"
     },
+    "./require.mjs": "./bundle/require.mjs",
     "./es5/*": "./bundle/*",
     "./*": "./*"
   },


### PR DESCRIPTION
This PR causes the `require.mjs` file from the `components` directory to be included in the `bundle` directory, so that it will be part of the `mathjax` npm package.  That way, if someone is loading components by hand in a node application and loads any of the components that use SRE components, they can import the `require.mjs` file that is needed for SRE in node.

The `package.json` file is set up so that `import 'mathjax-full/require.mjs'` will work in `mathjax-full`, just like `import 'mathjax/require.mjs'` will work in the `mathjax` package.