### PR TITLE
Removes occurrences of aliased `this`

### DIFF
--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -1176,23 +1176,21 @@ export abstract class AbstractMmlBaseNode extends AbstractMmlNode {
     this.getPrevClass(prev);
     this.texClass = TEXCLASS.ORD;
     const base = this.childNodes[0];
+    let result = null;
     if (base) {
       if (this.isEmbellished || base.isKind('mi')) {
-        prev = base.setTeXclass(prev);
+        result = base.setTeXclass(prev);
         this.updateTeXclass(this.core());
       } else {
         base.setTeXclass(null);
-        prev = this;
       }
-    } else {
-      prev = this;
     }
     for (const child of this.childNodes.slice(1)) {
       if (child) {
         child.setTeXclass(null);
       }
     }
-    return prev;
+    return result || this;
   }
 }
 

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -658,7 +658,7 @@ export abstract class AbstractMmlNode
    * @override
    */
   public childPosition() {
-    let child: MmlNode = this;
+    let child: MmlNode = this; // eslint-disable-line @typescript-eslint/no-this-alias
     let parent = child.parent;
     while (parent && parent.notParent) {
       child = parent;

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -658,12 +658,13 @@ export abstract class AbstractMmlNode
    * @override
    */
   public childPosition() {
-    let child: MmlNode = this; // eslint-disable-line @typescript-eslint/no-this-alias
-    let parent = child.parent;
+    let child: MmlNode = null;
+    let parent = this.parent;
     while (parent && parent.notParent) {
       child = parent;
       parent = parent.parent;
     }
+    child = child || this;
     if (parent) {
       let i = 0;
       for (const node of parent.childNodes) {

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -385,7 +385,7 @@ export class MmlMo extends AbstractMmlTokenNode {
       // Check if node is the last one in its container since the rule
       // above only takes effect if there is a node that follows.
       //
-      let child: MmlNode = this;
+      let child: MmlNode = this; // eslint-disable-line @typescript-eslint/no-this-alias
       let parent = this.parent;
       while (
         parent &&
@@ -472,7 +472,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    *                                     position of the element in its parent.
    */
   public getForms(): [string, string, string] {
-    let core: MmlNode = this;
+    let core: MmlNode = this; // eslint-disable-line @typescript-eslint/no-this-alias
     let parent = this.parent;
     let Parent = this.Parent;
     while (Parent && Parent.isEmbellished) {

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -385,7 +385,7 @@ export class MmlMo extends AbstractMmlTokenNode {
       // Check if node is the last one in its container since the rule
       // above only takes effect if there is a node that follows.
       //
-      let child: MmlNode = this; // eslint-disable-line @typescript-eslint/no-this-alias
+      let child: MmlNode = null;
       let parent = this.parent;
       while (
         parent &&
@@ -397,6 +397,7 @@ export class MmlMo extends AbstractMmlTokenNode {
         child = parent;
         parent = parent.parent;
       }
+      child = child || this;
       if (parent.childNodes[parent.childNodes.length - 1] === child) {
         this.texClass = TEXCLASS.ORD;
       }
@@ -472,7 +473,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    *                                     position of the element in its parent.
    */
   public getForms(): [string, string, string] {
-    let core: MmlNode = this; // eslint-disable-line @typescript-eslint/no-this-alias
+    let core: MmlNode = null;
     let parent = this.parent;
     let Parent = this.Parent;
     while (Parent && Parent.isEmbellished) {
@@ -480,6 +481,7 @@ export class MmlMo extends AbstractMmlTokenNode {
       parent = Parent.parent;
       Parent = Parent.Parent;
     }
+    core = core || this;
     if (
       parent &&
       parent.isKind('mrow') &&

--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -234,7 +234,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    *                    with this node as its core
    */
   public coreParent(): MmlNode {
-    let embellished = this;
+    let embellished = null;
     let parent = this as MmlNode;
     const math = this.factory.getNodeClass('math');
     while (
@@ -246,7 +246,7 @@ export class MmlMo extends AbstractMmlTokenNode {
       embellished = parent;
       parent = (parent as MmlNode).parent;
     }
-    return embellished;
+    return embellished || this;
   }
 
   /**

--- a/ts/core/Tree/Factory.ts
+++ b/ts/core/Tree/Factory.ts
@@ -167,12 +167,12 @@ export abstract class AbstractFactory<
    */
   public setNodeClass(kind: string, nodeClass: C) {
     this.nodeMap.set(kind, nodeClass);
-    const THIS = this;
     const KIND = this.nodeMap.get(kind);
     this.node[kind] = (...args: any[]) => {
-      return new KIND(THIS, ...args);
+      return new KIND(this, ...args);
     };
   }
+
   /**
    * @override
    */


### PR DESCRIPTION
Removes all aliasing of `this` in the code.
Note, that the function in `Factory.ts` works because arrow functions preserve lexical scope.