### PR TITLE
Make over- and under-lines not be accents, so they operate as in actual TeX

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -166,9 +166,8 @@ export class MmlMo extends AbstractMmlTokenNode {
    *   whose widths are to be respected (property mathaccent = false)
    */
   /* prettier-ignore */
-  protected static mathaccentsWithWidth = new RegExp([
+  public static mathaccentsWithWidth = new RegExp([
     '^[',
-    '\u2015',              // overline and underline
     '\u2190\u2192\u2194',  // arrows
     '\u23DC\u23DD',        // over and under parens
     '\u23DE\u23DF',        // over and under braces

--- a/ts/input/tex/base/BaseMethods.ts
+++ b/ts/input/tex/base/BaseMethods.ts
@@ -845,7 +845,9 @@ const BaseMethods: { [key: string]: ParseMethod } = {
       { stretchy: true, accent: true },
       entity
     );
-    mo.setProperty('mathaccent', false);
+    if (entity.match(MmlMo.mathaccentsWithWidth)) {
+      mo.setProperty('mathaccent', false);
+    }
     const pos = name.charAt(1) === 'o' ? 'over' : 'under';
     const base = parser.ParseArg(name);
     parser.Push(ParseUtil.underOver(parser, base, mo, pos, stack));


### PR DESCRIPTION
This was an issue reported by Peter, where `\overline{S}^2` would put the superscript too low.  TeX treats `\overline` and `\underline` specially, and not as other accents, but MathJax wasn't doing that.  The changes here make it work more like actual LaTeX.