### PR TITLE
Update tests to correspond with the changes for mathjax/MathJax#3300

### DIFF
--- a/testsuite/tests/input/tex/Ams.test.ts
+++ b/testsuite/tests/input/tex/Ams.test.ts
@@ -42,13 +42,9 @@ describe('Ams', () => {
       tex2mml('A\\implies B'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\implies B" display="block">
   <mi data-latex="A">A</mi>
-  <mstyle scriptlevel="0" data-latex="\\;">
-    <mspace width="0.278em"></mspace>
-  </mstyle>
+  <mspace width="0.278em" data-latex="\\;"></mspace>
   <mo stretchy="false" data-latex="\\Longrightarrow">&#x27F9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\;">
-    <mspace width="0.278em"></mspace>
-  </mstyle>
+  <mspace width="0.278em" data-latex="\\;"></mspace>
   <mi data-latex="B">B</mi>
 </math>`
     ));
@@ -85,7 +81,7 @@ describe('Ams', () => {
     toXmlMatch(
       tex2mml('\\tfrac{n}{k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tfrac{n}{k}" display="block">
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\tfrac{n}{k}">
+  <mstyle displaystyle="false" data-latex="\\tfrac{n}{k}">
     <mfrac>
       <mi data-latex="n">n</mi>
       <mi data-latex="k">k</mi>
@@ -97,12 +93,10 @@ describe('Ams', () => {
     toXmlMatch(
       tex2mml('\\dfrac{n}{k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dfrac{n}{k}" display="block">
-  <mstyle displaystyle="true" scriptlevel="0" data-latex="\\dfrac{n}{k}">
-    <mfrac>
-      <mi data-latex="n">n</mi>
-      <mi data-latex="k">k</mi>
-    </mfrac>
-  </mstyle>
+  <mfrac data-latex="\\dfrac{n}{k}">
+    <mi data-latex="n">n</mi>
+    <mi data-latex="k">k</mi>
+  </mfrac>
 </math>`
     ));
   it('Normal Sub Fraction', () =>
@@ -124,7 +118,7 @@ describe('Ams', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a_\\tfrac{n}{k}" display="block">
   <msub data-latex="a_\\tfrac{n}{k}">
     <mi data-latex="a">a</mi>
-    <mstyle displaystyle="false" scriptlevel="0" data-latex="{n}{k}">
+    <mstyle scriptlevel="0" data-latex="{n}{k}">
       <mfrac>
         <mi data-latex="n">n</mi>
         <mi data-latex="k">k</mi>
@@ -170,7 +164,7 @@ describe('Ams', () => {
     toXmlMatch(
       tex2mml('\\tbinom{n}{k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tbinom{n}{k}" display="block">
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\tbinom{n}{k}">
+  <mstyle displaystyle="false" data-latex="\\tbinom{n}{k}">
     <mrow data-mjx-texclass="ORD">
       <mrow data-mjx-texclass="OPEN" data-latex="\\bigl (">
         <mo minsize="1.2em" maxsize="1.2em">(</mo>
@@ -190,20 +184,18 @@ describe('Ams', () => {
     toXmlMatch(
       tex2mml('\\dbinom{n}{k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dbinom{n}{k}" display="block">
-  <mstyle displaystyle="true" scriptlevel="0" data-latex="\\dbinom{n}{k}">
-    <mrow data-mjx-texclass="ORD">
-      <mrow data-mjx-texclass="OPEN" data-latex="\\biggl (">
-        <mo minsize="2.047em" maxsize="2.047em">(</mo>
-      </mrow>
-      <mfrac linethickness="0">
-        <mi data-latex="n">n</mi>
-        <mi data-latex="k">k</mi>
-      </mfrac>
-      <mrow data-mjx-texclass="CLOSE" data-latex="\\biggr )">
-        <mo minsize="2.047em" maxsize="2.047em">)</mo>
-      </mrow>
+  <mrow data-mjx-texclass="ORD" data-latex="\\dbinom{n}{k}">
+    <mrow data-mjx-texclass="OPEN" data-latex="\\biggl (">
+      <mo minsize="2.047em" maxsize="2.047em">(</mo>
     </mrow>
-  </mstyle>
+    <mfrac linethickness="0">
+      <mi data-latex="n">n</mi>
+      <mi data-latex="k">k</mi>
+    </mfrac>
+    <mrow data-mjx-texclass="CLOSE" data-latex="\\biggr )">
+      <mo minsize="2.047em" maxsize="2.047em">)</mo>
+    </mrow>
+  </mrow>
 </math>`
     ));
   it('Normal Sub Binomial', () =>
@@ -233,7 +225,7 @@ describe('Ams', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a_\\tbinom{n}{k}" display="block">
   <msub data-latex="a_\\tbinom{n}{k}">
     <mi data-latex="a">a</mi>
-    <mstyle displaystyle="false" scriptlevel="0" data-latex="{n}{k}">
+    <mstyle scriptlevel="0" data-latex="{n}{k}">
       <mrow data-mjx-texclass="ORD">
         <mrow data-mjx-texclass="OPEN" data-latex="\\bigl (">
           <mo minsize="1.2em" maxsize="1.2em">(</mo>
@@ -282,23 +274,19 @@ describe('Ams', () => {
       <mpadded height="8.6pt" depth="3pt" width="0" data-latex="\\strut">
         <mrow></mrow>
       </mpadded>
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mrow data-mjx-texclass="ORD" data-latex="{a}">
-          <mi data-latex="a">a</mi>
-        </mrow>
-      </mstyle>
+      <mrow data-mjx-texclass="ORD" data-latex="{a}">
+        <mi data-latex="a">a</mi>
+      </mrow>
     </mrow>
     <mrow data-latex="\\strut\\textstyle{bbb}">
       <mpadded height="8.6pt" depth="3pt" width="0" data-latex="\\strut">
         <mrow></mrow>
       </mpadded>
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mrow data-mjx-texclass="ORD" data-latex="{b b b}">
-          <mi data-latex="b">b</mi>
-          <mi data-latex="b">b</mi>
-          <mi data-latex="b">b</mi>
-        </mrow>
-      </mstyle>
+      <mrow data-mjx-texclass="ORD" data-latex="{b b b}">
+        <mi data-latex="b">b</mi>
+        <mi data-latex="b">b</mi>
+        <mi data-latex="b">b</mi>
+      </mrow>
     </mrow>
   </mfrac>
 </math>`
@@ -312,23 +300,19 @@ describe('Ams', () => {
       <mpadded height="8.6pt" depth="3pt" width="0" data-latex="\\strut">
         <mrow></mrow>
       </mpadded>
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mrow data-mjx-texclass="ORD" data-latex="{a}">
-          <mi data-latex="a">a</mi>
-        </mrow>
-      </mstyle>
+      <mrow data-mjx-texclass="ORD" data-latex="{a}">
+        <mi data-latex="a">a</mi>
+      </mrow>
     </mrow>
     <mrow data-latex="\\strut\\textstyle{bbb}">
       <mpadded height="8.6pt" depth="3pt" width="0" data-latex="\\strut">
         <mrow></mrow>
       </mpadded>
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mrow data-mjx-texclass="ORD" data-latex="{b b b}">
-          <mi data-latex="b">b</mi>
-          <mi data-latex="b">b</mi>
-          <mi data-latex="b">b</mi>
-        </mrow>
-      </mstyle>
+      <mrow data-mjx-texclass="ORD" data-latex="{b b b}">
+        <mi data-latex="b">b</mi>
+        <mi data-latex="b">b</mi>
+        <mi data-latex="b">b</mi>
+      </mrow>
     </mrow>
   </mfrac>
 </math>`
@@ -342,23 +326,19 @@ describe('Ams', () => {
       <mpadded height="8.6pt" depth="3pt" width="0" data-latex="\\strut">
         <mrow></mrow>
       </mpadded>
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mrow data-mjx-texclass="ORD" data-latex="{a}">
-          <mi data-latex="a">a</mi>
-        </mrow>
-      </mstyle>
+      <mrow data-mjx-texclass="ORD" data-latex="{a}">
+        <mi data-latex="a">a</mi>
+      </mrow>
     </mrow>
     <mrow data-latex="\\strut\\textstyle{bbb}">
       <mpadded height="8.6pt" depth="3pt" width="0" data-latex="\\strut">
         <mrow></mrow>
       </mpadded>
-      <mstyle displaystyle="false" scriptlevel="0">
-        <mrow data-mjx-texclass="ORD" data-latex="{b b b}">
-          <mi data-latex="b">b</mi>
-          <mi data-latex="b">b</mi>
-          <mi data-latex="b">b</mi>
-        </mrow>
-      </mstyle>
+      <mrow data-mjx-texclass="ORD" data-latex="{b b b}">
+        <mi data-latex="b">b</mi>
+        <mi data-latex="b">b</mi>
+        <mi data-latex="b">b</mi>
+      </mrow>
     </mrow>
   </mfrac>
 </math>`
@@ -368,9 +348,7 @@ describe('Ams', () => {
       tex2mml('\\xleftarrow{abcd}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xleftarrow{abcd}" display="block">
   <mover data-latex="\\xleftarrow{abcd}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x2190;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x2190;</mo>
     <mpadded width="+0.833em" lspace="0.556em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -386,9 +364,7 @@ describe('Ams', () => {
       tex2mml('\\xleftarrow[xyz]{abcd}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xleftarrow[xyz]{abcd}" display="block">
   <munderover data-latex="\\xleftarrow[xyz]{abcd}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x2190;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x2190;</mo>
     <mpadded width="+0.833em" lspace="0.556em" voffset=".15em" depth="-.15em">
       <mi data-latex="x">x</mi>
       <mi data-latex="y">y</mi>
@@ -411,9 +387,7 @@ describe('Ams', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\xleftarrow{abcd}B" display="block">
   <mi data-latex="A">A</mi>
   <mover data-latex="\\xleftarrow{abcd}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x2190;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x2190;</mo>
     <mpadded width="+0.833em" lspace="0.556em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -430,9 +404,7 @@ describe('Ams', () => {
       tex2mml('\\xrightarrow{abcd}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xrightarrow{abcd}" display="block">
   <mover data-latex="\\xrightarrow{abcd}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x2192;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x2192;</mo>
     <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -448,9 +420,7 @@ describe('Ams', () => {
       tex2mml('\\xrightarrow[xyz]{abcd}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xrightarrow[xyz]{abcd}" display="block">
   <munderover data-latex="\\xrightarrow[xyz]{abcd}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x2192;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x2192;</mo>
     <mpadded width="+0.833em" lspace="0.278em" voffset=".15em" depth="-.15em">
       <mi data-latex="x">x</mi>
       <mi data-latex="y">y</mi>
@@ -473,9 +443,7 @@ describe('Ams', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\xrightarrow{abcd}B" display="block">
   <mi data-latex="A">A</mi>
   <mover data-latex="\\xrightarrow{abcd}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x2192;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x2192;</mo>
     <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -543,20 +511,12 @@ describe('Ams', () => {
     toXmlMatch(
       tex2mml('\\idotsint\\limits_a^b+3'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\idotsint\\limits_a^b+3" display="block">
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <munderover data-latex="\\limits_a^b">
     <mrow data-mjx-texclass="OP" data-latex="\\limits">
-      <mstyle scriptlevel="0" data-latex="\\,">
-        <mspace width="0.167em"></mspace>
-      </mstyle>
-      <mstyle scriptlevel="0" data-latex="\\,">
-        <mspace width="0.167em"></mspace>
-      </mstyle>
+      <mspace width="0.167em" data-latex="\\,"></mspace>
+      <mspace width="0.167em" data-latex="\\," data-latex="\\,"></mspace>
       <mo data-latex="\\int">&#x222B;</mo>
       <mo data-latex="\\cdots">&#x22EF;</mo>
       <mo data-latex="\\int">&#x222B;</mo>
@@ -581,11 +541,11 @@ describe('Ams', () => {
   it('Operatorname', () =>
     toXmlMatch(
       tex2mml('a\\operatorname{xyz}b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\operatorname{xyz}b\" display=\"block\">
-  <mi data-latex=\"a\">a</mi>
-  <mi data-latex=\"\\operatorname{xyz}\">xyz</mi>
-  <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-  <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\operatorname{xyz}b" display="block">
+  <mi data-latex="a">a</mi>
+  <mi data-latex="\\operatorname{xyz}">xyz</mi>
+  <mo data-mjx-texclass="NONE">&#x2061;</mo>
+  <mi data-latex="b">b</mi>
 </math>`
     ));
 });
@@ -595,33 +555,37 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{subarray}{c}a\\end{subarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{subarray}{c}a\\end{subarray}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" data-latex-item="{subarray}" data-latex="\\begin{subarray}{c}a\\end{subarray}">
-    <mtr data-latex-item="{c}" data-latex="{c}">
-      <mtd>
-        <mi data-latex="a">a</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+  <mstyle scriptlevel="1" data-latex-item="{subarray}" data-latex="\\begin{subarray}{c}a\\end{subarray}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" displaystyle="false">
+      <mtr data-latex-item="{c}" data-latex="{c}">
+        <mtd>
+          <mi data-latex="a">a</mi>
+        </mtd>
+       </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Small Matrix', () =>
     toXmlMatch(
       tex2mml('\\begin{smallmatrix}a\\end{smallmatrix}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}">
-    <mtr>
-      <mtd>
-        <mi data-latex="a">a</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtr>
+        <mtd>
+          <mi data-latex="a">a</mi>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Align', () =>
     toXmlMatch(
       tex2mml('\\begin{align} a&=b \\\\ c&=d \\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -653,7 +617,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{align*} a&=b \\\\ c&=d \\end{align*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -685,7 +649,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b \\\\ c \\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -708,7 +672,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -733,7 +697,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{split} r&=s\\\\ & =t \\end{split} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -743,7 +707,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
+          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
             <mtr>
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -789,7 +753,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather} a=b \\\\ c=d \\end{gather}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}" display="block">
-  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
+  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -811,7 +775,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather*} a=b \\\\ c=d \\end{gather*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}" display="block">
-  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
+  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -833,7 +797,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat}{2} a&=b \\\\ c&=d \\end{alignat}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
     <mtr data-latex-item="{2}" data-latex="{2}">
       <mtd>
         <mi data-latex="a">a</mi>
@@ -865,7 +829,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat*}{2} a&=b \\\\ c&=d \\end{alignat*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
     <mtr data-latex-item="{2}" data-latex="{2}">
       <mtd>
         <mi data-latex="a">a</mi>
@@ -899,7 +863,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{alignedat}{2} r&=s\\\\ & =t \\end{alignedat} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -909,7 +873,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
+          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
             <mtr data-latex-item="{2}" data-latex="{2}">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -957,7 +921,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{aligned} r&=s\\\\ & =t \\end{aligned} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -967,7 +931,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
+          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1015,7 +979,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1025,7 +989,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
+          <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1076,7 +1040,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray} a & = & b\\\\ c & = & d \\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}" display="block">
-  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
+  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1112,7 +1076,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray*} a & = & b\\\\ c & = & d \\end{eqnarray*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}" display="block">
-  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
+  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1152,33 +1116,37 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{subarray}{c}a\\end{subarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{subarray}{c}a\\end{subarray}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" data-latex-item="{subarray}" data-latex="\\begin{subarray}{c}a\\end{subarray}">
-    <mtr data-latex-item="{c}" data-latex="{c}">
-      <mtd>
-        <mi data-latex="a">a</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+  <mstyle scriptlevel="1" data-latex-item="{subarray}" data-latex="\\begin{subarray}{c}a\\end{subarray}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" displaystyle="false">
+      <mtr data-latex-item="{c}" data-latex="{c}">
+        <mtd>
+          <mi data-latex="a">a</mi>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Small Matrix', () =>
     toXmlMatch(
       tex2mml('\\begin{smallmatrix}a\\end{smallmatrix}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}">
-    <mtr>
-      <mtd>
-        <mi data-latex="a">a</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtr>
+        <mtd>
+          <mi data-latex="a">a</mi>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Align', () =>
     toXmlMatch(
       tex2mml('\\begin{align} a&=b \\\\ c&=d \\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1216,7 +1184,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{align*} a&=b \\\\ c&=d \\end{align*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1248,7 +1216,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b \\\\ c \\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1274,7 +1242,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1299,7 +1267,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{split} r&=s\\\\ & =t \\end{split} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1309,7 +1277,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
+          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
             <mtr>
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1355,7 +1323,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather} a=b \\\\ c=d \\end{gather}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}" display="block">
-  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
+  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1383,7 +1351,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather*} a=b \\\\ c=d \\end{gather*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}" display="block">
-  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
+  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1405,7 +1373,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat}{2} a&=b \\\\ c&=d \\end{alignat}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
     <mlabeledtr data-latex-item="{2}" data-latex="{2}">
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1443,7 +1411,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat*}{2} a&=b \\\\ c&=d \\end{alignat*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
     <mtr data-latex-item="{2}" data-latex="{2}">
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1477,7 +1445,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{alignedat}{2} r&=s\\\\ & =t \\end{alignedat} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1487,7 +1455,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
+          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
             <mtr data-latex-item="{2}" data-latex="{2}">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1535,7 +1503,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{aligned} r&=s\\\\ & =t \\end{aligned} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1545,7 +1513,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
+          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1593,7 +1561,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1603,7 +1571,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
+          <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1640,7 +1608,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{equation} a \\end{equation}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation} a \\end{equation}" display="block">
-  <mtable displaystyle="true" data-latex-item="{equation}" data-latex="\\begin{equation} a \\end{equation}">
+  <mtable data-latex-item="{equation}" data-latex="\\begin{equation} a \\end{equation}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1663,7 +1631,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray} a & = & b\\\\ c & = & d \\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}" display="block">
-  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
+  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1705,7 +1673,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray*} a & = & b\\\\ c & = & d \\end{eqnarray*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}" display="block">
-  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
+  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1795,7 +1763,7 @@ describe('InternalMath', () => {
       tex2mml('a\\mbox{ \\eqref{1} } c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mbox{ \\eqref{1} } c" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{ \\eqref{1} }">
+  <mstyle displaystyle="false" data-latex="\\mbox{ \\eqref{1} }">
     <mtext>&#xA0;</mtext>
     <mrow data-mjx-texclass="ORD">
       <mrow href="#" class="MathJax_ref" data-latex="\\eqref{1}">
@@ -1906,7 +1874,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1929,7 +1897,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1952,7 +1920,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1975,7 +1943,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1998,7 +1966,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="right">
         <mi data-latex="a">a</mi>
@@ -2021,7 +1989,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2044,7 +2012,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2069,7 +2037,7 @@ describe('MultlineShove', () => {
         '\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2094,7 +2062,7 @@ describe('MultlineShove', () => {
         '\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2158,7 +2126,7 @@ describe('Ams Complex', () => {
         '\\begin{align}\\dot{x} & = \\sigma(y-x) \\\\\\dot{y} & = \\rho x - y - xz \\\\\\dot{z} & = -\\beta z + xy\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}\\dot{x} &amp; = \\sigma(y-x) \\\\\\dot{y} &amp; = \\rho x - y - xz \\\\\\dot{z} &amp; = -\\beta z + xy\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}\\dot{x} &amp; = \\sigma(y-x) \\\\\\dot{y} &amp; = \\rho x - y - xz \\\\\\dot{z} &amp; = -\\beta z + xy\\end{align}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}\\dot{x} &amp; = \\sigma(y-x) \\\\\\dot{y} &amp; = \\rho x - y - xz \\\\\\dot{z} &amp; = -\\beta z + xy\\end{align}">
     <mtr>
       <mtd>
         <mrow data-mjx-texclass="ORD" data-latex="\\dot{x}">
@@ -2235,7 +2203,7 @@ describe('Ams Complex', () => {
         '\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} & = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} & = 0 \\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} &amp; = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} &amp; = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} &amp; = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} &amp; = 0 \\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} &amp; = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} &amp; = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} &amp; = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} &amp; = 0 \\end{align}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} &amp; = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} &amp; = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} &amp; = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} &amp; = 0 \\end{align}">
     <mtr>
       <mtd>
         <mi mathvariant="normal" data-latex="\\nabla">&#x2207;</mi>
@@ -2249,16 +2217,12 @@ describe('Ams Complex', () => {
           </mover>
         </mrow>
         <mo data-latex="-">&#x2212;</mo>
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
         <mfrac data-latex="\\frac1c">
           <mn data-latex="1">1</mn>
           <mi data-latex="c">c</mi>
         </mfrac>
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
         <mfrac data-latex="\\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t}">
           <mrow data-latex="\\partial\\vec{\\mathbf{E}}">
             <mi data-latex="\\partial">&#x2202;</mi>
@@ -2334,20 +2298,14 @@ describe('Ams Complex', () => {
             <mo stretchy="false">&#x2192;</mo>
           </mover>
         </mrow>
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
         <mo data-latex="+">+</mo>
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
         <mfrac data-latex="\\frac1c">
           <mn data-latex="1">1</mn>
           <mi data-latex="c">c</mi>
         </mfrac>
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
         <mfrac data-latex="\\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t}">
           <mrow data-latex="\\partial\\vec{\\mathbf{B}}">
             <mi data-latex="\\partial">&#x2202;</mi>
@@ -2525,27 +2483,27 @@ describe('Ams SideSet', () => {
   it('Sideset Empty', () =>
     toXmlMatch(
       tex2mml('\\sideset{}{}{}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sideset{}{}{}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OP\" data-latex=\"\\sideset{}{}{}\"></mrow>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sideset{}{}{}" display="block">
+      <mrow data-mjx-texclass="OP" data-latex="\\sideset{}{}{}"></mrow>
     </math>`
     ));
   it('Sideset Simple', () =>
     toXmlMatch(
       tex2mml('\\sideset{}{}{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sideset{}{}{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OP\" data-latex=\"\\sideset{}{}{a}\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sideset{}{}{a}" display="block">
+      <mrow data-mjx-texclass="OP" data-latex="\\sideset{}{}{a}">
+        <mi data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('Sideset Simple Right', () =>
     toXmlMatch(
       tex2mml('\\sideset{}{\'}{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sideset{}{'}{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OP\" data-latex=\"\\sideset{}{'}{a}\">
-        <msup data-latex=\"'\">
-          <mi data-latex=\"a\">a</mi>
-          <mo data-mjx-alternate=\"1\" data-latex=\"'\">&#x2032;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sideset{}{'}{a}" display="block">
+      <mrow data-mjx-texclass="OP" data-latex="\\sideset{}{'}{a}">
+        <msup data-latex="'">
+          <mi data-latex="a">a</mi>
+          <mo data-mjx-alternate="1" data-latex="'">&#x2032;</mo>
         </msup>
       </mrow>
     </math>`
@@ -2553,12 +2511,12 @@ describe('Ams SideSet', () => {
   it('Sideset Simple Left', () =>
     toXmlMatch(
       tex2mml('\\sideset{\'}{}{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sideset{'}{}{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OP\" data-latex=\"\\sideset{'}{}{a}\">
-        <mmultiscripts data-mjx-script-align=\"left\">
-          <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sideset{'}{}{a}" display="block">
+      <mrow data-mjx-texclass="OP" data-latex="\\sideset{'}{}{a}">
+        <mmultiscripts data-mjx-script-align="left">
+          <mi data-latex="a">a</mi>
           <mprescripts></mprescripts>
-          <mo data-mjx-alternate=\"1\" data-latex=\"'\">&#x2032;</mo>
+          <mo data-mjx-alternate="1" data-latex="'">&#x2032;</mo>
           <none></none>
         </mmultiscripts>
       </mrow>
@@ -2567,14 +2525,14 @@ describe('Ams SideSet', () => {
   it('Sideset Simple Left Right', () =>
     toXmlMatch(
       tex2mml('\\sideset{\'}{\'}{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sideset{'}{'}{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OP\" data-latex=\"\\sideset{'}{'}{a}\">
-        <mmultiscripts data-mjx-script-align=\"left\">
-          <mi data-latex=\"a\">a</mi>
-          <mo data-mjx-alternate=\"1\" data-latex=\"'\">&#x2032;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sideset{'}{'}{a}" display="block">
+      <mrow data-mjx-texclass="OP" data-latex="\\sideset{'}{'}{a}">
+        <mmultiscripts data-mjx-script-align="left">
+          <mi data-latex="a">a</mi>
+          <mo data-mjx-alternate="1" data-latex="'">&#x2032;</mo>
           <none></none>
           <mprescripts></mprescripts>
-          <mo data-mjx-alternate=\"1\" data-latex=\"'\">&#x2032;</mo>
+          <mo data-mjx-alternate="1" data-latex="'">&#x2032;</mo>
           <none></none>
         </mmultiscripts>
       </mrow>
@@ -2583,24 +2541,24 @@ describe('Ams SideSet', () => {
   it('Sideset Simple Sum', () =>
     toXmlMatch(
       tex2mml('\\sideset{}{\'}\\sum_{n=0}^{k}n'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sideset{}{'}\\sum_{n=0}^{k}n\" display=\"block\">
-      <munderover data-latex=\"\\sideset{}{'}\\sum_{n=0}^{k}\">
-        <mrow data-mjx-texclass=\"OP\" data-latex=\"\\sideset{}{'}\\sum\">
-          <msup data-latex=\"'\">
-            <mo data-latex=\"\\sum\">&#x2211;</mo>
-            <mo data-mjx-alternate=\"1\" data-latex=\"'\">&#x2032;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sideset{}{'}\\sum_{n=0}^{k}n" display="block">
+      <munderover data-latex="\\sideset{}{'}\\sum_{n=0}^{k}">
+        <mrow data-mjx-texclass="OP" data-latex="\\sideset{}{'}\\sum">
+          <msup data-latex="'">
+            <mo data-latex="\\sum">&#x2211;</mo>
+            <mo data-mjx-alternate="1" data-latex="'">&#x2032;</mo>
           </msup>
         </mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{n=0}\">
-          <mi data-latex=\"n\">n</mi>
-          <mo data-latex=\"=\">=</mo>
-          <mn data-latex=\"0\">0</mn>
+        <mrow data-mjx-texclass="ORD" data-latex="{n=0}">
+          <mi data-latex="n">n</mi>
+          <mo data-latex="=">=</mo>
+          <mn data-latex="0">0</mn>
         </mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{k}\">
-          <mi data-latex=\"k\">k</mi>
+        <mrow data-mjx-texclass="ORD" data-latex="{k}">
+          <mi data-latex="k">k</mi>
         </mrow>
       </munderover>
-      <mi data-latex=\"n\">n</mi>
+      <mi data-latex="n">n</mi>
     </math>`
     ));
 });

--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -9,7 +9,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -79,7 +79,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @<<< B @>>> C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -142,7 +142,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>b> B\\\\@VlVrV @AlArA\\\\C @<a<b< D\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -234,7 +234,7 @@ describe('AmsCD', () => {
         '\\begin{CD}A @>>> B@>\\text{very long label}>>C\\\\@VVV @VVV @VVV\\\\D @>>> E@>>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -314,7 +314,7 @@ describe('AmsCD', () => {
         '\\begin{CD}A @>>> B @>{\\text{very long label}}>> C \\\\@VVV @VVV @VVV \\\\D @>>> E @>{\\phantom{\\text{very long label}}}>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -402,7 +402,7 @@ describe('AmsCD', () => {
         '\\begin{CD}A @>>> B @>{\\text{very long label}}>> C \\\\@VVV @VVV @VVV \\\\D @>>> E @>{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -470,14 +470,12 @@ describe('AmsCD', () => {
             <mrow data-mjx-texclass="ORD" data-latex="{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}">
               <mrow data-mjx-texclass="ORD" data-latex="\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}">
                 <mpadded width="0">
-                  <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle{\\ \\ \\ \\text{shorter}}">
-                    <mrow data-mjx-texclass="ORD" data-latex="{\\text{shorter}}">
-                      <mtext>&#xA0;</mtext>
-                      <mtext>&#xA0;</mtext>
-                      <mtext>&#xA0;</mtext>
-                      <mtext data-latex="\\text{shorter}">shorter</mtext>
-                    </mrow>
-                  </mstyle>
+                  <mrow data-mjx-texclass="ORD" data-latex="\\scriptstyle{\\ \\ \\ \\text{shorter}}">
+                    <mtext>&#xA0;</mtext>
+                    <mtext>&#xA0;</mtext>
+                    <mtext>&#xA0;</mtext>
+                    <mtext data-latex="\\text{shorter}">shorter</mtext>
+                  </mrow>
                 </mpadded>
               </mrow>
               <mrow data-mjx-texclass="ORD" data-latex="\\phantom{\\text{very long label}}">
@@ -502,7 +500,7 @@ describe('AmsCD', () => {
         '\\minCDarrowwidth{5cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -574,7 +572,7 @@ describe('AmsCD', () => {
         '\\minCDarrowheight{4cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -646,7 +644,7 @@ describe('AmsCD', () => {
         '\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -715,20 +713,20 @@ describe('AmsCD', () => {
   it('Suspicious Return', () =>
     toXmlMatch(
       tex2mml('\\begin{CD}A @Ra>> BaD\\end{CD}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}\" display=\"block\">
-      <mtable columnspacing=\"5pt\" rowspacing=\"5pt\" displaystyle=\"true\" data-latex-item=\"{CD}\" data-latex=\"\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}" display="block">
+      <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}">
         <mtr>
           <mtd>
-            <mi data-latex=\"A\">A</mi>
-            <mrow data-mjx-texclass=\"ORD\">
-              <mo data-latex=\"@\">@</mo>
+            <mi data-latex="A">A</mi>
+            <mrow data-mjx-texclass="ORD">
+              <mo data-latex="@">@</mo>
             </mrow>
-            <mi data-latex=\"R\">R</mi>
-            <mi data-latex=\"a\">a</mi>
-            <mo data-latex=\"&gt;\">&gt;&gt;</mo>
-            <mi data-latex=\"B\">B</mi>
-            <mi data-latex=\"a\">a</mi>
-            <mi data-latex=\"D\">D</mi>
+            <mi data-latex="R">R</mi>
+            <mi data-latex="a">a</mi>
+            <mo data-latex="&gt;">&gt;&gt;</mo>
+            <mi data-latex="B">B</mi>
+            <mi data-latex="a">a</mi>
+            <mi data-latex="D">D</mi>
           </mtd>
         </mtr>
       </mtable>

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -460,11 +460,11 @@ describe('Roots', () => {
   it('Square Root Fraction', () =>
     toXmlMatch(
       tex2mml('\\sqrt\\frac{a}{b}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sqrt\\frac{a}{b}\" display=\"block\">
-      <msqrt data-latex=\"\\sqrt\\frac{a}{b}\">
-        <mfrac data-latex=\"\\frac{a}{b}\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt\\frac{a}{b}" display="block">
+      <msqrt data-latex="\\sqrt\\frac{a}{b}">
+        <mfrac data-latex="\\frac{a}{b}">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mfrac>
       </msqrt>
     </math>`
@@ -1153,12 +1153,8 @@ describe('Mathchoice', () => {
   <mi data-latex="a">a</mi>
   <mspace width="1em" linebreak="nobreak" data-latex="\\kern18mu"></mspace>
   <mi data-latex="\\mmlToken{mi}{mod}">mod</mi>
-  <mstyle scriptlevel="0" data-latex="\\,">
-    <mspace width="0.167em"></mspace>
-  </mstyle>
-  <mstyle scriptlevel="0" data-latex="\\,">
-    <mspace width="0.167em"></mspace>
-  </mstyle>
+  <mspace width="0.167em" data-latex="\\,"></mspace>
+  <mspace width="0.167em" data-latex="\\,"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -1279,23 +1275,23 @@ describe('Mathchoice', () => {
   it(`Pmod`, () =>
     toXmlMatch(
       tex2mml('a \\pmod b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a \\pmod b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace width=\"1em\" linebreak=\"nobreak\" data-latex=\"\\kern18mu\"></mspace>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"\\mmlToken{mi}{mod}\">mod</mi>
-      <mspace width=\"0.333em\" linebreak=\"nobreak\" data-latex=\"\\kern 6mu\"></mspace>
-      <mi data-latex=\"b\">b</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a \\pmod b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace width="1em" linebreak="nobreak" data-latex="\\kern18mu"></mspace>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="\\mmlToken{mi}{mod}">mod</mi>
+      <mspace width="0.333em" linebreak="nobreak" data-latex="\\kern 6mu"></mspace>
+      <mi data-latex="b">b</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it(`Bmod`, () =>
     toXmlMatch(
       tex2mml('a \\bmod b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a \\bmod b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo lspace=\"0.278em\" rspace=\"0.278em\" data-latex=\"\\mmlToken{mo}[lspace=&quot;0.278em&quot; rspace=&quot;0.278em&quot;]{mod}\">mod</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a \\bmod b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo lspace="0.278em" rspace="0.278em" data-latex="\\mmlToken{mo}[lspace=&quot;0.278em&quot; rspace=&quot;0.278em&quot;]{mod}">mod</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
 });
@@ -1334,11 +1330,11 @@ describe('Stacking expressions', () => {
   it('Overunderset', () =>
     toXmlMatch(
       tex2mml('\\overunderset{a}{b}{c}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\overunderset{a}{b}{c}\" display=\"block\">
-      <munderover data-latex=\"\\overunderset{a}{b}{c}\">
-        <mi data-latex=\"c\">c</mi>
-        <mi data-latex=\"b\">b</mi>
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\overunderset{a}{b}{c}" display="block">
+      <munderover data-latex="\\overunderset{a}{b}{c}">
+        <mi data-latex="c">c</mi>
+        <mi data-latex="b">b</mi>
+        <mi data-latex="a">a</mi>
       </munderover>
     </math>`
     ));
@@ -1826,63 +1822,63 @@ describe('Stacking expressions', () => {
   it('stackrel', () =>
     toXmlMatch(
       tex2mml('x\\stackrel{a}{b}y'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"x\\stackrel{a}{b}y\" display=\"block\">
-      <mi data-latex=\"x\">x</mi>
-      <mrow data-mjx-texclass=\"REL\" data-latex=\"\\mathrel{\\mathop{b}\\limits^{a}}\">
-        <mover data-latex=\"\\mathop{b}\\limits^{a}\">
-          <mrow data-mjx-texclass=\"OP\" data-latex=\"\\limits\">
-            <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x\\stackrel{a}{b}y" display="block">
+      <mi data-latex="x">x</mi>
+      <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\mathop{b}\\limits^{a}}">
+        <mover data-latex="\\mathop{b}\\limits^{a}">
+          <mrow data-mjx-texclass="OP" data-latex="\\limits">
+            <mi data-latex="b">b</mi>
           </mrow>
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"{a}\">
-            <mi data-latex=\"a\">a</mi>
+          <mrow data-mjx-texclass="ORD" data-latex="{a}">
+            <mi data-latex="a">a</mi>
           </mrow>
         </mover>
       </mrow>
-      <mi data-latex=\"y\">y</mi>
+      <mi data-latex="y">y</mi>
     </math>`
     ));
   it('stackbin', () =>
     toXmlMatch(
       tex2mml('x\\stackbin{a}{b}y'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"x\\stackbin{a}{b}y\" display=\"block\">
-      <mi data-latex=\"x\">x</mi>
-      <mrow data-mjx-texclass=\"BIN\" data-latex=\"\\mathbin{\\mathop{b}\\limits^{a}}\">
-        <mover data-latex=\"\\mathop{b}\\limits^{a}\">
-          <mrow data-mjx-texclass=\"OP\" data-latex=\"\\limits\">
-            <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x\\stackbin{a}{b}y" display="block">
+      <mi data-latex="x">x</mi>
+      <mrow data-mjx-texclass="BIN" data-latex="\\mathbin{\\mathop{b}\\limits^{a}}">
+        <mover data-latex="\\mathop{b}\\limits^{a}">
+          <mrow data-mjx-texclass="OP" data-latex="\\limits">
+            <mi data-latex="b">b</mi>
           </mrow>
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"{a}\">
-            <mi data-latex=\"a\">a</mi>
+          <mrow data-mjx-texclass="ORD" data-latex="{a}">
+            <mi data-latex="a">a</mi>
           </mrow>
         </mover>
       </mrow>
-      <mi data-latex=\"y\">y</mi>
+      <mi data-latex="y">y</mi>
     </math>`
     ));
   it('atop', () =>
     toXmlMatch(
       tex2mml('a \\atop b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a \\atop b\" display=\"block\">
-      <mfrac linethickness=\"0\" data-latex-item=\"\\atop\" data-latex=\"a \\atop b\">
-        <mi data-latex=\"a\">a</mi>
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a \\atop b" display="block">
+      <mfrac linethickness="0" data-latex-item="\\atop" data-latex="a \\atop b">
+        <mi data-latex="a">a</mi>
+        <mi data-latex="b">b</mi>
       </mfrac>
     </math>`
     ));
   it('atopwithdelims', () =>
     toXmlMatch(
       tex2mml('a \\atopwithdelims [ ] b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a \\atopwithdelims [ ] b\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex-item=\"\\atopwithdelims\" data-latex=\"a \\atopwithdelims [ ] b\">
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\biggl [\">
-          <mo minsize=\"2.047em\" maxsize=\"2.047em\">[</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a \\atopwithdelims [ ] b" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex-item="\\atopwithdelims" data-latex="a \\atopwithdelims [ ] b">
+        <mrow data-mjx-texclass="OPEN" data-latex="\\biggl [">
+          <mo minsize="2.047em" maxsize="2.047em">[</mo>
         </mrow>
-        <mfrac linethickness=\"0\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+        <mfrac linethickness="0">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mfrac>
-        <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\biggr ]\">
-          <mo minsize=\"2.047em\" maxsize=\"2.047em\">]</mo>
+        <mrow data-mjx-texclass="CLOSE" data-latex="\\biggr ]">
+          <mo minsize="2.047em" maxsize="2.047em">]</mo>
         </mrow>
       </mrow>
     </math>`
@@ -1890,17 +1886,17 @@ describe('Stacking expressions', () => {
   it('brack', () =>
     toXmlMatch(
       tex2mml('n \\brack k'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"n \\brack k\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex-item=\"\\brack\" data-latex=\"n \\brack k\">
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\biggl [\">
-          <mo minsize=\"2.047em\" maxsize=\"2.047em\">[</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="n \\brack k" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex-item="\\brack" data-latex="n \\brack k">
+        <mrow data-mjx-texclass="OPEN" data-latex="\\biggl [">
+          <mo minsize="2.047em" maxsize="2.047em">[</mo>
         </mrow>
-        <mfrac linethickness=\"0\">
-          <mi data-latex=\"n\">n</mi>
-          <mi data-latex=\"k\">k</mi>
+        <mfrac linethickness="0">
+          <mi data-latex="n">n</mi>
+          <mi data-latex="k">k</mi>
         </mfrac>
-        <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\biggr ]\">
-          <mo minsize=\"2.047em\" maxsize=\"2.047em\">]</mo>
+        <mrow data-mjx-texclass="CLOSE" data-latex="\\biggr ]">
+          <mo minsize="2.047em" maxsize="2.047em">]</mo>
         </mrow>
       </mrow>
     </math>`
@@ -1908,17 +1904,17 @@ describe('Stacking expressions', () => {
   it('brace', () =>
     toXmlMatch(
       tex2mml('n \\brace k'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"n \\brace k\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex-item=\"\\brace\" data-latex=\"n \\brace k\">
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\biggl \\{\">
-          <mo minsize=\"2.047em\" maxsize=\"2.047em\">{</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="n \\brace k" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex-item="\\brace" data-latex="n \\brace k">
+        <mrow data-mjx-texclass="OPEN" data-latex="\\biggl \\{">
+          <mo minsize="2.047em" maxsize="2.047em">{</mo>
         </mrow>
-        <mfrac linethickness=\"0\">
-          <mi data-latex=\"n\">n</mi>
-          <mi data-latex=\"k\">k</mi>
+        <mfrac linethickness="0">
+          <mi data-latex="n">n</mi>
+          <mi data-latex="k">k</mi>
         </mfrac>
-        <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\biggr \\}\">
-          <mo minsize=\"2.047em\" maxsize=\"2.047em\">}</mo>
+        <mrow data-mjx-texclass="CLOSE" data-latex="\\biggr \\}">
+          <mo minsize="2.047em" maxsize="2.047em">}</mo>
         </mrow>
       </mrow>
     </math>`
@@ -1959,36 +1955,36 @@ describe('MmlToken', () => {
   it('MmlToken mo', () =>
     toXmlMatch(
       tex2mml('\\mmlToken{mo}{rem}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mmlToken{mo}{rem}\" display=\"block\">
-      <mo data-latex=\"\\mmlToken{mo}{rem}\">rem</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mo}{rem}" display="block">
+      <mo data-latex="\\mmlToken{mo}{rem}">rem</mo>
     </math>`
     ));
   it('MmlToken mi', () =>
     toXmlMatch(
       tex2mml('\\mmlToken{mi}{=}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mmlToken{mi}{=}\" display=\"block\">
-      <mi data-latex=\"\\mmlToken{mi}{=}\">=</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mi}{=}" display="block">
+      <mi data-latex="\\mmlToken{mi}{=}">=</mi>
     </math>`
     ));
   it('MmlToken attribute', () =>
     toXmlMatch(
       tex2mml('\\mmlToken{mo}[mathvariant=normal]{=}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mmlToken{mo}[mathvariant=normal]{=}\" display=\"block\">
-      <mo mathvariant=\"normal\" data-latex=\"\\mmlToken{mo}[mathvariant=normal]{=}\">=</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mo}[mathvariant=normal]{=}" display="block">
+      <mo mathvariant="normal" data-latex="\\mmlToken{mo}[mathvariant=normal]{=}">=</mo>
     </math>`
     ));
   it('MmlToken attribute boolean', () =>
     toXmlMatch(
       tex2mml('\\mmlToken{mo}[mathvariant=normal,largeop=true]{=}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mmlToken{mo}[mathvariant=normal,largeop=true]{=}\" display=\"block\">
-      <mo mathvariant=\"normal\" largeop=\"true\" data-latex=\"\\mmlToken{mo}[mathvariant=normal,largeop=true]{=}\">=</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mo}[mathvariant=normal,largeop=true]{=}" display="block">
+      <mo mathvariant="normal" largeop="true" data-latex="\\mmlToken{mo}[mathvariant=normal,largeop=true]{=}">=</mo>
     </math>`
     ));
   it('MmlToken attribute boolean false', () =>
     toXmlMatch(
       tex2mml('\\mmlToken{mo}[mathvariant=normal,largeop=false]{=}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mmlToken{mo}[mathvariant=normal,largeop=false]{=}\" display=\"block\">
-      <mo mathvariant=\"normal\" largeop=\"false\" data-latex=\"\\mmlToken{mo}[mathvariant=normal,largeop=false]{=}\">=</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mo}[mathvariant=normal,largeop=false]{=}" display="block">
+      <mo mathvariant="normal" largeop="false" data-latex="\\mmlToken{mo}[mathvariant=normal,largeop=false]{=}">=</mo>
     </math>`
     ));
   it('Token Illegal Type', () =>
@@ -2217,96 +2213,88 @@ describe('Matrix', () => {
   it('Matrix Cases two columns', () =>
     toXmlMatch(
       tex2mml('\\cases{a & b}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cases{a &amp; b}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex=\"\\cases{a &amp; b}\">
-        <mo data-mjx-texclass=\"OPEN\">{</mo>
-        <mtable rowspacing=\".2em\" columnspacing=\"1em\" columnalign=\"left left\" data-frame-styles=\"\" framespacing=\".2em .125em\">
-          <mtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cases{a &amp; b}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex="\\cases{a &amp; b}">
+        <mo data-mjx-texclass="OPEN">{</mo>
+        <mtable rowspacing=".2em" columnspacing="1em" columnalign="left left" data-frame-styles="" framespacing=".2em .125em">
+          <mtr data-latex-item="{" data-latex="{">
             <mtd>
-              <mi data-latex=\"a\">a</mi>
+              <mi data-latex="a">a</mi>
             </mtd>
             <mtd>
-              <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"b\">
-                <mtext>b</mtext>
-              </mstyle>
+              <mtext data-latex="b">b</mtext>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\"></mo>
+        <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true"></mo>
       </mrow>
     </math>`
     ));
   it('Matrix Cases two columns braces', () =>
     toXmlMatch(
       tex2mml('\\cases{a & {b}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cases{a &amp; {b}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex=\"\\cases{a &amp; {b}}\">
-        <mo data-mjx-texclass=\"OPEN\">{</mo>
-        <mtable rowspacing=\".2em\" columnspacing=\"1em\" columnalign=\"left left\" data-frame-styles=\"\" framespacing=\".2em .125em\">
-          <mtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cases{a &amp; {b}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex="\\cases{a &amp; {b}}">
+        <mo data-mjx-texclass="OPEN">{</mo>
+        <mtable rowspacing=".2em" columnspacing="1em" columnalign="left left" data-frame-styles="" framespacing=".2em .125em">
+          <mtr data-latex-item="{" data-latex="{">
             <mtd>
-              <mi data-latex=\"a\">a</mi>
+              <mi data-latex="a">a</mi>
             </mtd>
             <mtd>
-              <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"{b}\">
-                <mtext>{b}</mtext>
-              </mstyle>
+              <mtext data-latex="{b}">{b}</mtext>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\"></mo>
+        <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true"></mo>
       </mrow>
     </math>`
     ));
   it('Matrix Cases two rows', () =>
     toXmlMatch(
       tex2mml('\\cases{a & b\\\\ c & d}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cases{a &amp; b\\\\ c &amp; d}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex=\"\\cases{a &amp; b\\\\ c &amp; d}\">
-        <mo data-mjx-texclass=\"OPEN\">{</mo>
-        <mtable rowspacing=\".2em\" columnspacing=\"1em\" columnalign=\"left left\" data-frame-styles=\"\" framespacing=\".2em .125em\">
-          <mtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cases{a &amp; b\\\\ c &amp; d}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex="\\cases{a &amp; b\\\\ c &amp; d}">
+        <mo data-mjx-texclass="OPEN">{</mo>
+        <mtable rowspacing=".2em" columnspacing="1em" columnalign="left left" data-frame-styles="" framespacing=".2em .125em">
+          <mtr data-latex-item="{" data-latex="{">
             <mtd>
-              <mi data-latex=\"a\">a</mi>
+              <mi data-latex="a">a</mi>
             </mtd>
             <mtd>
-              <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"b\">
-                <mtext>b</mtext>
-              </mstyle>
+              <mtext data-latex="b">b</mtext>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{\" data-latex=\"{\">
+          <mtr data-latex-item="{" data-latex="{">
             <mtd>
-              <mi data-latex=\"c\">c</mi>
+              <mi data-latex="c">c</mi>
             </mtd>
             <mtd>
-              <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"d\">
-                <mtext>d</mtext>
-              </mstyle>
+              <mtext data-latex="d">d</mtext>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\"></mo>
+        <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true"></mo>
       </mrow>
     </math>`
     ));
   it('Matrix Cases text', () =>
     toXmlMatch(
       tex2mml('\\cases{a & \\text{b}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cases{a &amp; \\text{b}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex=\"\\cases{a &amp; \\text{b}}\">
-        <mo data-mjx-texclass=\"OPEN\">{</mo>
-        <mtable rowspacing=\".2em\" columnspacing=\"1em\" columnalign=\"left left\" data-frame-styles=\"\" framespacing=\".2em .125em\">
-          <mtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cases{a &amp; \\text{b}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex="\\cases{a &amp; \\text{b}}">
+        <mo data-mjx-texclass="OPEN">{</mo>
+        <mtable rowspacing=".2em" columnspacing="1em" columnalign="left left" data-frame-styles="" framespacing=".2em .125em">
+          <mtr data-latex-item="{" data-latex="{">
             <mtd>
-              <mi data-latex=\"a\">a</mi>
+              <mi data-latex="a">a</mi>
             </mtd>
             <mtd>
-              <mtext data-latex=\"\\text{b}\">b</mtext>
+              <mtext data-latex="\\text{b}">b</mtext>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\"></mo>
+        <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true"></mo>
       </mrow>
     </math>`
     ));
@@ -2314,7 +2302,7 @@ describe('Matrix', () => {
     toXmlMatch(
       tex2mml('\\eqalignno{a&b&c}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalignno{a&amp;b&amp;c}" display="block">
-  <mtable rowspacing=".5em" columnspacing="0.278em" displaystyle="true" columnalign="right left" data-latex="\\eqalignno{a&amp;b&amp;c}">
+  <mtable rowspacing=".5em" columnspacing="0.278em" columnalign="right left" data-latex="\\eqalignno{a&amp;b&amp;c}">
     <mlabeledtr data-latex-item="{" data-latex="{">
       <mtd>
         <mi data-latex="c">c</mi>
@@ -2332,17 +2320,17 @@ describe('Matrix', () => {
   it('Matrix Numbered Left', () =>
     toXmlMatch(
       tex2mml('\\leqalignno{a&b&c}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\leqalignno{a&amp;b&amp;c}\" display=\"block\">
-      <mtable rowspacing=\".5em\" columnspacing=\"0.278em\" side=\"left\" displaystyle=\"true\" columnalign=\"right left\" data-latex=\"\\leqalignno{a&amp;b&amp;c}\">
-        <mlabeledtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\leqalignno{a&amp;b&amp;c}" display="block">
+      <mtable rowspacing=".5em" columnspacing="0.278em" side="left" columnalign="right left" data-latex="\\leqalignno{a&amp;b&amp;c}">
+        <mlabeledtr data-latex-item="{" data-latex="{">
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mlabeledtr>
       </mtable>
@@ -2351,17 +2339,17 @@ describe('Matrix', () => {
   it('Matrix Not Numbered', () =>
     toXmlMatch(
       tex2mml('\\eqalign{a&b&c}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\eqalign{a&amp;b&amp;c}\" display=\"block\">
-      <mtable rowspacing=\".5em\" columnspacing=\"0.278em\" displaystyle=\"true\" columnalign=\"right left\" data-latex=\"\\eqalign{a&amp;b&amp;c}\">
-        <mtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalign{a&amp;b&amp;c}" display="block">
+      <mtable rowspacing=".5em" columnspacing="0.278em" columnalign="right left" data-latex="\\eqalign{a&amp;b&amp;c}">
+        <mtr data-latex-item="{" data-latex="{">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -2370,16 +2358,16 @@ describe('Matrix', () => {
   it('Displaylines', () =>
     toXmlMatch(
       tex2mml('\\displaylines{a\\\\ b}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\displaylines{a\\\\ b}\" display=\"block\">
-      <mtable rowspacing=\".5em\" columnspacing=\"1em\" displaystyle=\"true\" data-latex=\"\\displaylines{a\\\\ b}\">
-        <mtr data-latex-item=\"{\" data-latex=\"{\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\displaylines{a\\\\ b}" display="block">
+      <mtable rowspacing=".5em" columnspacing="1em" data-latex="\\displaylines{a\\\\ b}">
+        <mtr data-latex-item="{" data-latex="{">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{\" data-latex=\"{\">
+        <mtr data-latex-item="{" data-latex="{">
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -2408,13 +2396,11 @@ describe('InternalMath', () => {
       tex2mml('a\\mbox{ b $a\\mbox{ b c } c$ c } c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mbox{ b $a\\mbox{ b c } c$ c } c" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{ b $a\\mbox{ b c } c$ c }">
+  <mstyle displaystyle="false" data-latex="\\mbox{ b $a\\mbox{ b c } c$ c }">
     <mtext>&#xA0;b&#xA0;</mtext>
     <mrow data-mjx-texclass="ORD">
       <mi data-latex="a">a</mi>
-      <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{ b c }">
-        <mtext>&#xA0;b c&#xA0;</mtext>
-      </mstyle>
+      <mtext data-latex="\\mbox{ b c }">&#xA0;b c&#xA0;</mtext>
       <mi data-latex="c">c</mi>
     </mrow>
     <mtext>&#xA0;c&#xA0;</mtext>
@@ -2427,7 +2413,7 @@ describe('InternalMath', () => {
       tex2mml('a\\mbox{ ${ab}$ } c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mbox{ \${ab}\$ } c" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{ \${ab}\$ }">
+  <mstyle displaystyle="false" data-latex="\\mbox{ \${ab}\$ }">
     <mtext>&#xA0;</mtext>
     <mrow data-mjx-texclass="ORD">
       <mrow data-mjx-texclass="ORD" data-latex="{ab}">
@@ -2445,7 +2431,7 @@ describe('InternalMath', () => {
       tex2mml('a\\mbox{aa \\\\ bb} c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mbox{aa \\\\ bb} c" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{aa \\\\ bb}">
+  <mstyle displaystyle="false" data-latex="\\mbox{aa \\\\ bb}">
     <mtext>aa \\ bb</mtext>
   </mstyle>
   <mi data-latex="c">c</mi>
@@ -2465,7 +2451,7 @@ describe('InternalMath', () => {
       tex2mml('a\\mbox{aa \\(\\frac{a}{b}\\) bb} c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mbox{aa \\(\\frac{a}{b}\\) bb} c" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{aa \\(\\frac{a}{b}\\) bb}">
+  <mstyle displaystyle="false" data-latex="\\mbox{aa \\(\\frac{a}{b}\\) bb}">
     <mtext>aa&#xA0;</mtext>
     <mrow data-mjx-texclass="ORD">
       <mfrac data-latex="\\frac{a}{b}">
@@ -2790,11 +2776,11 @@ describe('Array', () => {
     toXmlMatch(
       tex2mml('\\eqalignno{a &  & {\\hbox{(3)}}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}}" display="block">
-  <mtable rowspacing=".5em" columnspacing="0.278em" displaystyle="true" columnalign="right left" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}}">
+  <mtable rowspacing=".5em" columnspacing="0.278em" columnalign="right left" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}}">
     <mlabeledtr data-latex-item="{" data-latex="{">
       <mtd>
         <mrow data-mjx-texclass="ORD" data-latex="{\\hbox{(3)}}">
-          <mstyle displaystyle="false" scriptlevel="0" data-latex="\\hbox{(3)}">
+          <mstyle displaystyle="false" data-latex="\\hbox{(3)}">
             <mtext>(3)</mtext>
           </mstyle>
         </mrow>
@@ -3039,22 +3025,22 @@ describe('Array', () => {
   it('Newcolumntype', () =>
     toXmlMatch(
       tex2mml('\\newcolumntype{a}{c}\\begin{array}{a|a}a&b\\\\c&d\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\newcolumntype{a}{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center\" columnlines=\"solid\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\newcolumntype{a}{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}\">
-        <mtr data-latex-item=\"{a|a}\" data-latex=\"{a|a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\newcolumntype{a}{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" columnlines="solid" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\newcolumntype{a}{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}">
+        <mtr data-latex-item="{a|a}" data-latex="{a|a}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{a|a}\" data-latex=\"{a|a}\">
+        <mtr data-latex-item="{a|a}" data-latex="{a|a}">
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -3063,22 +3049,22 @@ describe('Array', () => {
   it('Newcolumntype Option', () =>
     toXmlMatch(
       tex2mml('\\newcolumntype{a}[1]{c}\\begin{array}{a|a}a&b\\\\c&d\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\newcolumntype{a}[1]{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\newcolumntype{a}[1]{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}\">
-        <mtr data-latex-item=\"{a|a}\" data-latex=\"{a|a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\newcolumntype{a}[1]{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\newcolumntype{a}[1]{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}">
+        <mtr data-latex-item="{a|a}" data-latex="{a|a}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{a|a}\" data-latex=\"{a|a}\">
+        <mtr data-latex-item="{a|a}" data-latex="{a|a}">
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -3087,8 +3073,8 @@ describe('Array', () => {
   it('Newcolumntype Error Argument', () =>
     toXmlMatch(
       tex2mml('\\newcolumntype{ab}{c}\\begin{array}{a|a}a&b\\\\c&d\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\newcolumntype{ab}{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}\" display=\"block\">
-      <merror data-mjx-error=\"Column specifier must be exactly one character: ab\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\newcolumntype{ab}{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}" display="block">
+      <merror data-mjx-error="Column specifier must be exactly one character: ab">
         <mtext>Column specifier must be exactly one character: ab</mtext>
       </merror>
     </math>`
@@ -3096,8 +3082,8 @@ describe('Array', () => {
   it('Newcolumntype Error Option', () =>
     toXmlMatch(
       tex2mml('\\newcolumntype{a}[-1]{c}\\begin{array}{a|a}a&b\\\\c&d\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\newcolumntype{a}[-1]{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}\" display=\"block\">
-      <merror data-mjx-error=\"Argument to -1 must be a positive integer\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\newcolumntype{a}[-1]{c}\\begin{array}{a|a}a&amp;b\\\\c&amp;d\\end{array}" display="block">
+      <merror data-mjx-error="Argument to -1 must be a positive integer">
         <mtext>Argument to -1 must be a positive integer</mtext>
       </merror>
     </math>`
@@ -3363,12 +3349,12 @@ describe('Moving limits', () => {
   it('Underleftrightarrow', () =>
     toXmlMatch(
       tex2mml('\\underleftrightarrow{abc}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\underleftrightarrow{abc}\" display=\"block\">
-      <munder data-latex=\"\\underleftrightarrow{abc}\">
-        <mrow data-latex=\"abc\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
-          <mi data-latex=\"c\">c</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\underleftrightarrow{abc}" display="block">
+      <munder data-latex="\\underleftrightarrow{abc}">
+        <mrow data-latex="abc">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
+          <mi data-latex="c">c</mi>
         </mrow>
         <mo>&#x2194;</mo>
       </munder>
@@ -3741,10 +3727,10 @@ describe('Other', () => {
   it('CKJ', () =>
     toXmlMatch(
       tex2mml('褯¥'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"&#x892F;&#xA5;\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"&#x892F;\">&#x892F;</mi>
-      <mrow data-mjx-texclass=\"ORD\">
-        <mo data-latex=\"&#xA5;\">&#xA5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="&#x892F;&#xA5;" display="block">
+      <mi mathvariant="normal" data-latex="&#x892F;">&#x892F;</mi>
+      <mrow data-mjx-texclass="ORD">
+        <mo data-latex="&#xA5;">&#xA5;</mo>
       </mrow>
     </math>`
     ));
@@ -4005,107 +3991,103 @@ describe('Base Complex', () => {
         '1 + \\frac{q^2}{(1-q)}  + \\frac{q^6}{(1-q)(1-q^2)} + \\cdots =\\prod_{j=0}^{\\infty}  \\frac{1}{(1-q^{5j+2})(1-q^{5j+3})},     \\quad\\quad \\text{for $|q|<1$}.'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="1 + \\frac{q^2}{(1-q)}  + \\frac{q^6}{(1-q)(1-q^2)} + \\cdots =\\prod_{j=0}^{\\infty}  \\frac{1}{(1-q^{5j+2})(1-q^{5j+3})},     \\quad\\quad \\text{for $|q|&lt;1$}." display="block">
-  <mn data-latex="1">1</mn>
-  <mo data-latex="+">+</mo>
-  <mfrac data-latex="\\frac{q^2}{(1-q)}">
-    <msup data-latex="q^2 ">
-      <mi data-latex="q">q</mi>
-      <mn data-latex="2">2</mn>
-    </msup>
-    <mrow data-latex="(1-q)">
-      <mo data-latex="(" stretchy="false">(</mo>
       <mn data-latex="1">1</mn>
-      <mo data-latex="-">&#x2212;</mo>
-      <mi data-latex="q">q</mi>
-      <mo data-latex=")" stretchy="false">)</mo>
-    </mrow>
-  </mfrac>
-  <mo data-latex="+">+</mo>
-  <mfrac data-latex="\\frac{q^6}{(1-q)(1-q^2)}">
-    <msup data-latex="q^6 ">
-      <mi data-latex="q">q</mi>
-      <mn data-latex="6">6</mn>
-    </msup>
-    <mrow data-latex="(1-q)(1-q^2 )">
-      <mo data-latex="(" stretchy="false">(</mo>
-      <mn data-latex="1">1</mn>
-      <mo data-latex="-">&#x2212;</mo>
-      <mi data-latex="q">q</mi>
-      <mo data-latex=")" stretchy="false">)</mo>
-      <mo data-latex="(" stretchy="false">(</mo>
-      <mn data-latex="1">1</mn>
-      <mo data-latex="-">&#x2212;</mo>
-      <msup data-latex="q^2">
-        <mi data-latex="q">q</mi>
-        <mn data-latex="2">2</mn>
-      </msup>
-      <mo data-latex=")" stretchy="false">)</mo>
-    </mrow>
-  </mfrac>
-  <mo data-latex="+">+</mo>
-  <mo data-latex="\\cdots">&#x22EF;</mo>
-  <mo data-latex="=">=</mo>
-  <munderover data-latex="\\prod_{j=0}^{\\infty}">
-    <mo data-latex="\\prod">&#x220F;</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{j=0}">
-      <mi data-latex="j">j</mi>
-      <mo data-latex="=">=</mo>
-      <mn data-latex="0">0</mn>
-    </mrow>
-    <mrow data-mjx-texclass="ORD" data-latex="{\\infty}">
-      <mi mathvariant="normal" data-latex="\\infty">&#x221E;</mi>
-    </mrow>
-  </munderover>
-  <mfrac data-latex="\\frac{1}{(1-q^{5j+2})(1-q^{5j+3})}">
-    <mn data-latex="1">1</mn>
-    <mrow data-latex="(1-q^{5j+2})(1-q^{5j+3})">
-      <mo data-latex="(" stretchy="false">(</mo>
-      <mn data-latex="1">1</mn>
-      <mo data-latex="-">&#x2212;</mo>
-      <msup data-latex="q^{5j+2}">
-        <mi data-latex="q">q</mi>
-        <mrow data-mjx-texclass="ORD" data-latex="{5j+2}">
-          <mn data-latex="5">5</mn>
-          <mi data-latex="j">j</mi>
-          <mo data-latex="+">+</mo>
+      <mo data-latex="+">+</mo>
+      <mfrac data-latex="\\frac{q^2}{(1-q)}">
+        <msup data-latex="q^2 ">
+          <mi data-latex="q">q</mi>
           <mn data-latex="2">2</mn>
+        </msup>
+        <mrow data-latex="(1-q)">
+          <mo data-latex="(" stretchy="false">(</mo>
+          <mn data-latex="1">1</mn>
+          <mo data-latex="-">&#x2212;</mo>
+          <mi data-latex="q">q</mi>
+          <mo data-latex=")" stretchy="false">)</mo>
         </mrow>
-      </msup>
-      <mo data-latex=")" stretchy="false">)</mo>
-      <mo data-latex="(" stretchy="false">(</mo>
-      <mn data-latex="1">1</mn>
-      <mo data-latex="-">&#x2212;</mo>
-      <msup data-latex="q^{5j+3}">
-        <mi data-latex="q">q</mi>
-        <mrow data-mjx-texclass="ORD" data-latex="{5j+3}">
-          <mn data-latex="5">5</mn>
+      </mfrac>
+      <mo data-latex="+">+</mo>
+      <mfrac data-latex="\\frac{q^6}{(1-q)(1-q^2)}">
+        <msup data-latex="q^6 ">
+          <mi data-latex="q">q</mi>
+          <mn data-latex="6">6</mn>
+        </msup>
+        <mrow data-latex="(1-q)(1-q^2 )">
+          <mo data-latex="(" stretchy="false">(</mo>
+          <mn data-latex="1">1</mn>
+          <mo data-latex="-">&#x2212;</mo>
+          <mi data-latex="q">q</mi>
+          <mo data-latex=")" stretchy="false">)</mo>
+          <mo data-latex="(" stretchy="false">(</mo>
+          <mn data-latex="1">1</mn>
+          <mo data-latex="-">&#x2212;</mo>
+          <msup data-latex="q^2">
+            <mi data-latex="q">q</mi>
+            <mn data-latex="2">2</mn>
+          </msup>
+          <mo data-latex=")" stretchy="false">)</mo>
+        </mrow>
+      </mfrac>
+      <mo data-latex="+">+</mo>
+      <mo data-latex="\\cdots">&#x22EF;</mo>
+      <mo data-latex="=">=</mo>
+      <munderover data-latex="\\prod_{j=0}^{\\infty}">
+        <mo data-latex="\\prod">&#x220F;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{j=0}">
           <mi data-latex="j">j</mi>
-          <mo data-latex="+">+</mo>
-          <mn data-latex="3">3</mn>
+          <mo data-latex="=">=</mo>
+          <mn data-latex="0">0</mn>
         </mrow>
-      </msup>
-      <mo data-latex=")" stretchy="false">)</mo>
-    </mrow>
-  </mfrac>
-  <mo data-latex=",">,</mo>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
-  <mrow data-latex="\\text{for $|q|&lt;1$}">
-    <mtext>for&#xA0;</mtext>
-    <mrow data-mjx-texclass="ORD">
-      <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-      <mi data-latex="q">q</mi>
-      <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-      <mo data-latex="&lt;">&lt;</mo>
-      <mn data-latex="1">1</mn>
-    </mrow>
-  </mrow>
-  <mo data-latex=".">.</mo>
-</math>`
+        <mrow data-mjx-texclass="ORD" data-latex="{\\infty}">
+          <mi mathvariant="normal" data-latex="\\infty">&#x221E;</mi>
+        </mrow>
+      </munderover>
+      <mfrac data-latex="\\frac{1}{(1-q^{5j+2})(1-q^{5j+3})}">
+        <mn data-latex="1">1</mn>
+        <mrow data-latex="(1-q^{5j+2})(1-q^{5j+3})">
+          <mo data-latex="(" stretchy="false">(</mo>
+          <mn data-latex="1">1</mn>
+          <mo data-latex="-">&#x2212;</mo>
+          <msup data-latex="q^{5j+2}">
+            <mi data-latex="q">q</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{5j+2}">
+              <mn data-latex="5">5</mn>
+              <mi data-latex="j">j</mi>
+              <mo data-latex="+">+</mo>
+              <mn data-latex="2">2</mn>
+            </mrow>
+          </msup>
+          <mo data-latex=")" stretchy="false">)</mo>
+          <mo data-latex="(" stretchy="false">(</mo>
+          <mn data-latex="1">1</mn>
+          <mo data-latex="-">&#x2212;</mo>
+          <msup data-latex="q^{5j+3}">
+            <mi data-latex="q">q</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{5j+3}">
+              <mn data-latex="5">5</mn>
+              <mi data-latex="j">j</mi>
+              <mo data-latex="+">+</mo>
+              <mn data-latex="3">3</mn>
+            </mrow>
+          </msup>
+          <mo data-latex=")" stretchy="false">)</mo>
+        </mrow>
+      </mfrac>
+      <mo data-latex=",">,</mo>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mrow data-latex="\\text{for $|q|&lt;1$}">
+        <mtext>for&#xA0;</mtext>
+        <mrow data-mjx-texclass="ORD">
+          <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+          <mi data-latex="q">q</mi>
+          <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+          <mo data-latex="&lt;">&lt;</mo>
+          <mn data-latex="1">1</mn>
+        </mrow>
+      </mrow>
+      <mo data-latex=".">.</mo>
+    </math>`
     ));
   it('A Summation Formula', () =>
     toXmlMatch(
@@ -4225,19 +4207,19 @@ describe('Environments', () => {
   it('Eqnarray', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4247,34 +4229,34 @@ describe('Environments', () => {
   it('Equation', () =>
     toXmlMatch(
       tex2mml('\\begin{equation}a=b\\end{equation}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{equation}a=b\\end{equation}\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\"=\">=</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation}a=b\\end{equation}" display="block">
+      <mi data-latex="a">a</mi>
+      <mo data-latex="=">=</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Displaymath', () =>
     toXmlMatch(
       tex2mml('\\begin{displaymath}a\\end{displaymath}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{displaymath}a\\end{displaymath}\" display=\"block\">
-      <mi data-latex=\"\\begin{displaymath}a\\end{displaymath}\" data-latex-item=\"{displaymath}\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{displaymath}a\\end{displaymath}" display="block">
+      <mi data-latex="\\begin{displaymath}a\\end{displaymath}" data-latex-item="{displaymath}">a</mi>
     </math>`
     ));
   it('math', () =>
     toXmlMatch(
       tex2mml('\\begin{math}a\\end{math}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{math}a\\end{math}\">
-      <mi data-latex=\"\\begin{math}a\\end{math}\" data-latex-item=\"{math}\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{math}a\\end{math}">
+      <mi data-latex="\\begin{math}a\\end{math}" data-latex-item="{math}">a</mi>
     </math>`
     ));
   it('Array Center', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{c}a\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{c}a\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{c}a\\end{array}\">
-        <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c}a\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{c}a\\end{array}">
+        <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4283,16 +4265,16 @@ describe('Environments', () => {
   it('Array Center Lines', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{c}a\\\\b\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{c}a\\\\b\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{c}a\\\\b\\end{array}\">
-        <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c}a\\\\b\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{c}a\\\\b\\end{array}">
+        <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+        <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4301,17 +4283,17 @@ describe('Environments', () => {
   it('Array RCL', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{rcl}a&=&b\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{rcl}a&amp;=&amp;b\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{rcl}a&amp;=&amp;b\\end{array}\">
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{rcl}a&amp;=&amp;b\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{rcl}a&amp;=&amp;b\\end{array}">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4320,28 +4302,28 @@ describe('Environments', () => {
   it('Array RCL Lines', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{rcl}a&=&b\\\\c&=&d\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{array}\">
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{array}">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4350,11 +4332,11 @@ describe('Environments', () => {
   it('Display Array Center', () =>
     toXmlMatch(
       tex2mml('\\begin{darray}{c}a\\end{darray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{darray}{c}a\\end{darray}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" displaystyle=\"true\" data-latex-item=\"{darray}\" data-latex=\"\\begin{darray}{c}a\\end{darray}\">
-        <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{c}a\\end{darray}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" data-latex-item="{darray}" data-latex="\\begin{darray}{c}a\\end{darray}">
+        <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4363,16 +4345,16 @@ describe('Environments', () => {
   it('Display Array Center Lines', () =>
     toXmlMatch(
       tex2mml('\\begin{darray}{c}a\\\\b\\end{darray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{darray}{c}a\\\\b\\end{darray}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" displaystyle=\"true\" data-latex-item=\"{darray}\" data-latex=\"\\begin{darray}{c}a\\\\b\\end{darray}\">
-        <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{c}a\\\\b\\end{darray}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" data-latex-item="{darray}" data-latex="\\begin{darray}{c}a\\\\b\\end{darray}">
+        <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+        <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4381,17 +4363,17 @@ describe('Environments', () => {
   it('Display Array RCL', () =>
     toXmlMatch(
       tex2mml('\\begin{darray}{rcl}a&=&b\\end{darray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" displaystyle=\"true\" data-latex-item=\"{darray}\" data-latex=\"\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}\">
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-latex-item="{darray}" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4400,28 +4382,28 @@ describe('Environments', () => {
   it('Display Array RCL Lines', () =>
     toXmlMatch(
       tex2mml('\\begin{darray}{rcl}a&=&b\\\\c&=&d\\end{darray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" displaystyle=\"true\" data-latex-item=\"{darray}\" data-latex=\"\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}\">
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-latex-item="{darray}" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4430,18 +4412,18 @@ describe('Environments', () => {
   it('IndentAlign', () =>
     toXmlMatch(
       tex2mml('\\begin{indentalign}[10cm][20cm][30cm]{lcr}a\\end{indentalign}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{lcr}a\\end{indentalign}\" display=\"block\">
-      <mstyle indentshiftfirst=\"10cm\" indentshift=\"20cm\" indentshiftlast=\"30cm\" indentalignfirst=\"left\" indentalign=\"center\" indentalignlast=\"right\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{lcr}a\\end{indentalign}\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{indentalign}[10cm][20cm][30cm]{lcr}a\\end{indentalign}" display="block">
+      <mstyle indentshiftfirst="10cm" indentshift="20cm" indentshiftlast="30cm" indentalignfirst="left" indentalign="center" indentalignlast="right" data-latex="\\begin{indentalign}[10cm][20cm][30cm]{lcr}a\\end{indentalign}">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('IndentAlign Single', () =>
     toXmlMatch(
       tex2mml('\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}\" display=\"block\">
-      <mstyle indentshiftfirst=\"10cm\" indentshift=\"20cm\" indentshiftlast=\"30cm\" indentalignfirst=\"center\" indentalign=\"center\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}" display="block">
+      <mstyle indentshiftfirst="10cm" indentshift="20cm" indentshiftlast="30cm" indentalignfirst="center" indentalign="center" data-latex="\\begin{indentalign}[10cm][20cm][30cm]{c}a\\end{indentalign}">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
@@ -4451,8 +4433,8 @@ describe('Environment Errors', () => {
   it('IndentAlign BadAlignment', () =>
     toXmlMatch(
       tex2mml('\\begin{indentalign}[10cm][20cm][30cm]{lkr}a\\end{indentalign}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{indentalign}[10cm][20cm][30cm]{lkr}a\\end{indentalign}\" display=\"block\">
-      <merror data-mjx-error=\"Alignment must be one to three copies of l, c, or r\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{indentalign}[10cm][20cm][30cm]{lkr}a\\end{indentalign}" display="block">
+      <merror data-mjx-error="Alignment must be one to three copies of l, c, or r">
         <mtext>Alignment must be one to three copies of l, c, or r</mtext>
       </merror>
     </math>`
@@ -4460,8 +4442,8 @@ describe('Environment Errors', () => {
   it('IndentAlign BadDimension', () =>
     toXmlMatch(
       tex2mml('\\begin{indentalign}[10cm][20cm][30]{lcr}a\\end{indentalign}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{indentalign}[10cm][20cm][30]{lcr}a\\end{indentalign}\" display=\"block\">
-      <merror data-mjx-error=\"Bracket argument to \\begin{indentalign} must be a dimension\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{indentalign}[10cm][20cm][30]{lcr}a\\end{indentalign}" display="block">
+      <merror data-mjx-error="Bracket argument to \\begin{indentalign} must be a dimension">
         <mtext>Bracket argument to \\begin{indentalign} must be a dimension</mtext>
       </merror>
     </math>`
@@ -4469,8 +4451,8 @@ describe('Environment Errors', () => {
   it('BreakAlign BadBreakAlign', () =>
     toXmlMatch(
       tex2mml('\\begin{indentalign}[10cm][20cm][30]{lcr}a\\end{indentalign}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{indentalign}[10cm][20cm][30]{lcr}a\\end{indentalign}\" display=\"block\">
-      <merror data-mjx-error=\"Bracket argument to \\begin{indentalign} must be a dimension\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{indentalign}[10cm][20cm][30]{lcr}a\\end{indentalign}" display="block">
+      <merror data-mjx-error="Bracket argument to \\begin{indentalign} must be a dimension">
         <mtext>Bracket argument to \\begin{indentalign} must be a dimension</mtext>
       </merror>
     </math>`
@@ -4481,19 +4463,19 @@ describe('BreakAlign', () => {
   it('BreakAlign Case c', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{c}{t}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}">
         <mtr>
-          <mtd data-vertical-align=\"top\">
-            <mi data-latex=\"a\">a</mi>
+          <mtd data-vertical-align="top">
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4503,19 +4485,19 @@ describe('BreakAlign', () => {
   it('BreakAlign Case c second cell', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&\\breakAlign{c}{t}=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
-          <mtd data-vertical-align=\"top\">
+          <mtd data-vertical-align="top">
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4525,19 +4507,19 @@ describe('BreakAlign', () => {
   it('BreakAlign Case r', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{r}{t}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}\">
-        <mtr data-break-align=\"top\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}">
+        <mtr data-break-align="top">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4547,33 +4529,33 @@ describe('BreakAlign', () => {
   it('BreakAlign Case r second row', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{r}{t}a&=&b\\\\\\breakAlign{r}{t}c&=&d\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}\">
-        <mtr data-break-align=\"top\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}">
+        <mtr data-break-align="top">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
-        <mtr data-break-align=\"top\">
+        <mtr data-break-align="top">
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"d\">d</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="d">d</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4583,19 +4565,19 @@ describe('BreakAlign', () => {
   it('BreakAlign Case r multi split', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{r}{tbmc}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}\">
-        <mtr data-break-align=\"top bottom middle center\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}">
+        <mtr data-break-align="top bottom middle center">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4605,19 +4587,19 @@ describe('BreakAlign', () => {
   it('BreakAlign Case t', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{t}{t}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left\" columnspacing=\"0em 0.278em\" rowspacing=\"3pt\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
             <mi></mi>
-            <mo data-latex=\"=\">=</mo>
+            <mo data-latex="=">=</mo>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"b\">b</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="b">b</mi>
             </mstyle>
           </mtd>
         </mtr>
@@ -4630,8 +4612,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign not in environment', () =>
     toXmlMatch(
       tex2mml('\\breakAlign{c}{t}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\breakAlign{c}{t}\" display=\"block\">
-      <merror data-mjx-error=\"\\breakAlign must be used in an alignment environment\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\breakAlign{c}{t}" display="block">
+      <merror data-mjx-error="\\breakAlign must be used in an alignment environment">
         <mtext>\\breakAlign must be used in an alignment environment</mtext>
       </merror>
     </math>`
@@ -4639,8 +4621,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case c', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\breakAlign{c}{t}&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a\\breakAlign{c}{t}&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"\\breakAlign{c} must be at the beginning of an alignment entry\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\breakAlign{c}{t}&amp;=&amp;b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="\\breakAlign{c} must be at the beginning of an alignment entry">
         <mtext>\\breakAlign{c} must be at the beginning of an alignment entry</mtext>
       </merror>
     </math>`
@@ -4648,8 +4630,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case c split', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\breakAlign{c}{tb}&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a\\breakAlign{c}{tb}&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"\\breakAlign{c} must be at the beginning of an alignment entry\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\breakAlign{c}{tb}&amp;=&amp;b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="\\breakAlign{c} must be at the beginning of an alignment entry">
         <mtext>\\breakAlign{c} must be at the beginning of an alignment entry</mtext>
       </merror>
     </math>`
@@ -4657,8 +4639,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case r', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&=&\\breakAlign{r}{t}b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a&amp;=&amp;\\breakAlign{r}{t}b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"\\breakAlign{r} must be at the beginning of an alignment row\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;=&amp;\\breakAlign{r}{t}b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="\\breakAlign{r} must be at the beginning of an alignment row">
         <mtext>\\breakAlign{r} must be at the beginning of an alignment row</mtext>
       </merror>
     </math>`
@@ -4666,8 +4648,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case t', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&=&\\breakAlign{t}{t}b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a&amp;=&amp;\\breakAlign{t}{t}b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"\\breakAlign{t} must be at the beginning of an alignment\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;=&amp;\\breakAlign{t}{t}b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="\\breakAlign{t} must be at the beginning of an alignment">
         <mtext>\\breakAlign{t} must be at the beginning of an alignment</mtext>
       </merror>
     </math>`
@@ -4675,8 +4657,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case t second row', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&=&b\\\\\\breakAlign{t}{t}c&=&d\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a&amp;=&amp;b\\\\\\breakAlign{t}{t}c&amp;=&amp;d\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"\\breakAlign{t} must be at the beginning of an alignment\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;=&amp;b\\\\\\breakAlign{t}{t}c&amp;=&amp;d\\end{eqnarray}" display="block">
+      <merror data-mjx-error="\\breakAlign{t} must be at the beginning of an alignment">
         <mtext>\\breakAlign{t} must be at the beginning of an alignment</mtext>
       </merror>
     </math>`
@@ -4684,8 +4666,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case t split', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{c}{tb}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{c}{tb}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"Too many alignment characters: tb\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{c}{tb}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="Too many alignment characters: tb">
         <mtext>Too many alignment characters: tb</mtext>
       </merror>
     </math>`
@@ -4693,8 +4675,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case unknown', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{a}{t}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{a}{t}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"First argument to \\breakAlign must be one of c, r, or t\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{a}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="First argument to \\breakAlign must be one of c, r, or t">
         <mtext>First argument to \\breakAlign must be one of c, r, or t</mtext>
       </merror>
     </math>`
@@ -4702,8 +4684,8 @@ describe('BreakAlign Errors', () => {
   it('BreakAlign Case unknown split', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{t}{a}a&=&b\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}\\breakAlign{t}{a}a&amp;=&amp;b\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"Invalid alignment character: a\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{t}{a}a&amp;=&amp;b\\end{eqnarray}" display="block">
+      <merror data-mjx-error="Invalid alignment character: a">
         <mtext>Invalid alignment character: a</mtext>
       </merror>
     </math>`
@@ -4715,90 +4697,90 @@ describe('Setting sizes', () => {
   it('tiny', () =>
     toXmlMatch(
       tex2mml('\\tiny a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tiny a\" display=\"block\">
-      <mstyle mathsize=\"0.5em\" data-latex=\"\\tiny a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tiny a" display="block">
+      <mstyle mathsize="0.5em" data-latex="\\tiny a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('Tiny', () =>
     toXmlMatch(
       tex2mml('\\Tiny a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Tiny a\" display=\"block\">
-      <mstyle mathsize=\"0.6em\" data-latex=\"\\Tiny a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Tiny a" display="block">
+      <mstyle mathsize="0.6em" data-latex="\\Tiny a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('scriptsize', () =>
     toXmlMatch(
       tex2mml('\\scriptsize a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\scriptsize a\" display=\"block\">
-      <mstyle mathsize=\"0.7em\" data-latex=\"\\scriptsize a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\scriptsize a" display="block">
+      <mstyle mathsize="0.7em" data-latex="\\scriptsize a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('small', () =>
     toXmlMatch(
       tex2mml('\\small a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\small a\" display=\"block\">
-      <mstyle mathsize=\"0.85em\" data-latex=\"\\small a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\small a" display="block">
+      <mstyle mathsize="0.85em" data-latex="\\small a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('normalsize', () =>
     toXmlMatch(
       tex2mml('\\normalsize a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\normalsize a\" display=\"block\">
-      <mstyle mathsize=\"1em\" data-latex=\"\\normalsize a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\normalsize a" display="block">
+      <mstyle mathsize="1em" data-latex="\\normalsize a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('large', () =>
     toXmlMatch(
       tex2mml('\\large a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\large a\" display=\"block\">
-      <mstyle mathsize=\"1.2em\" data-latex=\"\\large a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\large a" display="block">
+      <mstyle mathsize="1.2em" data-latex="\\large a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('Large', () =>
     toXmlMatch(
       tex2mml('\\Large a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Large a\" display=\"block\">
-      <mstyle mathsize=\"1.44em\" data-latex=\"\\Large a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Large a" display="block">
+      <mstyle mathsize="1.44em" data-latex="\\Large a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('LARGE', () =>
     toXmlMatch(
       tex2mml('\\LARGE a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\LARGE a\" display=\"block\">
-      <mstyle mathsize=\"1.73em\" data-latex=\"\\LARGE a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\LARGE a" display="block">
+      <mstyle mathsize="1.73em" data-latex="\\LARGE a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('huge', () =>
     toXmlMatch(
       tex2mml('\\huge a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\huge a\" display=\"block\">
-      <mstyle mathsize=\"2.07em\" data-latex=\"\\huge a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\huge a" display="block">
+      <mstyle mathsize="2.07em" data-latex="\\huge a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
   it('Huge', () =>
     toXmlMatch(
       tex2mml('\\Huge a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Huge a\" display=\"block\">
-      <mstyle mathsize=\"2.49em\" data-latex=\"\\Huge a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Huge a" display="block">
+      <mstyle mathsize="2.49em" data-latex="\\Huge a">
+        <mi data-latex="a">a</mi>
       </mstyle>
     </math>`
     ));
@@ -4810,9 +4792,7 @@ describe('Spaces', () => {
       tex2mml('a\\quad b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\quad b" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -4821,12 +4801,8 @@ describe('Spaces', () => {
       tex2mml('a\\!\\!b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\!\\!b" display="block">
   <mi data-latex="a">a</mi>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -4835,132 +4811,112 @@ describe('Spaces', () => {
       tex2mml('A\\,B'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\,B" display="block">
   <mi data-latex="A">A</mi>
-  <mstyle scriptlevel="0" data-latex="\\,">
-    <mspace width="0.167em"></mspace>
-  </mstyle>
+  <mspace width="0.167em" data-latex="\\,"></mspace>
   <mi data-latex="B">B</mi>
 </math>`
     ));
   it('spaces :', () =>
     toXmlMatch(
       tex2mml('A\\:B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\:B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\:\">
-        <mspace width=\"0.222em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\:B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="0.222em" data-latex="\\:"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces >', () =>
     toXmlMatch(
       tex2mml('A\\>B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\&gt;B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\&gt;\">
-        <mspace width=\"0.222em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\&gt;B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="0.222em" data-latex="\\&gt;"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces ;', () =>
     toXmlMatch(
       tex2mml('A\\;B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\;B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\;\">
-        <mspace width=\"0.278em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\;B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="0.278em" data-latex="\\;"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces !', () =>
     toXmlMatch(
       tex2mml('A\\!B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\!B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\!\">
-        <mspace width=\"-0.167em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\!B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="-0.167em" data-latex="\\!"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces quad', () =>
     toXmlMatch(
       tex2mml('A\\quad B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\quad B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\quad B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces qquad', () =>
     toXmlMatch(
       tex2mml('A\\qquad B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\qquad B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\qquad\">
-        <mspace width=\"2em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\qquad B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="2em" data-latex="\\qquad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces enspace', () =>
     toXmlMatch(
       tex2mml('A\\enspace B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\enspace B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\enspace\">
-        <mspace width=\"0.5em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\enspace B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="0.5em" data-latex="\\enspace"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces thinspace', () =>
     toXmlMatch(
       tex2mml('A\\thinspace B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\thinspace B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\thinspace\">
-        <mspace width=\"0.167em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\thinspace B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="0.167em" data-latex="\\thinspace"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('spaces negthinspace', () =>
     toXmlMatch(
       tex2mml('A\\negthinspace B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A\\negthinspace B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\negthinspace\">
-        <mspace width=\"-0.167em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A\\negthinspace B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="-0.167em" data-latex="\\negthinspace"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('Hfil', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{cc}a&\\hfil b\\\\d&ccc\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{cc}a&amp;\\hfil b\\\\d&amp;ccc\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{cc}a&amp;\\hfil b\\\\d&amp;ccc\\end{array}\">
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc}a&amp;\\hfil b\\\\d&amp;ccc\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc}a&amp;\\hfil b\\\\d&amp;ccc\\end{array}">
+        <mtr data-latex-item="{cc}" data-latex="{cc}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
-          <mtd columnalign=\"right\">
-            <mi data-latex=\"b\">b</mi>
+          <mtd columnalign="right">
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
+        <mtr data-latex-item="{cc}" data-latex="{cc}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
-            <mi data-latex=\"c\">c</mi>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
+            <mi data-latex="c">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4969,24 +4925,24 @@ describe('Spaces', () => {
   it('Hfill', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{cc}a&\\hfill b\\\\d&ccc\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{cc}a&amp;\\hfill b\\\\d&amp;ccc\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{cc}a&amp;\\hfill b\\\\d&amp;ccc\\end{array}\">
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc}a&amp;\\hfill b\\\\d&amp;ccc\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc}a&amp;\\hfill b\\\\d&amp;ccc\\end{array}">
+        <mtr data-latex-item="{cc}" data-latex="{cc}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
-          <mtd columnalign=\"right\">
-            <mi data-latex=\"b\">b</mi>
+          <mtd columnalign="right">
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
+        <mtr data-latex-item="{cc}" data-latex="{cc}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
-            <mi data-latex=\"c\">c</mi>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
+            <mi data-latex="c">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -4995,24 +4951,24 @@ describe('Spaces', () => {
   it('Hfilll', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{cc}a&\\hfilll b\\\\d&ccc\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{cc}a&amp;\\hfilll b\\\\d&amp;ccc\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{cc}a&amp;\\hfilll b\\\\d&amp;ccc\\end{array}\">
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc}a&amp;\\hfilll b\\\\d&amp;ccc\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc}a&amp;\\hfilll b\\\\d&amp;ccc\\end{array}">
+        <mtr data-latex-item="{cc}" data-latex="{cc}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
-          <mtd columnalign=\"right\">
-            <mi data-latex=\"b\">b</mi>
+          <mtd columnalign="right">
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
+        <mtr data-latex-item="{cc}" data-latex="{cc}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
-            <mi data-latex=\"c\">c</mi>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
+            <mi data-latex="c">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -5025,304 +4981,302 @@ describe('Delimiters', () => {
   it('<', () =>
     toXmlMatch(
       tex2mml('< a >'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"&lt; a &gt;\" display=\"block\">
-      <mo data-latex=\"&lt;\">&lt;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\"&gt;\">&gt;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="&lt; a &gt;" display="block">
+      <mo data-latex="&lt;">&lt;</mo>
+      <mi data-latex="a">a</mi>
+      <mo data-latex="&gt;">&gt;</mo>
     </math>`
     ));
   it('left right <', () =>
     toXmlMatch(
       tex2mml('\\left< a \\right>'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left&lt; a \\right&gt;\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left&lt; a \\right&gt;\" data-latex=\"\\left&lt; a \\right&gt;\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left&lt;\" data-latex=\"\\left&lt;\">&#x27E8;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right&gt;\" data-latex=\"\\right&gt;\">&#x27E9;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left&lt; a \\right&gt;" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left&lt; a \\right&gt;" data-latex="\\left&lt; a \\right&gt;">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left&lt;" data-latex="\\left&lt;">&#x27E8;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right&gt;" data-latex="\\right&gt;">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('lt', () =>
     toXmlMatch(
       tex2mml('\\lt a \\gt'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lt a \\gt\" display=\"block\">
-      <mo data-latex=\"\\lt\">&lt;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\"\\gt\">&gt;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lt a \\gt" display="block">
+      <mo data-latex="\\lt">&lt;</mo>
+      <mi data-latex="a">a</mi>
+      <mo data-latex="\\gt">&gt;</mo>
     </math>`
     ));
   it('left right lt', () =>
     toXmlMatch(
       tex2mml('\\left\\lt a \\right\\gt'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\lt a \\right\\gt\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\lt a \\right\\gt\" data-latex=\"\\left\\lt a \\right\\gt\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\lt \" data-latex=\"\\left\\lt \">&#x27E8;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\gt\" data-latex=\"\\right\\gt\">&#x27E9;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\lt a \\right\\gt" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lt a \\right\\gt" data-latex="\\left\\lt a \\right\\gt">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lt " data-latex="\\left\\lt ">&#x27E8;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\gt" data-latex="\\right\\gt">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('/', () =>
     toXmlMatch(
       tex2mml('/ a \\\\'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"/ a \\\\\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\">
-        <mo data-latex=\"/\">/</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="/ a \\\\" display="block">
+      <mrow data-mjx-texclass="ORD">
+        <mo data-latex="/">/</mo>
       </mrow>
-      <mi data-latex=\"a\">a</mi>
-      <mspace linebreak=\"newline\" data-latex=\"\\\\\"></mspace>
+      <mi data-latex="a">a</mi>
+      <mspace linebreak="newline" data-latex="\\\\"></mspace>
     </math>`
     ));
   it('left right /', () =>
     toXmlMatch(
       tex2mml('\\left/ a \\right\\\\'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left/ a \\right\\\\\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left/ a \\right\\\\\" data-latex=\"\\left/ a \\right\\\\\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\left/\" data-latex=\"\\left/\">/</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\right\\\\\" data-latex=\"\\right\\\\\">\\</mo>
-      </mrow>
-    </math>`
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left/ a \\right\\\\" display="block">
+  <merror data-mjx-error="Missing or unrecognized delimiter for \\right">
+    <mtext>Missing or unrecognized delimiter for \\right</mtext>
+  </merror>
+</math>`
     ));
   it('lmoustache', () =>
     toXmlMatch(
       tex2mml('\\lmoustache a \\rmoustache'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lmoustache a \\rmoustache\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\lmoustache\">&#x23B0;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rmoustache\">&#x23B1;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lmoustache a \\rmoustache" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\lmoustache">&#x23B0;</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\rmoustache">&#x23B1;</mo>
     </math>`
     ));
   it('left right lmoustache', () =>
     toXmlMatch(
       tex2mml('\\left\\lmoustache a \\right\\rmoustache'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\lmoustache a \\right\\rmoustache\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\lmoustache a \\right\\rmoustache\" data-latex=\"\\left\\lmoustache a \\right\\rmoustache\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\lmoustache \" data-latex=\"\\left\\lmoustache \">&#x23B0;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rmoustache\" data-latex=\"\\right\\rmoustache\">&#x23B1;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\lmoustache a \\right\\rmoustache" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lmoustache a \\right\\rmoustache" data-latex="\\left\\lmoustache a \\right\\rmoustache">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lmoustache " data-latex="\\left\\lmoustache ">&#x23B0;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rmoustache" data-latex="\\right\\rmoustache">&#x23B1;</mo>
       </mrow>
     </math>`
     ));
   it('lgroup', () =>
     toXmlMatch(
       tex2mml('\\lgroup a \\rgroup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lgroup a \\rgroup\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\lgroup\">&#x27EE;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rgroup\">&#x27EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lgroup a \\rgroup" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\lgroup">&#x27EE;</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\rgroup">&#x27EF;</mo>
     </math>`
     ));
   it('left right lgroup', () =>
     toXmlMatch(
       tex2mml('\\left\\lgroup a \\right\\rgroup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\lgroup a \\right\\rgroup\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\lgroup a \\right\\rgroup\" data-latex=\"\\left\\lgroup a \\right\\rgroup\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\lgroup \" data-latex=\"\\left\\lgroup \">&#x27EE;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rgroup\" data-latex=\"\\right\\rgroup\">&#x27EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\lgroup a \\right\\rgroup" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup a \\right\\rgroup" data-latex="\\left\\lgroup a \\right\\rgroup">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup " data-latex="\\left\\lgroup ">&#x27EE;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rgroup" data-latex="\\right\\rgroup">&#x27EF;</mo>
       </mrow>
     </math>`
     ));
   it('arrowvert', () =>
     toXmlMatch(
       tex2mml('\\arrowvert a \\Arrowvert'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arrowvert a \\Arrowvert\" display=\"block\">
-      <mo data-latex=\"\\arrowvert\">&#x23D0;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\Arrowvert\">&#x2016;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arrowvert a \\Arrowvert" display="block">
+      <mo data-latex="\\arrowvert">&#x23D0;</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\Arrowvert">&#x2016;</mo>
     </math>`
     ));
   it('left right arrowvert', () =>
     toXmlMatch(
       tex2mml('\\left\\arrowvert a \\right\\Arrowvert'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\arrowvert a \\right\\Arrowvert\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\arrowvert a \\right\\Arrowvert\" data-latex=\"\\left\\arrowvert a \\right\\Arrowvert\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\left\\arrowvert \" data-latex=\"\\left\\arrowvert \">&#x23D0;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" symmetric=\"true\" data-latex-item=\"\\right\\Arrowvert\" data-latex=\"\\right\\Arrowvert\">&#x2016;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\arrowvert a \\right\\Arrowvert" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\arrowvert a \\right\\Arrowvert" data-latex="\\left\\arrowvert a \\right\\Arrowvert">
+        <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex-item="\\left\\arrowvert " data-latex="\\left\\arrowvert ">&#x23D0;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" symmetric="true" data-latex-item="\\right\\Arrowvert" data-latex="\\right\\Arrowvert">&#x2016;</mo>
       </mrow>
     </math>`
     ));
   it('bracevert', () =>
     toXmlMatch(
       tex2mml('\\bracevert a \\Vert'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bracevert a \\Vert\" display=\"block\">
-      <mo data-latex=\"\\bracevert\">&#x23AA;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo data-mjx-texclass=\"ORD\" fence=\"false\" stretchy=\"false\" data-latex=\"\\Vert\">&#x2016;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bracevert a \\Vert" display="block">
+      <mo data-latex="\\bracevert">&#x23AA;</mo>
+      <mi data-latex="a">a</mi>
+      <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\Vert">&#x2016;</mo>
     </math>`
     ));
   it('left right bracevert', () =>
     toXmlMatch(
       tex2mml('\\left\\bracevert a \\right\\Vert'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\bracevert a \\right\\Vert\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\bracevert a \\right\\Vert\" data-latex=\"\\left\\bracevert a \\right\\Vert\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\left\\bracevert \" data-latex=\"\\left\\bracevert \">&#x23AA;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" symmetric=\"true\" data-latex-item=\"\\right\\Vert\" data-latex=\"\\right\\Vert\">&#x2016;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\bracevert a \\right\\Vert" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\bracevert a \\right\\Vert" data-latex="\\left\\bracevert a \\right\\Vert">
+        <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex-item="\\left\\bracevert " data-latex="\\left\\bracevert ">&#x23AA;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" symmetric="true" data-latex-item="\\right\\Vert" data-latex="\\right\\Vert">&#x2016;</mo>
       </mrow>
     </math>`
     ));
   it('updownarrow', () =>
     toXmlMatch(
       tex2mml('\\updownarrow a \\Updownarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\updownarrow a \\Updownarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\updownarrow\">&#x2195;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo stretchy=\"false\" data-latex=\"\\Updownarrow\">&#x21D5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\updownarrow a \\Updownarrow" display="block">
+      <mo stretchy="false" data-latex="\\updownarrow">&#x2195;</mo>
+      <mi data-latex="a">a</mi>
+      <mo stretchy="false" data-latex="\\Updownarrow">&#x21D5;</mo>
     </math>`
     ));
   it('left right updownarrow', () =>
     toXmlMatch(
       tex2mml('\\left\\updownarrow a \\right\\Updownarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\updownarrow a \\right\\Updownarrow\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\updownarrow a \\right\\Updownarrow\" data-latex=\"\\left\\updownarrow a \\right\\Updownarrow\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" symmetric=\"true\" data-latex-item=\"\\left\\updownarrow \" data-latex=\"\\left\\updownarrow \">&#x2195;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" symmetric=\"true\" data-latex-item=\"\\right\\Updownarrow\" data-latex=\"\\right\\Updownarrow\">&#x21D5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\updownarrow a \\right\\Updownarrow" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\updownarrow a \\right\\Updownarrow" data-latex="\\left\\updownarrow a \\right\\Updownarrow">
+        <mo data-mjx-texclass="OPEN" fence="true" symmetric="true" data-latex-item="\\left\\updownarrow " data-latex="\\left\\updownarrow ">&#x2195;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" fence="true" symmetric="true" data-latex-item="\\right\\Updownarrow" data-latex="\\right\\Updownarrow">&#x21D5;</mo>
       </mrow>
     </math>`
     ));
   it('backslash', () =>
     toXmlMatch(
       tex2mml('/ a \\backslash'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"/ a \\backslash\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\">
-        <mo data-latex=\"/\">/</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="/ a \\backslash" display="block">
+      <mrow data-mjx-texclass="ORD">
+        <mo data-latex="/">/</mo>
       </mrow>
-      <mi data-latex=\"a\">a</mi>
-      <mi mathvariant=\"normal\" data-latex=\"\\backslash\">\\</mi>
+      <mi data-latex="a">a</mi>
+      <mi mathvariant="normal" data-latex="\\backslash">\\</mi>
     </math>`
     ));
   it('left right left/', () =>
     toXmlMatch(
       tex2mml('\\left/ a \\right\\backslash'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left/ a \\right\\backslash\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left/ a \\right\\backslash\" data-latex=\"\\left/ a \\right\\backslash\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\left/\" data-latex=\"\\left/\">/</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\right\\backslash\" data-latex=\"\\right\\backslash\">\\</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left/ a \\right\\backslash" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left/ a \\right\\backslash" data-latex="\\left/ a \\right\\backslash">
+        <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex-item="\\left/" data-latex="\\left/">/</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true" data-latex-item="\\right\\backslash" data-latex="\\right\\backslash">\\</mo>
       </mrow>
     </math>`
     ));
   it('Uparrow', () =>
     toXmlMatch(
       tex2mml('\\Uparrow a \\Downarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Uparrow a \\Downarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\Uparrow\">&#x21D1;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo stretchy=\"false\" data-latex=\"\\Downarrow\">&#x21D3;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Uparrow a \\Downarrow" display="block">
+      <mo stretchy="false" data-latex="\\Uparrow">&#x21D1;</mo>
+      <mi data-latex="a">a</mi>
+      <mo stretchy="false" data-latex="\\Downarrow">&#x21D3;</mo>
     </math>`
     ));
   it('left right Uparrow', () =>
     toXmlMatch(
       tex2mml('\\left\\Uparrow a \\right\\Downarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\Uparrow a \\right\\Downarrow\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\Uparrow a \\right\\Downarrow\" data-latex=\"\\left\\Uparrow a \\right\\Downarrow\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" symmetric=\"true\" data-latex-item=\"\\left\\Uparrow \" data-latex=\"\\left\\Uparrow \">&#x21D1;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" symmetric=\"true\" data-latex-item=\"\\right\\Downarrow\" data-latex=\"\\right\\Downarrow\">&#x21D3;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\Uparrow a \\right\\Downarrow" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\Uparrow a \\right\\Downarrow" data-latex="\\left\\Uparrow a \\right\\Downarrow">
+        <mo data-mjx-texclass="OPEN" fence="true" symmetric="true" data-latex-item="\\left\\Uparrow " data-latex="\\left\\Uparrow ">&#x21D1;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" fence="true" symmetric="true" data-latex-item="\\right\\Downarrow" data-latex="\\right\\Downarrow">&#x21D3;</mo>
       </mrow>
     </math>`
     ));
   it('rangle', () =>
     toXmlMatch(
       tex2mml('\\rangle a \\langle'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rangle a \\langle\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rangle\">&#x27E9;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\langle\">&#x27E8;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rangle a \\langle" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
     </math>`
     ));
   it('left right rangle', () =>
     toXmlMatch(
       tex2mml('\\left\\rangle a \\right\\langle'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\rangle a \\right\\langle\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\rangle a \\right\\langle\" data-latex=\"\\left\\rangle a \\right\\langle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\rangle \" data-latex=\"\\left\\rangle \">&#x27E9;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\langle\" data-latex=\"\\right\\langle\">&#x27E8;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\rangle a \\right\\langle" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\rangle a \\right\\langle" data-latex="\\left\\rangle a \\right\\langle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\rangle " data-latex="\\left\\rangle ">&#x27E9;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\langle" data-latex="\\right\\langle">&#x27E8;</mo>
       </mrow>
     </math>`
     ));
   it('rbrace', () =>
     toXmlMatch(
       tex2mml('\\rbrace a \\lbrace'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rbrace a \\lbrace\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rbrace\">}</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\lbrace\">{</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rbrace a \\lbrace" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\rbrace">}</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\lbrace">{</mo>
     </math>`
     ));
   it('left right rbrace', () =>
     toXmlMatch(
       tex2mml('\\left\\rbrace a \\right\\lbrace'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\rbrace a \\right\\lbrace\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\rbrace a \\right\\lbrace\" data-latex=\"\\left\\rbrace a \\right\\lbrace\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\rbrace \" data-latex=\"\\left\\rbrace \">}</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\lbrace\" data-latex=\"\\right\\lbrace\">{</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\rbrace a \\right\\lbrace" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\rbrace a \\right\\lbrace" data-latex="\\left\\rbrace a \\right\\lbrace">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\rbrace " data-latex="\\left\\rbrace ">}</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\lbrace" data-latex="\\right\\lbrace">{</mo>
       </mrow>
     </math>`
     ));
   it('rceil', () =>
     toXmlMatch(
       tex2mml('\\rceil a \\lceil'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rceil a \\lceil\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rceil\">&#x2309;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\lceil\">&#x2308;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rceil a \\lceil" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\rceil">&#x2309;</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\lceil">&#x2308;</mo>
     </math>`
     ));
   it('left right rceil', () =>
     toXmlMatch(
       tex2mml('\\left\\rceil a \\right\\lceil'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\rceil a \\right\\lceil\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\rceil a \\right\\lceil\" data-latex=\"\\left\\rceil a \\right\\lceil\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\rceil \" data-latex=\"\\left\\rceil \">&#x2309;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\lceil\" data-latex=\"\\right\\lceil\">&#x2308;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\rceil a \\right\\lceil" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\rceil a \\right\\lceil" data-latex="\\left\\rceil a \\right\\lceil">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\rceil " data-latex="\\left\\rceil ">&#x2309;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\lceil" data-latex="\\right\\lceil">&#x2308;</mo>
       </mrow>
     </math>`
     ));
   it('rfloor', () =>
     toXmlMatch(
       tex2mml('\\rfloor a \\lfloor'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rfloor a \\lfloor\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rfloor\">&#x230B;</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\lfloor\">&#x230A;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rfloor a \\lfloor" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\rfloor">&#x230B;</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\lfloor">&#x230A;</mo>
     </math>`
     ));
   it('left right rfloor', () =>
     toXmlMatch(
       tex2mml('\\left\\rfloor a \\right\\lfloor'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\rfloor a \\right\\lfloor\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\rfloor a \\right\\lfloor\" data-latex=\"\\left\\rfloor a \\right\\lfloor\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\rfloor \" data-latex=\"\\left\\rfloor \">&#x230B;</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\lfloor\" data-latex=\"\\right\\lfloor\">&#x230A;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\rfloor a \\right\\lfloor" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\rfloor a \\right\\lfloor" data-latex="\\left\\rfloor a \\right\\lfloor">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\rfloor " data-latex="\\left\\rfloor ">&#x230B;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\lfloor" data-latex="\\right\\lfloor">&#x230A;</mo>
       </mrow>
     </math>`
     ));
   it('lbrack', () =>
     toXmlMatch(
       tex2mml('\\lbrack a \\rbrack'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lbrack a \\rbrack\" display=\"block\">
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\lbrack\">[</mo>
-      <mi data-latex=\"a\">a</mi>
-      <mo fence=\"false\" stretchy=\"false\" data-latex=\"\\rbrack\">]</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lbrack a \\rbrack" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\lbrack">[</mo>
+      <mi data-latex="a">a</mi>
+      <mo fence="false" stretchy="false" data-latex="\\rbrack">]</mo>
     </math>`
     ));
   it('left right lbrack', () =>
     toXmlMatch(
       tex2mml('\\left\\lbrack a \\right\\rbrack'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left\\lbrack a \\right\\rbrack\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\lbrack a \\right\\rbrack\" data-latex=\"\\left\\lbrack a \\right\\rbrack\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\lbrack \" data-latex=\"\\left\\lbrack \">[</mo>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rbrack\" data-latex=\"\\right\\rbrack\">]</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\lbrack a \\right\\rbrack" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lbrack a \\right\\rbrack" data-latex="\\left\\lbrack a \\right\\rbrack">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lbrack " data-latex="\\left\\lbrack ">[</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rbrack" data-latex="\\right\\rbrack">]</mo>
       </mrow>
     </math>`
     ));
@@ -5361,9 +5315,7 @@ describe('Named Functions', () => {
       tex2mml('\\sin\\quad x'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sin\\quad x" display="block">
   <mi data-latex="\\sin">sin</mi>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="x">x</mi>
 </math>`
     ));
@@ -5372,9 +5324,7 @@ describe('Named Functions', () => {
       tex2mml('\\sin\\! x'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sin\\! x" display="block">
   <mi data-latex="\\sin">sin</mi>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mi data-latex="x">x</mi>
 </math>`
     ));
@@ -5401,211 +5351,211 @@ describe('Named Functions', () => {
   it('arcsin', () =>
     toXmlMatch(
       tex2mml('\\arcsin'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arcsin\" display=\"block\">
-      <mi data-latex=\"\\arcsin\">arcsin</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arcsin" display="block">
+      <mi data-latex="\\arcsin">arcsin</mi>
     </math>`
     ));
   it('arccos', () =>
     toXmlMatch(
       tex2mml('\\arccos'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arccos\" display=\"block\">
-      <mi data-latex=\"\\arccos\">arccos</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arccos" display="block">
+      <mi data-latex="\\arccos">arccos</mi>
     </math>`
     ));
   it('arctan', () =>
     toXmlMatch(
       tex2mml('\\arctan'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arctan\" display=\"block\">
-      <mi data-latex=\"\\arctan\">arctan</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arctan" display="block">
+      <mi data-latex="\\arctan">arctan</mi>
     </math>`
     ));
   it('arg', () =>
     toXmlMatch(
       tex2mml('\\arg'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arg\" display=\"block\">
-      <mi data-latex=\"\\arg\">arg</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arg" display="block">
+      <mi data-latex="\\arg">arg</mi>
     </math>`
     ));
   it('cos', () =>
     toXmlMatch(
       tex2mml('\\cos'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cos\" display=\"block\">
-      <mi data-latex=\"\\cos\">cos</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cos" display="block">
+      <mi data-latex="\\cos">cos</mi>
     </math>`
     ));
   it('cosh', () =>
     toXmlMatch(
       tex2mml('\\cosh'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cosh\" display=\"block\">
-      <mi data-latex=\"\\cosh\">cosh</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cosh" display="block">
+      <mi data-latex="\\cosh">cosh</mi>
     </math>`
     ));
   it('cot', () =>
     toXmlMatch(
       tex2mml('\\cot'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cot\" display=\"block\">
-      <mi data-latex=\"\\cot\">cot</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cot" display="block">
+      <mi data-latex="\\cot">cot</mi>
     </math>`
     ));
   it('coth', () =>
     toXmlMatch(
       tex2mml('\\coth'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\coth\" display=\"block\">
-      <mi data-latex=\"\\coth\">coth</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\coth" display="block">
+      <mi data-latex="\\coth">coth</mi>
     </math>`
     ));
   it('csc', () =>
     toXmlMatch(
       tex2mml('\\csc'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\csc\" display=\"block\">
-      <mi data-latex=\"\\csc\">csc</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\csc" display="block">
+      <mi data-latex="\\csc">csc</mi>
     </math>`
     ));
   it('deg', () =>
     toXmlMatch(
       tex2mml('\\deg'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\deg\" display=\"block\">
-      <mi data-latex=\"\\deg\">deg</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\deg" display="block">
+      <mi data-latex="\\deg">deg</mi>
     </math>`
     ));
   it('det', () =>
     toXmlMatch(
       tex2mml('\\det'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\det\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\det\">det</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\det" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\det">det</mo>
     </math>`
     ));
   it('dim', () =>
     toXmlMatch(
       tex2mml('\\dim'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dim\" display=\"block\">
-      <mi data-latex=\"\\dim\">dim</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dim" display="block">
+      <mi data-latex="\\dim">dim</mi>
     </math>`
     ));
   it('exp', () =>
     toXmlMatch(
       tex2mml('\\exp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\exp\" display=\"block\">
-      <mi data-latex=\"\\exp\">exp</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\exp" display="block">
+      <mi data-latex="\\exp">exp</mi>
     </math>`
     ));
   it('gcd', () =>
     toXmlMatch(
       tex2mml('\\gcd'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\gcd\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\gcd\">gcd</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\gcd" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\gcd">gcd</mo>
     </math>`
     ));
   it('hom', () =>
     toXmlMatch(
       tex2mml('\\hom'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hom\" display=\"block\">
-      <mi data-latex=\"\\hom\">hom</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hom" display="block">
+      <mi data-latex="\\hom">hom</mi>
     </math>`
     ));
   it('inf', () =>
     toXmlMatch(
       tex2mml('\\inf'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\inf\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\inf\">inf</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\inf" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\inf">inf</mo>
     </math>`
     ));
   it('ker', () =>
     toXmlMatch(
       tex2mml('\\ker'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ker\" display=\"block\">
-      <mi data-latex=\"\\ker\">ker</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ker" display="block">
+      <mi data-latex="\\ker">ker</mi>
     </math>`
     ));
   it('lg', () =>
     toXmlMatch(
       tex2mml('\\lg'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lg\" display=\"block\">
-      <mi data-latex=\"\\lg\">lg</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lg" display="block">
+      <mi data-latex="\\lg">lg</mi>
     </math>`
     ));
   it('liminf', () =>
     toXmlMatch(
       tex2mml('\\liminf'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\liminf\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\liminf\">lim&#x2006;inf</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\liminf" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\liminf">lim&#x2006;inf</mo>
     </math>`
     ));
   it('limsup', () =>
     toXmlMatch(
       tex2mml('\\limsup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\limsup\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\limsup\">lim&#x2006;sup</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\limsup" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\limsup">lim&#x2006;sup</mo>
     </math>`
     ));
   it('ln', () =>
     toXmlMatch(
       tex2mml('\\ln'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ln\" display=\"block\">
-      <mi data-latex=\"\\ln\">ln</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ln" display="block">
+      <mi data-latex="\\ln">ln</mi>
     </math>`
     ));
   it('log', () =>
     toXmlMatch(
       tex2mml('\\log'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\log\" display=\"block\">
-      <mi data-latex=\"\\log\">log</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\log" display="block">
+      <mi data-latex="\\log">log</mi>
     </math>`
     ));
   it('max', () =>
     toXmlMatch(
       tex2mml('\\max'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\max\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\max\">max</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\max" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\max">max</mo>
     </math>`
     ));
   it('min', () =>
     toXmlMatch(
       tex2mml('\\min'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\min\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\min\">min</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\min" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\min">min</mo>
     </math>`
     ));
   it('Pr', () =>
     toXmlMatch(
       tex2mml('\\Pr'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Pr\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\Pr\">Pr</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Pr" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\Pr">Pr</mo>
     </math>`
     ));
   it('sec', () =>
     toXmlMatch(
       tex2mml('\\sec'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sec\" display=\"block\">
-      <mi data-latex=\"\\sec\">sec</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sec" display="block">
+      <mi data-latex="\\sec">sec</mi>
     </math>`
     ));
   it('sinh', () =>
     toXmlMatch(
       tex2mml('\\sinh'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sinh\" display=\"block\">
-      <mi data-latex=\"\\sinh\">sinh</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sinh" display="block">
+      <mi data-latex="\\sinh">sinh</mi>
     </math>`
     ));
   it('sup', () =>
     toXmlMatch(
       tex2mml('\\sup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sup\" display=\"block\">
-      <mo data-mjx-texclass=\"OP\" movablelimits=\"true\" data-latex=\"\\sup\">sup</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sup" display="block">
+      <mo data-mjx-texclass="OP" movablelimits="true" data-latex="\\sup">sup</mo>
     </math>`
     ));
   it('tan', () =>
     toXmlMatch(
       tex2mml('\\tan'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tan\" display=\"block\">
-      <mi data-latex=\"\\tan\">tan</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tan" display="block">
+      <mi data-latex="\\tan">tan</mi>
     </math>`
     ));
   it('tanh', () =>
     toXmlMatch(
       tex2mml('\\tanh'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tanh\" display=\"block\">
-      <mi data-latex=\"\\tanh\">tanh</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tanh" display="block">
+      <mi data-latex="\\tanh">tanh</mi>
     </math>`
     ));
 });
@@ -5628,211 +5578,211 @@ describe('Greek characters', () => {
   it('delta', () =>
     toXmlMatch(
       tex2mml('\\delta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\delta\" display=\"block\">
-      <mi data-latex=\"\\delta\">&#x3B4;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\delta" display="block">
+      <mi data-latex="\\delta">&#x3B4;</mi>
     </math>`
     ));
   it('epsilon', () =>
     toXmlMatch(
       tex2mml('\\epsilon'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\epsilon\" display=\"block\">
-      <mi data-latex=\"\\epsilon\">&#x3F5;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\epsilon" display="block">
+      <mi data-latex="\\epsilon">&#x3F5;</mi>
     </math>`
     ));
   it('zeta', () =>
     toXmlMatch(
       tex2mml('\\zeta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\zeta\" display=\"block\">
-      <mi data-latex=\"\\zeta\">&#x3B6;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\zeta" display="block">
+      <mi data-latex="\\zeta">&#x3B6;</mi>
     </math>`
     ));
   it('eta', () =>
     toXmlMatch(
       tex2mml('\\eta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\eta\" display=\"block\">
-      <mi data-latex=\"\\eta\">&#x3B7;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eta" display="block">
+      <mi data-latex="\\eta">&#x3B7;</mi>
     </math>`
     ));
   it('theta', () =>
     toXmlMatch(
       tex2mml('\\theta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\theta\" display=\"block\">
-      <mi data-latex=\"\\theta\">&#x3B8;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\theta" display="block">
+      <mi data-latex="\\theta">&#x3B8;</mi>
     </math>`
     ));
   it('iota', () =>
     toXmlMatch(
       tex2mml('\\iota'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\iota\" display=\"block\">
-      <mi data-latex=\"\\iota\">&#x3B9;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\iota" display="block">
+      <mi data-latex="\\iota">&#x3B9;</mi>
     </math>`
     ));
   it('kappa', () =>
     toXmlMatch(
       tex2mml('\\kappa'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\kappa\" display=\"block\">
-      <mi data-latex=\"\\kappa\">&#x3BA;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\kappa" display="block">
+      <mi data-latex="\\kappa">&#x3BA;</mi>
     </math>`
     ));
   it('lambda', () =>
     toXmlMatch(
       tex2mml('\\lambda'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lambda\" display=\"block\">
-      <mi data-latex=\"\\lambda\">&#x3BB;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lambda" display="block">
+      <mi data-latex="\\lambda">&#x3BB;</mi>
     </math>`
     ));
   it('nu', () =>
     toXmlMatch(
       tex2mml('\\nu'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\nu\" display=\"block\">
-      <mi data-latex=\"\\nu\">&#x3BD;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\nu" display="block">
+      <mi data-latex="\\nu">&#x3BD;</mi>
     </math>`
     ));
   it('xi', () =>
     toXmlMatch(
       tex2mml('\\xi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\xi\" display=\"block\">
-      <mi data-latex=\"\\xi\">&#x3BE;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xi" display="block">
+      <mi data-latex="\\xi">&#x3BE;</mi>
     </math>`
     ));
   it('omicron', () =>
     toXmlMatch(
       tex2mml('\\omicron'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\omicron\" display=\"block\">
-      <mi data-latex=\"\\omicron\">&#x3BF;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\omicron" display="block">
+      <mi data-latex="\\omicron">&#x3BF;</mi>
     </math>`
     ));
   it('rho', () =>
     toXmlMatch(
       tex2mml('\\rho'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rho\" display=\"block\">
-      <mi data-latex=\"\\rho\">&#x3C1;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rho" display="block">
+      <mi data-latex="\\rho">&#x3C1;</mi>
     </math>`
     ));
   it('tau', () =>
     toXmlMatch(
       tex2mml('\\tau'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tau\" display=\"block\">
-      <mi data-latex=\"\\tau\">&#x3C4;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tau" display="block">
+      <mi data-latex="\\tau">&#x3C4;</mi>
     </math>`
     ));
   it('upsilon', () =>
     toXmlMatch(
       tex2mml('\\upsilon'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\upsilon\" display=\"block\">
-      <mi data-latex=\"\\upsilon\">&#x3C5;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upsilon" display="block">
+      <mi data-latex="\\upsilon">&#x3C5;</mi>
     </math>`
     ));
   it('chi', () =>
     toXmlMatch(
       tex2mml('\\chi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\chi\" display=\"block\">
-      <mi data-latex=\"\\chi\">&#x3C7;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\chi" display="block">
+      <mi data-latex="\\chi">&#x3C7;</mi>
     </math>`
     ));
   it('psi', () =>
     toXmlMatch(
       tex2mml('\\psi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\psi\" display=\"block\">
-      <mi data-latex=\"\\psi\">&#x3C8;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\psi" display="block">
+      <mi data-latex="\\psi">&#x3C8;</mi>
     </math>`
     ));
   it('omega', () =>
     toXmlMatch(
       tex2mml('\\omega'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\omega\" display=\"block\">
-      <mi data-latex=\"\\omega\">&#x3C9;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\omega" display="block">
+      <mi data-latex="\\omega">&#x3C9;</mi>
     </math>`
     ));
   it('varepsilon', () =>
     toXmlMatch(
       tex2mml('\\varepsilon'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\varepsilon\" display=\"block\">
-      <mi data-latex=\"\\varepsilon\">&#x3B5;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\varepsilon" display="block">
+      <mi data-latex="\\varepsilon">&#x3B5;</mi>
     </math>`
     ));
   it('vartheta', () =>
     toXmlMatch(
       tex2mml('\\vartheta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vartheta\" display=\"block\">
-      <mi data-latex=\"\\vartheta\">&#x3D1;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vartheta" display="block">
+      <mi data-latex="\\vartheta">&#x3D1;</mi>
     </math>`
     ));
   it('varpi', () =>
     toXmlMatch(
       tex2mml('\\varpi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\varpi\" display=\"block\">
-      <mi data-latex=\"\\varpi\">&#x3D6;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\varpi" display="block">
+      <mi data-latex="\\varpi">&#x3D6;</mi>
     </math>`
     ));
   it('varrho', () =>
     toXmlMatch(
       tex2mml('\\varrho'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\varrho\" display=\"block\">
-      <mi data-latex=\"\\varrho\">&#x3F1;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\varrho" display="block">
+      <mi data-latex="\\varrho">&#x3F1;</mi>
     </math>`
     ));
   it('varsigma', () =>
     toXmlMatch(
       tex2mml('\\varsigma'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\varsigma\" display=\"block\">
-      <mi data-latex=\"\\varsigma\">&#x3C2;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\varsigma" display="block">
+      <mi data-latex="\\varsigma">&#x3C2;</mi>
     </math>`
     ));
   it('varphi', () =>
     toXmlMatch(
       tex2mml('\\varphi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\varphi\" display=\"block\">
-      <mi data-latex=\"\\varphi\">&#x3C6;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\varphi" display="block">
+      <mi data-latex="\\varphi">&#x3C6;</mi>
     </math>`
     ));
   it('Delta', () =>
     toXmlMatch(
       tex2mml('\\Delta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Delta\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Delta\">&#x394;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Delta" display="block">
+      <mi mathvariant="normal" data-latex="\\Delta">&#x394;</mi>
     </math>`
     ));
   it('Theta', () =>
     toXmlMatch(
       tex2mml('\\Theta'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Theta\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Theta\">&#x398;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Theta" display="block">
+      <mi mathvariant="normal" data-latex="\\Theta">&#x398;</mi>
     </math>`
     ));
   it('Xi', () =>
     toXmlMatch(
       tex2mml('\\Xi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Xi\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Xi\">&#x39E;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Xi" display="block">
+      <mi mathvariant="normal" data-latex="\\Xi">&#x39E;</mi>
     </math>`
     ));
   it('Pi', () =>
     toXmlMatch(
       tex2mml('\\Pi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Pi\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Pi\">&#x3A0;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Pi" display="block">
+      <mi mathvariant="normal" data-latex="\\Pi">&#x3A0;</mi>
     </math>`
     ));
   it('Sigma', () =>
     toXmlMatch(
       tex2mml('\\Sigma'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Sigma\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Sigma\">&#x3A3;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Sigma" display="block">
+      <mi mathvariant="normal" data-latex="\\Sigma">&#x3A3;</mi>
     </math>`
     ));
   it('Phi', () =>
     toXmlMatch(
       tex2mml('\\Phi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Phi\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Phi\">&#x3A6;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Phi" display="block">
+      <mi mathvariant="normal" data-latex="\\Phi">&#x3A6;</mi>
     </math>`
     ));
   it('Psi', () =>
     toXmlMatch(
       tex2mml('\\Psi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Psi\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Psi\">&#x3A8;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Psi" display="block">
+      <mi mathvariant="normal" data-latex="\\Psi">&#x3A8;</mi>
     </math>`
     ));
 });
@@ -5841,197 +5791,197 @@ describe('Mathchar0mi', () => {
   it('AA', () =>
     toXmlMatch(
       tex2mml('\\AA'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\AA\" display=\"block\">
-      <mi data-latex=\"\\AA\">&#x212B;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\AA" display="block">
+      <mi data-latex="\\AA">&#x212B;</mi>
     </math>`
     ));
   it('S', () =>
     toXmlMatch(
       tex2mml('\\S'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\S\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\S\">&#xA7;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\S" display="block">
+      <mi mathvariant="normal" data-latex="\\S">&#xA7;</mi>
     </math>`
     ));
   it('aleph', () =>
     toXmlMatch(
       tex2mml('\\aleph'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\aleph\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\aleph\">&#x2135;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\aleph" display="block">
+      <mi mathvariant="normal" data-latex="\\aleph">&#x2135;</mi>
     </math>`
     ));
   it('hbar', () =>
     toXmlMatch(
       tex2mml('\\hbar'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hbar\" display=\"block\">
-      <mi data-mjx-alternate=\"1\" data-latex=\"\\hbar\">&#x210F;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hbar" display="block">
+      <mi data-mjx-alternate="1" data-latex="\\hbar">&#x210F;</mi>
     </math>`
     ));
   it('imath', () =>
     toXmlMatch(
       tex2mml('\\imath'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\imath\" display=\"block\">
-      <mi data-latex=\"\\imath\">&#x131;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\imath" display="block">
+      <mi data-latex="\\imath">&#x131;</mi>
     </math>`
     ));
   it('jmath', () =>
     toXmlMatch(
       tex2mml('\\jmath'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\jmath\" display=\"block\">
-      <mi data-latex=\"\\jmath\">&#x237;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\jmath" display="block">
+      <mi data-latex="\\jmath">&#x237;</mi>
     </math>`
     ));
   it('ell', () =>
     toXmlMatch(
       tex2mml('\\ell'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ell\" display=\"block\">
-      <mi data-latex=\"\\ell\">&#x2113;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ell" display="block">
+      <mi data-latex="\\ell">&#x2113;</mi>
     </math>`
     ));
   it('wp', () =>
     toXmlMatch(
       tex2mml('\\wp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\wp\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\wp\">&#x2118;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\wp" display="block">
+      <mi mathvariant="normal" data-latex="\\wp">&#x2118;</mi>
     </math>`
     ));
   it('Re', () =>
     toXmlMatch(
       tex2mml('\\Re'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Re\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Re\">&#x211C;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Re" display="block">
+      <mi mathvariant="normal" data-latex="\\Re">&#x211C;</mi>
     </math>`
     ));
   it('Im', () =>
     toXmlMatch(
       tex2mml('\\Im'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Im\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\Im\">&#x2111;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Im" display="block">
+      <mi mathvariant="normal" data-latex="\\Im">&#x2111;</mi>
     </math>`
     ));
   it('partial', () =>
     toXmlMatch(
       tex2mml('\\partial'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\partial\" display=\"block\">
-      <mi data-latex=\"\\partial\">&#x2202;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\partial" display="block">
+      <mi data-latex="\\partial">&#x2202;</mi>
     </math>`
     ));
   it('emptyset', () =>
     toXmlMatch(
       tex2mml('\\emptyset'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\emptyset\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\emptyset\">&#x2205;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\emptyset" display="block">
+      <mi mathvariant="normal" data-latex="\\emptyset">&#x2205;</mi>
     </math>`
     ));
   it('nabla', () =>
     toXmlMatch(
       tex2mml('\\nabla'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\nabla\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\nabla\">&#x2207;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\nabla" display="block">
+      <mi mathvariant="normal" data-latex="\\nabla">&#x2207;</mi>
     </math>`
     ));
   it('top', () =>
     toXmlMatch(
       tex2mml('\\top'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\top\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\top\">&#x22A4;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\top" display="block">
+      <mi mathvariant="normal" data-latex="\\top">&#x22A4;</mi>
     </math>`
     ));
   it('bot', () =>
     toXmlMatch(
       tex2mml('\\bot'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bot\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\bot\">&#x22A5;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bot" display="block">
+      <mi mathvariant="normal" data-latex="\\bot">&#x22A5;</mi>
     </math>`
     ));
   it('angle', () =>
     toXmlMatch(
       tex2mml('\\angle'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\angle\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\angle\">&#x2220;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\angle" display="block">
+      <mi mathvariant="normal" data-latex="\\angle">&#x2220;</mi>
     </math>`
     ));
   it('triangle', () =>
     toXmlMatch(
       tex2mml('\\triangle'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\triangle\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\triangle\">&#x25B3;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\triangle" display="block">
+      <mi mathvariant="normal" data-latex="\\triangle">&#x25B3;</mi>
     </math>`
     ));
   it('forall', () =>
     toXmlMatch(
       tex2mml('\\forall'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\forall\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\forall\">&#x2200;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\forall" display="block">
+      <mi mathvariant="normal" data-latex="\\forall">&#x2200;</mi>
     </math>`
     ));
   it('exists', () =>
     toXmlMatch(
       tex2mml('\\exists'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\exists\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\exists\">&#x2203;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\exists" display="block">
+      <mi mathvariant="normal" data-latex="\\exists">&#x2203;</mi>
     </math>`
     ));
   it('neg', () =>
     toXmlMatch(
       tex2mml('\\neg'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\neg\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\neg\">&#xAC;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\neg" display="block">
+      <mi mathvariant="normal" data-latex="\\neg">&#xAC;</mi>
     </math>`
     ));
   it('lnot', () =>
     toXmlMatch(
       tex2mml('\\lnot'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lnot\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\lnot\">&#xAC;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lnot" display="block">
+      <mi mathvariant="normal" data-latex="\\lnot">&#xAC;</mi>
     </math>`
     ));
   it('flat', () =>
     toXmlMatch(
       tex2mml('\\flat'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\flat\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\flat\">&#x266D;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\flat" display="block">
+      <mi mathvariant="normal" data-latex="\\flat">&#x266D;</mi>
     </math>`
     ));
   it('natural', () =>
     toXmlMatch(
       tex2mml('\\natural'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\natural\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\natural\">&#x266E;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\natural" display="block">
+      <mi mathvariant="normal" data-latex="\\natural">&#x266E;</mi>
     </math>`
     ));
   it('sharp', () =>
     toXmlMatch(
       tex2mml('\\sharp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sharp\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\sharp\">&#x266F;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sharp" display="block">
+      <mi mathvariant="normal" data-latex="\\sharp">&#x266F;</mi>
     </math>`
     ));
   it('clubsuit', () =>
     toXmlMatch(
       tex2mml('\\clubsuit'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\clubsuit\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\clubsuit\">&#x2663;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\clubsuit" display="block">
+      <mi mathvariant="normal" data-latex="\\clubsuit">&#x2663;</mi>
     </math>`
     ));
   it('diamondsuit', () =>
     toXmlMatch(
       tex2mml('\\diamondsuit'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\diamondsuit\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\diamondsuit\">&#x2662;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\diamondsuit" display="block">
+      <mi mathvariant="normal" data-latex="\\diamondsuit">&#x2662;</mi>
     </math>`
     ));
   it('heartsuit', () =>
     toXmlMatch(
       tex2mml('\\heartsuit'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\heartsuit\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\heartsuit\">&#x2661;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\heartsuit" display="block">
+      <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
     </math>`
     ));
   it('spadesuit', () =>
     toXmlMatch(
       tex2mml('\\spadesuit'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\spadesuit\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\spadesuit\">&#x2660;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\spadesuit" display="block">
+      <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
     </math>`
     ));
 });
@@ -6047,45 +5997,45 @@ describe('Mathchar0mo', () => {
   it('surd', () =>
     toXmlMatch(
       tex2mml('\\surd'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\surd\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\">
-        <mo stretchy=\"false\" data-latex=\"\\surd\">&#x221A;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\surd" display="block">
+      <mrow data-mjx-texclass="ORD">
+        <mo stretchy="false" data-latex="\\surd">&#x221A;</mo>
       </mrow>
     </math>`
     ));
   it('coprod', () =>
     toXmlMatch(
       tex2mml('\\coprod'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\coprod\" display=\"block\">
-      <mo data-latex=\"\\coprod\">&#x2210;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\coprod" display="block">
+      <mo data-latex="\\coprod">&#x2210;</mo>
     </math>`
     ));
   it('bigvee', () =>
     toXmlMatch(
       tex2mml('\\bigvee'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigvee\" display=\"block\">
-      <mo data-latex=\"\\bigvee\">&#x22C1;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigvee" display="block">
+      <mo data-latex="\\bigvee">&#x22C1;</mo>
     </math>`
     ));
   it('bigwedge', () =>
     toXmlMatch(
       tex2mml('\\bigwedge'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigwedge\" display=\"block\">
-      <mo data-latex=\"\\bigwedge\">&#x22C0;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigwedge" display="block">
+      <mo data-latex="\\bigwedge">&#x22C0;</mo>
     </math>`
     ));
   it('biguplus', () =>
     toXmlMatch(
       tex2mml('\\biguplus'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\biguplus\" display=\"block\">
-      <mo data-latex=\"\\biguplus\">&#x2A04;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\biguplus" display="block">
+      <mo data-latex="\\biguplus">&#x2A04;</mo>
     </math>`
     ));
   it('bigcap', () =>
     toXmlMatch(
       tex2mml('\\bigcap'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigcap\" display=\"block\">
-      <mo data-latex=\"\\bigcap\">&#x22C2;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigcap" display="block">
+      <mo data-latex="\\bigcap">&#x22C2;</mo>
     </math>`
     ));
   it('bigcup', () =>
@@ -6098,729 +6048,729 @@ describe('Mathchar0mo', () => {
   it('intop', () =>
     toXmlMatch(
       tex2mml('\\intop'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\intop\" display=\"block\">
-      <mo movablelimits=\"true\" data-latex=\"\\intop\">&#x222B;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\intop" display="block">
+      <mo movablelimits="true" data-latex="\\intop">&#x222B;</mo>
     </math>`
     ));
   it('iint', () =>
     toXmlMatch(
       tex2mml('\\iint'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\iint\" display=\"block\">
-      <mo data-latex=\"\\iint\">&#x222C;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\iint" display="block">
+      <mo data-latex="\\iint">&#x222C;</mo>
     </math>`
     ));
   it('iiint', () =>
     toXmlMatch(
       tex2mml('\\iiint'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\iiint\" display=\"block\">
-      <mo data-latex=\"\\iiint\">&#x222D;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\iiint" display="block">
+      <mo data-latex="\\iiint">&#x222D;</mo>
     </math>`
     ));
   it('bigotimes', () =>
     toXmlMatch(
       tex2mml('\\bigotimes'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigotimes\" display=\"block\">
-      <mo data-latex=\"\\bigotimes\">&#x2A02;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigotimes" display="block">
+      <mo data-latex="\\bigotimes">&#x2A02;</mo>
     </math>`
     ));
   it('bigoplus', () =>
     toXmlMatch(
       tex2mml('\\bigoplus'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigoplus\" display=\"block\">
-      <mo data-latex=\"\\bigoplus\">&#x2A01;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigoplus" display="block">
+      <mo data-latex="\\bigoplus">&#x2A01;</mo>
     </math>`
     ));
   it('bigodot', () =>
     toXmlMatch(
       tex2mml('\\bigodot'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigodot\" display=\"block\">
-      <mo data-latex=\"\\bigodot\">&#x2A00;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigodot" display="block">
+      <mo data-latex="\\bigodot">&#x2A00;</mo>
     </math>`
     ));
   it('ointop', () =>
     toXmlMatch(
       tex2mml('\\ointop'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ointop\" display=\"block\">
-      <mo movablelimits=\"true\" data-latex=\"\\ointop\">&#x222E;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ointop" display="block">
+      <mo movablelimits="true" data-latex="\\ointop">&#x222E;</mo>
     </math>`
     ));
   it('oiint', () =>
     toXmlMatch(
       tex2mml('\\oiint'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\oiint\" display=\"block\">
-      <mo data-latex=\"\\oiint\">&#x222F;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\oiint" display="block">
+      <mo data-latex="\\oiint">&#x222F;</mo>
     </math>`
     ));
   it('oiiint', () =>
     toXmlMatch(
       tex2mml('\\oiiint'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\oiiint\" display=\"block\">
-      <mo data-latex=\"\\oiiint\">&#x2230;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\oiiint" display="block">
+      <mo data-latex="\\oiiint">&#x2230;</mo>
     </math>`
     ));
   it('bigsqcup', () =>
     toXmlMatch(
       tex2mml('\\bigsqcup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigsqcup\" display=\"block\">
-      <mo data-latex=\"\\bigsqcup\">&#x2A06;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigsqcup" display="block">
+      <mo data-latex="\\bigsqcup">&#x2A06;</mo>
     </math>`
     ));
   it('smallint', () =>
     toXmlMatch(
       tex2mml('\\smallint'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smallint\" display=\"block\">
-      <mo largeop=\"false\" data-latex=\"\\smallint\">&#x222B;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallint" display="block">
+      <mo largeop="false" data-latex="\\smallint">&#x222B;</mo>
     </math>`
     ));
   it('triangleleft', () =>
     toXmlMatch(
       tex2mml('\\triangleleft'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\triangleleft\" display=\"block\">
-      <mo data-latex=\"\\triangleleft\">&#x25C3;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\triangleleft" display="block">
+      <mo data-latex="\\triangleleft">&#x25C3;</mo>
     </math>`
     ));
   it('triangleright', () =>
     toXmlMatch(
       tex2mml('\\triangleright'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\triangleright\" display=\"block\">
-      <mo data-latex=\"\\triangleright\">&#x25B9;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\triangleright" display="block">
+      <mo data-latex="\\triangleright">&#x25B9;</mo>
     </math>`
     ));
   it('bigtriangleup', () =>
     toXmlMatch(
       tex2mml('\\bigtriangleup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigtriangleup\" display=\"block\">
-      <mo data-latex=\"\\bigtriangleup\">&#x25B3;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigtriangleup" display="block">
+      <mo data-latex="\\bigtriangleup">&#x25B3;</mo>
     </math>`
     ));
   it('bigtriangledown', () =>
     toXmlMatch(
       tex2mml('\\bigtriangledown'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigtriangledown\" display=\"block\">
-      <mo data-latex=\"\\bigtriangledown\">&#x25BD;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigtriangledown" display="block">
+      <mo data-latex="\\bigtriangledown">&#x25BD;</mo>
     </math>`
     ));
   it('wedge', () =>
     toXmlMatch(
       tex2mml('\\wedge'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\wedge\" display=\"block\">
-      <mo data-latex=\"\\wedge\">&#x2227;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\wedge" display="block">
+      <mo data-latex="\\wedge">&#x2227;</mo>
     </math>`
     ));
   it('land', () =>
     toXmlMatch(
       tex2mml('\\land'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\land\" display=\"block\">
-      <mo data-latex=\"\\land\">&#x2227;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\land" display="block">
+      <mo data-latex="\\land">&#x2227;</mo>
     </math>`
     ));
   it('vee', () =>
     toXmlMatch(
       tex2mml('\\vee'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vee\" display=\"block\">
-      <mo data-latex=\"\\vee\">&#x2228;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vee" display="block">
+      <mo data-latex="\\vee">&#x2228;</mo>
     </math>`
     ));
   it('lor', () =>
     toXmlMatch(
       tex2mml('\\lor'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\lor\" display=\"block\">
-      <mo data-latex=\"\\lor\">&#x2228;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\lor" display="block">
+      <mo data-latex="\\lor">&#x2228;</mo>
     </math>`
     ));
   it('cap', () =>
     toXmlMatch(
       tex2mml('\\cap'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cap\" display=\"block\">
-      <mo data-latex=\"\\cap\">&#x2229;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cap" display="block">
+      <mo data-latex="\\cap">&#x2229;</mo>
     </math>`
     ));
   it('cup', () =>
     toXmlMatch(
       tex2mml('\\cup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cup\" display=\"block\">
-      <mo data-latex=\"\\cup\">&#x222A;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cup" display="block">
+      <mo data-latex="\\cup">&#x222A;</mo>
     </math>`
     ));
   it('ddagger', () =>
     toXmlMatch(
       tex2mml('\\ddagger'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ddagger\" display=\"block\">
-      <mo data-latex=\"\\ddagger\">&#x2021;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ddagger" display="block">
+      <mo data-latex="\\ddagger">&#x2021;</mo>
     </math>`
     ));
   it('dagger', () =>
     toXmlMatch(
       tex2mml('\\dagger'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dagger\" display=\"block\">
-      <mo data-latex=\"\\dagger\">&#x2020;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dagger" display="block">
+      <mo data-latex="\\dagger">&#x2020;</mo>
     </math>`
     ));
   it('sqcap', () =>
     toXmlMatch(
       tex2mml('\\sqcap'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sqcap\" display=\"block\">
-      <mo data-latex=\"\\sqcap\">&#x2293;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqcap" display="block">
+      <mo data-latex="\\sqcap">&#x2293;</mo>
     </math>`
     ));
   it('sqcup', () =>
     toXmlMatch(
       tex2mml('\\sqcup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sqcup\" display=\"block\">
-      <mo data-latex=\"\\sqcup\">&#x2294;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqcup" display="block">
+      <mo data-latex="\\sqcup">&#x2294;</mo>
     </math>`
     ));
   it('uplus', () =>
     toXmlMatch(
       tex2mml('\\uplus'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\uplus\" display=\"block\">
-      <mo data-latex=\"\\uplus\">&#x228E;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uplus" display="block">
+      <mo data-latex="\\uplus">&#x228E;</mo>
     </math>`
     ));
   it('amalg', () =>
     toXmlMatch(
       tex2mml('\\amalg'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\amalg\" display=\"block\">
-      <mo data-latex=\"\\amalg\">&#x2A3F;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\amalg" display="block">
+      <mo data-latex="\\amalg">&#x2A3F;</mo>
     </math>`
     ));
   it('diamond', () =>
     toXmlMatch(
       tex2mml('\\diamond'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\diamond\" display=\"block\">
-      <mo data-latex=\"\\diamond\">&#x22C4;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\diamond" display="block">
+      <mo data-latex="\\diamond">&#x22C4;</mo>
     </math>`
     ));
   it('bullet', () =>
     toXmlMatch(
       tex2mml('\\bullet'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bullet\" display=\"block\">
-      <mo data-latex=\"\\bullet\">&#x2219;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bullet" display="block">
+      <mo data-latex="\\bullet">&#x2219;</mo>
     </math>`
     ));
   it('wr', () =>
     toXmlMatch(
       tex2mml('\\wr'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\wr\" display=\"block\">
-      <mo data-latex=\"\\wr\">&#x2240;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\wr" display="block">
+      <mo data-latex="\\wr">&#x2240;</mo>
     </math>`
     ));
   it('div', () =>
     toXmlMatch(
       tex2mml('\\div'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\div\" display=\"block\">
-      <mo data-latex=\"\\div\">&#xF7;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\div" display="block">
+      <mo data-latex="\\div">&#xF7;</mo>
     </math>`
     ));
   it('odot', () =>
     toXmlMatch(
       tex2mml('\\odot'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\odot\" display=\"block\">
-      <mo data-latex=\"\\odot\">&#x2299;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\odot" display="block">
+      <mo data-latex="\\odot">&#x2299;</mo>
     </math>`
     ));
   it('oslash', () =>
     toXmlMatch(
       tex2mml('\\oslash'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\oslash\" display=\"block\">
-      <mo data-latex=\"\\oslash\">&#x2298;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\oslash" display="block">
+      <mo data-latex="\\oslash">&#x2298;</mo>
     </math>`
     ));
   it('otimes', () =>
     toXmlMatch(
       tex2mml('\\otimes'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\otimes\" display=\"block\">
-      <mo data-latex=\"\\otimes\">&#x2297;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\otimes" display="block">
+      <mo data-latex="\\otimes">&#x2297;</mo>
     </math>`
     ));
   it('ominus', () =>
     toXmlMatch(
       tex2mml('\\ominus'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ominus\" display=\"block\">
-      <mo data-latex=\"\\ominus\">&#x2296;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ominus" display="block">
+      <mo data-latex="\\ominus">&#x2296;</mo>
     </math>`
     ));
   it('oplus', () =>
     toXmlMatch(
       tex2mml('\\oplus'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\oplus\" display=\"block\">
-      <mo data-latex=\"\\oplus\">&#x2295;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\oplus" display="block">
+      <mo data-latex="\\oplus">&#x2295;</mo>
     </math>`
     ));
   it('mp', () =>
     toXmlMatch(
       tex2mml('\\mp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mp\" display=\"block\">
-      <mo data-latex=\"\\mp\">&#x2213;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mp" display="block">
+      <mo data-latex="\\mp">&#x2213;</mo>
     </math>`
     ));
   it('circ', () =>
     toXmlMatch(
       tex2mml('\\circ'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\circ\" display=\"block\">
-      <mo data-latex=\"\\circ\">&#x2218;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\circ" display="block">
+      <mo data-latex="\\circ">&#x2218;</mo>
     </math>`
     ));
   it('bigcirc', () =>
     toXmlMatch(
       tex2mml('\\bigcirc'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigcirc\" display=\"block\">
-      <mo data-latex=\"\\bigcirc\">&#x25EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigcirc" display="block">
+      <mo data-latex="\\bigcirc">&#x25EF;</mo>
     </math>`
     ));
   it('setminus', () =>
     toXmlMatch(
       tex2mml('\\setminus'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\setminus\" display=\"block\">
-      <mo data-latex=\"\\setminus\">&#x2216;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setminus" display="block">
+      <mo data-latex="\\setminus">&#x2216;</mo>
     </math>`
     ));
   it('cdot', () =>
     toXmlMatch(
       tex2mml('\\cdot'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cdot\" display=\"block\">
-      <mo data-latex=\"\\cdot\">&#x22C5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cdot" display="block">
+      <mo data-latex="\\cdot">&#x22C5;</mo>
     </math>`
     ));
   it('ast', () =>
     toXmlMatch(
       tex2mml('\\ast'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ast\" display=\"block\">
-      <mo data-latex=\"\\ast\">&#x2217;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ast" display="block">
+      <mo data-latex="\\ast">&#x2217;</mo>
     </math>`
     ));
   it('times', () =>
     toXmlMatch(
       tex2mml('\\times'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\times\" display=\"block\">
-      <mo data-latex=\"\\times\">&#xD7;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\times" display="block">
+      <mo data-latex="\\times">&#xD7;</mo>
     </math>`
     ));
   it('star', () =>
     toXmlMatch(
       tex2mml('\\star'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\star\" display=\"block\">
-      <mo data-latex=\"\\star\">&#x22C6;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\star" display="block">
+      <mo data-latex="\\star">&#x22C6;</mo>
     </math>`
     ));
   it('propto', () =>
     toXmlMatch(
       tex2mml('\\propto'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\propto\" display=\"block\">
-      <mo data-latex=\"\\propto\">&#x221D;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\propto" display="block">
+      <mo data-latex="\\propto">&#x221D;</mo>
     </math>`
     ));
   it('sqsubseteq', () =>
     toXmlMatch(
       tex2mml('\\sqsubseteq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sqsubseteq\" display=\"block\">
-      <mo data-latex=\"\\sqsubseteq\">&#x2291;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqsubseteq" display="block">
+      <mo data-latex="\\sqsubseteq">&#x2291;</mo>
     </math>`
     ));
   it('sqsupseteq', () =>
     toXmlMatch(
       tex2mml('\\sqsupseteq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sqsupseteq\" display=\"block\">
-      <mo data-latex=\"\\sqsupseteq\">&#x2292;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqsupseteq" display="block">
+      <mo data-latex="\\sqsupseteq">&#x2292;</mo>
     </math>`
     ));
   it('parallel', () =>
     toXmlMatch(
       tex2mml('\\parallel'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\parallel\" display=\"block\">
-      <mo data-latex=\"\\parallel\">&#x2225;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\parallel" display="block">
+      <mo data-latex="\\parallel">&#x2225;</mo>
     </math>`
     ));
   it('mid', () =>
     toXmlMatch(
       tex2mml('\\mid'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mid\" display=\"block\">
-      <mo data-latex=\"\\mid\">&#x2223;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mid" display="block">
+      <mo data-latex="\\mid">&#x2223;</mo>
     </math>`
     ));
   it('dashv', () =>
     toXmlMatch(
       tex2mml('\\dashv'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dashv\" display=\"block\">
-      <mo data-latex=\"\\dashv\">&#x22A3;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dashv" display="block">
+      <mo data-latex="\\dashv">&#x22A3;</mo>
     </math>`
     ));
   it('vdash', () =>
     toXmlMatch(
       tex2mml('\\vdash'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vdash\" display=\"block\">
-      <mo data-latex=\"\\vdash\">&#x22A2;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vdash" display="block">
+      <mo data-latex="\\vdash">&#x22A2;</mo>
     </math>`
     ));
   it('le', () =>
     toXmlMatch(
       tex2mml('\\le'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\le\" display=\"block\">
-      <mo data-latex=\"\\le\">&#x2264;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\le" display="block">
+      <mo data-latex="\\le">&#x2264;</mo>
     </math>`
     ));
   it('geq', () =>
     toXmlMatch(
       tex2mml('\\geq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\geq\" display=\"block\">
-      <mo data-latex=\"\\geq\">&#x2265;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\geq" display="block">
+      <mo data-latex="\\geq">&#x2265;</mo>
     </math>`
     ));
   it('ge', () =>
     toXmlMatch(
       tex2mml('\\ge'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ge\" display=\"block\">
-      <mo data-latex=\"\\ge\">&#x2265;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ge" display="block">
+      <mo data-latex="\\ge">&#x2265;</mo>
     </math>`
     ));
   it('succ', () =>
     toXmlMatch(
       tex2mml('\\succ'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\succ\" display=\"block\">
-      <mo data-latex=\"\\succ\">&#x227B;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\succ" display="block">
+      <mo data-latex="\\succ">&#x227B;</mo>
     </math>`
     ));
   it('prec', () =>
     toXmlMatch(
       tex2mml('\\prec'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\prec\" display=\"block\">
-      <mo data-latex=\"\\prec\">&#x227A;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\prec" display="block">
+      <mo data-latex="\\prec">&#x227A;</mo>
     </math>`
     ));
   it('approx', () =>
     toXmlMatch(
       tex2mml('\\approx'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\approx\" display=\"block\">
-      <mo data-latex=\"\\approx\">&#x2248;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\approx" display="block">
+      <mo data-latex="\\approx">&#x2248;</mo>
     </math>`
     ));
   it('succeq', () =>
     toXmlMatch(
       tex2mml('\\succeq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\succeq\" display=\"block\">
-      <mo data-latex=\"\\succeq\">&#x2AB0;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\succeq" display="block">
+      <mo data-latex="\\succeq">&#x2AB0;</mo>
     </math>`
     ));
   it('preceq', () =>
     toXmlMatch(
       tex2mml('\\preceq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\preceq\" display=\"block\">
-      <mo data-latex=\"\\preceq\">&#x2AAF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\preceq" display="block">
+      <mo data-latex="\\preceq">&#x2AAF;</mo>
     </math>`
     ));
   it('supset', () =>
     toXmlMatch(
       tex2mml('\\supset'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\supset\" display=\"block\">
-      <mo data-latex=\"\\supset\">&#x2283;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\supset" display="block">
+      <mo data-latex="\\supset">&#x2283;</mo>
     </math>`
     ));
   it('subset', () =>
     toXmlMatch(
       tex2mml('\\subset'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\subset\" display=\"block\">
-      <mo data-latex=\"\\subset\">&#x2282;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\subset" display="block">
+      <mo data-latex="\\subset">&#x2282;</mo>
     </math>`
     ));
   it('supseteq', () =>
     toXmlMatch(
       tex2mml('\\supseteq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\supseteq\" display=\"block\">
-      <mo data-latex=\"\\supseteq\">&#x2287;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\supseteq" display="block">
+      <mo data-latex="\\supseteq">&#x2287;</mo>
     </math>`
     ));
   it('subseteq', () =>
     toXmlMatch(
       tex2mml('\\subseteq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\subseteq\" display=\"block\">
-      <mo data-latex=\"\\subseteq\">&#x2286;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\subseteq" display="block">
+      <mo data-latex="\\subseteq">&#x2286;</mo>
     </math>`
     ));
   it('in', () =>
     toXmlMatch(
       tex2mml('\\in'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\in\" display=\"block\">
-      <mo data-latex=\"\\in\">&#x2208;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\in" display="block">
+      <mo data-latex="\\in">&#x2208;</mo>
     </math>`
     ));
   it('ni', () =>
     toXmlMatch(
       tex2mml('\\ni'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ni\" display=\"block\">
-      <mo data-latex=\"\\ni\">&#x220B;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ni" display="block">
+      <mo data-latex="\\ni">&#x220B;</mo>
     </math>`
     ));
   it('notin', () =>
     toXmlMatch(
       tex2mml('\\notin'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\notin\" display=\"block\">
-      <mo data-latex=\"\\notin\">&#x2209;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\notin" display="block">
+      <mo data-latex="\\notin">&#x2209;</mo>
     </math>`
     ));
   it('owns', () =>
     toXmlMatch(
       tex2mml('\\owns'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\owns\" display=\"block\">
-      <mo data-latex=\"\\owns\">&#x220B;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\owns" display="block">
+      <mo data-latex="\\owns">&#x220B;</mo>
     </math>`
     ));
   it('gg', () =>
     toXmlMatch(
       tex2mml('\\gg'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\gg\" display=\"block\">
-      <mo data-latex=\"\\gg\">&#x226B;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\gg" display="block">
+      <mo data-latex="\\gg">&#x226B;</mo>
     </math>`
     ));
   it('ll', () =>
     toXmlMatch(
       tex2mml('\\ll'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ll\" display=\"block\">
-      <mo data-latex=\"\\ll\">&#x226A;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ll" display="block">
+      <mo data-latex="\\ll">&#x226A;</mo>
     </math>`
     ));
   it('perp', () =>
     toXmlMatch(
       tex2mml('\\perp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\perp\" display=\"block\">
-      <mo data-latex=\"\\perp\">&#x22A5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\perp" display="block">
+      <mo data-latex="\\perp">&#x22A5;</mo>
     </math>`
     ));
   it('equiv', () =>
     toXmlMatch(
       tex2mml('\\equiv'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\equiv\" display=\"block\">
-      <mo data-latex=\"\\equiv\">&#x2261;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\equiv" display="block">
+      <mo data-latex="\\equiv">&#x2261;</mo>
     </math>`
     ));
   it('smile', () =>
     toXmlMatch(
       tex2mml('\\smile'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smile\" display=\"block\">
-      <mo data-latex=\"\\smile\">&#x2323;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smile" display="block">
+      <mo data-latex="\\smile">&#x2323;</mo>
     </math>`
     ));
   it('frown', () =>
     toXmlMatch(
       tex2mml('\\frown'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\frown\" display=\"block\">
-      <mo data-latex=\"\\frown\">&#x2322;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\frown" display="block">
+      <mo data-latex="\\frown">&#x2322;</mo>
     </math>`
     ));
   it('ne', () =>
     toXmlMatch(
       tex2mml('\\ne'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ne\" display=\"block\">
-      <mo data-latex=\"\\ne\">&#x2260;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ne" display="block">
+      <mo data-latex="\\ne">&#x2260;</mo>
     </math>`
     ));
   it('neq', () =>
     toXmlMatch(
       tex2mml('\\neq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\neq\" display=\"block\">
-      <mo data-latex=\"\\neq\">&#x2260;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\neq" display="block">
+      <mo data-latex="\\neq">&#x2260;</mo>
     </math>`
     ));
   it('doteq', () =>
     toXmlMatch(
       tex2mml('\\doteq'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\doteq\" display=\"block\">
-      <mo data-latex=\"\\doteq\">&#x2250;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\doteq" display="block">
+      <mo data-latex="\\doteq">&#x2250;</mo>
     </math>`
     ));
   it('bowtie', () =>
     toXmlMatch(
       tex2mml('\\bowtie'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bowtie\" display=\"block\">
-      <mo data-latex=\"\\bowtie\">&#x22C8;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bowtie" display="block">
+      <mo data-latex="\\bowtie">&#x22C8;</mo>
     </math>`
     ));
   it('models', () =>
     toXmlMatch(
       tex2mml('\\models'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\models\" display=\"block\">
-      <mo data-latex=\"\\models\">&#x22A7;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\models" display="block">
+      <mo data-latex="\\models">&#x22A7;</mo>
     </math>`
     ));
   it('notChar', () =>
     toXmlMatch(
       tex2mml('\\notChar'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\notChar\" display=\"block\">
-      <mo data-latex=\"\\notChar\">&#x29F8;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\notChar" display="block">
+      <mo data-latex="\\notChar">&#x29F8;</mo>
     </math>`
     ));
   it('Leftrightarrow', () =>
     toXmlMatch(
       tex2mml('\\Leftrightarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Leftrightarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\Leftrightarrow\">&#x21D4;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Leftrightarrow" display="block">
+      <mo stretchy="false" data-latex="\\Leftrightarrow">&#x21D4;</mo>
     </math>`
     ));
   it('Leftarrow', () =>
     toXmlMatch(
       tex2mml('\\Leftarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Leftarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\Leftarrow\">&#x21D0;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Leftarrow" display="block">
+      <mo stretchy="false" data-latex="\\Leftarrow">&#x21D0;</mo>
     </math>`
     ));
   it('leftrightarrow', () =>
     toXmlMatch(
       tex2mml('\\leftrightarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\leftrightarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\leftrightarrow\">&#x2194;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\leftrightarrow" display="block">
+      <mo stretchy="false" data-latex="\\leftrightarrow">&#x2194;</mo>
     </math>`
     ));
   it('leftarrow', () =>
     toXmlMatch(
       tex2mml('\\leftarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\leftarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\leftarrow\">&#x2190;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\leftarrow" display="block">
+      <mo stretchy="false" data-latex="\\leftarrow">&#x2190;</mo>
     </math>`
     ));
   it('gets', () =>
     toXmlMatch(
       tex2mml('\\gets'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\gets\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\gets\">&#x2190;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\gets" display="block">
+      <mo stretchy="false" data-latex="\\gets">&#x2190;</mo>
     </math>`
     ));
   it('to', () =>
     toXmlMatch(
       tex2mml('\\to'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\to\" display=\"block\">
-      <mo accent=\"false\" stretchy=\"false\" data-latex=\"\\to\">&#x2192;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\to" display="block">
+      <mo accent="false" stretchy="false" data-latex="\\to">&#x2192;</mo>
     </math>`
     ));
   it('mapsto', () =>
     toXmlMatch(
       tex2mml('\\mapsto'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mapsto\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\mapsto\">&#x21A6;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mapsto" display="block">
+      <mo stretchy="false" data-latex="\\mapsto">&#x21A6;</mo>
     </math>`
     ));
   it('leftharpoonup', () =>
     toXmlMatch(
       tex2mml('\\leftharpoonup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\leftharpoonup\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\leftharpoonup\">&#x21BC;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\leftharpoonup" display="block">
+      <mo stretchy="false" data-latex="\\leftharpoonup">&#x21BC;</mo>
     </math>`
     ));
   it('leftharpoondown', () =>
     toXmlMatch(
       tex2mml('\\leftharpoondown'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\leftharpoondown\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\leftharpoondown\">&#x21BD;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\leftharpoondown" display="block">
+      <mo stretchy="false" data-latex="\\leftharpoondown">&#x21BD;</mo>
     </math>`
     ));
   it('rightharpoonup', () =>
     toXmlMatch(
       tex2mml('\\rightharpoonup'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rightharpoonup\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\rightharpoonup\">&#x21C0;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rightharpoonup" display="block">
+      <mo stretchy="false" data-latex="\\rightharpoonup">&#x21C0;</mo>
     </math>`
     ));
   it('rightharpoondown', () =>
     toXmlMatch(
       tex2mml('\\rightharpoondown'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rightharpoondown\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\rightharpoondown\">&#x21C1;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rightharpoondown" display="block">
+      <mo stretchy="false" data-latex="\\rightharpoondown">&#x21C1;</mo>
     </math>`
     ));
   it('nearrow', () =>
     toXmlMatch(
       tex2mml('\\nearrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\nearrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\nearrow\">&#x2197;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\nearrow" display="block">
+      <mo stretchy="false" data-latex="\\nearrow">&#x2197;</mo>
     </math>`
     ));
   it('searrow', () =>
     toXmlMatch(
       tex2mml('\\searrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\searrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\searrow\">&#x2198;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\searrow" display="block">
+      <mo stretchy="false" data-latex="\\searrow">&#x2198;</mo>
     </math>`
     ));
   it('nwarrow', () =>
     toXmlMatch(
       tex2mml('\\nwarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\nwarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\nwarrow\">&#x2196;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\nwarrow" display="block">
+      <mo stretchy="false" data-latex="\\nwarrow">&#x2196;</mo>
     </math>`
     ));
   it('swarrow', () =>
     toXmlMatch(
       tex2mml('\\swarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\swarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\swarrow\">&#x2199;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\swarrow" display="block">
+      <mo stretchy="false" data-latex="\\swarrow">&#x2199;</mo>
     </math>`
     ));
   it('rightleftharpoons', () =>
     toXmlMatch(
       tex2mml('\\rightleftharpoons'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rightleftharpoons\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\rightleftharpoons\">&#x21CC;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rightleftharpoons" display="block">
+      <mo stretchy="false" data-latex="\\rightleftharpoons">&#x21CC;</mo>
     </math>`
     ));
   it('hookrightarrow', () =>
     toXmlMatch(
       tex2mml('\\hookrightarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hookrightarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\hookrightarrow\">&#x21AA;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hookrightarrow" display="block">
+      <mo stretchy="false" data-latex="\\hookrightarrow">&#x21AA;</mo>
     </math>`
     ));
   it('hookleftarrow', () =>
     toXmlMatch(
       tex2mml('\\hookleftarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hookleftarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\hookleftarrow\">&#x21A9;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hookleftarrow" display="block">
+      <mo stretchy="false" data-latex="\\hookleftarrow">&#x21A9;</mo>
     </math>`
     ));
   it('longleftarrow', () =>
     toXmlMatch(
       tex2mml('\\longleftarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\longleftarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\longleftarrow\">&#x27F5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\longleftarrow" display="block">
+      <mo stretchy="false" data-latex="\\longleftarrow">&#x27F5;</mo>
     </math>`
     ));
   it('Longleftarrow', () =>
     toXmlMatch(
       tex2mml('\\Longleftarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Longleftarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\Longleftarrow\">&#x27F8;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Longleftarrow" display="block">
+      <mo stretchy="false" data-latex="\\Longleftarrow">&#x27F8;</mo>
     </math>`
     ));
   it('Longrightarrow', () =>
     toXmlMatch(
       tex2mml('\\Longrightarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Longrightarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\Longrightarrow\">&#x27F9;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Longrightarrow" display="block">
+      <mo stretchy="false" data-latex="\\Longrightarrow">&#x27F9;</mo>
     </math>`
     ));
   it('Longleftrightarrow', () =>
     toXmlMatch(
       tex2mml('\\Longleftrightarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Longleftrightarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\Longleftrightarrow\">&#x27FA;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Longleftrightarrow" display="block">
+      <mo stretchy="false" data-latex="\\Longleftrightarrow">&#x27FA;</mo>
     </math>`
     ));
   it('longleftrightarrow', () =>
     toXmlMatch(
       tex2mml('\\longleftrightarrow'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\longleftrightarrow\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\longleftrightarrow\">&#x27F7;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\longleftrightarrow" display="block">
+      <mo stretchy="false" data-latex="\\longleftrightarrow">&#x27F7;</mo>
     </math>`
     ));
   it('longmapsto', () =>
     toXmlMatch(
       tex2mml('\\longmapsto'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\longmapsto\" display=\"block\">
-      <mo stretchy=\"false\" data-latex=\"\\longmapsto\">&#x27FC;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\longmapsto" display="block">
+      <mo stretchy="false" data-latex="\\longmapsto">&#x27FC;</mo>
     </math>`
     ));
   it('colon', () =>
     toXmlMatch(
       tex2mml('\\colon'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\colon\" display=\"block\">
-      <mo data-mjx-texclass=\"PUNCT\" data-latex=\"\\colon\">:</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\colon" display="block">
+      <mo data-mjx-texclass="PUNCT" data-latex="\\colon">:</mo>
     </math>`
     ));
 });
@@ -6847,109 +6797,109 @@ describe('Dots', () => {
   it('Dots Left', () =>
     toXmlMatch(
       tex2mml('\\dots\\left( A\\right)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dots\\left( A\\right)\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dots\\left( A\\right)" display="block">
       <mo>&#x2026;</mo>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left( A\\right)\" data-latex=\"\\left( A\\right)\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mi data-latex=\"A\">A</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left( A\\right)" data-latex="\\left( A\\right)">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mi data-latex="A">A</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('Dots Open', () =>
     toXmlMatch(
       tex2mml('\\dots{\\alpha}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dots{\\alpha}\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dots{\\alpha}" display="block">
       <mo>&#x2026;</mo>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\alpha}\">
-        <mi data-latex=\"\\alpha\">&#x3B1;</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{\\alpha}">
+        <mi data-latex="\\alpha">&#x3B1;</mi>
       </mrow>
     </math>`
     ));
   it('ldots', () =>
     toXmlMatch(
       tex2mml('\\ldots'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ldots\" display=\"block\">
-      <mo data-latex=\"\\ldots\">&#x2026;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ldots" display="block">
+      <mo data-latex="\\ldots">&#x2026;</mo>
     </math>`
     ));
   it('vdots', () =>
     toXmlMatch(
       tex2mml('\\vdots'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vdots\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\">
-        <mo data-latex=\"\\vdots\">&#x22EE;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vdots" display="block">
+      <mrow data-mjx-texclass="ORD">
+        <mo data-latex="\\vdots">&#x22EE;</mo>
       </mrow>
     </math>`
     ));
   it('cdots', () =>
     toXmlMatch(
       tex2mml('\\cdots'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cdots\" display=\"block\">
-      <mo data-latex=\"\\cdots\">&#x22EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cdots" display="block">
+      <mo data-latex="\\cdots">&#x22EF;</mo>
     </math>`
     ));
   it('ddots', () =>
     toXmlMatch(
       tex2mml('\\ddots'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ddots\" display=\"block\">
-      <mo data-latex=\"\\ddots\">&#x22F1;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ddots" display="block">
+      <mo data-latex="\\ddots">&#x22F1;</mo>
     </math>`
     ));
   it('iddots', () =>
     toXmlMatch(
       tex2mml('\\iddots'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\iddots\" display=\"block\">
-      <mo data-latex=\"\\iddots\">&#x22F0;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\iddots" display="block">
+      <mo data-latex="\\iddots">&#x22F0;</mo>
     </math>`
     ));
   it('dotsc', () =>
     toXmlMatch(
       tex2mml('\\dotsc'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dotsc\" display=\"block\">
-      <mo data-latex=\"\\dotsc\">&#x2026;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dotsc" display="block">
+      <mo data-latex="\\dotsc">&#x2026;</mo>
     </math>`
     ));
   it('dotsb', () =>
     toXmlMatch(
       tex2mml('\\dotsb'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dotsb\" display=\"block\">
-      <mo data-latex=\"\\dotsb\">&#x22EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dotsb" display="block">
+      <mo data-latex="\\dotsb">&#x22EF;</mo>
     </math>`
     ));
   it('dotsm', () =>
     toXmlMatch(
       tex2mml('\\dotsm'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dotsm\" display=\"block\">
-      <mo data-latex=\"\\dotsm\">&#x22EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dotsm" display="block">
+      <mo data-latex="\\dotsm">&#x22EF;</mo>
     </math>`
     ));
   it('dotsi', () =>
     toXmlMatch(
       tex2mml('\\dotsi'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dotsi\" display=\"block\">
-      <mo data-latex=\"\\dotsi\">&#x22EF;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dotsi" display="block">
+      <mo data-latex="\\dotsi">&#x22EF;</mo>
     </math>`
     ));
   it('dotso', () =>
     toXmlMatch(
       tex2mml('\\dotso'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dotso\" display=\"block\">
-      <mo data-latex=\"\\dotso\">&#x2026;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dotso" display="block">
+      <mo data-latex="\\dotso">&#x2026;</mo>
     </math>`
     ));
   it('ldotp', () =>
     toXmlMatch(
       tex2mml('\\ldotp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ldotp\" display=\"block\">
-      <mo data-mjx-texclass=\"PUNCT\" data-latex=\"\\ldotp\">.</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ldotp" display="block">
+      <mo data-mjx-texclass="PUNCT" data-latex="\\ldotp">.</mo>
     </math>`
     ));
   it('cdotp', () =>
     toXmlMatch(
       tex2mml('\\cdotp'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cdotp\" display=\"block\">
-      <mo data-mjx-texclass=\"PUNCT\" data-latex=\"\\cdotp\">&#x22C5;</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cdotp" display="block">
+      <mo data-mjx-texclass="PUNCT" data-latex="\\cdotp">&#x22C5;</mo>
     </math>`
     ));
 });
@@ -6959,67 +6909,67 @@ describe('Font Simple', () => {
   it('rm', () =>
     toXmlMatch(
       tex2mml('\\rm a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rm a\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\rm a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rm a" display="block">
+      <mi mathvariant="normal" data-latex="\\rm a">a</mi>
     </math>`
     ));
   it('mit', () =>
     toXmlMatch(
       tex2mml('\\mit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mit a\" display=\"block\">
-      <mi data-latex=\"\\mit a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mit a" display="block">
+      <mi data-latex="\\mit a">a</mi>
     </math>`
     ));
   it('oldstyle', () =>
     toXmlMatch(
       tex2mml('\\oldstyle 9'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\oldstyle 9\" display=\"block\">
-      <mn data-mjx-variant=\"-tex-oldstyle\" mathvariant=\"normal\" data-latex=\"\\oldstyle 9\">9</mn>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\oldstyle 9" display="block">
+      <mn data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\oldstyle 9">9</mn>
     </math>`
     ));
   it('it', () =>
     toXmlMatch(
       tex2mml('\\it a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\it a\" display=\"block\">
-      <mi data-mjx-variant=\"-tex-mathit\" mathvariant=\"italic\" data-latex=\"\\it a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\it a" display="block">
+      <mi data-mjx-variant="-tex-mathit" mathvariant="italic" data-latex="\\it a">a</mi>
     </math>`
     ));
   it('bf', () =>
     toXmlMatch(
       tex2mml('\\bf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bf a\" display=\"block\">
-      <mi mathvariant=\"bold\" data-latex=\"\\bf a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bf a" display="block">
+      <mi mathvariant="bold" data-latex="\\bf a">a</mi>
     </math>`
     ));
   it('sf', () =>
     toXmlMatch(
       tex2mml('\\sf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sf a\" display=\"block\">
-      <mi mathvariant=\"sans-serif\" data-latex=\"\\sf a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sf a" display="block">
+      <mi mathvariant="sans-serif" data-latex="\\sf a">a</mi>
     </math>`
     ));
   it('tt', () =>
     toXmlMatch(
       tex2mml('\\tt a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tt a\" display=\"block\">
-      <mi mathvariant=\"monospace\" data-latex=\"\\tt a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tt a" display="block">
+      <mi mathvariant="monospace" data-latex="\\tt a">a</mi>
     </math>`
     ));
   it('frak', () =>
     toXmlMatch(
       tex2mml('\\frak a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\frak a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\frak a\">
-        <mi mathvariant=\"fraktur\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\frak a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\frak a">
+        <mi mathvariant="fraktur" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('Bbb', () =>
     toXmlMatch(
       tex2mml('\\Bbb a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Bbb a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\Bbb a\">
-        <mi mathvariant=\"double-struck\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Bbb a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\Bbb a">
+        <mi mathvariant="double-struck" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
@@ -7035,410 +6985,410 @@ describe('Font Simple', () => {
   it('mathup', () =>
     toXmlMatch(
       tex2mml('\\mathup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathup a\">
-        <mi mathvariant=\"normal\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathup a">
+        <mi mathvariant="normal" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathnormal', () =>
     toXmlMatch(
       tex2mml('\\mathnormal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathnormal a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathnormal a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathnormal a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathnormal a">
+        <mi data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfup', () =>
     toXmlMatch(
       tex2mml('\\mathbfup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfup a\">
-        <mi mathvariant=\"bold\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfup a">
+        <mi mathvariant="bold" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathit', () =>
     toXmlMatch(
       tex2mml('\\mathit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathit a\">
-        <mi data-mjx-variant=\"-tex-mathit\" mathvariant=\"italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathit a">
+        <mi data-mjx-variant="-tex-mathit" mathvariant="italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfit', () =>
     toXmlMatch(
       tex2mml('\\mathbfit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfit a\">
-        <mi mathvariant=\"bold-italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfit a">
+        <mi mathvariant="bold-italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbb', () =>
     toXmlMatch(
       tex2mml('\\mathbb a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbb a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbb a\">
-        <mi mathvariant=\"double-struck\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbb a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbb a">
+        <mi mathvariant="double-struck" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathfrak', () =>
     toXmlMatch(
       tex2mml('\\mathfrak a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathfrak a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathfrak a\">
-        <mi mathvariant=\"fraktur\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathfrak a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathfrak a">
+        <mi mathvariant="fraktur" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbffrak', () =>
     toXmlMatch(
       tex2mml('\\mathbffrak a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbffrak a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbffrak a\">
-        <mi mathvariant=\"bold-fraktur\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbffrak a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbffrak a">
+        <mi mathvariant="bold-fraktur" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathscr', () =>
     toXmlMatch(
       tex2mml('\\mathscr a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathscr a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathscr a\">
-        <mi mathvariant=\"script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathscr a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathscr a">
+        <mi mathvariant="script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfscr', () =>
     toXmlMatch(
       tex2mml('\\mathbfscr a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfscr a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfscr a\">
-        <mi mathvariant=\"bold-script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfscr a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfscr a">
+        <mi mathvariant="bold-script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathsf', () =>
     toXmlMatch(
       tex2mml('\\mathsf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathsf a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathsf a\">
-        <mi mathvariant=\"sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathsf a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathsf a">
+        <mi mathvariant="sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathsfup', () =>
     toXmlMatch(
       tex2mml('\\mathsfup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathsfup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathsfup a\">
-        <mi mathvariant=\"sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathsfup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathsfup a">
+        <mi mathvariant="sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfsf', () =>
     toXmlMatch(
       tex2mml('\\mathbfsf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfsf a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfsf a\">
-        <mi mathvariant=\"bold-sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfsf a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfsf a">
+        <mi mathvariant="bold-sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfsfup', () =>
     toXmlMatch(
       tex2mml('\\mathbfsfup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfsfup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfsfup a\">
-        <mi mathvariant=\"bold-sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfsfup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfsfup a">
+        <mi mathvariant="bold-sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathsfit', () =>
     toXmlMatch(
       tex2mml('\\mathsfit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathsfit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathsfit a\">
-        <mi mathvariant=\"sans-serif-italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathsfit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathsfit a">
+        <mi mathvariant="sans-serif-italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfsfit', () =>
     toXmlMatch(
       tex2mml('\\mathbfsfit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfsfit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfsfit a\">
-        <mi mathvariant=\"sans-serif-bold-italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfsfit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfsfit a">
+        <mi mathvariant="sans-serif-bold-italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathtt', () =>
     toXmlMatch(
       tex2mml('\\mathtt a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathtt a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathtt a\">
-        <mi mathvariant=\"monospace\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathtt a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathtt a">
+        <mi mathvariant="monospace" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathcal', () =>
     toXmlMatch(
       tex2mml('\\mathcal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathcal a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathcal a\">
-        <mi data-mjx-variant=\"-tex-calligraphic\" mathvariant=\"script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathcal a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathcal a">
+        <mi data-mjx-variant="-tex-calligraphic" mathvariant="script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('mathbfcal', () =>
     toXmlMatch(
       tex2mml('\\mathbfcal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathbfcal a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathbfcal a\">
-        <mi data-mjx-variant=\"-tex-bold-calligraphic\" mathvariant=\"bold-script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathbfcal a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathbfcal a">
+        <mi data-mjx-variant="-tex-bold-calligraphic" mathvariant="bold-script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symrm', () =>
     toXmlMatch(
       tex2mml('\\symrm a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symrm a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symrm a\">
-        <mi mathvariant=\"normal\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symrm a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symrm a">
+        <mi mathvariant="normal" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symup', () =>
     toXmlMatch(
       tex2mml('\\symup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symup a\">
-        <mi mathvariant=\"normal\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symup a">
+        <mi mathvariant="normal" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symnormal', () =>
     toXmlMatch(
       tex2mml('\\symnormal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symnormal a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symnormal a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symnormal a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symnormal a">
+        <mi data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbf', () =>
     toXmlMatch(
       tex2mml('\\symbf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbf a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbf a\">
-        <mi mathvariant=\"bold\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbf a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbf a">
+        <mi mathvariant="bold" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfup', () =>
     toXmlMatch(
       tex2mml('\\symbfup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfup a\">
-        <mi mathvariant=\"bold\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfup a">
+        <mi mathvariant="bold" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symit', () =>
     toXmlMatch(
       tex2mml('\\symit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symit a\">
-        <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symit a">
+        <mi data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfit', () =>
     toXmlMatch(
       tex2mml('\\symbfit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfit a\">
-        <mi mathvariant=\"bold-italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfit a">
+        <mi mathvariant="bold-italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbb', () =>
     toXmlMatch(
       tex2mml('\\symbb a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbb a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbb a\">
-        <mi mathvariant=\"double-struck\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbb a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbb a">
+        <mi mathvariant="double-struck" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symfrak', () =>
     toXmlMatch(
       tex2mml('\\symfrak a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symfrak a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symfrak a\">
-        <mi mathvariant=\"fraktur\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symfrak a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symfrak a">
+        <mi mathvariant="fraktur" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbffrak', () =>
     toXmlMatch(
       tex2mml('\\symbffrak a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbffrak a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbffrak a\">
-        <mi mathvariant=\"bold-fraktur\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbffrak a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbffrak a">
+        <mi mathvariant="bold-fraktur" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symscr', () =>
     toXmlMatch(
       tex2mml('\\symscr a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symscr a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symscr a\">
-        <mi mathvariant=\"script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symscr a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symscr a">
+        <mi mathvariant="script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfscr', () =>
     toXmlMatch(
       tex2mml('\\symbfscr a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfscr a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfscr a\">
-        <mi mathvariant=\"bold-script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfscr a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfscr a">
+        <mi mathvariant="bold-script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symsf', () =>
     toXmlMatch(
       tex2mml('\\symsf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symsf a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symsf a\">
-        <mi mathvariant=\"sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symsf a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symsf a">
+        <mi mathvariant="sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symsfup', () =>
     toXmlMatch(
       tex2mml('\\symsfup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symsfup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symsfup a\">
-        <mi mathvariant=\"sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symsfup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symsfup a">
+        <mi mathvariant="sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfsf', () =>
     toXmlMatch(
       tex2mml('\\symbfsf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfsf a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfsf a\">
-        <mi mathvariant=\"bold-sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfsf a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfsf a">
+        <mi mathvariant="bold-sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfsfup', () =>
     toXmlMatch(
       tex2mml('\\symbfsfup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfsfup a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfsfup a\">
-        <mi mathvariant=\"bold-sans-serif\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfsfup a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfsfup a">
+        <mi mathvariant="bold-sans-serif" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symsfit', () =>
     toXmlMatch(
       tex2mml('\\symsfit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symsfit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symsfit a\">
-        <mi mathvariant=\"sans-serif-italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symsfit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symsfit a">
+        <mi mathvariant="sans-serif-italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfsfit', () =>
     toXmlMatch(
       tex2mml('\\symbfsfit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfsfit a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfsfit a\">
-        <mi mathvariant=\"sans-serif-bold-italic\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfsfit a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfsfit a">
+        <mi mathvariant="sans-serif-bold-italic" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symtt', () =>
     toXmlMatch(
       tex2mml('\\symtt a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symtt a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symtt a\">
-        <mi mathvariant=\"monospace\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symtt a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symtt a">
+        <mi mathvariant="monospace" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symcal', () =>
     toXmlMatch(
       tex2mml('\\symcal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symcal a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symcal a\">
-        <mi data-mjx-variant=\"-tex-calligraphic\" mathvariant=\"script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symcal a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symcal a">
+        <mi data-mjx-variant="-tex-calligraphic" mathvariant="script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('symbfcal', () =>
     toXmlMatch(
       tex2mml('\\symbfcal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\symbfcal a\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\symbfcal a\">
-        <mi data-mjx-variant=\"-tex-bold-calligraphic\" mathvariant=\"bold-script\" data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\symbfcal a" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\symbfcal a">
+        <mi data-mjx-variant="-tex-bold-calligraphic" mathvariant="bold-script" data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('textrm', () =>
     toXmlMatch(
       tex2mml('\\textrm a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textrm a\" display=\"block\">
-      <mtext data-latex=\"\\textrm a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textrm a" display="block">
+      <mtext data-latex="\\textrm a">a</mtext>
     </math>`
     ));
   it('textup', () =>
     toXmlMatch(
       tex2mml('\\textup a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textup a\" display=\"block\">
-      <mtext data-latex=\"\\textup a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textup a" display="block">
+      <mtext data-latex="\\textup a">a</mtext>
     </math>`
     ));
   it('textnormal', () =>
     toXmlMatch(
       tex2mml('\\textnormal a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textnormal a\" display=\"block\">
-      <mtext data-latex=\"\\textnormal a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textnormal a" display="block">
+      <mtext data-latex="\\textnormal a">a</mtext>
     </math>`
     ));
   it('textit', () =>
     toXmlMatch(
       tex2mml('\\textit a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textit a\" display=\"block\">
-      <mtext mathvariant=\"italic\" data-latex=\"\\textit a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textit a" display="block">
+      <mtext mathvariant="italic" data-latex="\\textit a">a</mtext>
     </math>`
     ));
   it('textbf', () =>
     toXmlMatch(
       tex2mml('\\textbf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textbf a\" display=\"block\">
-      <mtext mathvariant=\"bold\" data-latex=\"\\textbf a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbf a" display="block">
+      <mtext mathvariant="bold" data-latex="\\textbf a">a</mtext>
     </math>`
     ));
   it('textsf', () =>
     toXmlMatch(
       tex2mml('\\textsf a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textsf a\" display=\"block\">
-      <mtext mathvariant=\"sans-serif\" data-latex=\"\\textsf a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textsf a" display="block">
+      <mtext mathvariant="sans-serif" data-latex="\\textsf a">a</mtext>
     </math>`
     ));
   it('texttt', () =>
     toXmlMatch(
       tex2mml('\\texttt a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\texttt a\" display=\"block\">
-      <mtext mathvariant=\"monospace\" data-latex=\"\\texttt a\">a</mtext>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texttt a" display="block">
+      <mtext mathvariant="monospace" data-latex="\\texttt a">a</mtext>
     </math>`
     ));
 });
@@ -7447,11 +7397,11 @@ describe('Over Under Extenders', () => {
   it('overparen', () =>
     toXmlMatch(
       tex2mml('\\overparen{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\overparen{ab}\" display=\"block\">
-      <mover data-latex=\"\\overparen{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\overparen{ab}" display="block">
+      <mover data-latex="\\overparen{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x23DC;</mo>
       </mover>
@@ -7460,11 +7410,11 @@ describe('Over Under Extenders', () => {
   it('underparen', () =>
     toXmlMatch(
       tex2mml('\\underparen{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\underparen{ab}\" display=\"block\">
-      <munder data-latex=\"\\underparen{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\underparen{ab}" display="block">
+      <munder data-latex="\\underparen{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x23DD;</mo>
       </munder>
@@ -7473,11 +7423,11 @@ describe('Over Under Extenders', () => {
   it('overrightarrow', () =>
     toXmlMatch(
       tex2mml('\\overrightarrow{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\overrightarrow{ab}\" display=\"block\">
-      <mover data-latex=\"\\overrightarrow{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\overrightarrow{ab}" display="block">
+      <mover data-latex="\\overrightarrow{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x2192;</mo>
       </mover>
@@ -7486,11 +7436,11 @@ describe('Over Under Extenders', () => {
   it('underrightarrow', () =>
     toXmlMatch(
       tex2mml('\\underrightarrow{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\underrightarrow{ab}\" display=\"block\">
-      <munder data-latex=\"\\underrightarrow{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\underrightarrow{ab}" display="block">
+      <munder data-latex="\\underrightarrow{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x2192;</mo>
       </munder>
@@ -7499,11 +7449,11 @@ describe('Over Under Extenders', () => {
   it('overleftarrow', () =>
     toXmlMatch(
       tex2mml('\\overleftarrow{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\overleftarrow{ab}\" display=\"block\">
-      <mover data-latex=\"\\overleftarrow{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\overleftarrow{ab}" display="block">
+      <mover data-latex="\\overleftarrow{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x2190;</mo>
       </mover>
@@ -7512,11 +7462,11 @@ describe('Over Under Extenders', () => {
   it('underleftarrow', () =>
     toXmlMatch(
       tex2mml('\\underleftarrow{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\underleftarrow{ab}\" display=\"block\">
-      <munder data-latex=\"\\underleftarrow{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\underleftarrow{ab}" display="block">
+      <munder data-latex="\\underleftarrow{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x2190;</mo>
       </munder>
@@ -7525,11 +7475,11 @@ describe('Over Under Extenders', () => {
   it('overleftrightarrow', () =>
     toXmlMatch(
       tex2mml('\\overleftrightarrow{ab}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\overleftrightarrow{ab}\" display=\"block\">
-      <mover data-latex=\"\\overleftrightarrow{ab}\">
-        <mrow data-latex=\"ab\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\overleftrightarrow{ab}" display="block">
+      <mover data-latex="\\overleftrightarrow{ab}">
+        <mrow data-latex="ab">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="b">b</mi>
         </mrow>
         <mo>&#x2194;</mo>
       </mover>
@@ -7541,27 +7491,25 @@ describe('Math style sizes', () => {
   it('displaystyle', () =>
     toXmlMatch(
       tex2mml('\\displaystyle A', false),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\displaystyle A\">
-      <mstyle displaystyle=\"true\" scriptlevel=\"0\" data-latex=\"\\displaystyle A\">
-        <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\displaystyle A">
+      <mstyle displaystyle="true" data-latex="\\displaystyle A">
+        <mi data-latex="A">A</mi>
       </mstyle>
     </math>`
     ));
   it('textstyle', () =>
     toXmlMatch(
       tex2mml('\\textstyle B', false),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\textstyle B\">
-      <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"\\textstyle B\">
-        <mi data-latex=\"B\">B</mi>
-      </mstyle>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textstyle B">
+      <mi data-latex="\\textstyle B">B</mi>
     </math>`
     ));
   it('scriptstyle', () =>
     toXmlMatch(
       tex2mml('\\scriptstyle C', false),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\scriptstyle C\">
-      <mstyle displaystyle=\"false\" scriptlevel=\"1\" data-latex=\"\\scriptstyle C\">
-        <mi data-latex=\"C\">C</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\scriptstyle C">
+      <mstyle scriptlevel="1" data-latex="\\scriptstyle C">
+        <mi data-latex="C">C</mi>
       </mstyle>
     </math>`
     ));
@@ -7580,53 +7528,53 @@ describe('Special characters', () => {
   it('Space', () =>
     toXmlMatch(
       tex2mml('a b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a b" display="block">
+      <mi data-latex="a">a</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Tab', () =>
     toXmlMatch(
       tex2mml('a\tb'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a	b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a	b" display="block">
+      <mi data-latex="a">a</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('CR', () =>
     toXmlMatch(
       tex2mml('a\rb'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\rb\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\rb" display="block">
+      <mi data-latex="a">a</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Newline', () =>
     toXmlMatch(
       tex2mml('a\nb'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\nb\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\nb" display="block">
+      <mi data-latex="a">a</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('No break space', () =>
     toXmlMatch(
       tex2mml('a{\u00A0}b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a{&#xA0;}b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{}\"></mrow>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a{&#xA0;}b" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Prime', () =>
     toXmlMatch(
       tex2mml('a\u2019b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a&#x2019;b\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a&#x2019;b" display="block">
       <msup>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-mjx-alternate=\"1\" data-latex=\"&#x2019;\">&#x2032;</mo>
+        <mi data-latex="a">a</mi>
+        <mo data-mjx-alternate="1" data-latex="&#x2019;">&#x2032;</mo>
       </msup>
-      <mi data-latex=\"b\">b</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
 });
@@ -7635,107 +7583,103 @@ describe('Special macros', () => {
   it('Iff', () =>
     toXmlMatch(
       tex2mml('A \\iff B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\iff B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\;\">
-        <mspace width=\"0.278em\"></mspace>
-      </mstyle>
-      <mo stretchy=\"false\" data-latex=\"\\Longleftrightarrow\">&#x27FA;</mo>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\;\">
-        <mspace width=\"0.278em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\iff B" display="block">
+      <mi data-latex="A">A</mi>
+      <mspace width="0.278em" data-latex="\\;"></mspace>
+      <mo stretchy="false" data-latex="\\Longleftrightarrow">&#x27FA;</mo>
+      <mspace width="0.278em" data-latex="\\;"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('TeX', () =>
     toXmlMatch(
       tex2mml('\\TeX'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\TeX\" display=\"block\">
-      <mi data-latex=\"T\">T</mi>
-      <mspace width=\"-.14em\" linebreak=\"nobreak\" data-latex=\"\\kern-.14em\"></mspace>
-      <mpadded height=\"-.5ex\" depth=\"+.5ex\" voffset=\"-.5ex\" data-latex=\"{}\">
-        <mrow data-mjx-texclass=\"ORD\">
-          <mi data-latex=\"E\">E</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\TeX" display="block">
+      <mi data-latex="T">T</mi>
+      <mspace width="-.14em" linebreak="nobreak" data-latex="\\kern-.14em"></mspace>
+      <mpadded height="-.5ex" depth="+.5ex" voffset="-.5ex" data-latex="{}">
+        <mrow data-mjx-texclass="ORD">
+          <mi data-latex="E">E</mi>
         </mrow>
       </mpadded>
-      <mspace width=\"-.115em\" linebreak=\"nobreak\" data-latex=\"\\kern-.115em\"></mspace>
-      <mi data-latex=\"X\">X</mi>
+      <mspace width="-.115em" linebreak="nobreak" data-latex="\\kern-.115em"></mspace>
+      <mi data-latex="X">X</mi>
     </math>`
     ));
   it('LaTeX', () =>
     toXmlMatch(
       tex2mml('\\LaTeX'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\LaTeX\" display=\"block\">
-      <mi data-latex=\"L\">L</mi>
-      <mspace width=\"-.325em\" linebreak=\"nobreak\" data-latex=\"\\kern-.325em\"></mspace>
-      <mpadded height=\"+.21em\" depth=\"-.21em\" voffset=\"+.21em\" data-latex=\"{}\">
-        <mrow data-mjx-texclass=\"ORD\">
-          <mstyle displaystyle=\"false\" scriptlevel=\"1\">
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-              <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\LaTeX" display="block">
+      <mi data-latex="L">L</mi>
+      <mspace width="-.325em" linebreak="nobreak" data-latex="\\kern-.325em"></mspace>
+      <mpadded height="+.21em" depth="-.21em" voffset="+.21em" data-latex="{}">
+        <mrow data-mjx-texclass="ORD">
+          <mstyle displaystyle="false" scriptlevel="1">
+            <mrow data-mjx-texclass="ORD" data-latex="{A}">
+              <mi data-latex="A">A</mi>
             </mrow>
           </mstyle>
         </mrow>
       </mpadded>
-      <mspace width=\"-.17em\" linebreak=\"nobreak\" data-latex=\"\\kern-.17em\"></mspace>
-      <mi data-latex=\"T\">T</mi>
-      <mspace width=\"-.14em\" linebreak=\"nobreak\" data-latex=\"\\kern-.14em\"></mspace>
-      <mpadded height=\"-.5ex\" depth=\"+.5ex\" voffset=\"-.5ex\" data-latex=\"{}\">
-        <mrow data-mjx-texclass=\"ORD\">
-          <mi data-latex=\"E\">E</mi>
+      <mspace width="-.17em" linebreak="nobreak" data-latex="\\kern-.17em"></mspace>
+      <mi data-latex="T">T</mi>
+      <mspace width="-.14em" linebreak="nobreak" data-latex="\\kern-.14em"></mspace>
+      <mpadded height="-.5ex" depth="+.5ex" voffset="-.5ex" data-latex="{}">
+        <mrow data-mjx-texclass="ORD">
+          <mi data-latex="E">E</mi>
         </mrow>
       </mpadded>
-      <mspace width=\"-.115em\" linebreak=\"nobreak\" data-latex=\"\\kern-.115em\"></mspace>
-      <mi data-latex=\"X\">X</mi>
+      <mspace width="-.115em" linebreak="nobreak" data-latex="\\kern-.115em"></mspace>
+      <mi data-latex="X">X</mi>
     </math>`
     ));
   it('Skew 7', () =>
     toXmlMatch(
       tex2mml('\\skew7\\hat A'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\skew7\\hat A\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{{\\hat{A\\mkern7mu}\\mkern-7mu}{}}\">
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\hat{A\\mkern7mu}\\mkern-7mu}\">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\hat{A\\mkern7mu}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\skew7\\hat A" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="{{\\hat{A\\mkern7mu}\\mkern-7mu}{}}">
+        <mrow data-mjx-texclass="ORD" data-latex="{\\hat{A\\mkern7mu}\\mkern-7mu}">
+          <mrow data-mjx-texclass="ORD" data-latex="\\hat{A\\mkern7mu}">
             <mover>
-              <mrow data-latex=\"A\\mkern7mu\">
-                <mi data-latex=\"A\">A</mi>
-                <mspace width=\"0.389em\" linebreak=\"nobreak\" data-latex=\"\\mkern7mu\"></mspace>
+              <mrow data-latex="A\\mkern7mu">
+                <mi data-latex="A">A</mi>
+                <mspace width="0.389em" linebreak="nobreak" data-latex="\\mkern7mu"></mspace>
               </mrow>
-              <mo stretchy=\"false\">^</mo>
+              <mo stretchy="false">^</mo>
             </mover>
           </mrow>
-          <mspace width=\"-0.389em\" linebreak=\"nobreak\" data-latex=\"\\mkern-7mu\"></mspace>
+          <mspace width="-0.389em" linebreak="nobreak" data-latex="\\mkern-7mu"></mspace>
         </mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{}\"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
       </mrow>
     </math>`
     ));
   it('Skew 20', () =>
     toXmlMatch(
       tex2mml('\\skew{20}\\hat A'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\skew{20}\\hat A\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{{\\hat{A\\mkern20mu}\\mkern-20mu}{}}\">
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\hat{A\\mkern20mu}\\mkern-20mu}\">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\hat{A\\mkern20mu}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\skew{20}\\hat A" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="{{\\hat{A\\mkern20mu}\\mkern-20mu}{}}">
+        <mrow data-mjx-texclass="ORD" data-latex="{\\hat{A\\mkern20mu}\\mkern-20mu}">
+          <mrow data-mjx-texclass="ORD" data-latex="\\hat{A\\mkern20mu}">
             <mover>
-              <mrow data-latex=\"A\\mkern20mu\">
-                <mi data-latex=\"A\">A</mi>
-                <mspace width=\"1.111em\" linebreak=\"nobreak\" data-latex=\"\\mkern20mu\"></mspace>
+              <mrow data-latex="A\\mkern20mu">
+                <mi data-latex="A">A</mi>
+                <mspace width="1.111em" linebreak="nobreak" data-latex="\\mkern20mu"></mspace>
               </mrow>
-              <mo stretchy=\"false\">^</mo>
+              <mo stretchy="false">^</mo>
             </mover>
           </mrow>
-          <mspace width=\"-1.111em\" linebreak=\"nobreak\" data-latex=\"\\mkern-20mu\"></mspace>
+          <mspace width="-1.111em" linebreak="nobreak" data-latex="\\mkern-20mu"></mspace>
         </mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{}\"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
       </mrow>
     </math>`
     ));
   it('Pmb', () =>
     toXmlMatch(
       tex2mml('a \\pmb a \\boldsymbol a'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a \\pmb a \\boldsymbol a\" display=\"block\">
-      <merror data-mjx-error=\"Undefined control sequence \\boldsymbol\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a \\pmb a \\boldsymbol a" display="block">
+      <merror data-mjx-error="Undefined control sequence \\boldsymbol">
         <mtext>Undefined control sequence \\boldsymbol</mtext>
       </merror>
     </math>`
@@ -7743,28 +7687,28 @@ describe('Special macros', () => {
   it('Space', () =>
     toXmlMatch(
       tex2mml('A \\space B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\space B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mtext data-latex=\"\\space\">&#xA0;</mtext>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\space B" display="block">
+      <mi data-latex="A">A</mi>
+      <mtext data-latex="\\space">&#xA0;</mtext>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('Space 2', () =>
     toXmlMatch(
       tex2mml('A \\ B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\ B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\ B" display="block">
+      <mi data-latex="A">A</mi>
       <mtext>&#xA0;</mtext>
-      <mi data-latex=\"B\">B</mi>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('Space 3', () =>
     toXmlMatch(
       tex2mml('A \\ B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\&#xA0;B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\&#xA0;B" display="block">
+      <mi data-latex="A">A</mi>
       <mtext>&#xA0;</mtext>
-      <mi data-latex=\"B\">B</mi>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
 });
@@ -7773,90 +7717,90 @@ describe('Big Commands for Delimiters', () => {
   it('big', () =>
     toXmlMatch(
       tex2mml('\\big|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\big|\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\big|\">
-        <mo minsize=\"1.2em\" maxsize=\"1.2em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\big|" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\big|">
+        <mo minsize="1.2em" maxsize="1.2em">|</mo>
       </mrow>
     </math>`
     ));
   it('Big', () =>
     toXmlMatch(
       tex2mml('\\Big|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Big|\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\Big|\">
-        <mo minsize=\"1.623em\" maxsize=\"1.623em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Big|" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\Big|">
+        <mo minsize="1.623em" maxsize="1.623em">|</mo>
       </mrow>
     </math>`
     ));
   it('bigg', () =>
     toXmlMatch(
       tex2mml('\\bigg|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigg|\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\bigg|\">
-        <mo minsize=\"2.047em\" maxsize=\"2.047em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigg|" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\bigg|">
+        <mo minsize="2.047em" maxsize="2.047em">|</mo>
       </mrow>
     </math>`
     ));
   it('Bigg', () =>
     toXmlMatch(
       tex2mml('\\Bigg|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Bigg|\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\Bigg|\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Bigg|" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\Bigg|">
+        <mo minsize="2.470em" maxsize="2.470em">|</mo>
       </mrow>
     </math>`
     ));
   it('Biggl', () =>
     toXmlMatch(
       tex2mml('\\Biggl|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Biggl|\" display=\"block\">
-      <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\Biggl|\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Biggl|" display="block">
+      <mrow data-mjx-texclass="OPEN" data-latex="\\Biggl|">
+        <mo minsize="2.470em" maxsize="2.470em">|</mo>
       </mrow>
     </math>`
     ));
   it('Biggr', () =>
     toXmlMatch(
       tex2mml('\\Biggr|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Biggr|\" display=\"block\">
-      <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\Biggr|\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Biggr|" display="block">
+      <mrow data-mjx-texclass="CLOSE" data-latex="\\Biggr|">
+        <mo minsize="2.470em" maxsize="2.470em">|</mo>
       </mrow>
     </math>`
     ));
   it('bigm', () =>
     toXmlMatch(
       tex2mml('\\bigm|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bigm|\" display=\"block\">
-      <mrow data-mjx-texclass=\"REL\" data-latex=\"\\bigm|\">
-        <mo minsize=\"1.2em\" maxsize=\"1.2em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bigm|" display="block">
+      <mrow data-mjx-texclass="REL" data-latex="\\bigm|">
+        <mo minsize="1.2em" maxsize="1.2em">|</mo>
       </mrow>
     </math>`
     ));
   it('Bigm', () =>
     toXmlMatch(
       tex2mml('\\Bigm|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Bigm|\" display=\"block\">
-      <mrow data-mjx-texclass=\"REL\" data-latex=\"\\Bigm|\">
-        <mo minsize=\"1.623em\" maxsize=\"1.623em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Bigm|" display="block">
+      <mrow data-mjx-texclass="REL" data-latex="\\Bigm|">
+        <mo minsize="1.623em" maxsize="1.623em">|</mo>
       </mrow>
     </math>`
     ));
   it('biggm', () =>
     toXmlMatch(
       tex2mml('\\biggm|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\biggm|\" display=\"block\">
-      <mrow data-mjx-texclass=\"REL\" data-latex=\"\\biggm|\">
-        <mo minsize=\"2.047em\" maxsize=\"2.047em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\biggm|" display="block">
+      <mrow data-mjx-texclass="REL" data-latex="\\biggm|">
+        <mo minsize="2.047em" maxsize="2.047em">|</mo>
       </mrow>
     </math>`
     ));
   it('Biggm', () =>
     toXmlMatch(
       tex2mml('\\Biggm|'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Biggm|\" display=\"block\">
-      <mrow data-mjx-texclass=\"REL\" data-latex=\"\\Biggm|\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Biggm|" display="block">
+      <mrow data-mjx-texclass="REL" data-latex="\\Biggm|">
+        <mo minsize="2.470em" maxsize="2.470em">|</mo>
       </mrow>
     </math>`
     ));
@@ -7876,7 +7820,7 @@ describe('Boxes', () => {
     toXmlMatch(
       tex2mml('\\hbox{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hbox{x}" display="block">
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\hbox{x}">
+  <mstyle displaystyle="false" data-latex="\\hbox{x}">
     <mtext>x</mtext>
   </mstyle>
 </math>`
@@ -7884,71 +7828,71 @@ describe('Boxes', () => {
   it('Vtop', () =>
     toXmlMatch(
       tex2mml('\\vtop{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vtop{x}\" display=\"block\">
-      <mpadded data-mjx-vbox=\"top\" data-mjx-texclass=\"ORD\" data-vertical-align=\"top\" data-latex=\"\\vtop{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vtop{x}" display="block">
+      <mpadded data-mjx-vbox="top" data-mjx-texclass="ORD" data-vertical-align="top" data-latex="\\vtop{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Vtop Hsize', () =>
     toXmlMatch(
       tex2mml('\\hsize{2cm}\\vtop{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hsize{2cm}\\vtop{x}\" display=\"block\" maxwidth=\"2cm\" overflow=\"linebreak\">
-      <mpadded data-mjx-vbox=\"top\" data-mjx-texclass=\"ORD\" data-vertical-align=\"top\" width=\"2cm\" data-overflow=\"linebreak\" data-latex=\"\\hsize{2cm}\\vtop{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hsize{2cm}\\vtop{x}" display="block" maxwidth="2cm" overflow="linebreak">
+      <mpadded data-mjx-vbox="top" data-mjx-texclass="ORD" data-vertical-align="top" width="2cm" data-overflow="linebreak" data-latex="\\hsize{2cm}\\vtop{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Vtop Hsize =', () =>
     toXmlMatch(
       tex2mml('\\hsize=2cm\\vtop{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hsize=2cm\\vtop{x}\" display=\"block\" maxwidth=\"2cm\" overflow=\"linebreak\">
-      <mpadded data-mjx-vbox=\"top\" data-mjx-texclass=\"ORD\" data-vertical-align=\"top\" width=\"2cm\" data-overflow=\"linebreak\" data-latex=\"\\hsize=2cm\\vtop{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hsize=2cm\\vtop{x}" display="block" maxwidth="2cm" overflow="linebreak">
+      <mpadded data-mjx-vbox="top" data-mjx-texclass="ORD" data-vertical-align="top" width="2cm" data-overflow="linebreak" data-latex="\\hsize=2cm\\vtop{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Vcenter', () =>
     toXmlMatch(
       tex2mml('\\vcenter{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vcenter{x}\" display=\"block\">
-      <mpadded data-mjx-vbox=\"center\" data-mjx-texclass=\"ORD\" data-vertical-align=\"center\" data-latex=\"\\vcenter{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vcenter{x}" display="block">
+      <mpadded data-mjx-vbox="center" data-mjx-texclass="ORD" data-vertical-align="center" data-latex="\\vcenter{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Vcenter Hsize', () =>
     toXmlMatch(
       tex2mml('\\hsize{2cm}\\vcenter{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hsize{2cm}\\vcenter{x}\" display=\"block\" maxwidth=\"2cm\" overflow=\"linebreak\">
-      <mpadded data-mjx-vbox=\"center\" data-mjx-texclass=\"ORD\" data-vertical-align=\"center\" width=\"2cm\" data-overflow=\"linebreak\" data-latex=\"\\hsize{2cm}\\vcenter{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hsize{2cm}\\vcenter{x}" display="block" maxwidth="2cm" overflow="linebreak">
+      <mpadded data-mjx-vbox="center" data-mjx-texclass="ORD" data-vertical-align="center" width="2cm" data-overflow="linebreak" data-latex="\\hsize{2cm}\\vcenter{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Vbox', () =>
     toXmlMatch(
       tex2mml('\\vbox{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vbox{x}\" display=\"block\">
-      <mpadded data-mjx-vbox=\"bottom\" data-mjx-texclass=\"ORD\" data-vertical-align=\"bottom\" data-latex=\"\\vbox{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vbox{x}" display="block">
+      <mpadded data-mjx-vbox="bottom" data-mjx-texclass="ORD" data-vertical-align="bottom" data-latex="\\vbox{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Vbox Hsize', () =>
     toXmlMatch(
       tex2mml('\\hsize{2cm}\\vbox{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hsize{2cm}\\vbox{x}\" display=\"block\" maxwidth=\"2cm\" overflow=\"linebreak\">
-      <mpadded data-mjx-vbox=\"bottom\" data-mjx-texclass=\"ORD\" data-vertical-align=\"bottom\" width=\"2cm\" data-overflow=\"linebreak\" data-latex=\"\\hsize{2cm}\\vbox{x}\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hsize{2cm}\\vbox{x}" display="block" maxwidth="2cm" overflow="linebreak">
+      <mpadded data-mjx-vbox="bottom" data-mjx-texclass="ORD" data-vertical-align="bottom" width="2cm" data-overflow="linebreak" data-latex="\\hsize{2cm}\\vbox{x}">
+        <mi data-latex="x">x</mi>
       </mpadded>
     </math>`
     ));
   it('Parbox', () =>
     toXmlMatch(
       tex2mml('\\parbox{2cm}{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\parbox{2cm}{x}\" display=\"block\">
-      <mpadded data-mjx-vbox=\"center\" width=\"2cm\" data-overflow=\"linebreak\" data-vertical-align=\"center\" data-latex=\"\\parbox{2cm}{x}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\parbox{2cm}{x}" display="block">
+      <mpadded data-mjx-vbox="center" width="2cm" data-overflow="linebreak" data-vertical-align="center" data-latex="\\parbox{2cm}{x}">
         <mtext>x</mtext>
       </mpadded>
     </math>`
@@ -7956,14 +7900,12 @@ describe('Boxes', () => {
   it('Boxed', () =>
     toXmlMatch(
       tex2mml('\\boxed{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\boxed{x}\" display=\"block\">
-      <menclose notation=\"box\" data-latex=\"\\fbox{$\\displaystyle{x}$}\">
-        <mrow data-mjx-texclass=\"ORD\">
-          <mstyle displaystyle=\"true\" scriptlevel=\"0\" data-latex=\"\\displaystyle{x}\">
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{x}\">
-              <mi data-latex=\"x\">x</mi>
-            </mrow>
-          </mstyle>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\boxed{x}" display="block">
+      <menclose notation="box" data-latex="\\fbox{$\\displaystyle{x}$}">
+        <mrow data-mjx-texclass="ORD">
+          <mrow data-mjx-texclass="ORD" data-latex="\\displaystyle{x}">
+            <mi data-latex="x">x</mi>
+          </mrow>
         </mrow>
       </menclose>
     </math>`
@@ -7971,9 +7913,9 @@ describe('Boxes', () => {
   it('Framebox', () =>
     toXmlMatch(
       tex2mml('\\framebox{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\framebox{x}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\framebox{x}\">
-        <menclose notation=\"box\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\framebox{x}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\framebox{x}">
+        <menclose notation="box">
           <mtext>x</mtext>
         </menclose>
       </mrow>
@@ -7982,10 +7924,10 @@ describe('Boxes', () => {
   it('Framebox dimension', () =>
     toXmlMatch(
       tex2mml('\\framebox[2cm]{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\framebox[2cm]{x}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\framebox[2cm]{x}\">
-        <menclose notation=\"box\">
-          <mpadded width=\"2cm\" data-align=\"center\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\framebox[2cm]{x}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\framebox[2cm]{x}">
+        <menclose notation="box">
+          <mpadded width="2cm" data-align="center">
             <mtext>x</mtext>
           </mpadded>
         </menclose>
@@ -7995,10 +7937,10 @@ describe('Boxes', () => {
   it('Framebox dimension position', () =>
     toXmlMatch(
       tex2mml('\\framebox[2cm][c]{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\framebox[2cm][c]{x}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\framebox[2cm][c]{x}\">
-        <menclose notation=\"box\">
-          <mpadded width=\"2cm\" data-align=\"center\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\framebox[2cm][c]{x}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\framebox[2cm][c]{x}">
+        <menclose notation="box">
+          <mpadded width="2cm" data-align="center">
             <mtext>x</mtext>
           </mpadded>
         </menclose>
@@ -8008,8 +7950,8 @@ describe('Boxes', () => {
   it('Makebox', () =>
     toXmlMatch(
       tex2mml('\\makebox{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\makebox{x}\" display=\"block\">
-      <mpadded data-align=\"center\" data-latex=\"\\makebox{x}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\makebox{x}" display="block">
+      <mpadded data-align="center" data-latex="\\makebox{x}">
         <mtext>x</mtext>
       </mpadded>
     </math>`
@@ -8017,8 +7959,8 @@ describe('Boxes', () => {
   it('Makebox dimension', () =>
     toXmlMatch(
       tex2mml('\\makebox[2cm]{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\makebox[2cm]{x}\" display=\"block\">
-      <mpadded width=\"2cm\" data-align=\"center\" data-latex=\"\\makebox[2cm]{x}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\makebox[2cm]{x}" display="block">
+      <mpadded width="2cm" data-align="center" data-latex="\\makebox[2cm]{x}">
         <mtext>x</mtext>
       </mpadded>
     </math>`
@@ -8026,8 +7968,8 @@ describe('Boxes', () => {
   it('Makebox dimension position', () =>
     toXmlMatch(
       tex2mml('\\makebox[2cm][c]{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\makebox[2cm][c]{x}\" display=\"block\">
-      <mpadded width=\"2cm\" data-align=\"center\" data-latex=\"\\makebox[2cm][c]{x}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\makebox[2cm][c]{x}" display="block">
+      <mpadded width="2cm" data-align="center" data-latex="\\makebox[2cm][c]{x}">
         <mtext>x</mtext>
       </mpadded>
     </math>`
@@ -8035,8 +7977,8 @@ describe('Boxes', () => {
   it('Makebox Cap position', () =>
     toXmlMatch(
       tex2mml('\\makebox[2cm][C]{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\makebox[2cm][C]{x}\" display=\"block\">
-      <mpadded width=\"2cm\" data-align=\"center\" data-overflow=\"linebreak\" data-latex=\"\\makebox[2cm][C]{x}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\makebox[2cm][C]{x}" display="block">
+      <mpadded width="2cm" data-align="center" data-overflow="linebreak" data-latex="\\makebox[2cm][C]{x}">
         <mtext>x</mtext>
       </mpadded>
     </math>`
@@ -8051,18 +7993,18 @@ describe('Boxes', () => {
   it('Rule 2D positive raise', () =>
     toXmlMatch(
       tex2mml('\\rule[3cm]{2cm}{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rule[3cm]{2cm}{1cm}\" display=\"block\">
-      <mpadded voffset=\"3cm\" height=\"+3cm\" data-latex=\"\\rule[3cm]{2cm}{1cm}\">
-        <mspace width=\"2cm\" height=\"1cm\" mathbackground=\"black\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rule[3cm]{2cm}{1cm}" display="block">
+      <mpadded voffset="3cm" height="+3cm" data-latex="\\rule[3cm]{2cm}{1cm}">
+        <mspace width="2cm" height="1cm" mathbackground="black"></mspace>
       </mpadded>
     </math>`
     ));
   it('Rule 2D negative raise', () =>
     toXmlMatch(
       tex2mml('\\rule[-3cm]{2cm}{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\rule[-3cm]{2cm}{1cm}\" display=\"block\">
-      <mpadded voffset=\"-3cm\" height=\"-3cm\" depth=\"+3cm\" data-latex=\"\\rule[-3cm]{2cm}{1cm}\">
-        <mspace width=\"2cm\" height=\"1cm\" mathbackground=\"black\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rule[-3cm]{2cm}{1cm}" display="block">
+      <mpadded voffset="-3cm" height="-3cm" depth="+3cm" data-latex="\\rule[-3cm]{2cm}{1cm}">
+        <mspace width="2cm" height="1cm" mathbackground="black"></mspace>
       </mpadded>
     </math>`
     ));
@@ -8201,9 +8143,7 @@ describe('Moving Elements', () => {
   <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\rlap{\\,/}{=}}">
     <mrow data-mjx-texclass="ORD" data-latex="\\rlap{\\,/}">
       <mpadded width="0">
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
         <mrow data-mjx-texclass="ORD">
           <mo data-latex="/">/</mo>
         </mrow>
@@ -8230,9 +8170,7 @@ describe('Moving Elements', () => {
         <mrow data-mjx-texclass="ORD">
           <mo data-latex="/">/</mo>
         </mrow>
-        <mstyle scriptlevel="0" data-latex="\\,">
-          <mspace width="0.167em"></mspace>
-        </mstyle>
+        <mspace width="0.167em" data-latex="\\,"></mspace>
       </mpadded>
     </mrow>
   </mrow>
@@ -8316,64 +8254,64 @@ describe('Moving Elements', () => {
   it('Moveright', () =>
     toXmlMatch(
       tex2mml('\\moveright 1em {x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\moveright 1em {x}\" display=\"block\">
-      <mspace width=\"1em\"></mspace>
-      <mrow data-mjx-texclass=\"ORD\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\moveright 1em {x}" display="block">
+      <mspace width="1em"></mspace>
+      <mrow data-mjx-texclass="ORD">
+        <mi data-latex="x">x</mi>
       </mrow>
-      <mspace width=\"-1em\" data-latex=\"{}\"></mspace>
+      <mspace width="-1em" data-latex="{}"></mspace>
     </math>`
     ));
   it('Moveleft', () =>
     toXmlMatch(
       tex2mml('\\moveleft 1em {x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\moveleft 1em {x}\" display=\"block\">
-      <mspace width=\"-1em\"></mspace>
-      <mrow data-mjx-texclass=\"ORD\">
-        <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\moveleft 1em {x}" display="block">
+      <mspace width="-1em"></mspace>
+      <mrow data-mjx-texclass="ORD">
+        <mi data-latex="x">x</mi>
       </mrow>
-      <mspace width=\"1em\" data-latex=\"{}\"></mspace>
+      <mspace width="1em" data-latex="{}"></mspace>
     </math>`
     ));
   it('Move Left Negative', () =>
     toXmlMatch(
       tex2mml('x\\moveleft -2pt {y} z'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"x\\moveleft -2pt {y} z\" display=\"block\">
-      <mi data-latex=\"x\">x</mi>
-      <mspace width=\"2pt\"></mspace>
-      <mrow data-mjx-texclass=\"ORD\">
-        <mi data-latex=\"y\">y</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x\\moveleft -2pt {y} z" display="block">
+      <mi data-latex="x">x</mi>
+      <mspace width="2pt"></mspace>
+      <mrow data-mjx-texclass="ORD">
+        <mi data-latex="y">y</mi>
       </mrow>
-      <mspace width=\"-2pt\" data-latex=\"{}\"></mspace>
-      <mi data-latex=\"z\">z</mi>
+      <mspace width="-2pt" data-latex="{}"></mspace>
+      <mi data-latex="z">z</mi>
     </math>`
     ));
   it('Move Right Negative', () =>
     toXmlMatch(
       tex2mml('x\\moveright -2pt {y} z'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"x\\moveright -2pt {y} z\" display=\"block\">
-      <mi data-latex=\"x\">x</mi>
-      <mspace width=\"-2pt\"></mspace>
-      <mrow data-mjx-texclass=\"ORD\">
-        <mi data-latex=\"y\">y</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x\\moveright -2pt {y} z" display="block">
+      <mi data-latex="x">x</mi>
+      <mspace width="-2pt"></mspace>
+      <mrow data-mjx-texclass="ORD">
+        <mi data-latex="y">y</mi>
       </mrow>
-      <mspace width=\"2pt\" data-latex=\"{}\"></mspace>
-      <mi data-latex=\"z\">z</mi>
+      <mspace width="2pt" data-latex="{}"></mspace>
+      <mi data-latex="z">z</mi>
     </math>`
     ));
   it('Mathstrut', () =>
     toXmlMatch(
       tex2mml('\\mathstrut{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mathstrut{x}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\vphantom{(}\">
-        <mpadded width=\"0\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathstrut{x}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\vphantom{(}">
+        <mpadded width="0">
           <mphantom>
-            <mo data-latex=\"(\" stretchy=\"false\">(</mo>
+            <mo data-latex="(" stretchy="false">(</mo>
           </mphantom>
         </mpadded>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{x}\">
-        <mi data-latex=\"x\">x</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{x}">
+        <mi data-latex="x">x</mi>
       </mrow>
     </math>`
     ));
@@ -8455,135 +8393,135 @@ describe('Linebreaks', () => {
   it('allowbreak', () =>
     toXmlMatch(
       tex2mml('a\\allowbreak b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\allowbreak b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace data-latex=\"\\allowbreak\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\allowbreak b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace data-latex="\\allowbreak"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('allowbreak cdot', () =>
     toXmlMatch(
       tex2mml('a\\allowbreak \cdot b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\allowbreak cdot b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace data-latex=\"\\allowbreak\"></mspace>
-      <mi data-latex=\"c\">c</mi>
-      <mi data-latex=\"d\">d</mi>
-      <mi data-latex=\"o\">o</mi>
-      <mi data-latex=\"t\">t</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\allowbreak cdot b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace data-latex="\\allowbreak"></mspace>
+      <mi data-latex="c">c</mi>
+      <mi data-latex="d">d</mi>
+      <mi data-latex="o">o</mi>
+      <mi data-latex="t">t</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('goodbreak', () =>
     toXmlMatch(
       tex2mml('a\\goodbreak b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\goodbreak b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace linebreak=\"goodbreak\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\goodbreak b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace linebreak="goodbreak"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('goodbreak cdot', () =>
     toXmlMatch(
       tex2mml('a\\goodbreak\\cdot b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\goodbreak\\cdot b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo linebreak=\"goodbreak\" data-latex=\"\\cdot\">&#x22C5;</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\goodbreak\\cdot b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo linebreak="goodbreak" data-latex="\\cdot">&#x22C5;</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('goodbreak cdot cdot', () =>
     toXmlMatch(
       tex2mml('a\\cdot\\goodbreak\\cdot b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\cdot\\goodbreak\\cdot b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\"\\cdot\">&#x22C5;</mo>
-      <mo linebreak=\"goodbreak\" data-latex=\"\\cdot\">&#x22C5;</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\cdot\\goodbreak\\cdot b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo data-latex="\\cdot">&#x22C5;</mo>
+      <mo linebreak="goodbreak" data-latex="\\cdot">&#x22C5;</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('goodbreak comma cdot', () =>
     toXmlMatch(
       tex2mml('a,\\goodbreak\\cdot b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a,\\goodbreak\\cdot b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\",\" linebreak=\"goodbreak\">,</mo>
-      <mo linebreak=\"goodbreak\" data-latex=\"\\cdot\">&#x22C5;</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a,\\goodbreak\\cdot b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo data-latex="," linebreak="goodbreak">,</mo>
+      <mo linebreak="goodbreak" data-latex="\\cdot">&#x22C5;</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('badbreak', () =>
     toXmlMatch(
       tex2mml('a\\badbreak b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\badbreak b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace linebreak=\"badbreak\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\badbreak b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace linebreak="badbreak"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('badbreak cdot', () =>
     toXmlMatch(
       tex2mml('a\\badbreak\\cdot b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\badbreak\\cdot b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo linebreak=\"badbreak\" data-latex=\"\\cdot\">&#x22C5;</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\badbreak\\cdot b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo linebreak="badbreak" data-latex="\\cdot">&#x22C5;</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('nobreak', () =>
     toXmlMatch(
       tex2mml('a\\nobreak b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\nobreak b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace linebreak=\"nobreak\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\nobreak b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace linebreak="nobreak"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('nobreak cdot', () =>
     toXmlMatch(
       tex2mml('a\\nobreak\\cdot b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\nobreak\\cdot b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo linebreak=\"nobreak\" data-latex=\"\\cdot\">&#x22C5;</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\nobreak\\cdot b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo linebreak="nobreak" data-latex="\\cdot">&#x22C5;</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('break', () =>
     toXmlMatch(
       tex2mml('a\\break b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\break b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace linebreak=\"newline\" data-latex=\"\\break\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\break b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace linebreak="newline" data-latex="\\break"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('newline', () =>
     toXmlMatch(
       tex2mml('a\\newline b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\newline b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mspace linebreak=\"newline\" data-latex=\"\\newline\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\newline b" display="block">
+      <mi data-latex="a">a</mi>
+      <mspace linebreak="newline" data-latex="\\newline"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('goodbreak comma', () =>
     toXmlMatch(
       tex2mml('a,\\goodbreak b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a,\\goodbreak b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\",\" linebreak=\"goodbreak\">,</mo>
-      <mspace linebreak=\"goodbreak\"></mspace>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a,\\goodbreak b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo data-latex="," linebreak="goodbreak">,</mo>
+      <mspace linebreak="goodbreak"></mspace>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('goodbreak comma comma', () =>
     toXmlMatch(
       tex2mml('a,\\goodbreak, b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a,\\goodbreak, b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo data-latex=\",\" linebreak=\"goodbreak\">,</mo>
-      <mo data-latex=\",\">,</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a,\\goodbreak, b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo data-latex="," linebreak="goodbreak">,</mo>
+      <mo data-latex=",">,</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
 });
@@ -8644,37 +8582,37 @@ describe('MathChar7', () => {
   it('Underscore', () =>
     toXmlMatch(
       tex2mml('a\\_b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\_b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi mathvariant=\"normal\" data-latex=\"\\_\">_</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\_b" display="block">
+      <mi data-latex="a">a</mi>
+      <mi mathvariant="normal" data-latex="\\_">_</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Hash', () =>
     toXmlMatch(
       tex2mml('a\\#b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\#b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi mathvariant=\"normal\" data-latex=\"\\#\">#</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\#b" display="block">
+      <mi data-latex="a">a</mi>
+      <mi mathvariant="normal" data-latex="\\#">#</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Dollar', () =>
     toXmlMatch(
       tex2mml('a\\$b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\$b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi mathvariant=\"normal\" data-latex=\"\\$\">$</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\$b" display="block">
+      <mi data-latex="a">a</mi>
+      <mi mathvariant="normal" data-latex="\\$">$</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
   it('Percentage', () =>
     toXmlMatch(
       tex2mml('a\\%b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\%b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mi mathvariant=\"normal\" data-latex=\"\\%\">%</mi>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\%b" display="block">
+      <mi data-latex="a">a</mi>
+      <mi mathvariant="normal" data-latex="\\%">%</mi>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
 });
@@ -8726,11 +8664,11 @@ describe('Accents', () => {
   it('acute', () =>
     toXmlMatch(
       tex2mml('\\acute{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\acute{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\acute{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\acute{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\acute{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
-          <mo data-mjx-pseudoscript=\"true\">&#xB4;</mo>
+          <mi data-latex="a">a</mi>
+          <mo data-mjx-pseudoscript="true">&#xB4;</mo>
         </mover>
       </mrow>
     </math>`
@@ -8738,11 +8676,11 @@ describe('Accents', () => {
   it('grave', () =>
     toXmlMatch(
       tex2mml('\\grave{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\grave{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\grave{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\grave{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\grave{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
-          <mo data-mjx-pseudoscript=\"true\">\`</mo>
+          <mi data-latex="a">a</mi>
+          <mo data-mjx-pseudoscript="true">\`</mo>
         </mover>
       </mrow>
     </math>`
@@ -8750,10 +8688,10 @@ describe('Accents', () => {
   it('ddot', () =>
     toXmlMatch(
       tex2mml('\\ddot{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ddot{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\ddot{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ddot{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\ddot{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
+          <mi data-latex="a">a</mi>
           <mo>&#xA8;</mo>
         </mover>
       </mrow>
@@ -8762,10 +8700,10 @@ describe('Accents', () => {
   it('dddot', () =>
     toXmlMatch(
       tex2mml('\\dddot{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dddot{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\dddot{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dddot{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\dddot{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
+          <mi data-latex="a">a</mi>
           <mo>&#x20DB;</mo>
         </mover>
       </mrow>
@@ -8774,10 +8712,10 @@ describe('Accents', () => {
   it('ddddot', () =>
     toXmlMatch(
       tex2mml('\\ddddot{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ddddot{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\ddddot{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ddddot{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\ddddot{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
+          <mi data-latex="a">a</mi>
           <mo>&#x20DC;</mo>
         </mover>
       </mrow>
@@ -8786,11 +8724,11 @@ describe('Accents', () => {
   it('tilde', () =>
     toXmlMatch(
       tex2mml('\\tilde{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tilde{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\tilde{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tilde{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\tilde{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
-          <mo stretchy=\"false\">~</mo>
+          <mi data-latex="a">a</mi>
+          <mo stretchy="false">~</mo>
         </mover>
       </mrow>
     </math>`
@@ -8798,11 +8736,11 @@ describe('Accents', () => {
   it('bar', () =>
     toXmlMatch(
       tex2mml('\\bar{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bar{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\bar{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bar{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\bar{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
-          <mo stretchy=\"false\">&#xAF;</mo>
+          <mi data-latex="a">a</mi>
+          <mo stretchy="false">&#xAF;</mo>
         </mover>
       </mrow>
     </math>`
@@ -8810,10 +8748,10 @@ describe('Accents', () => {
   it('breve', () =>
     toXmlMatch(
       tex2mml('\\breve{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\breve{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\breve{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\breve{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\breve{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
+          <mi data-latex="a">a</mi>
           <mo>&#x2D8;</mo>
         </mover>
       </mrow>
@@ -8822,11 +8760,11 @@ describe('Accents', () => {
   it('check', () =>
     toXmlMatch(
       tex2mml('\\check{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\check{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\check{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\check{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\check{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
-          <mo stretchy=\"false\">&#x2C7;</mo>
+          <mi data-latex="a">a</mi>
+          <mo stretchy="false">&#x2C7;</mo>
         </mover>
       </mrow>
     </math>`
@@ -8834,11 +8772,11 @@ describe('Accents', () => {
   it('hat', () =>
     toXmlMatch(
       tex2mml('\\hat{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hat{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\hat{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hat{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\hat{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
-          <mo stretchy=\"false\">^</mo>
+          <mi data-latex="a">a</mi>
+          <mo stretchy="false">^</mo>
         </mover>
       </mrow>
     </math>`
@@ -8846,10 +8784,10 @@ describe('Accents', () => {
   it('dot', () =>
     toXmlMatch(
       tex2mml('\\dot{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\dot{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\dot{a}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\dot{a}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\dot{a}">
         <mover>
-          <mi data-latex=\"a\">a</mi>
+          <mi data-latex="a">a</mi>
           <mo>&#x2D9;</mo>
         </mover>
       </mrow>
@@ -8858,13 +8796,13 @@ describe('Accents', () => {
   it('widetilde', () =>
     toXmlMatch(
       tex2mml('\\widetilde{abc}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\widetilde{abc}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\widetilde{abc}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\widetilde{abc}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\widetilde{abc}">
         <mover>
-          <mrow data-latex=\"abc\">
-            <mi data-latex=\"a\">a</mi>
-            <mi data-latex=\"b\">b</mi>
-            <mi data-latex=\"c\">c</mi>
+          <mrow data-latex="abc">
+            <mi data-latex="a">a</mi>
+            <mi data-latex="b">b</mi>
+            <mi data-latex="c">c</mi>
           </mrow>
           <mo>~</mo>
         </mover>
@@ -8874,13 +8812,13 @@ describe('Accents', () => {
   it('widehat', () =>
     toXmlMatch(
       tex2mml('\\widehat{abc}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\widehat{abc}\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\widehat{abc}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\widehat{abc}" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\widehat{abc}">
         <mover>
-          <mrow data-latex=\"abc\">
-            <mi data-latex=\"a\">a</mi>
-            <mi data-latex=\"b\">b</mi>
-            <mi data-latex=\"c\">c</mi>
+          <mrow data-latex="abc">
+            <mi data-latex="a">a</mi>
+            <mi data-latex="b">b</mi>
+            <mi data-latex="c">c</mi>
           </mrow>
           <mo>^</mo>
         </mover>
@@ -8951,67 +8889,67 @@ describe('Character Class Changes', () => {
   it('mathord', () =>
     toXmlMatch(
       tex2mml('a\\mathord{b}c'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\mathord{b}c\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\mathord{b}\">
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mathord{b}c" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="\\mathord{b}">
+        <mi data-latex="b">b</mi>
       </mrow>
-      <mi data-latex=\"c\">c</mi>
+      <mi data-latex="c">c</mi>
     </math>`
     ));
   it('mathopen', () =>
     toXmlMatch(
       tex2mml('a\\mathopen{b}c'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\mathopen{b}c\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\mathopen{b}\">
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mathopen{b}c" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="OPEN" data-latex="\\mathopen{b}">
+        <mi data-latex="b">b</mi>
       </mrow>
-      <mi data-latex=\"c\">c</mi>
+      <mi data-latex="c">c</mi>
     </math>`
     ));
   it('mathclose', () =>
     toXmlMatch(
       tex2mml('a\\mathclose{b}c'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\mathclose{b}c\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\mathclose{b}\">
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mathclose{b}c" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="CLOSE" data-latex="\\mathclose{b}">
+        <mi data-latex="b">b</mi>
       </mrow>
-      <mi data-latex=\"c\">c</mi>
+      <mi data-latex="c">c</mi>
     </math>`
     ));
   it('mathbin', () =>
     toXmlMatch(
       tex2mml('a\\mathbin{b}c'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\mathbin{b}c\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"BIN\" data-latex=\"\\mathbin{b}\">
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mathbin{b}c" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="BIN" data-latex="\\mathbin{b}">
+        <mi data-latex="b">b</mi>
       </mrow>
-      <mi data-latex=\"c\">c</mi>
+      <mi data-latex="c">c</mi>
     </math>`
     ));
   it('mathpunct', () =>
     toXmlMatch(
       tex2mml('a\\mathpunct{b}c'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\mathpunct{b}c\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"PUNCT\" data-latex=\"\\mathpunct{b}\">
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mathpunct{b}c" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="PUNCT" data-latex="\\mathpunct{b}">
+        <mi data-latex="b">b</mi>
       </mrow>
-      <mi data-latex=\"c\">c</mi>
+      <mi data-latex="c">c</mi>
     </math>`
     ));
   it('mathinner', () =>
     toXmlMatch(
       tex2mml('a\\mathinner{b}c'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\mathinner{b}c\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"INNER\" data-latex=\"\\mathinner{b}\">
-        <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\mathinner{b}c" display="block">
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="INNER" data-latex="\\mathinner{b}">
+        <mi data-latex="b">b</mi>
       </mrow>
-      <mi data-latex=\"c\">c</mi>
+      <mi data-latex="c">c</mi>
     </math>`
     ));
 });
@@ -9021,39 +8959,35 @@ describe('Spacing', () => {
     it('Nonscript toplevel', () =>
     toXmlMatch(
       tex2mml('\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.\" data-latex=\"\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.\">
-        <mo data-mjx-texclass=\"OPEN\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\left.\" data-latex=\"\\left.\"></mo>
-        <mi data-latex=\"a\">a</mi>
-        <mstyle scriptlevel=\"0\">
-          <mspace width=\"0.278em\"></mspace>
-        </mstyle>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle|\" data-latex=\"\\middle|\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle|\"></mrow>
-        <mstyle scriptlevel=\"0\">
-          <mspace width=\"0.278em\"></mspace>
-        </mstyle>
-        <mi data-latex=\"b\">b</mi>
-        <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\right.\" data-latex=\"\\right.\"></mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right." display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right." data-latex="\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.">
+        <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex-item="\\left." data-latex="\\left."></mo>
+        <mi data-latex="a">a</mi>
+        <mspace width="0.278em"></mspace>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle|" data-latex="\\middle|">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
+        <mspace width="0.278em"></mspace>
+        <mi data-latex="b">b</mi>
+        <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true" data-latex-item="\\right." data-latex="\\right."></mo>
       </mrow>
     </math>`
     ));
   it('Nonscript scriptlevel', () =>
     toXmlMatch(
       tex2mml('X_{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"X_{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}\" display=\"block\">
-      <msub data-latex=\"X_{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}\">
-        <mi data-latex=\"X\">X</mi>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}\">
-          <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.\" data-latex=\"\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.\">
-            <mo data-mjx-texclass=\"OPEN\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\left.\" data-latex=\"\\left.\"></mo>
-            <mi data-latex=\"a\">a</mi>
-            <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-            <mo data-latex-item=\"\\middle|\" data-latex=\"\\middle|\">|</mo>
-            <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle|\"></mrow>
-            <mi data-latex=\"b\">b</mi>
-            <mo data-mjx-texclass=\"CLOSE\" fence=\"true\" stretchy=\"true\" symmetric=\"true\" data-latex-item=\"\\right.\" data-latex=\"\\right.\"></mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="X_{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}" display="block">
+      <msub data-latex="X_{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}">
+        <mi data-latex="X">X</mi>
+        <mrow data-mjx-texclass="ORD" data-latex="{\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.}">
+          <mrow data-mjx-texclass="INNER" data-latex-item="\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right." data-latex="\\left. a \\nonscript\\;\\middle|\\nonscript\\; b \\right.">
+            <mo data-mjx-texclass="OPEN" fence="true" stretchy="true" symmetric="true" data-latex-item="\\left." data-latex="\\left."></mo>
+            <mi data-latex="a">a</mi>
+            <mrow data-mjx-texclass="CLOSE"></mrow>
+            <mo data-latex-item="\\middle|" data-latex="\\middle|">|</mo>
+            <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
+            <mi data-latex="b">b</mi>
+            <mo data-mjx-texclass="CLOSE" fence="true" stretchy="true" symmetric="true" data-latex-item="\\right." data-latex="\\right."></mo>
           </mrow>
         </mrow>
       </msub>
@@ -9062,36 +8996,36 @@ describe('Spacing', () => {
   it('hskip', () =>
     toXmlMatch(
       tex2mml('\\hskip{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hskip{1cm}\" display=\"block\">
-      <mspace width=\"1cm\" data-latex=\"\\hskip{1cm}\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hskip{1cm}" display="block">
+      <mspace width="1cm" data-latex="\\hskip{1cm}"></mspace>
     </math>`
     ));
   it('hspace', () =>
     toXmlMatch(
       tex2mml('\\hspace{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hspace{1cm}\" display=\"block\">
-      <mspace width=\"1cm\" data-latex=\"\\hspace{1cm}\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hspace{1cm}" display="block">
+      <mspace width="1cm" data-latex="\\hspace{1cm}"></mspace>
     </math>`
     ));
   it('mskip', () =>
     toXmlMatch(
       tex2mml('\\mskip{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mskip{1cm}\" display=\"block\">
-      <mspace width=\"1cm\" data-latex=\"\\mskip{1cm}\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mskip{1cm}" display="block">
+      <mspace width="1cm" data-latex="\\mskip{1cm}"></mspace>
     </math>`
     ));
   it('mspace', () =>
     toXmlMatch(
       tex2mml('\\mspace{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mspace{1cm}\" display=\"block\">
-      <mspace width=\"1cm\" data-latex=\"\\mspace{1cm}\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mspace{1cm}" display="block">
+      <mspace width="1cm" data-latex="\\mspace{1cm}"></mspace>
     </math>`
     ));
   it('mkern', () =>
     toXmlMatch(
       tex2mml('\\mkern{1cm}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\mkern{1cm}\" display=\"block\">
-      <mspace width=\"1cm\" linebreak=\"nobreak\" data-latex=\"\\mkern{1cm}\"></mspace>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mkern{1cm}" display="block">
+      <mspace width="1cm" linebreak="nobreak" data-latex="\\mkern{1cm}"></mspace>
     </math>`
     ));
 });
@@ -9101,17 +9035,17 @@ describe('Complete Base Methods', () => {
   it('Comment', () =>
     toXmlMatch(
       tex2mml('a %comment'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a %comment\" display=\"block\">
-      <mi data-latex=\"a %comment\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a %comment" display="block">
+      <mi data-latex="a %comment">a</mi>
     </math>`
     ));
   it('Elided Times', () =>
     toXmlMatch(
       tex2mml('a\\* b'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\* b\" display=\"block\">
-      <mi data-latex=\"a\">a</mi>
-      <mo linebreakmultchar=\"&#xD7;\" data-latex=\"\\*\">&#x2062;</mo>
-      <mi data-latex=\"b\">b</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\* b" display="block">
+      <mi data-latex="a">a</mi>
+      <mo linebreakmultchar="&#xD7;" data-latex="\\*">&#x2062;</mo>
+      <mi data-latex="b">b</mi>
     </math>`
     ));
 });
@@ -9123,14 +9057,14 @@ describe('Referencing', () => {
   it('Label', () =>
     toXmlMatch(
       tex2mml('a\\label{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\label{A}\" display=\"block\">
-      <mtable displaystyle=\"true\" data-latex=\"a\\label{A}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}" display="block">
+      <mtable data-latex="a\\label{A}">
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:A\">
-            <mtext data-latex=\"\\text{(1)}\">(1)</mtext>
+          <mtd id="mjx-eqn:A">
+            <mtext data-latex="\\text{(1)}">(1)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\label{A}\">a</mi>
+            <mi data-latex="\\label{A}">a</mi>
           </mtd>
         </mlabeledtr>
       </mtable>
@@ -9139,14 +9073,14 @@ describe('Referencing', () => {
   it('Label Empty', () =>
     toXmlMatch(
       tex2mml('a\\label{}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\label{}\" display=\"block\">
-      <mtable displaystyle=\"true\" data-latex=\"a\\label{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{}" display="block">
+      <mtable data-latex="a\\label{}">
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:1\">
-            <mtext data-latex=\"\\text{(1)}\">(1)</mtext>
+          <mtd id="mjx-eqn:1">
+            <mtext data-latex="\\text{(1)}">(1)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\label{}\">a</mi>
+            <mi data-latex="\\label{}">a</mi>
           </mtd>
         </mlabeledtr>
       </mtable>
@@ -9155,22 +9089,22 @@ describe('Referencing', () => {
   it('Label Multiple', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right\" columnspacing=\"\" rowspacing=\"3pt\" data-break-align=\"bottom\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}" display="block">
+      <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}">
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:A\">
-            <mtext data-latex=\"\\text{(1)}\">(1)</mtext>
+          <mtd id="mjx-eqn:A">
+            <mtext data-latex="\\text{(1)}">(1)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\label{A}\">a</mi>
+            <mi data-latex="\\label{A}">a</mi>
           </mtd>
         </mlabeledtr>
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:B\">
-            <mtext data-latex=\"\\text{(2)}\">(2)</mtext>
+          <mtd id="mjx-eqn:B">
+            <mtext data-latex="\\text{(2)}">(2)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\label{B}\">c</mi>
+            <mi data-latex="\\label{B}">c</mi>
           </mtd>
         </mlabeledtr>
       </mtable>
@@ -9179,8 +9113,8 @@ describe('Referencing', () => {
   it('Label Multiple Error', () =>
     toXmlMatch(
       tex2mml('a\\label{A}c\\label{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\label{A}c\\label{B}\" display=\"block\">
-      <merror data-mjx-error=\"Multiple \\label\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}c\\label{B}" display="block">
+      <merror data-mjx-error="Multiple \\label">
         <mtext>Multiple \\label</mtext>
       </merror>
     </math>`
@@ -9188,8 +9122,8 @@ describe('Referencing', () => {
   it('Label Multiply Defined Error', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\label{A}\\\\c\\label{A}\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a\\label{A}\\\\c\\label{A}\\end{eqnarray}\" display=\"block\">
-      <merror data-mjx-error=\"Label 'A' multiply defined\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\label{A}\\\\c\\label{A}\\end{eqnarray}" display="block">
+      <merror data-mjx-error="Label 'A' multiply defined">
         <mtext>Label 'A' multiply defined</mtext>
       </merror>
     </math>`
@@ -9197,15 +9131,15 @@ describe('Referencing', () => {
   it('Ref', () =>
     toXmlMatch(
       tex2mml('a\\label{A}\\ref{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\label{A}\\ref{A}\" display=\"block\">
-      <mtable displaystyle=\"true\" data-latex=\"a\\label{A}\\ref{A}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}\\ref{A}" display="block">
+      <mtable data-latex="a\\label{A}\\ref{A}">
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:A\">
-            <mtext data-latex=\"\\text{(1)}\">(1)</mtext>
+          <mtd id="mjx-eqn:A">
+            <mtext data-latex="\\text{(1)}">(1)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\label{A}\">a</mi>
-            <mrow href=\"#\" class=\"MathJax_ref\" data-latex=\"\\ref{A}\">
+            <mi data-latex="\\label{A}">a</mi>
+            <mrow href="#" class="MathJax_ref" data-latex="\\ref{A}">
               <mtext>???</mtext>
             </mrow>
           </mtd>
@@ -9216,15 +9150,15 @@ describe('Referencing', () => {
   it('Ref Unknown', () =>
     toXmlMatch(
       tex2mml('a\\label{A}\\ref{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\label{A}\\ref{B}\" display=\"block\">
-      <mtable displaystyle=\"true\" data-latex=\"a\\label{A}\\ref{B}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}\\ref{B}" display="block">
+      <mtable data-latex="a\\label{A}\\ref{B}">
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:A\">
-            <mtext data-latex=\"\\text{(1)}\">(1)</mtext>
+          <mtd id="mjx-eqn:A">
+            <mtext data-latex="\\text{(1)}">(1)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\label{A}\">a</mi>
-            <mrow href=\"#\" class=\"MathJax_ref\" data-latex=\"\\ref{B}\">
+            <mi data-latex="\\label{A}">a</mi>
+            <mrow href="#" class="MathJax_ref" data-latex="\\ref{B}">
               <mtext>???</mtext>
             </mrow>
           </mtd>
@@ -9235,19 +9169,19 @@ describe('Referencing', () => {
   it('Nonumber', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right\" columnspacing=\"\" rowspacing=\"3pt\" data-break-align=\"bottom\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}" display="block">
+      <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}">
         <mlabeledtr>
-          <mtd id=\"mjx-eqn:1\">
-            <mtext data-latex=\"\\text{(1)}\">(1)</mtext>
+          <mtd id="mjx-eqn:1">
+            <mtext data-latex="\\text{(1)}">(1)</mtext>
           </mtd>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mlabeledtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"\\nonumber\">c</mi>
+            <mi data-latex="\\nonumber">c</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9259,28 +9193,28 @@ describe('Complete Array', () => {
   it('column r c l', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{rcl}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{rcl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{rcl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\">
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{rcl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{rcl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9289,28 +9223,28 @@ describe('Complete Array', () => {
   it('column r c l | ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r|c|l}a & b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r|c|l}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" columnlines=\"solid solid\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{r|c|l}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\">
-        <mtr data-latex-item=\"{r|c|l}\" data-latex=\"{r|c|l}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r|c|l}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" columnlines="solid solid" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{r|c|l}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}">
+        <mtr data-latex-item="{r|c|l}" data-latex="{r|c|l}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{r|c|l}\" data-latex=\"{r|c|l}\">
+        <mtr data-latex-item="{r|c|l}" data-latex="{r|c|l}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9319,28 +9253,28 @@ describe('Complete Array', () => {
   it('column r c l : ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r:c:l}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r:c:l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" columnlines=\"dashed dashed\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{r:c:l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\">
-        <mtr data-latex-item=\"{r:c:l}\" data-latex=\"{r:c:l}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r:c:l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" columnlines="dashed dashed" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{r:c:l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}">
+        <mtr data-latex-item="{r:c:l}" data-latex="{r:c:l}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{r:c:l}\" data-latex=\"{r:c:l}\">
+        <mtr data-latex-item="{r:c:l}" data-latex="{r:c:l}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9349,40 +9283,40 @@ describe('Complete Array', () => {
   it('column r c l @ ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r@{h}c@{h}l}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r@{h}c@{h}l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0 0 0\" rowspacing=\"4pt\" columnalign=\"right center center center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"h&amp;f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r@{h}c@{h}l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="0 0 0 0" rowspacing="4pt" columnalign="right center center center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="h&amp;f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9391,40 +9325,40 @@ describe('Complete Array', () => {
   it('column r c l ! ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r!{h}c!{h}l}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r!{h}c!{h}l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\".5em .5em .5em .5em\" rowspacing=\"4pt\" columnalign=\"right center center center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"h&amp;f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r!{h}c!{h}l}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing=".5em .5em .5em .5em" rowspacing="4pt" columnalign="right center center center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="h&amp;f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9433,39 +9367,39 @@ describe('Complete Array', () => {
   it('column p ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{p{1cm}p{1cm}p{1cm}}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{p{1cm}p{1cm}p{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"left left left\" columnwidth=\"1cm 1cm 1cm\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\text{f}\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{p{1cm}p{1cm}p{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="left left left" columnwidth="1cm 1cm 1cm" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\text{f}\\end{array}">
         <mtr>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{a}\">a</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="top">
+              <mtext data-latex="\\text{a}">a</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{b}\">b</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="top">
+              <mtext data-latex="\\text{b}">b</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{c}\">c</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="top">
+              <mtext data-latex="\\text{c}">c</mtext>
             </mpadded>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{d}\">d</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="top">
+              <mtext data-latex="\\text{d}">d</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{e}\">e</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="top">
+              <mtext data-latex="\\text{e}">e</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{f}\">f</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="top">
+              <mtext data-latex="\\text{f}">f</mtext>
             </mpadded>
           </mtd>
         </mtr>
@@ -9475,39 +9409,39 @@ describe('Complete Array', () => {
   it('column m ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{m{1cm}m{1cm}m{1cm}}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{m{1cm}m{1cm}m{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"left left left\" columnwidth=\"1cm 1cm 1cm\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\text{f}\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{m{1cm}m{1cm}m{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="left left left" columnwidth="1cm 1cm 1cm" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\text{f}\\end{array}">
         <mtr>
           <mtd>
-            <mpadded data-mjx-vbox=\"middle\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"middle\">
-              <mtext data-latex=\"\\text{a}\">a</mtext>
+            <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
+              <mtext data-latex="\\text{a}">a</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"middle\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"middle\">
-              <mtext data-latex=\"\\text{b}\">b</mtext>
+            <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
+              <mtext data-latex="\\text{b}">b</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"middle\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"middle\">
-              <mtext data-latex=\"\\text{c}\">c</mtext>
+            <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
+              <mtext data-latex="\\text{c}">c</mtext>
             </mpadded>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mpadded data-mjx-vbox=\"middle\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"middle\">
-              <mtext data-latex=\"\\text{d}\">d</mtext>
+            <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
+              <mtext data-latex="\\text{d}">d</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"middle\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"middle\">
-              <mtext data-latex=\"\\text{e}\">e</mtext>
+            <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
+              <mtext data-latex="\\text{e}">e</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"middle\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"middle\">
-              <mtext data-latex=\"\\text{f}\">f</mtext>
+            <mpadded data-mjx-vbox="middle" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="middle">
+              <mtext data-latex="\\text{f}">f</mtext>
             </mpadded>
           </mtd>
         </mtr>
@@ -9517,39 +9451,39 @@ describe('Complete Array', () => {
   it('column b ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{b{1cm}b{1cm}b{1cm}}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{b{1cm}b{1cm}b{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"left left left\" columnwidth=\"1cm 1cm 1cm\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\text{f}\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{b{1cm}b{1cm}b{1cm}}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="left left left" columnwidth="1cm 1cm 1cm" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\text{f}\\end{array}">
         <mtr>
           <mtd>
-            <mpadded data-mjx-vbox=\"bottom\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"bottom\">
-              <mtext data-latex=\"\\text{a}\">a</mtext>
+            <mpadded data-mjx-vbox="bottom" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="bottom">
+              <mtext data-latex="\\text{a}">a</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"bottom\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"bottom\">
-              <mtext data-latex=\"\\text{b}\">b</mtext>
+            <mpadded data-mjx-vbox="bottom" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="bottom">
+              <mtext data-latex="\\text{b}">b</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"bottom\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"bottom\">
-              <mtext data-latex=\"\\text{c}\">c</mtext>
+            <mpadded data-mjx-vbox="bottom" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="bottom">
+              <mtext data-latex="\\text{c}">c</mtext>
             </mpadded>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mpadded data-mjx-vbox=\"bottom\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"bottom\">
-              <mtext data-latex=\"\\text{d}\">d</mtext>
+            <mpadded data-mjx-vbox="bottom" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="bottom">
+              <mtext data-latex="\\text{d}">d</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"bottom\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"bottom\">
-              <mtext data-latex=\"\\text{e}\">e</mtext>
+            <mpadded data-mjx-vbox="bottom" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="bottom">
+              <mtext data-latex="\\text{e}">e</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"bottom\" width=\"1cm\" data-overflow=\"auto\" data-align=\"left\" data-vertical-align=\"bottom\">
-              <mtext data-latex=\"\\text{f}\">f</mtext>
+            <mpadded data-mjx-vbox="bottom" width="1cm" data-overflow="auto" data-align="left" data-vertical-align="bottom">
+              <mtext data-latex="\\text{f}">f</mtext>
             </mpadded>
           </mtd>
         </mtr>
@@ -9559,30 +9493,30 @@ describe('Complete Array', () => {
   it('column r c l >', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{>{A}rcl}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{&gt;{A}rcl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"Ad&amp; e &amp; f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{&gt;{A}rcl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="Ad&amp; e &amp; f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"A\">A</mi>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="A">A</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"A\">A</mi>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="A">A</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9591,30 +9525,30 @@ describe('Complete Array', () => {
   it('column r c l <', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r<{A}cl}a & b &c\\\\ d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r&lt;{A}cl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"dA&amp; e &amp; f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r&lt;{A}cl}a &amp; b &amp;c\\\\ d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="dA&amp; e &amp; f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
-            <mi data-latex=\"A\">A</mi>
+            <mi data-latex="a">a</mi>
+            <mi data-latex="A">A</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
-            <mi data-latex=\"A\">A</mi>
+            <mi data-latex="d">d</mi>
+            <mi data-latex="A">A</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9623,18 +9557,18 @@ describe('Complete Array', () => {
   it('column c >', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{>{A}c}a \\\\ d\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{&gt;{A}c}a \\\\ d\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"Ad\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{&gt;{A}c}a \\\\ d\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="Ad\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"A\">A</mi>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="A">A</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"A\">A</mi>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="A">A</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9643,18 +9577,18 @@ describe('Complete Array', () => {
   it('column c <', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{c<{A}}a\\\\ d \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{c&lt;{A}}a\\\\ d \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"dA\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c&lt;{A}}a\\\\ d \\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="dA\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
-            <mi data-latex=\"A\">A</mi>
+            <mi data-latex="a">a</mi>
+            <mi data-latex="A">A</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
-            <mi data-latex=\"A\">A</mi>
+            <mi data-latex="d">d</mi>
+            <mi data-latex="A">A</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9663,22 +9597,22 @@ describe('Complete Array', () => {
   it('column c @ end', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{c@{h}}a\\\\ d \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{c@{h}}a\\\\ d \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"center center\" data-array-padding=\".5em 0\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"h\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c@{h}}a\\\\ d \\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="center center" data-array-padding=".5em 0" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="h\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"h\">h</mi>
+            <mi data-latex="h">h</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9687,30 +9621,30 @@ describe('Complete Array', () => {
   it('column c @&', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{c@{\\alpha}c}a&\\hfill&b\\\\ d&\\hfill&e \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{c@{\\alpha}c}a&amp;\\hfill&amp;b\\\\ d&amp;\\hfill&amp;e \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"center center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\hfill\\alpha&amp;&amp;e \\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c@{\\alpha}c}a&amp;\\hfill&amp;b\\\\ d&amp;\\hfill&amp;e \\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="center center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\hfill\\alpha&amp;&amp;e \\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
-          <mtd columnalign=\"right\">
-            <mi data-latex=\"\\alpha\">&#x3B1;</mi>
+          <mtd columnalign="right">
+            <mi data-latex="\\alpha">&#x3B1;</mi>
           </mtd>
           <mtd></mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
-          <mtd columnalign=\"right\">
-            <mi data-latex=\"\\alpha\">&#x3B1;</mi>
+          <mtd columnalign="right">
+            <mi data-latex="\\alpha">&#x3B1;</mi>
           </mtd>
           <mtd></mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9719,32 +9653,32 @@ describe('Complete Array', () => {
   it('column c w', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{cw{c}{1cm}c}a&b&c\\\\ d&e&f \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{cw{c}{1cm}c}a&amp;b&amp;c\\\\ d&amp;e&amp;f \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center center\" columnwidth=\"auto 1cm auto\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\text{e}&amp;f \\end{array}\">
-        <mtr data-latex-item=\"{cw{c}{1cm}c}\" data-latex=\"{cw{c}{1cm}c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cw{c}{1cm}c}a&amp;b&amp;c\\\\ d&amp;e&amp;f \\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center center" columnwidth="auto 1cm auto" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\text{e}&amp;f \\end{array}">
+        <mtr data-latex-item="{cw{c}{1cm}c}" data-latex="{cw{c}{1cm}c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"center\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{b}\">b</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="center" data-vertical-align="top">
+              <mtext data-latex="\\text{b}">b</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{cw{c}{1cm}c}\" data-latex=\"{cw{c}{1cm}c}\">
+        <mtr data-latex-item="{cw{c}{1cm}c}" data-latex="{cw{c}{1cm}c}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"center\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{e}\">e</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="center" data-vertical-align="top">
+              <mtext data-latex="\\text{e}">e</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9753,32 +9687,32 @@ describe('Complete Array', () => {
   it('column c W', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{cW{c}{1cm}c}a&b&c\\\\ d&e&f \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{cW{c}{1cm}c}a&amp;b&amp;c\\\\ d&amp;e&amp;f \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"center center center\" columnwidth=\"auto 1cm auto\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\text{e}&amp;f \\end{array}\">
-        <mtr data-latex-item=\"{cW{c}{1cm}c}\" data-latex=\"{cW{c}{1cm}c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cW{c}{1cm}c}a&amp;b&amp;c\\\\ d&amp;e&amp;f \\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center center" columnwidth="auto 1cm auto" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\text{e}&amp;f \\end{array}">
+        <mtr data-latex-item="{cW{c}{1cm}c}" data-latex="{cW{c}{1cm}c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"center\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{b}\">b</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="center" data-vertical-align="top">
+              <mtext data-latex="\\text{b}">b</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{cW{c}{1cm}c}\" data-latex=\"{cW{c}{1cm}c}\">
+        <mtr data-latex-item="{cW{c}{1cm}c}" data-latex="{cW{c}{1cm}c}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mpadded data-mjx-vbox=\"top\" width=\"1cm\" data-overflow=\"auto\" data-align=\"center\" data-vertical-align=\"top\">
-              <mtext data-latex=\"\\text{e}\">e</mtext>
+            <mpadded data-mjx-vbox="top" width="1cm" data-overflow="auto" data-align="center" data-vertical-align="top">
+              <mtext data-latex="\\text{e}">e</mtext>
             </mpadded>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9787,28 +9721,28 @@ describe('Complete Array', () => {
   it('column repeat r c ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{*{2}rc}a & b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{*{2}rc}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right right center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{*{2}rc}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\">
-        <mtr data-latex-item=\"{*{2}rc}\" data-latex=\"{*{2}rc}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{*{2}rc}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right right center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{*{2}rc}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}">
+        <mtr data-latex-item="{*{2}rc}" data-latex="{*{2}rc}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{*{2}rc}\" data-latex=\"{*{2}rc}\">
+        <mtr data-latex-item="{*{2}rc}" data-latex="{*{2}rc}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9817,28 +9751,28 @@ describe('Complete Array', () => {
   it('column r repeat c ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r*{2}c}a & b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r*{2}c}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"right center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{r*{2}c}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\">
-        <mtr data-latex-item=\"{r*{2}c}\" data-latex=\"{r*{2}c}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r*{2}c}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{r*{2}c}a &amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}">
+        <mtr data-latex-item="{r*{2}c}" data-latex="{r*{2}c}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{r*{2}c}\" data-latex=\"{r*{2}c}\">
+        <mtr data-latex-item="{r*{2}c}" data-latex="{r*{2}c}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9847,42 +9781,38 @@ describe('Complete Array', () => {
   it('column r c repeat | ', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r*{2}|c}a& b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r*{2}|c}a&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"right center center\" columnlines=\"solid solid\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\hspace{.5em}e&amp; f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r*{2}|c}a&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="right center center" columnlines="solid solid" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\hspace{.5em}e&amp; f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mi data-latex="a">a</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"b\">b</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mi data-latex="d">d</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"e\">e</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9892,47 +9822,41 @@ describe('Complete Array', () => {
   it('column r c repeat | {}', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r*{2}|c}a {\\hbox{(3)}}& b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r*{2}|c}a {\\hbox{(3)}}&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"right center center\" columnlines=\"solid solid\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\hspace{.5em}e&amp; f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r*{2}|c}a {\\hbox{(3)}}&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="right center center" columnlines="solid solid" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\hspace{.5em}e&amp; f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\hbox{(3)}}\">
-              <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"\\hbox{(3)}\">
-                <mtext>(3)</mtext>
-              </mstyle>
+            <mi data-latex="a">a</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{\\hbox{(3)}}">
+              <mtext data-latex="\\hbox{(3)}">(3)</mtext>
             </mrow>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"b\">b</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mi data-latex="d">d</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"e\">e</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9941,51 +9865,47 @@ describe('Complete Array', () => {
   it('column r c repeat | {}', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r*{2}|c}a {\\begin{array}{c}Q\\end{array}}& b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r*{2}|c}a {\\begin{array}{c}Q\\end{array}}&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"right center center\" columnlines=\"solid solid\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\hspace{.5em}e&amp; f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r*{2}|c}a {\\begin{array}{c}Q\\end{array}}&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="right center center" columnlines="solid solid" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\hspace{.5em}e&amp; f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{{array}}\">
-              <mtable columnspacing=\"1em\" rowspacing=\"4pt\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-                <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+            <mi data-latex="a">a</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{{array}}">
+              <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+                <mtr data-latex-item="{c}" data-latex="{c}">
                   <mtd>
-                    <mi data-latex=\"Q\">Q</mi>
+                    <mi data-latex="Q">Q</mi>
                   </mtd>
                 </mtr>
               </mtable>
             </mrow>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"b\">b</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mi data-latex="d">d</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"e\">e</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -9994,49 +9914,45 @@ describe('Complete Array', () => {
   it('column r c repeat | {}', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{r*{2}|c}a \\begin{array}{c}Q\\end{array}& b & c\\\\d & e & f\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{r*{2}|c}a \\begin{array}{c}Q\\end{array}&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"right center center\" columnlines=\"solid solid\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\hspace{.5em}e&amp; f\\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{r*{2}|c}a \\begin{array}{c}Q\\end{array}&amp; b &amp; c\\\\d &amp; e &amp; f\\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="right center center" columnlines="solid solid" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\hspace{.5em}e&amp; f\\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
-            <mtable columnspacing=\"1em\" rowspacing=\"4pt\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-              <mtr data-latex-item=\"{c}\" data-latex=\"{c}\">
+            <mi data-latex="a">a</mi>
+            <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+              <mtr data-latex-item="{c}" data-latex="{c}">
                 <mtd>
-                  <mi data-latex=\"Q\">Q</mi>
+                  <mi data-latex="Q">Q</mi>
                 </mtd>
               </mtr>
             </mtable>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"b\">b</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
+            <mi data-latex="d">d</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
           </mtd>
           <mtd>
-            <mstyle scriptlevel=\"0\" data-latex=\"\\,\">
-              <mspace width=\"0.167em\"></mspace>
-            </mstyle>
+            <mspace width="0.167em" data-latex="\\,"></mspace>
           </mtd>
           <mtd>
-            <mspace width=\".5em\" data-latex=\"\\hspace{.5em}\"></mspace>
-            <mi data-latex=\"e\">e</mi>
+            <mspace width=".5em" data-latex="\\hspace{.5em}"></mspace>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -10046,30 +9962,30 @@ describe('Complete Array', () => {
   it('column c @& hfil', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{c@{\\alpha}c}a&&b\\\\ d&&e\\hfil \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{c@{\\alpha}c}a&amp;&amp;b\\\\ d&amp;&amp;e\\hfil \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"0 0\" rowspacing=\"4pt\" columnalign=\"center center center\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\alpha&amp;&amp;e\\hfil \\end{array}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c@{\\alpha}c}a&amp;&amp;b\\\\ d&amp;&amp;e\\hfil \\end{array}" display="block">
+      <mtable columnspacing="0 0" rowspacing="4pt" columnalign="center center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\alpha&amp;&amp;e\\hfil \\end{array}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\alpha\">&#x3B1;</mi>
+            <mi data-latex="\\alpha">&#x3B1;</mi>
           </mtd>
           <mtd></mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"\\alpha\">&#x3B1;</mi>
+            <mi data-latex="\\alpha">&#x3B1;</mi>
           </mtd>
           <mtd></mtd>
-          <mtd columnalign=\"left\">
-            <mi data-latex=\"\\hfil\">e</mi>
+          <mtd columnalign="left">
+            <mi data-latex="\\hfil">e</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -10078,8 +9994,8 @@ describe('Complete Array', () => {
   it('Label Error', () =>
     toXmlMatch(
       tex2mml('\\eqalignno{a &  & {\\hbox{(3)}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}\" display=\"block\">
-      <merror data-mjx-error=\"Missing close brace\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}" display="block">
+      <merror data-mjx-error="Missing close brace">
         <mtext>Missing close brace</mtext>
       </merror>
     </math>`
@@ -10088,28 +10004,28 @@ describe('Complete Array', () => {
   it('end row spacing r c l', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{rcl}a & b &c\\\\[2cm] d & e & f\\\\[2cm] \\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{rcl}a &amp; b &amp;c\\\\[2cm] d &amp; e &amp; f\\\\[2cm] \\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"6.069em 6.069em\" columnalign=\"right center left\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{rcl}a &amp; b &amp;c\\\\[2cm] d &amp; e &amp; f\\\\[2cm] \\end{array}\">
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{rcl}a &amp; b &amp;c\\\\[2cm] d &amp; e &amp; f\\\\[2cm] \\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="6.069em 6.069em" columnalign="right center left" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{rcl}a &amp; b &amp;c\\\\[2cm] d &amp; e &amp; f\\\\[2cm] \\end{array}">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{rcl}\" data-latex=\"{rcl}\">
+        <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"e\">e</mi>
+            <mi data-latex="e">e</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"f\">f</mi>
+            <mi data-latex="f">f</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -10118,35 +10034,35 @@ describe('Complete Array', () => {
   it('eqnarray extend last row', () =>
     toXmlMatch(
       tex2mml('\\begin{eqnarray}{rcl}a & b \\\\d&c&c&c \\\\\\end{eqnarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnalign=\"right center left right\" columnspacing=\"0em 0.278em 0em\" rowspacing=\"3pt\" data-break-align=\"bottom middle top bottom\" data-latex-item=\"{eqnarray}\" data-latex=\"\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}" display="block">
+      <mtable columnalign="right center left right" columnspacing="0em 0.278em 0em" rowspacing="3pt" data-break-align="bottom middle top bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}">
         <mtr>
           <mtd>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{r c l}\">
-              <mi data-latex=\"r\">r</mi>
-              <mi data-latex=\"c\">c</mi>
-              <mi data-latex=\"l\">l</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{r c l}">
+              <mi data-latex="r">r</mi>
+              <mi data-latex="c">c</mi>
+              <mi data-latex="l">l</mi>
             </mrow>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
         <mtr>
           <mtd>
-            <mi data-latex=\"d\">d</mi>
+            <mi data-latex="d">d</mi>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
           <mtd>
-            <mstyle indentshift=\".7em\">
-              <mi data-latex=\"c\">c</mi>
+            <mstyle indentshift=".7em">
+              <mi data-latex="c">c</mi>
             </mstyle>
           </mtd>
           <mtd>
-            <mi data-latex=\"c\">c</mi>
+            <mi data-latex="c">c</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -10155,16 +10071,16 @@ describe('Complete Array', () => {
   it('end row hline c', () =>
     toXmlMatch(
       tex2mml('\\begin{array}{|c|}\\hline a\\\\\\hline b\\\\\\hline\\end{array}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{array}{|c|}\\hline a\\\\\\hline b\\\\\\hline\\end{array}\" display=\"block\">
-      <mtable columnspacing=\"1em\" rowspacing=\"4pt\" rowlines=\"solid\" framespacing=\".5em .125em\" frame=\"solid\" data-latex-item=\"{array}\" data-latex=\"\\begin{array}{|c|}\\hline a\\\\\\hline b\\\\\\hline\\end{array}\">
-        <mtr data-latex-item=\"{|c|}\" data-latex=\"{|c|}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{|c|}\\hline a\\\\\\hline b\\\\\\hline\\end{array}" display="block">
+      <mtable columnspacing="1em" rowspacing="4pt" rowlines="solid" framespacing=".5em .125em" frame="solid" data-latex-item="{array}" data-latex="\\begin{array}{|c|}\\hline a\\\\\\hline b\\\\\\hline\\end{array}">
+        <mtr data-latex-item="{|c|}" data-latex="{|c|}">
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
-        <mtr data-latex-item=\"{|c|}\" data-latex=\"{|c|}\">
+        <mtr data-latex-item="{|c|}" data-latex="{|c|}">
           <mtd>
-            <mi data-latex=\"b\">b</mi>
+            <mi data-latex="b">b</mi>
           </mtd>
         </mtr>
       </mtable>
@@ -10220,18 +10136,18 @@ describe('User Defined Macros', () => {
   it('Macro with optional def', () =>
     toXmlMatch(
       tex2mml('\\RR'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\RR\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\bf R}\">
-        <mi mathvariant=\"bold\" data-latex=\"R\">R</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\RR" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
+        <mi mathvariant="bold" data-latex="R">R</mi>
       </mrow>
     </math>`
     ));
   it('EqRef', () =>
     toXmlMatch(
       tex2mml('a\\label{A}\\eqref{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"a\\label{A}\\eqref{A}\" display=\"block\">
-      <mi data-latex=\"\\label{A}\">a</mi>
-      <mrow href=\"#\" class=\"MathJax_ref\" data-latex=\"\\eqref{A}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}\\eqref{A}" display="block">
+      <mi data-latex="\\label{A}">a</mi>
+      <mrow href="#" class="MathJax_ref" data-latex="\\eqref{A}">
         <mtext>(???)</mtext>
       </mrow>
     </math>`
@@ -10239,32 +10155,32 @@ describe('User Defined Macros', () => {
   it('Right Color', () =>
     toXmlMatch(
       tex2mml('\\left(A\\middle|B\\color{red}\\right)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left(A\\middle|B\\color{red}\\right)\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left(A\\middle|B\\color{red}\\right)\" data-latex=\"\\left(A\\middle|B\\color{red}\\right)\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mi data-latex=\"A\">A</mi>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle|\" data-latex=\"\\middle|\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle|\"></mrow>
-        <mi data-latex=\"B\">B</mi>
-        <mstyle mathcolor=\"red\"></mstyle>
-        <mo data-mjx-texclass=\"CLOSE\" mathcolor=\"red\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left(A\\middle|B\\color{red}\\right)" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left(A\\middle|B\\color{red}\\right)" data-latex="\\left(A\\middle|B\\color{red}\\right)">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mi data-latex="A">A</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle|" data-latex="\\middle|">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
+        <mi data-latex="B">B</mi>
+        <mstyle mathcolor="red"></mstyle>
+        <mo data-mjx-texclass="CLOSE" mathcolor="red" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('Middle Color', () =>
     toXmlMatch(
       tex2mml('\\left(A\\color{red}\\middle|B\\right)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\left(A\\color{red}\\middle|B\\right)\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left(A\\color{red}\\middle|B\\right)\" data-latex=\"\\left(A\\color{red}\\middle|B\\right)\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mi data-latex=\"A\">A</mi>
-        <mstyle mathcolor=\"red\"></mstyle>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo mathcolor=\"red\" data-latex-item=\"\\middle|\" data-latex=\"\\middle|\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle|\"></mrow>
-        <mi data-latex=\"B\">B</mi>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left(A\\color{red}\\middle|B\\right)" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left(A\\color{red}\\middle|B\\right)" data-latex="\\left(A\\color{red}\\middle|B\\right)">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mi data-latex="A">A</mi>
+        <mstyle mathcolor="red"></mstyle>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo mathcolor="red" data-latex-item="\\middle|" data-latex="\\middle|">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle|"></mrow>
+        <mi data-latex="B">B</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
@@ -10307,87 +10223,91 @@ describe('User Defined Environments', () => {
   it('smallmatrix', () =>
     toXmlMatch(
       tex2mml('\\begin{smallmatrix} a & b \\\\ c & d \\end{smallmatrix}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}\" display=\"block\">
-      <mtable data-mjx-smallmatrix=\"true\" columnspacing=\"1\" rowspacing=\".2em\" data-latex-item=\"{smallmatrix}\" data-latex=\"\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}\">
-        <mtr>
-          <mtd>
-            <mi data-latex=\"a\">a</mi>
-          </mtd>
-          <mtd>
-            <mi data-latex=\"b\">b</mi>
-          </mtd>
-        </mtr>
-        <mtr>
-          <mtd>
-            <mi data-latex=\"c\">c</mi>
-          </mtd>
-          <mtd>
-            <mi data-latex=\"d\">d</mi>
-          </mtd>
-        </mtr>
-      </mtable>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}" display="block">
+      <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}">
+        <mtable data-mjx-smallmatrix="true" columnspacing="1" rowspacing=".2em" displaystyle="false">
+          <mtr>
+            <mtd>
+              <mi data-latex="a">a</mi>
+            </mtd>
+            <mtd>
+              <mi data-latex="b">b</mi>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mi data-latex="c">c</mi>
+            </mtd>
+            <mtd>
+              <mi data-latex="d">d</mi>
+            </mtd>
+          </mtr>
+        </mtable>
+      </mstyle>
     </math>`
     ));
   it('pmatrix', () =>
     toXmlMatch(
       tex2mml('\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{pmatrix} a &amp; b \\\\ c &amp; d \\end{pmatrix}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"{pmatrix}\" data-latex=\"\\begin{pmatrix} a &amp; b \\\\ c &amp; d \\end{pmatrix}\">
-        <mo data-mjx-texclass=\"OPEN\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{pmatrix} a &amp; b \\\\ c &amp; d \\end{pmatrix}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="{pmatrix}" data-latex="\\begin{pmatrix} a &amp; b \\\\ c &amp; d \\end{pmatrix}">
+        <mo data-mjx-texclass="OPEN">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt">
           <mtr>
             <mtd>
-              <mi data-latex=\"a\">a</mi>
+              <mi data-latex="a">a</mi>
             </mtd>
             <mtd>
-              <mi data-latex=\"b\">b</mi>
+              <mi data-latex="b">b</mi>
             </mtd>
           </mtr>
           <mtr>
             <mtd>
-              <mi data-latex=\"c\">c</mi>
+              <mi data-latex="c">c</mi>
             </mtd>
             <mtd>
-              <mi data-latex=\"d\">d</mi>
+              <mi data-latex="d">d</mi>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\">)</mo>
+        <mo data-mjx-texclass="CLOSE">)</mo>
       </mrow>
     </math>`
     ));
   it('Crampedsubarray', () =>
     toXmlMatch(
       tex2mml('\\begin{crampedsubarray}{cc} a & b \\\\ c & d \\end{crampedsubarray}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{crampedsubarray}{cc} a &amp; b \\\\ c &amp; d \\end{crampedsubarray}\" display=\"block\">
-      <mtable data-mjx-smallmatrix=\"true\" columnspacing=\"0em\" rowspacing=\"0.1em\" columnalign=\"center center\" data-cramped=\"true\" data-latex-item=\"{crampedsubarray}\" data-latex=\"\\begin{crampedsubarray}{cc} a &amp; b \\\\ c &amp; d \\end{crampedsubarray}\">
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
-          <mtd>
-            <mi data-latex=\"a\">a</mi>
-          </mtd>
-          <mtd>
-            <mi data-latex=\"b\">b</mi>
-          </mtd>
-        </mtr>
-        <mtr data-latex-item=\"{cc}\" data-latex=\"{cc}\">
-          <mtd>
-            <mi data-latex=\"c\">c</mi>
-          </mtd>
-          <mtd>
-            <mi data-latex=\"d\">d</mi>
-          </mtd>
-        </mtr>
-      </mtable>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{crampedsubarray}{cc} a &amp; b \\\\ c &amp; d \\end{crampedsubarray}" display="block">
+      <mstyle scriptlevel="1" data-latex-item="{crampedsubarray}" data-latex="\\begin{crampedsubarray}{cc} a &amp; b \\\\ c &amp; d \\end{crampedsubarray}">
+        <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" columnalign="center center" data-cramped="true" displaystyle="false">
+          <mtr data-latex-item="{cc}" data-latex="{cc}">
+            <mtd>
+              <mi data-latex="a">a</mi>
+            </mtd>
+            <mtd>
+              <mi data-latex="b">b</mi>
+            </mtd>
+          </mtr>
+          <mtr data-latex-item="{cc}" data-latex="{cc}">
+            <mtd>
+              <mi data-latex="c">c</mi>
+            </mtd>
+            <mtd>
+              <mi data-latex="d">d</mi>
+            </mtd>
+          </mtr>
+        </mtable>
+      </mstyle>
     </math>`
     ));
   it('Gather', () =>
     toXmlMatch(
       tex2mml('\\begin{gather}a\\end{gather}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{gather}a\\end{gather}\" display=\"block\">
-      <mtable displaystyle=\"true\" columnspacing=\"1em\" rowspacing=\"3pt\" data-break-align=\"middle\" data-latex-item=\"{gather}\" data-latex=\"\\begin{gather}a\\end{gather}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather}a\\end{gather}" display="block">
+      <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather}a\\end{gather}">
         <mtr>
           <mtd>
-            <mi data-latex=\"a\">a</mi>
+            <mi data-latex="a">a</mi>
           </mtd>
         </mtr>
       </mtable>

--- a/testsuite/tests/input/tex/Boldsymbol.test.ts
+++ b/testsuite/tests/input/tex/Boldsymbol.test.ts
@@ -47,7 +47,7 @@ describe('Boldsymbol', () => {
   <mi data-latex="a" mathvariant="bold-italic">a</mi>
   <mo data-latex="+" mathvariant="bold">+</mo>
   <mi data-latex="b" mathvariant="bold-italic">b</mi>
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{ w $c+\\boldsymbol{d+e}$ w }">
+  <mstyle displaystyle="false" data-latex="\\mbox{ w $c+\\boldsymbol{d+e}$ w }">
     <mtext>&#xA0;w&#xA0;</mtext>
     <mrow data-mjx-texclass="ORD">
       <mi data-latex="c">c</mi>

--- a/testsuite/tests/input/tex/Braket.test.ts
+++ b/testsuite/tests/input/tex/Braket.test.ts
@@ -205,11 +205,11 @@ describe('Braket', () => {
   it('Braket-Set-small', () =>
     toXmlMatch(
       tex2mml('\\set{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\set{x}\" display=\"block\">
-      <mrow data-latex=\"\\set{x}\">
-        <mo data-mjx-texclass=\"OPEN\" stretchy=\"false\">{</mo>
-        <mi data-latex=\"x\">x</mi>
-        <mo data-mjx-texclass=\"CLOSE\" stretchy=\"false\">}</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\set{x}" display="block">
+      <mrow data-latex="\\set{x}">
+        <mo data-mjx-texclass="OPEN" stretchy="false">{</mo>
+        <mi data-latex="x">x</mi>
+        <mo data-mjx-texclass="CLOSE" stretchy="false">}</mo>
       </mrow>
     </math>`
     ));
@@ -265,16 +265,16 @@ describe('Braket', () => {
   it('Braket-Set-over', () =>
     toXmlMatch(
       tex2mml('\\Set{x\\over y}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Set{x\\over y}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex=\"\\Set{x\\over y}\">
-        <mo data-mjx-texclass=\"OPEN\">{</mo>
-        <mspace width=\"0.167em\"></mspace>
-        <mfrac data-latex-item=\"\\over\">
-          <mi data-latex=\"x\">x</mi>
-          <mi data-latex=\"y\">y</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{x\\over y}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex="\\Set{x\\over y}">
+        <mo data-mjx-texclass="OPEN">{</mo>
+        <mspace width="0.167em"></mspace>
+        <mfrac data-latex-item="\\over">
+          <mi data-latex="x">x</mi>
+          <mi data-latex="y">y</mi>
         </mfrac>
-        <mspace width=\"0.167em\"></mspace>
-        <mo data-mjx-texclass=\"CLOSE\">}</mo>
+        <mspace width="0.167em"></mspace>
+        <mo data-mjx-texclass="CLOSE">}</mo>
       </mrow>
     </math>`
     ));

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -12,7 +12,7 @@ describe('BussproofsRegInf', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\end{prooftree}" display="block">
   <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_axiom:true;bspr_proof:true">
     <mspace width=".5ex"></mspace>
-    <mstyle displaystyle="false" scriptlevel="0">
+    <mstyle displaystyle="false">
       <mtext>A</mtext>
     </mstyle>
     <mspace width=".5ex"></mspace>
@@ -31,9 +31,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -45,9 +43,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>B</mtext>
-          </mstyle>
+          <mtext>B</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -69,9 +65,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -79,9 +73,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -93,9 +85,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>C</mtext>
-          </mstyle>
+          <mtext>C</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -117,9 +107,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -127,9 +115,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -137,9 +123,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>C</mtext>
-                </mstyle>
+                <mtext>C</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -151,9 +135,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>D</mtext>
-          </mstyle>
+          <mtext>D</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -175,9 +157,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -185,9 +165,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -195,9 +173,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>C</mtext>
-                </mstyle>
+                <mtext>C</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -205,9 +181,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>D</mtext>
-                </mstyle>
+                <mtext>D</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -219,9 +193,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>E</mtext>
-          </mstyle>
+          <mtext>E</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -243,9 +215,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -253,9 +223,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -263,9 +231,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>C</mtext>
-                </mstyle>
+                <mtext>C</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -273,9 +239,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>D</mtext>
-                </mstyle>
+                <mtext>D</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -283,9 +247,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AxiomC{E}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>E</mtext>
-                </mstyle>
+                <mtext>E</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -297,9 +259,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>F</mtext>
-          </mstyle>
+          <mtext>F</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -315,7 +275,7 @@ describe('BussproofsRegInf', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" display="block">
       <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
@@ -327,9 +287,7 @@ describe('BussproofsRegInf', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>A</mtext>
-                      </mstyle>
+                      <mtext>A</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -341,9 +299,7 @@ describe('BussproofsRegInf', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -367,9 +323,7 @@ describe('BussproofsRegInf', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>A</mtext>
-                      </mstyle>
+                      <mtext>A</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -381,16 +335,14 @@ describe('BussproofsRegInf', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -405,7 +357,7 @@ describe('BussproofsRegInf', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
       <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
@@ -417,9 +369,7 @@ describe('BussproofsRegInf', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>A</mtext>
-                      </mstyle>
+                      <mtext>A</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -431,16 +381,14 @@ describe('BussproofsRegInf', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -453,7 +401,7 @@ describe('BussproofsRegInf', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\end{prooftree}" display="block">
   <mrow data-latex="\\begin{prooftree}\\AXC{A}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_axiom:true;bspr_proof:true">
     <mspace width=".5ex"></mspace>
-    <mstyle displaystyle="false" scriptlevel="0">
+    <mstyle displaystyle="false">
       <mtext>A</mtext>
     </mstyle>
     <mspace width=".5ex"></mspace>
@@ -472,9 +420,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -486,9 +432,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>B</mtext>
-          </mstyle>
+          <mtext>B</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -508,9 +452,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -518,9 +460,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AXC{B}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -532,9 +472,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>C</mtext>
-          </mstyle>
+          <mtext>C</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -556,9 +494,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>A</mtext>
-                </mstyle>
+                <mtext>A</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -566,9 +502,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AXC{B}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -576,9 +510,7 @@ describe('BussproofsRegInf', () => {
             <mtd rowalign="bottom">
               <mrow data-latex="\\AXC{C}" semantics="bspr_axiom:true">
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>C</mtext>
-                </mstyle>
+                <mtext>C</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -590,9 +522,7 @@ describe('BussproofsRegInf', () => {
       <mtd>
         <mrow>
           <mspace width=".5ex"></mspace>
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mtext>D</mtext>
-          </mstyle>
+          <mtext>D</mtext>
           <mspace width=".5ex"></mspace>
         </mrow>
       </mtd>
@@ -608,7 +538,7 @@ describe('BussproofsRegInf', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" display="block">
       <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
@@ -620,9 +550,7 @@ describe('BussproofsRegInf', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>A</mtext>
-                      </mstyle>
+                      <mtext>A</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -634,9 +562,7 @@ describe('BussproofsRegInf', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -660,9 +586,7 @@ describe('BussproofsRegInf', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>A</mtext>
-                      </mstyle>
+                      <mtext>A</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -674,16 +598,14 @@ describe('BussproofsRegInf', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -698,7 +620,7 @@ describe('BussproofsRegInf', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
       <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>L</mtext>
           </mstyle>
         </mpadded>
@@ -710,9 +632,7 @@ describe('BussproofsRegInf', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>A</mtext>
-                      </mstyle>
+                      <mtext>A</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -724,16 +644,14 @@ describe('BussproofsRegInf', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>B</mtext>
-                </mstyle>
+                <mtext>B</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
           </mtr>
         </mtable>
         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false" scriptlevel="0">
+          <mstyle displaystyle="false">
             <mtext>R</mtext>
           </mstyle>
         </mpadded>
@@ -758,9 +676,7 @@ describe('BussproofsRegProofs', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>D</mtext>
-                      </mstyle>
+                      <mtext>D</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -775,9 +691,7 @@ describe('BussproofsRegProofs', () => {
                                 <mtd rowalign="bottom">
                                   <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                     <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mtext>A</mtext>
-                                    </mstyle>
+                                    <mtext>A</mtext>
                                     <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
@@ -791,9 +705,7 @@ describe('BussproofsRegProofs', () => {
                                             <mtd rowalign="bottom">
                                               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                 <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>B</mtext>
-                                                </mstyle>
+                                                <mtext>B</mtext>
                                                 <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
@@ -801,9 +713,7 @@ describe('BussproofsRegProofs', () => {
                                             <mtd rowalign="bottom">
                                               <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
                                                 <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>R</mtext>
-                                                </mstyle>
+                                                <mtext>R</mtext>
                                                 <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
@@ -815,15 +725,13 @@ describe('BussproofsRegProofs', () => {
                                       <mtd>
                                         <mrow>
                                           <mspace width=".5ex"></mspace>
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mrow data-mjx-texclass="ORD">
-                                              <mi data-latex="C">C</mi>
-                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                              <mi data-latex="D">D</mi>
-                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                              <mi data-latex="Q">Q</mi>
-                                            </mrow>
-                                          </mstyle>
+                                          <mrow data-mjx-texclass="ORD">
+                                            <mi data-latex="C">C</mi>
+                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                            <mi data-latex="D">D</mi>
+                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                            <mi data-latex="Q">Q</mi>
+                                          </mrow>
                                           <mspace width=".5ex"></mspace>
                                         </mrow>
                                       </mtd>
@@ -838,9 +746,7 @@ describe('BussproofsRegProofs', () => {
                           <mtd>
                             <mrow>
                               <mspace width=".5ex"></mspace>
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>E</mtext>
-                              </mstyle>
+                              <mtext>E</mtext>
                               <mspace width=".5ex"></mspace>
                             </mrow>
                           </mtd>
@@ -857,9 +763,7 @@ describe('BussproofsRegProofs', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>F</mtext>
-                </mstyle>
+                <mtext>F</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -891,9 +795,7 @@ describe('BussproofsRegProofs', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>D</mtext>
-                      </mstyle>
+                      <mtext>D</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -908,9 +810,7 @@ describe('BussproofsRegProofs', () => {
                                 <mtd rowalign="bottom">
                                   <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                     <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mtext>A</mtext>
-                                    </mstyle>
+                                    <mtext>A</mtext>
                                     <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
@@ -924,9 +824,7 @@ describe('BussproofsRegProofs', () => {
                                             <mtd rowalign="bottom">
                                               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                 <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>B</mtext>
-                                                </mstyle>
+                                                <mtext>B</mtext>
                                                 <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
@@ -934,9 +832,7 @@ describe('BussproofsRegProofs', () => {
                                             <mtd rowalign="bottom">
                                               <mrow data-latex="$" semantics="bspr_axiom:true">
                                                 <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>R</mtext>
-                                                </mstyle>
+                                                <mtext>R</mtext>
                                                 <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
@@ -948,15 +844,13 @@ describe('BussproofsRegProofs', () => {
                                       <mtd>
                                         <mrow>
                                           <mspace width=".5ex"></mspace>
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mrow data-mjx-texclass="ORD">
-                                              <mi data-latex="C">C</mi>
-                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                              <mi data-latex="D">D</mi>
-                                              <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                              <mi data-latex="Q">Q</mi>
-                                            </mrow>
-                                          </mstyle>
+                                          <mrow data-mjx-texclass="ORD">
+                                            <mi data-latex="C">C</mi>
+                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                            <mi data-latex="D">D</mi>
+                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                            <mi data-latex="Q">Q</mi>
+                                          </mrow>
                                           <mspace width=".5ex"></mspace>
                                         </mrow>
                                       </mtd>
@@ -971,9 +865,7 @@ describe('BussproofsRegProofs', () => {
                           <mtd>
                             <mrow>
                               <mspace width=".5ex"></mspace>
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>E</mtext>
-                              </mstyle>
+                              <mtext>E</mtext>
                               <mspace width=".5ex"></mspace>
                             </mrow>
                           </mtd>
@@ -990,9 +882,7 @@ describe('BussproofsRegProofs', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mtext>F</mtext>
-                </mstyle>
+                <mtext>F</mtext>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -1034,9 +924,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd rowalign="bottom">
                                                 <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>D</mtext>
-                                                  </mstyle>
+                                                  <mtext>D</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1044,9 +932,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd rowalign="bottom">
                                                 <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>A1</mtext>
-                                                  </mstyle>
+                                                  <mtext>A1</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1054,9 +940,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd rowalign="bottom">
                                                 <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>A2</mtext>
-                                                  </mstyle>
+                                                  <mtext>A2</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1068,9 +952,7 @@ describe('BussproofsRegProofs', () => {
                                         <mtd>
                                           <mrow>
                                             <mspace width=".5ex"></mspace>
-                                            <mstyle displaystyle="false" scriptlevel="0">
-                                              <mtext>Q</mtext>
-                                            </mstyle>
+                                            <mtext>Q</mtext>
                                             <mspace width=".5ex"></mspace>
                                           </mrow>
                                         </mtd>
@@ -1089,9 +971,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd rowalign="bottom">
                                                 <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>A</mtext>
-                                                  </mstyle>
+                                                  <mtext>A</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1105,9 +985,7 @@ describe('BussproofsRegProofs', () => {
                                                           <mtd rowalign="bottom">
                                                             <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                               <mspace width=".5ex"></mspace>
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mtext>B</mtext>
-                                                              </mstyle>
+                                                              <mtext>B</mtext>
                                                               <mspace width=".5ex"></mspace>
                                                             </mrow>
                                                           </mtd>
@@ -1115,9 +993,7 @@ describe('BussproofsRegProofs', () => {
                                                           <mtd rowalign="bottom">
                                                             <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
                                                               <mspace width=".5ex"></mspace>
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mtext>R</mtext>
-                                                              </mstyle>
+                                                              <mtext>R</mtext>
                                                               <mspace width=".5ex"></mspace>
                                                             </mrow>
                                                           </mtd>
@@ -1129,15 +1005,13 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd>
                                                       <mrow>
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mrow data-mjx-texclass="ORD">
-                                                            <mi data-latex="C">C</mi>
-                                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                            <mi data-latex="D">D</mi>
-                                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                            <mi data-latex="Q">Q</mi>
-                                                          </mrow>
-                                                        </mstyle>
+                                                        <mrow data-mjx-texclass="ORD">
+                                                          <mi data-latex="C">C</mi>
+                                                          <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                          <mi data-latex="D">D</mi>
+                                                          <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                          <mi data-latex="Q">Q</mi>
+                                                        </mrow>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1152,9 +1026,7 @@ describe('BussproofsRegProofs', () => {
                                         <mtd>
                                           <mrow>
                                             <mspace width=".5ex"></mspace>
-                                            <mstyle displaystyle="false" scriptlevel="0">
-                                              <mtext>E</mtext>
-                                            </mstyle>
+                                            <mtext>E</mtext>
                                             <mspace width=".5ex"></mspace>
                                           </mrow>
                                         </mtd>
@@ -1171,9 +1043,7 @@ describe('BussproofsRegProofs', () => {
                           <mtd>
                             <mrow>
                               <mspace width=".5ex"></mspace>
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>F</mtext>
-                              </mstyle>
+                              <mtext>F</mtext>
                               <mspace width=".5ex"></mspace>
                             </mrow>
                           </mtd>
@@ -1187,9 +1057,7 @@ describe('BussproofsRegProofs', () => {
                   <mtd rowalign="bottom">
                     <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
                       <mspace width=".5ex"></mspace>
-                      <mstyle displaystyle="false" scriptlevel="0">
-                        <mtext>M</mtext>
-                      </mstyle>
+                      <mtext>M</mtext>
                       <mspace width=".5ex"></mspace>
                     </mrow>
                   </mtd>
@@ -1201,13 +1069,11 @@ describe('BussproofsRegProofs', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="N">N</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="R">R</mi>
-                  </mrow>
-                </mstyle>
+                <mrow data-mjx-texclass="ORD">
+                  <mi data-latex="N">N</mi>
+                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                  <mi data-latex="R">R</mi>
+                </mrow>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -1252,9 +1118,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>D</mtext>
-                                                        </mstyle>
+                                                        <mtext>D</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1262,9 +1126,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A1</mtext>
-                                                        </mstyle>
+                                                        <mtext>A1</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1272,9 +1134,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A2</mtext>
-                                                        </mstyle>
+                                                        <mtext>A2</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1286,9 +1146,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd>
                                                 <mrow>
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>Q</mtext>
-                                                  </mstyle>
+                                                  <mtext>Q</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1308,9 +1166,7 @@ describe('BussproofsRegProofs', () => {
                                                       <mtd rowalign="bottom">
                                                         <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                                           <mspace width=".5ex"></mspace>
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>A</mtext>
-                                                          </mstyle>
+                                                          <mtext>A</mtext>
                                                           <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
@@ -1326,9 +1182,7 @@ describe('BussproofsRegProofs', () => {
                                                                       <mtd rowalign="bottom">
                                                                         <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                                           <mspace width=".5ex"></mspace>
-                                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                                            <mtext>B</mtext>
-                                                                          </mstyle>
+                                                                          <mtext>B</mtext>
                                                                           <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
@@ -1336,9 +1190,7 @@ describe('BussproofsRegProofs', () => {
                                                                       <mtd rowalign="bottom">
                                                                         <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
                                                                           <mspace width=".5ex"></mspace>
-                                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                                            <mtext>R</mtext>
-                                                                          </mstyle>
+                                                                          <mtext>R</mtext>
                                                                           <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
@@ -1350,24 +1202,20 @@ describe('BussproofsRegProofs', () => {
                                                                 <mtd>
                                                                   <mrow>
                                                                     <mspace width=".5ex"></mspace>
-                                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                                      <mrow data-mjx-texclass="ORD">
-                                                                        <mi data-latex="C">C</mi>
-                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                        <mi data-latex="D">D</mi>
-                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                        <mi data-latex="Q">Q</mi>
-                                                                      </mrow>
-                                                                    </mstyle>
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <mi data-latex="C">C</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="D">D</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="Q">Q</mi>
+                                                                    </mrow>
                                                                     <mspace width=".5ex"></mspace>
                                                                   </mrow>
                                                                 </mtd>
                                                               </mtr>
                                                             </mtable>
                                                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mtext>AAAA</mtext>
-                                                              </mstyle>
+                                                              <mtext>AAAA</mtext>
                                                             </mpadded>
                                                           </mrow>
                                                           <mspace width="-3.216em"></mspace>
@@ -1381,18 +1229,14 @@ describe('BussproofsRegProofs', () => {
                                                 <mtd>
                                                   <mrow>
                                                     <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>E</mtext>
-                                                    </mstyle>
+                                                    <mtext>E</mtext>
                                                     <mspace width=".5ex"></mspace>
                                                   </mrow>
                                                 </mtd>
                                               </mtr>
                                             </mtable>
                                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>BBB</mtext>
-                                              </mstyle>
+                                              <mtext>BBB</mtext>
                                             </mpadded>
                                           </mrow>
                                           <mspace width="-6.134em"></mspace>
@@ -1406,18 +1250,14 @@ describe('BussproofsRegProofs', () => {
                                 <mtd>
                                   <mrow>
                                     <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mtext>F</mtext>
-                                    </mstyle>
+                                    <mtext>F</mtext>
                                     <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
                               </mtr>
                             </mtable>
                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>CCCCC</mtext>
-                              </mstyle>
+                              <mtext>CCCCC</mtext>
                             </mpadded>
                           </mrow>
                         </mrow>
@@ -1429,9 +1269,7 @@ describe('BussproofsRegProofs', () => {
                     <mtd rowalign="bottom">
                       <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
                         <mspace width=".5ex"></mspace>
-                        <mstyle displaystyle="false" scriptlevel="0">
-                          <mtext>M</mtext>
-                        </mstyle>
+                        <mtext>M</mtext>
                         <mspace width=".5ex"></mspace>
                       </mrow>
                     </mtd>
@@ -1443,20 +1281,18 @@ describe('BussproofsRegProofs', () => {
               <mtd>
                 <mrow>
                   <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mrow data-mjx-texclass="ORD">
-                      <mi data-latex="N">N</mi>
-                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                      <mi data-latex="R">R</mi>
-                    </mrow>
-                  </mstyle>
+                  <mrow data-mjx-texclass="ORD">
+                    <mi data-latex="N">N</mi>
+                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                    <mi data-latex="R">R</mi>
+                  </mrow>
                   <mspace width=".5ex"></mspace>
                 </mrow>
               </mtd>
             </mtr>
           </mtable>
           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle displaystyle="false">
               <mtext>QERE</mtext>
             </mstyle>
           </mpadded>
@@ -1474,7 +1310,7 @@ describe('BussproofsRegProofs', () => {
         <mspace width="3.835em"></mspace>
         <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle displaystyle="false">
               <mtext>QERE</mtext>
             </mstyle>
           </mpadded>
@@ -1491,9 +1327,7 @@ describe('BussproofsRegProofs', () => {
                           <mrow data-latex="\\LeftLabel{QERE}">
                             <mspace width="0.551em"></mspace>
                             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>CCCCC</mtext>
-                              </mstyle>
+                              <mtext>CCCCC</mtext>
                             </mpadded>
                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
@@ -1511,9 +1345,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>D</mtext>
-                                                        </mstyle>
+                                                        <mtext>D</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1521,9 +1353,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A1</mtext>
-                                                        </mstyle>
+                                                        <mtext>A1</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1531,9 +1361,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A2</mtext>
-                                                        </mstyle>
+                                                        <mtext>A2</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1545,9 +1373,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd>
                                                 <mrow>
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>Q</mtext>
-                                                  </mstyle>
+                                                  <mtext>Q</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1560,9 +1386,7 @@ describe('BussproofsRegProofs', () => {
                                         <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
                                           <mrow data-latex="\\LeftLabel{CCCCC}">
                                             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>BBB</mtext>
-                                              </mstyle>
+                                              <mtext>BBB</mtext>
                                             </mpadded>
                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
@@ -1572,9 +1396,7 @@ describe('BussproofsRegProofs', () => {
                                                       <mtd rowalign="bottom">
                                                         <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                                           <mspace width=".5ex"></mspace>
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>A</mtext>
-                                                          </mstyle>
+                                                          <mtext>A</mtext>
                                                           <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
@@ -1582,9 +1404,7 @@ describe('BussproofsRegProofs', () => {
                                                       <mtd rowalign="bottom">
                                                         <mrow data-latex="\\LeftLabel{BBB}" semantics="bspr_labelledRule:left;bspr_inference:2">
                                                           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                              <mtext>AAAA</mtext>
-                                                            </mstyle>
+                                                            <mtext>AAAA</mtext>
                                                           </mpadded>
                                                           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                             <mtr>
@@ -1594,9 +1414,7 @@ describe('BussproofsRegProofs', () => {
                                                                     <mtd rowalign="bottom">
                                                                       <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                                         <mspace width=".5ex"></mspace>
-                                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                                          <mtext>B</mtext>
-                                                                        </mstyle>
+                                                                        <mtext>B</mtext>
                                                                         <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
@@ -1604,9 +1422,7 @@ describe('BussproofsRegProofs', () => {
                                                                     <mtd rowalign="bottom">
                                                                       <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
                                                                         <mspace width=".5ex"></mspace>
-                                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                                          <mtext>R</mtext>
-                                                                        </mstyle>
+                                                                        <mtext>R</mtext>
                                                                         <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
@@ -1618,15 +1434,13 @@ describe('BussproofsRegProofs', () => {
                                                               <mtd>
                                                                 <mrow>
                                                                   <mspace width=".5ex"></mspace>
-                                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                                    <mrow data-mjx-texclass="ORD">
-                                                                      <mi data-latex="C">C</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="D">D</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="Q">Q</mi>
-                                                                    </mrow>
-                                                                  </mstyle>
+                                                                  <mrow data-mjx-texclass="ORD">
+                                                                    <mi data-latex="C">C</mi>
+                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                    <mi data-latex="D">D</mi>
+                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                    <mi data-latex="Q">Q</mi>
+                                                                  </mrow>
                                                                   <mspace width=".5ex"></mspace>
                                                                 </mrow>
                                                               </mtd>
@@ -1642,9 +1456,7 @@ describe('BussproofsRegProofs', () => {
                                                 <mtd>
                                                   <mrow>
                                                     <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>E</mtext>
-                                                    </mstyle>
+                                                    <mtext>E</mtext>
                                                     <mspace width=".5ex"></mspace>
                                                   </mrow>
                                                 </mtd>
@@ -1662,9 +1474,7 @@ describe('BussproofsRegProofs', () => {
                                 <mtd>
                                   <mrow>
                                     <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mtext>F</mtext>
-                                    </mstyle>
+                                    <mtext>F</mtext>
                                     <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
@@ -1680,9 +1490,7 @@ describe('BussproofsRegProofs', () => {
                     <mtd rowalign="bottom">
                       <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
                         <mspace width=".5ex"></mspace>
-                        <mstyle displaystyle="false" scriptlevel="0">
-                          <mtext>M</mtext>
-                        </mstyle>
+                        <mtext>M</mtext>
                         <mspace width=".5ex"></mspace>
                       </mrow>
                     </mtd>
@@ -1694,13 +1502,11 @@ describe('BussproofsRegProofs', () => {
               <mtd>
                 <mrow>
                   <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mrow data-mjx-texclass="ORD">
-                      <mi data-latex="N">N</mi>
-                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                      <mi data-latex="R">R</mi>
-                    </mrow>
-                  </mstyle>
+                  <mrow data-mjx-texclass="ORD">
+                    <mi data-latex="N">N</mi>
+                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                    <mi data-latex="R">R</mi>
+                  </mrow>
                   <mspace width=".5ex"></mspace>
                 </mrow>
               </mtd>
@@ -1720,7 +1526,7 @@ describe('BussproofsRegProofs', () => {
         <mspace width="4.379em"></mspace>
         <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle displaystyle="false">
               <mtext>DD</mtext>
             </mstyle>
           </mpadded>
@@ -1737,9 +1543,7 @@ describe('BussproofsRegProofs', () => {
                           <mrow data-latex="\\LeftLabel{DD}">
                             <mspace width="0.551em"></mspace>
                             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mtext>CCCCC</mtext>
-                              </mstyle>
+                              <mtext>CCCCC</mtext>
                             </mpadded>
                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                               <mtr>
@@ -1757,9 +1561,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>D</mtext>
-                                                        </mstyle>
+                                                        <mtext>D</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1767,9 +1569,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A1</mtext>
-                                                        </mstyle>
+                                                        <mtext>A1</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1777,9 +1577,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A2</mtext>
-                                                        </mstyle>
+                                                        <mtext>A2</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -1791,9 +1589,7 @@ describe('BussproofsRegProofs', () => {
                                               <mtd>
                                                 <mrow>
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>Q</mtext>
-                                                  </mstyle>
+                                                  <mtext>Q</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
@@ -1806,9 +1602,7 @@ describe('BussproofsRegProofs', () => {
                                         <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
                                           <mrow data-latex="\\LeftLabel{CCCCC}">
                                             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>BBB</mtext>
-                                              </mstyle>
+                                              <mtext>BBB</mtext>
                                             </mpadded>
                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                               <mtr>
@@ -1818,9 +1612,7 @@ describe('BussproofsRegProofs', () => {
                                                       <mtd rowalign="bottom">
                                                         <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                                           <mspace width=".5ex"></mspace>
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>A</mtext>
-                                                          </mstyle>
+                                                          <mtext>A</mtext>
                                                           <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
@@ -1836,9 +1628,7 @@ describe('BussproofsRegProofs', () => {
                                                                       <mtd rowalign="bottom">
                                                                         <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                                           <mspace width=".5ex"></mspace>
-                                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                                            <mtext>B</mtext>
-                                                                          </mstyle>
+                                                                          <mtext>B</mtext>
                                                                           <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
@@ -1846,9 +1636,7 @@ describe('BussproofsRegProofs', () => {
                                                                       <mtd rowalign="bottom">
                                                                         <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
                                                                           <mspace width=".5ex"></mspace>
-                                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                                            <mtext>R</mtext>
-                                                                          </mstyle>
+                                                                          <mtext>R</mtext>
                                                                           <mspace width=".5ex"></mspace>
                                                                         </mrow>
                                                                       </mtd>
@@ -1860,24 +1648,20 @@ describe('BussproofsRegProofs', () => {
                                                                 <mtd>
                                                                   <mrow>
                                                                     <mspace width=".5ex"></mspace>
-                                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                                      <mrow data-mjx-texclass="ORD">
-                                                                        <mi data-latex="C">C</mi>
-                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                        <mi data-latex="D">D</mi>
-                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                        <mi data-latex="Q">Q</mi>
-                                                                      </mrow>
-                                                                    </mstyle>
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <mi data-latex="C">C</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="D">D</mi>
+                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                      <mi data-latex="Q">Q</mi>
+                                                                    </mrow>
                                                                     <mspace width=".5ex"></mspace>
                                                                   </mrow>
                                                                 </mtd>
                                                               </mtr>
                                                             </mtable>
                                                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mtext>AAAA</mtext>
-                                                              </mstyle>
+                                                              <mtext>AAAA</mtext>
                                                             </mpadded>
                                                           </mrow>
                                                           <mspace width="-3.216em"></mspace>
@@ -1891,9 +1675,7 @@ describe('BussproofsRegProofs', () => {
                                                 <mtd>
                                                   <mrow>
                                                     <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mtext>E</mtext>
-                                                    </mstyle>
+                                                    <mtext>E</mtext>
                                                     <mspace width=".5ex"></mspace>
                                                   </mrow>
                                                 </mtd>
@@ -1911,9 +1693,7 @@ describe('BussproofsRegProofs', () => {
                                 <mtd>
                                   <mrow>
                                     <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mtext>F</mtext>
-                                    </mstyle>
+                                    <mtext>F</mtext>
                                     <mspace width=".5ex"></mspace>
                                   </mrow>
                                 </mtd>
@@ -1929,9 +1709,7 @@ describe('BussproofsRegProofs', () => {
                     <mtd rowalign="bottom">
                       <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
                         <mspace width=".5ex"></mspace>
-                        <mstyle displaystyle="false" scriptlevel="0">
-                          <mtext>M</mtext>
-                        </mstyle>
+                        <mtext>M</mtext>
                         <mspace width=".5ex"></mspace>
                       </mrow>
                     </mtd>
@@ -1943,20 +1721,18 @@ describe('BussproofsRegProofs', () => {
               <mtd>
                 <mrow>
                   <mspace width=".5ex"></mspace>
-                  <mstyle displaystyle="false" scriptlevel="0">
-                    <mrow data-mjx-texclass="ORD">
-                      <mi data-latex="N">N</mi>
-                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                      <mi data-latex="R">R</mi>
-                    </mrow>
-                  </mstyle>
+                  <mrow data-mjx-texclass="ORD">
+                    <mi data-latex="N">N</mi>
+                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                    <mi data-latex="R">R</mi>
+                  </mrow>
                   <mspace width=".5ex"></mspace>
                 </mrow>
               </mtd>
             </mtr>
           </mtable>
           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle displaystyle="false">
               <mtext>QERE</mtext>
             </mstyle>
           </mpadded>
@@ -2000,9 +1776,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>D</mtext>
-                                                        </mstyle>
+                                                        <mtext>D</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -2010,9 +1784,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A1</mtext>
-                                                        </mstyle>
+                                                        <mtext>A1</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -2020,9 +1792,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\RightLabel{AAAA}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A2</mtext>
-                                                        </mstyle>
+                                                        <mtext>A2</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -2034,18 +1804,14 @@ describe('BussproofsRegProofs', () => {
                                               <mtd>
                                                 <mrow>
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>Q</mtext>
-                                                  </mstyle>
+                                                  <mtext>Q</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
                                           </mtable>
                                           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                            <mstyle displaystyle="false" scriptlevel="0">
-                                              <mtext>AAAA</mtext>
-                                            </mstyle>
+                                            <mtext>AAAA</mtext>
                                           </mpadded>
                                         </mrow>
                                       </mrow>
@@ -2062,9 +1828,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd rowalign="bottom">
                                                       <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>A</mtext>
-                                                        </mstyle>
+                                                        <mtext>A</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
@@ -2080,9 +1844,7 @@ describe('BussproofsRegProofs', () => {
                                                                     <mtd rowalign="bottom">
                                                                       <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                                         <mspace width=".5ex"></mspace>
-                                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                                          <mtext>B</mtext>
-                                                                        </mstyle>
+                                                                        <mtext>B</mtext>
                                                                         <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
@@ -2090,9 +1852,7 @@ describe('BussproofsRegProofs', () => {
                                                                     <mtd rowalign="bottom">
                                                                       <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
                                                                         <mspace width=".5ex"></mspace>
-                                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                                          <mtext>R</mtext>
-                                                                        </mstyle>
+                                                                        <mtext>R</mtext>
                                                                         <mspace width=".5ex"></mspace>
                                                                       </mrow>
                                                                     </mtd>
@@ -2104,24 +1864,20 @@ describe('BussproofsRegProofs', () => {
                                                               <mtd>
                                                                 <mrow>
                                                                   <mspace width=".5ex"></mspace>
-                                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                                    <mrow data-mjx-texclass="ORD">
-                                                                      <mi data-latex="C">C</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="D">D</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="Q">Q</mi>
-                                                                    </mrow>
-                                                                  </mstyle>
+                                                                  <mrow data-mjx-texclass="ORD">
+                                                                    <mi data-latex="C">C</mi>
+                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                    <mi data-latex="D">D</mi>
+                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                    <mi data-latex="Q">Q</mi>
+                                                                  </mrow>
                                                                   <mspace width=".5ex"></mspace>
                                                                 </mrow>
                                                               </mtd>
                                                             </mtr>
                                                           </mtable>
                                                           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                              <mtext>Nowhere</mtext>
-                                                            </mstyle>
+                                                            <mtext>Nowhere</mtext>
                                                           </mpadded>
                                                         </mrow>
                                                         <mspace width="-4.023em"></mspace>
@@ -2135,18 +1891,14 @@ describe('BussproofsRegProofs', () => {
                                               <mtd>
                                                 <mrow>
                                                   <mspace width=".5ex"></mspace>
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>E</mtext>
-                                                  </mstyle>
+                                                  <mtext>E</mtext>
                                                   <mspace width=".5ex"></mspace>
                                                 </mrow>
                                               </mtd>
                                             </mtr>
                                           </mtable>
                                           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                            <mstyle displaystyle="false" scriptlevel="0">
-                                              <mtext>BBB</mtext>
-                                            </mstyle>
+                                            <mtext>BBB</mtext>
                                           </mpadded>
                                         </mrow>
                                         <mspace width="-6.135em"></mspace>
@@ -2160,18 +1912,14 @@ describe('BussproofsRegProofs', () => {
                               <mtd>
                                 <mrow>
                                   <mspace width=".5ex"></mspace>
-                                  <mstyle displaystyle="false" scriptlevel="0">
-                                    <mtext>F</mtext>
-                                  </mstyle>
+                                  <mtext>F</mtext>
                                   <mspace width=".5ex"></mspace>
                                 </mrow>
                               </mtd>
                             </mtr>
                           </mtable>
                           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                            <mstyle displaystyle="false" scriptlevel="0">
-                              <mtext>CCCCC</mtext>
-                            </mstyle>
+                            <mtext>CCCCC</mtext>
                           </mpadded>
                         </mrow>
                       </mrow>
@@ -2203,9 +1951,7 @@ describe('BussproofsRegProofs', () => {
                                                           <mtd rowalign="bottom">
                                                             <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
                                                               <mspace width=".5ex"></mspace>
-                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                <mtext>M</mtext>
-                                                              </mstyle>
+                                                              <mtext>M</mtext>
                                                               <mspace width=".5ex"></mspace>
                                                             </mrow>
                                                           </mtd>
@@ -2217,18 +1963,14 @@ describe('BussproofsRegProofs', () => {
                                                     <mtd>
                                                       <mrow>
                                                         <mspace width=".5ex"></mspace>
-                                                        <mstyle displaystyle="false" scriptlevel="0">
-                                                          <mtext>More and more</mtext>
-                                                        </mstyle>
+                                                        <mtext>More and more</mtext>
                                                         <mspace width=".5ex"></mspace>
                                                       </mrow>
                                                     </mtd>
                                                   </mtr>
                                                 </mtable>
                                                 <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                  <mstyle displaystyle="false" scriptlevel="0">
-                                                    <mtext>QERE</mtext>
-                                                  </mstyle>
+                                                  <mtext>QERE</mtext>
                                                 </mpadded>
                                               </mrow>
                                               <mspace width="-3.092em"></mspace>
@@ -2242,9 +1984,7 @@ describe('BussproofsRegProofs', () => {
                                     <mtd>
                                       <mrow>
                                         <mspace width=".5ex"></mspace>
-                                        <mstyle displaystyle="false" scriptlevel="0">
-                                          <mtext>More and more</mtext>
-                                        </mstyle>
+                                        <mtext>More and more</mtext>
                                         <mspace width=".5ex"></mspace>
                                       </mrow>
                                     </mtd>
@@ -2259,9 +1999,7 @@ describe('BussproofsRegProofs', () => {
                         <mtd>
                           <mrow>
                             <mspace width=".5ex"></mspace>
-                            <mstyle displaystyle="false" scriptlevel="0">
-                              <mtext>More and more</mtext>
-                            </mstyle>
+                            <mtext>More and more</mtext>
                             <mspace width=".5ex"></mspace>
                           </mrow>
                         </mtd>
@@ -2276,13 +2014,11 @@ describe('BussproofsRegProofs', () => {
             <mtd>
               <mrow>
                 <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="N">N</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="R">R</mi>
-                  </mrow>
-                </mstyle>
+                <mrow data-mjx-texclass="ORD">
+                  <mi data-latex="N">N</mi>
+                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                  <mi data-latex="R">R</mi>
+                </mrow>
                 <mspace width=".5ex"></mspace>
               </mrow>
             </mtd>
@@ -2297,636 +2033,584 @@ describe('BussproofsRegProofs', () => {
       tex2mml(
         '\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
-    <mrow>
-      <mspace width="13.248em"></mspace>
-      <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" data-latex-item="{prooftree}">
-        <mspace width="-1.155em"></mspace>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                      <mrow>
-                        <mspace width="-13.248em"></mspace>
-                        <mrow>
-                          <mspace width="9.11em"></mspace>
-                          <mrow data-latex="\\RL{\${\\rightarrow_I}^1\$}">
-                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                              <mtr>
-                                <mtd>
-                                  <mtable framespacing="0 0">
-                                    <mtr>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mspace width="-9.11em"></mspace>
-                                          <mrow>
-                                            <mspace width="3.592em"></mspace>
-                                            <mrow data-latex="\\BIC{\$R\$}">
-                                              <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                <mtr>
-                                                  <mtd>
-                                                    <mtable framespacing="0 0">
-                                                      <mtr>
-                                                        <mtd rowalign="bottom">
-                                                          <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                            <mspace width="-3.592em"></mspace>
-                                                            <mrow data-latex="\\BIC{\$Q^2\$}">
-                                                              <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                                <mtr>
-                                                                  <mtd>
-                                                                    <mtable framespacing="0 0">
-                                                                      <mtr>
-                                                                        <mtd rowalign="bottom">
-                                                                          <mrow data-latex="\\UIC{\$P\$}" semantics="bspr_labelledRule:right;bspr_inference:0">
-                                                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                                              <mtr>
-                                                                                <mtd>
-                                                                                  <mtable framespacing="0 0">
-                                                                                    <mtr>
-                                                                                      <mtd rowalign="bottom">
-                                                                                        <mrow data-latex="\\RL{\$Hyp^{1}\$}" semantics="bspr_axiom:true"></mrow>
-                                                                                      </mtd>
-                                                                                    </mtr>
-                                                                                  </mtable>
-                                                                                </mtd>
-                                                                              </mtr>
-                                                                              <mtr>
-                                                                                <mtd>
-                                                                                  <mrow>
-                                                                                    <mspace width=".5ex"></mspace>
-                                                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                                                      <mrow data-mjx-texclass="ORD">
-                                                                                        <mi data-latex="P">P</mi>
-                                                                                      </mrow>
-                                                                                    </mstyle>
-                                                                                    <mspace width=".5ex"></mspace>
-                                                                                  </mrow>
-                                                                                </mtd>
-                                                                              </mtr>
-                                                                            </mtable>
-                                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                                <mrow data-mjx-texclass="ORD">
-                                                                                  <mi data-latex="H">H</mi>
-                                                                                  <mi data-latex="y">y</mi>
-                                                                                  <msup data-latex="p^{1}">
-                                                                                    <mi data-latex="p">p</mi>
-                                                                                    <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                                                                                      <mn data-latex="1">1</mn>
-                                                                                    </mrow>
-                                                                                  </msup>
-                                                                                </mrow>
-                                                                              </mstyle>
-                                                                            </mpadded>
-                                                                          </mrow>
-                                                                        </mtd>
-                                                                        <mtd></mtd>
-                                                                        <mtd rowalign="bottom">
-                                                                          <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
-                                                                            <mspace width=".5ex"></mspace>
-                                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                                              <mrow data-mjx-texclass="ORD">
-                                                                                <mi data-latex="P">P</mi>
-                                                                                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                                <mi data-latex="Q">Q</mi>
-                                                                              </mrow>
-                                                                            </mstyle>
-                                                                            <mspace width=".5ex"></mspace>
-                                                                          </mrow>
-                                                                        </mtd>
-                                                                      </mtr>
-                                                                    </mtable>
-                                                                  </mtd>
-                                                                </mtr>
-                                                                <mtr>
-                                                                  <mtd>
-                                                                    <mrow>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mrow data-mjx-texclass="ORD">
-                                                                          <msup data-latex="Q^2 ">
-                                                                            <mi data-latex="Q">Q</mi>
-                                                                            <mn data-latex="2">2</mn>
-                                                                          </msup>
-                                                                        </mrow>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                </mtr>
-                                                              </mtable>
-                                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <msub data-latex="\\rightarrow_E">
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="E">E</mi>
-                                                                    </msub>
-                                                                  </mrow>
-                                                                </mstyle>
-                                                              </mpadded>
-                                                            </mrow>
-                                                          </mrow>
-                                                        </mtd>
-                                                        <mtd></mtd>
-                                                        <mtd rowalign="bottom">
-                                                          <mrow data-latex="\\RL{\$\\rightarrow_E\$}" semantics="bspr_axiom:true">
-                                                            <mspace width=".5ex"></mspace>
-                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                              <mrow data-mjx-texclass="ORD">
-                                                                <mi data-latex="Q">Q</mi>
-                                                                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                <mi data-latex="R">R</mi>
-                                                              </mrow>
-                                                            </mstyle>
-                                                            <mspace width=".5ex"></mspace>
-                                                          </mrow>
-                                                        </mtd>
-                                                      </mtr>
-                                                    </mtable>
-                                                  </mtd>
-                                                </mtr>
-                                                <mtr>
-                                                  <mtd>
-                                                    <mrow>
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mrow data-mjx-texclass="ORD">
-                                                          <mi data-latex="R">R</mi>
-                                                        </mrow>
-                                                      </mstyle>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mrow data-mjx-texclass="ORD">
-                                                    <msub data-latex="\\rightarrow_E">
-                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                      <mi data-latex="E">E</mi>
-                                                    </msub>
-                                                  </mrow>
-                                                </mstyle>
-                                              </mpadded>
-                                            </mrow>
-                                          </mrow>
-                                        </mrow>
-                                      </mtd>
-                                      <mtd></mtd>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
-                                          <mrow data-latex="\\RL{\$\\wedge_I\$}">
-                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                              <mtr>
-                                                <mtd>
-                                                  <mtable framespacing="0 0">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+        <mrow>
+          <mspace width="13.248em"></mspace>
+          <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" data-latex-item="{prooftree}">
+            <mspace width="-1.155em"></mspace>
+            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+              <mtr>
+                <mtd>
+                  <mtable framespacing="0 0">
+                    <mtr>
+                      <mtd rowalign="bottom">
+                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                          <mrow>
+                            <mspace width="-13.248em"></mspace>
+                            <mrow>
+                              <mspace width="9.11em"></mspace>
+                              <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
+                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                  <mtr>
+                                    <mtd>
+                                      <mtable framespacing="0 0">
+                                        <mtr>
+                                          <mtd rowalign="bottom">
+                                            <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                              <mspace width="-9.11em"></mspace>
+                                              <mrow>
+                                                <mspace width="3.592em"></mspace>
+                                                <mrow data-latex="\\BIC{$R$}">
+                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                     <mtr>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow data-latex="\\RL{Rit\$^2\$}" semantics="bspr_axiom:true">
+                                                      <mtd>
+                                                        <mtable framespacing="0 0">
+                                                          <mtr>
+                                                            <mtd rowalign="bottom">
+                                                              <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                                <mspace width="-3.592em"></mspace>
+                                                                <mrow data-latex="\\BIC{$Q^2$}">
+                                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                    <mtr>
+                                                                      <mtd>
+                                                                        <mtable framespacing="0 0">
+                                                                          <mtr>
+                                                                            <mtd rowalign="bottom">
+                                                                              <mrow data-latex="\\UIC{$P$}" semantics="bspr_labelledRule:right;bspr_inference:0">
+                                                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                                  <mtr>
+                                                                                    <mtd>
+                                                                                      <mtable framespacing="0 0">
+                                                                                        <mtr>
+                                                                                          <mtd rowalign="bottom">
+                                                                                            <mrow data-latex="\\RL{$Hyp^{1}$}" semantics="bspr_axiom:true"></mrow>
+                                                                                          </mtd>
+                                                                                        </mtr>
+                                                                                      </mtable>
+                                                                                    </mtd>
+                                                                                  </mtr>
+                                                                                  <mtr>
+                                                                                    <mtd>
+                                                                                      <mrow>
+                                                                                        <mspace width=".5ex"></mspace>
+                                                                                        <mrow data-mjx-texclass="ORD">
+                                                                                          <mi data-latex="P">P</mi>
+                                                                                        </mrow>
+                                                                                        <mspace width=".5ex"></mspace>
+                                                                                      </mrow>
+                                                                                    </mtd>
+                                                                                  </mtr>
+                                                                                </mtable>
+                                                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                                  <mrow data-mjx-texclass="ORD">
+                                                                                    <mi data-latex="H">H</mi>
+                                                                                    <mi data-latex="y">y</mi>
+                                                                                    <msup data-latex="p^{1}">
+                                                                                      <mi data-latex="p">p</mi>
+                                                                                      <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                                                                                        <mn data-latex="1">1</mn>
+                                                                                      </mrow>
+                                                                                    </msup>
+                                                                                  </mrow>
+                                                                                </mpadded>
+                                                                              </mrow>
+                                                                            </mtd>
+                                                                            <mtd></mtd>
+                                                                            <mtd rowalign="bottom">
+                                                                              <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
+                                                                                <mspace width=".5ex"></mspace>
+                                                                                <mrow data-mjx-texclass="ORD">
+                                                                                  <mi data-latex="P">P</mi>
+                                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                                  <mi data-latex="Q">Q</mi>
+                                                                                </mrow>
+                                                                                <mspace width=".5ex"></mspace>
+                                                                              </mrow>
+                                                                            </mtd>
+                                                                          </mtr>
+                                                                        </mtable>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                    <mtr>
+                                                                      <mtd>
+                                                                        <mrow>
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mrow data-mjx-texclass="ORD">
+                                                                            <msup data-latex="Q^2 ">
+                                                                              <mi data-latex="Q">Q</mi>
+                                                                              <mn data-latex="2">2</mn>
+                                                                            </msup>
+                                                                          </mrow>
+                                                                          <mspace width=".5ex"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                  </mtable>
+                                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <msub data-latex="\\rightarrow_E">
+                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                        <mi data-latex="E">E</mi>
+                                                                      </msub>
+                                                                    </mrow>
+                                                                  </mpadded>
+                                                                </mrow>
+                                                              </mrow>
+                                                            </mtd>
+                                                            <mtd></mtd>
+                                                            <mtd rowalign="bottom">
+                                                              <mrow data-latex="\\RL{$\\rightarrow_E$}" semantics="bspr_axiom:true">
+                                                                <mspace width=".5ex"></mspace>
+                                                                <mrow data-mjx-texclass="ORD">
+                                                                  <mi data-latex="Q">Q</mi>
+                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                  <mi data-latex="R">R</mi>
+                                                                </mrow>
+                                                                <mspace width=".5ex"></mspace>
+                                                              </mrow>
+                                                            </mtd>
+                                                          </mtr>
+                                                        </mtable>
+                                                      </mtd>
+                                                    </mtr>
+                                                    <mtr>
+                                                      <mtd>
+                                                        <mrow>
                                                           <mspace width=".5ex"></mspace>
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mrow data-mjx-texclass="ORD">
-                                                              <mi data-latex="Q">Q</mi>
-                                                            </mrow>
-                                                          </mstyle>
+                                                          <mrow data-mjx-texclass="ORD">
+                                                            <mi data-latex="R">R</mi>
+                                                          </mrow>
                                                           <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                     </mtr>
                                                   </mtable>
-                                                </mtd>
-                                              </mtr>
-                                              <mtr>
-                                                <mtd>
-                                                  <mrow>
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mrow data-mjx-texclass="ORD">
-                                                        <mi data-latex="Q">Q</mi>
-                                                      </mrow>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>Rit</mtext>
-                                                <mrow data-mjx-texclass="ORD">
-                                                  <msup data-latex="^2 ">
-                                                    <mi></mi>
-                                                    <mn data-latex="2">2</mn>
-                                                  </msup>
+                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                    <mrow data-mjx-texclass="ORD">
+                                                      <msub data-latex="\\rightarrow_E">
+                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                        <mi data-latex="E">E</mi>
+                                                      </msub>
+                                                    </mrow>
+                                                  </mpadded>
                                                 </mrow>
-                                              </mstyle>
-                                            </mpadded>
-                                          </mrow>
-                                          <mspace width="-2.055em"></mspace>
+                                              </mrow>
+                                            </mrow>
+                                          </mtd>
+                                          <mtd></mtd>
+                                          <mtd rowalign="bottom">
+                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                              <mrow data-latex="\\RL{$\\wedge_I$}">
+                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mtable framespacing="0 0">
+                                                        <mtr>
+                                                          <mtd rowalign="bottom">
+                                                            <mrow data-latex="\\RL{Rit$^2$}" semantics="bspr_axiom:true">
+                                                              <mspace width=".5ex"></mspace>
+                                                              <mrow data-mjx-texclass="ORD">
+                                                                <mi data-latex="Q">Q</mi>
+                                                              </mrow>
+                                                              <mspace width=".5ex"></mspace>
+                                                            </mrow>
+                                                          </mtd>
+                                                        </mtr>
+                                                      </mtable>
+                                                    </mtd>
+                                                  </mtr>
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mrow>
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mrow data-mjx-texclass="ORD">
+                                                          <mi data-latex="Q">Q</mi>
+                                                        </mrow>
+                                                        <mspace width=".5ex"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                  <mstyle>
+                                                    <mtext>Rit</mtext>
+                                                    <mrow data-mjx-texclass="ORD">
+                                                      <msup data-latex="^2 ">
+                                                        <mi></mi>
+                                                        <mn data-latex="2">2</mn>
+                                                      </msup>
+                                                    </mrow>
+                                                  </mstyle>
+                                                </mpadded>
+                                              </mrow>
+                                              <mspace width="-2.055em"></mspace>
+                                            </mrow>
+                                          </mtd>
+                                        </mtr>
+                                      </mtable>
+                                    </mtd>
+                                  </mtr>
+                                  <mtr>
+                                    <mtd>
+                                      <mrow>
+                                        <mspace width=".5ex"></mspace>
+                                        <mrow data-mjx-texclass="ORD">
+                                          <mi data-latex="Q">Q</mi>
+                                          <mo data-latex="\\wedge">&#x2227;</mo>
+                                          <mi data-latex="R">R</mi>
                                         </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                              <mtr>
-                                <mtd>
-                                  <mrow>
-                                    <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mrow data-mjx-texclass="ORD">
-                                        <mi data-latex="Q">Q</mi>
-                                        <mo data-latex="\\wedge">&#x2227;</mo>
-                                        <mi data-latex="R">R</mi>
+                                        <mspace width=".5ex"></mspace>
                                       </mrow>
-                                    </mstyle>
-                                    <mspace width=".5ex"></mspace>
+                                    </mtd>
+                                  </mtr>
+                                </mtable>
+                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                  <mrow data-mjx-texclass="ORD">
+                                    <msub data-latex="\\wedge_I">
+                                      <mo data-latex="\\wedge">&#x2227;</mo>
+                                      <mi data-latex="I">I</mi>
+                                    </msub>
                                   </mrow>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mrow data-mjx-texclass="ORD">
-                                  <msub data-latex="\\wedge_I">
-                                    <mo data-latex="\\wedge">&#x2227;</mo>
-                                    <mi data-latex="I">I</mi>
-                                  </msub>
-                                </mrow>
-                              </mstyle>
-                            </mpadded>
+                                </mpadded>
+                              </mrow>
+                            </mrow>
                           </mrow>
+                          <mspace width="-5.455em"></mspace>
                         </mrow>
-                      </mrow>
-                      <mspace width="-5.455em"></mspace>
+                      </mtd>
+                    </mtr>
+                  </mtable>
+                </mtd>
+              </mtr>
+              <mtr>
+                <mtd>
+                  <mrow>
+                    <mspace width=".5ex"></mspace>
+                    <mrow data-mjx-texclass="ORD">
+                      <mi data-latex="P">P</mi>
+                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                      <mi data-latex="Q">Q</mi>
+                      <mo data-latex="\\wedge">&#x2227;</mo>
+                      <mi data-latex="R">R</mi>
                     </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="P">P</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="Q">Q</mi>
-                    <mo data-latex="\\wedge">&#x2227;</mo>
-                    <mi data-latex="R">R</mi>
+                    <mspace width=".5ex"></mspace>
                   </mrow>
-                </mstyle>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mrow data-mjx-texclass="ORD">
-              <msup data-latex="{\\rightarrow_I}^1 ">
-                <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
-                  <msub data-latex="\\rightarrow_I">
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="I">I</mi>
-                  </msub>
+                </mtd>
+              </mtr>
+            </mtable>
+            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+              <mstyle displaystyle="false">
+                <mrow data-mjx-texclass="ORD">
+                  <msup data-latex="{\\rightarrow_I}^1 ">
+                    <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
+                      <msub data-latex="\\rightarrow_I">
+                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                        <mi data-latex="I">I</mi>
+                      </msub>
+                    </mrow>
+                    <mn data-latex="1">1</mn>
+                  </msup>
                 </mrow>
-                <mn data-latex="1">1</mn>
-              </msup>
-            </mrow>
-          </mstyle>
-        </mpadded>
+              </mstyle>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mspace width="2.952em"></mspace>
       </mrow>
-    </mrow>
-    <mspace width="2.952em"></mspace>
-  </mrow>
-</math>`
+    </math>`
     ));
   it('Proof Mixing Order', () =>
     toXmlMatch(
       tex2mml(
-        '\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
+        '\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
       ),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\alwaysRootAtBottom\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
-    <mrow>
-      <mspace width="13.248em"></mspace>
-      <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{\$Hyp^{1}\$}\\UIC{\$P\$}\\AXC{\$P\\rightarrow Q\$}\\RL{\$\\rightarrow_E\$}\\solidLine\\BIC{\$Q^2\$}\\alwaysRootAtBottom\\AXC{\$Q\\rightarrow R\$} \\RL{\$\\rightarrow_E\$} \\BIC{\$R\$} \\AXC{\$Q\$}\\RL{Rit\$^2\$} \\UIC{\$Q\$}\\RL{\$\\wedge_I\$}\\BIC{\$Q\\wedge R\$}\\RL{\${\\rightarrow_I}^1\$}\\UIC{\$P\\rightarrow Q\\wedge R\$}\\end{prooftree}" data-latex-item="{prooftree}">
-        <mspace width="-1.155em"></mspace>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                      <mrow>
-                        <mspace width="-13.248em"></mspace>
-                        <mrow>
-                          <mspace width="9.11em"></mspace>
-                          <mrow data-latex="\\RL{\${\\rightarrow_I}^1\$}">
-                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                              <mtr>
-                                <mtd>
-                                  <mtable framespacing="0 0">
-                                    <mtr>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mspace width="-9.11em"></mspace>
-                                          <mrow>
-                                            <mspace width="3.592em"></mspace>
-                                            <mrow data-latex="\\BIC{\$R\$}">
-                                              <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                <mtr>
-                                                  <mtd>
-                                                    <mtable framespacing="0 0">
-                                                      <mtr>
-                                                        <mtd rowalign="bottom">
-                                                          <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                            <mspace width="-3.592em"></mspace>
-                                                            <mrow data-latex="\\alwaysRootAtBottom">
-                                                              <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
-                                                                <mtr>
-                                                                  <mtd>
-                                                                    <mrow>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mrow data-mjx-texclass="ORD">
-                                                                          <msup data-latex="Q^2 ">
-                                                                            <mi data-latex="Q">Q</mi>
-                                                                            <mn data-latex="2">2</mn>
-                                                                          </msup>
-                                                                        </mrow>
-                                                                      </mstyle>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                </mtr>
-                                                                <mtr>
-                                                                  <mtd>
-                                                                    <mtable framespacing="0 0">
-                                                                      <mtr>
-                                                                        <mtd rowalign="top">
-                                                                          <mrow data-latex="\\UIC{\$P\$}" semantics="bspr_labelledRule:right;bspr_inference:0">
-                                                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
-                                                                              <mtr>
-                                                                                <mtd>
-                                                                                  <mrow>
-                                                                                    <mspace width=".5ex"></mspace>
-                                                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                                                      <mrow data-mjx-texclass="ORD">
-                                                                                        <mi data-latex="P">P</mi>
-                                                                                      </mrow>
-                                                                                    </mstyle>
-                                                                                    <mspace width=".5ex"></mspace>
-                                                                                  </mrow>
-                                                                                </mtd>
-                                                                              </mtr>
-                                                                              <mtr>
-                                                                                <mtd>
-                                                                                  <mtable framespacing="0 0">
-                                                                                    <mtr>
-                                                                                      <mtd rowalign="top">
-                                                                                        <mrow data-latex="\\RL{\$Hyp^{1}\$}" semantics="bspr_axiom:true"></mrow>
-                                                                                      </mtd>
-                                                                                    </mtr>
-                                                                                  </mtable>
-                                                                                </mtd>
-                                                                              </mtr>
-                                                                            </mtable>
-                                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                                                <mrow data-mjx-texclass="ORD">
-                                                                                  <mi data-latex="H">H</mi>
-                                                                                  <mi data-latex="y">y</mi>
-                                                                                  <msup data-latex="p^{1}">
-                                                                                    <mi data-latex="p">p</mi>
-                                                                                    <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                                                                                      <mn data-latex="1">1</mn>
-                                                                                    </mrow>
-                                                                                  </msup>
-                                                                                </mrow>
-                                                                              </mstyle>
-                                                                            </mpadded>
-                                                                          </mrow>
-                                                                        </mtd>
-                                                                        <mtd></mtd>
-                                                                        <mtd rowalign="top">
-                                                                          <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
-                                                                            <mspace width=".5ex"></mspace>
-                                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                                              <mrow data-mjx-texclass="ORD">
-                                                                                <mi data-latex="P">P</mi>
-                                                                                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                                <mi data-latex="Q">Q</mi>
-                                                                              </mrow>
-                                                                            </mstyle>
-                                                                            <mspace width=".5ex"></mspace>
-                                                                          </mrow>
-                                                                        </mtd>
-                                                                      </mtr>
-                                                                    </mtable>
-                                                                  </mtd>
-                                                                </mtr>
-                                                              </mtable>
-                                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <msub data-latex="\\rightarrow_E">
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="E">E</mi>
-                                                                    </msub>
-                                                                  </mrow>
-                                                                </mstyle>
-                                                              </mpadded>
-                                                            </mrow>
-                                                          </mrow>
-                                                        </mtd>
-                                                        <mtd></mtd>
-                                                        <mtd rowalign="bottom">
-                                                          <mrow data-latex="\\RL{\$\\rightarrow_E\$}" semantics="bspr_axiom:true">
-                                                            <mspace width=".5ex"></mspace>
-                                                            <mstyle displaystyle="false" scriptlevel="0">
-                                                              <mrow data-mjx-texclass="ORD">
-                                                                <mi data-latex="Q">Q</mi>
-                                                                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                <mi data-latex="R">R</mi>
-                                                              </mrow>
-                                                            </mstyle>
-                                                            <mspace width=".5ex"></mspace>
-                                                          </mrow>
-                                                        </mtd>
-                                                      </mtr>
-                                                    </mtable>
-                                                  </mtd>
-                                                </mtr>
-                                                <mtr>
-                                                  <mtd>
-                                                    <mrow>
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mrow data-mjx-texclass="ORD">
-                                                          <mi data-latex="R">R</mi>
-                                                        </mrow>
-                                                      </mstyle>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                              <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mrow data-mjx-texclass="ORD">
-                                                    <msub data-latex="\\rightarrow_E">
-                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                      <mi data-latex="E">E</mi>
-                                                    </msub>
-                                                  </mrow>
-                                                </mstyle>
-                                              </mpadded>
-                                            </mrow>
-                                          </mrow>
-                                        </mrow>
-                                      </mtd>
-                                      <mtd></mtd>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
-                                          <mrow data-latex="\\RL{\$\\wedge_I\$}">
-                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                              <mtr>
-                                                <mtd>
-                                                  <mtable framespacing="0 0">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" display="block">
+      <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+        <mrow>
+          <mspace width="13.248em"></mspace>
+          <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" data-latex-item="{prooftree}">
+            <mspace width="-1.155em"></mspace>
+            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+              <mtr>
+                <mtd>
+                  <mtable framespacing="0 0">
+                    <mtr>
+                      <mtd rowalign="bottom">
+                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                          <mrow>
+                            <mspace width="-13.248em"></mspace>
+                            <mrow>
+                              <mspace width="9.11em"></mspace>
+                              <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
+                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                  <mtr>
+                                    <mtd>
+                                      <mtable framespacing="0 0">
+                                        <mtr>
+                                          <mtd rowalign="bottom">
+                                            <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                              <mspace width="-9.11em"></mspace>
+                                              <mrow>
+                                                <mspace width="3.592em"></mspace>
+                                                <mrow data-latex="\\BIC{$R$}">
+                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                     <mtr>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow data-latex="\\RL{Rit\$^2\$}" semantics="bspr_axiom:true">
+                                                      <mtd>
+                                                        <mtable framespacing="0 0">
+                                                          <mtr>
+                                                            <mtd rowalign="bottom">
+                                                              <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                                <mspace width="-3.592em"></mspace>
+                                                                <mrow data-latex="\\alwaysRootAtBottom">
+                                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
+                                                                    <mtr>
+                                                                      <mtd>
+                                                                        <mrow>
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mrow data-mjx-texclass="ORD">
+                                                                            <msup data-latex="Q^2 ">
+                                                                              <mi data-latex="Q">Q</mi>
+                                                                              <mn data-latex="2">2</mn>
+                                                                            </msup>
+                                                                          </mrow>
+                                                                          <mspace width=".5ex"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                    <mtr>
+                                                                      <mtd>
+                                                                        <mtable framespacing="0 0">
+                                                                          <mtr>
+                                                                            <mtd rowalign="top">
+                                                                              <mrow data-latex="\\UIC{$P$}" semantics="bspr_labelledRule:right;bspr_inference:0">
+                                                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
+                                                                                  <mtr>
+                                                                                    <mtd>
+                                                                                      <mrow>
+                                                                                        <mspace width=".5ex"></mspace>
+                                                                                        <mrow data-mjx-texclass="ORD">
+                                                                                          <mi data-latex="P">P</mi>
+                                                                                        </mrow>
+                                                                                        <mspace width=".5ex"></mspace>
+                                                                                      </mrow>
+                                                                                    </mtd>
+                                                                                  </mtr>
+                                                                                  <mtr>
+                                                                                    <mtd>
+                                                                                      <mtable framespacing="0 0">
+                                                                                        <mtr>
+                                                                                          <mtd rowalign="top">
+                                                                                            <mrow data-latex="\\RL{$Hyp^{1}$}" semantics="bspr_axiom:true"></mrow>
+                                                                                          </mtd>
+                                                                                        </mtr>
+                                                                                      </mtable>
+                                                                                    </mtd>
+                                                                                  </mtr>
+                                                                                </mtable>
+                                                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                                  <mrow data-mjx-texclass="ORD">
+                                                                                    <mi data-latex="H">H</mi>
+                                                                                    <mi data-latex="y">y</mi>
+                                                                                    <msup data-latex="p^{1}">
+                                                                                      <mi data-latex="p">p</mi>
+                                                                                      <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                                                                                        <mn data-latex="1">1</mn>
+                                                                                      </mrow>
+                                                                                    </msup>
+                                                                                  </mrow>
+                                                                                </mpadded>
+                                                                              </mrow>
+                                                                            </mtd>
+                                                                            <mtd></mtd>
+                                                                            <mtd rowalign="top">
+                                                                              <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
+                                                                                <mspace width=".5ex"></mspace>
+                                                                                <mrow data-mjx-texclass="ORD">
+                                                                                  <mi data-latex="P">P</mi>
+                                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                                  <mi data-latex="Q">Q</mi>
+                                                                                </mrow>
+                                                                                <mspace width=".5ex"></mspace>
+                                                                              </mrow>
+                                                                            </mtd>
+                                                                          </mtr>
+                                                                        </mtable>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                  </mtable>
+                                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <msub data-latex="\\rightarrow_E">
+                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                        <mi data-latex="E">E</mi>
+                                                                      </msub>
+                                                                    </mrow>
+                                                                  </mpadded>
+                                                                </mrow>
+                                                              </mrow>
+                                                            </mtd>
+                                                            <mtd></mtd>
+                                                            <mtd rowalign="bottom">
+                                                              <mrow data-latex="\\RL{$\\rightarrow_E$}" semantics="bspr_axiom:true">
+                                                                <mspace width=".5ex"></mspace>
+                                                                <mrow data-mjx-texclass="ORD">
+                                                                  <mi data-latex="Q">Q</mi>
+                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                  <mi data-latex="R">R</mi>
+                                                                </mrow>
+                                                                <mspace width=".5ex"></mspace>
+                                                              </mrow>
+                                                            </mtd>
+                                                          </mtr>
+                                                        </mtable>
+                                                      </mtd>
+                                                    </mtr>
+                                                    <mtr>
+                                                      <mtd>
+                                                        <mrow>
                                                           <mspace width=".5ex"></mspace>
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mrow data-mjx-texclass="ORD">
-                                                              <mi data-latex="Q">Q</mi>
-                                                            </mrow>
-                                                          </mstyle>
+                                                          <mrow data-mjx-texclass="ORD">
+                                                            <mi data-latex="R">R</mi>
+                                                          </mrow>
                                                           <mspace width=".5ex"></mspace>
                                                         </mrow>
                                                       </mtd>
                                                     </mtr>
                                                   </mtable>
-                                                </mtd>
-                                              </mtr>
-                                              <mtr>
-                                                <mtd>
-                                                  <mrow>
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mstyle displaystyle="false" scriptlevel="0">
-                                                      <mrow data-mjx-texclass="ORD">
-                                                        <mi data-latex="Q">Q</mi>
-                                                      </mrow>
-                                                    </mstyle>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                              <mstyle displaystyle="false" scriptlevel="0">
-                                                <mtext>Rit</mtext>
-                                                <mrow data-mjx-texclass="ORD">
-                                                  <msup data-latex="^2 ">
-                                                    <mi></mi>
-                                                    <mn data-latex="2">2</mn>
-                                                  </msup>
+                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                    <mrow data-mjx-texclass="ORD">
+                                                      <msub data-latex="\\rightarrow_E">
+                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                        <mi data-latex="E">E</mi>
+                                                      </msub>
+                                                    </mrow>
+                                                  </mpadded>
                                                 </mrow>
-                                              </mstyle>
-                                            </mpadded>
-                                          </mrow>
-                                          <mspace width="-2.055em"></mspace>
+                                              </mrow>
+                                            </mrow>
+                                          </mtd>
+                                          <mtd></mtd>
+                                          <mtd rowalign="bottom">
+                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                              <mrow data-latex="\\RL{$\\wedge_I$}">
+                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mtable framespacing="0 0">
+                                                        <mtr>
+                                                          <mtd rowalign="bottom">
+                                                            <mrow data-latex="\\RL{Rit$^2$}" semantics="bspr_axiom:true">
+                                                              <mspace width=".5ex"></mspace>
+                                                              <mrow data-mjx-texclass="ORD">
+                                                                <mi data-latex="Q">Q</mi>
+                                                              </mrow>
+                                                              <mspace width=".5ex"></mspace>
+                                                            </mrow>
+                                                          </mtd>
+                                                        </mtr>
+                                                      </mtable>
+                                                    </mtd>
+                                                  </mtr>
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mrow>
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mrow data-mjx-texclass="ORD">
+                                                          <mi data-latex="Q">Q</mi>
+                                                        </mrow>
+                                                        <mspace width=".5ex"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                  <mstyle>
+                                                    <mtext>Rit</mtext>
+                                                    <mrow data-mjx-texclass="ORD">
+                                                      <msup data-latex="^2 ">
+                                                        <mi></mi>
+                                                        <mn data-latex="2">2</mn>
+                                                      </msup>
+                                                    </mrow>
+                                                  </mstyle>
+                                                </mpadded>
+                                              </mrow>
+                                              <mspace width="-2.055em"></mspace>
+                                            </mrow>
+                                          </mtd>
+                                        </mtr>
+                                      </mtable>
+                                    </mtd>
+                                  </mtr>
+                                  <mtr>
+                                    <mtd>
+                                      <mrow>
+                                        <mspace width=".5ex"></mspace>
+                                        <mrow data-mjx-texclass="ORD">
+                                          <mi data-latex="Q">Q</mi>
+                                          <mo data-latex="\\wedge">&#x2227;</mo>
+                                          <mi data-latex="R">R</mi>
                                         </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                              <mtr>
-                                <mtd>
-                                  <mrow>
-                                    <mspace width=".5ex"></mspace>
-                                    <mstyle displaystyle="false" scriptlevel="0">
-                                      <mrow data-mjx-texclass="ORD">
-                                        <mi data-latex="Q">Q</mi>
-                                        <mo data-latex="\\wedge">&#x2227;</mo>
-                                        <mi data-latex="R">R</mi>
+                                        <mspace width=".5ex"></mspace>
                                       </mrow>
-                                    </mstyle>
-                                    <mspace width=".5ex"></mspace>
+                                    </mtd>
+                                  </mtr>
+                                </mtable>
+                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                  <mrow data-mjx-texclass="ORD">
+                                    <msub data-latex="\\wedge_I">
+                                      <mo data-latex="\\wedge">&#x2227;</mo>
+                                      <mi data-latex="I">I</mi>
+                                    </msub>
                                   </mrow>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                              <mstyle displaystyle="false" scriptlevel="0">
-                                <mrow data-mjx-texclass="ORD">
-                                  <msub data-latex="\\wedge_I">
-                                    <mo data-latex="\\wedge">&#x2227;</mo>
-                                    <mi data-latex="I">I</mi>
-                                  </msub>
-                                </mrow>
-                              </mstyle>
-                            </mpadded>
+                                </mpadded>
+                              </mrow>
+                            </mrow>
                           </mrow>
+                          <mspace width="-5.455em"></mspace>
                         </mrow>
-                      </mrow>
-                      <mspace width="-5.455em"></mspace>
+                      </mtd>
+                    </mtr>
+                  </mtable>
+                </mtd>
+              </mtr>
+              <mtr>
+                <mtd>
+                  <mrow>
+                    <mspace width=".5ex"></mspace>
+                    <mrow data-mjx-texclass="ORD">
+                      <mi data-latex="P">P</mi>
+                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                      <mi data-latex="Q">Q</mi>
+                      <mo data-latex="\\wedge">&#x2227;</mo>
+                      <mi data-latex="R">R</mi>
                     </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mstyle displaystyle="false" scriptlevel="0">
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="P">P</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="Q">Q</mi>
-                    <mo data-latex="\\wedge">&#x2227;</mo>
-                    <mi data-latex="R">R</mi>
+                    <mspace width=".5ex"></mspace>
                   </mrow>
-                </mstyle>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false" scriptlevel="0">
-            <mrow data-mjx-texclass="ORD">
-              <msup data-latex="{\\rightarrow_I}^1 ">
-                <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
-                  <msub data-latex="\\rightarrow_I">
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="I">I</mi>
-                  </msub>
+                </mtd>
+              </mtr>
+            </mtable>
+            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+              <mstyle displaystyle="false">
+                <mrow data-mjx-texclass="ORD">
+                  <msup data-latex="{\\rightarrow_I}^1 ">
+                    <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
+                      <msub data-latex="\\rightarrow_I">
+                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                        <mi data-latex="I">I</mi>
+                      </msub>
+                    </mrow>
+                    <mn data-latex="1">1</mn>
+                  </msup>
                 </mrow>
-                <mn data-latex="1">1</mn>
-              </msup>
-            </mrow>
-          </mstyle>
-        </mpadded>
+              </mstyle>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mspace width="2.952em"></mspace>
       </mrow>
-    </mrow>
-    <mspace width="2.952em"></mspace>
-  </mrow>
-</math>`
+    </math>`
     ));
   it('Extreme', () =>
     toXmlMatch(
@@ -2938,7 +2622,7 @@ describe('BussproofsRegProofs', () => {
     <mspace width="16.317em"></mspace>
     <mrow data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
       <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-        <mstyle displaystyle="false" scriptlevel="0">
+        <mstyle displaystyle="false">
           <mtext>BBB</mtext>
         </mstyle>
       </mpadded>
@@ -2954,9 +2638,7 @@ describe('BussproofsRegProofs', () => {
                       <mspace width="3.94em"></mspace>
                       <mrow data-latex="\\RightLabel{QERE}">
                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>WWW</mtext>
-                          </mstyle>
+                          <mtext>WWW</mtext>
                         </mpadded>
                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                           <mtr>
@@ -2968,9 +2650,7 @@ describe('BussproofsRegProofs', () => {
                                       <mspace width="-7.239em"></mspace>
                                       <mrow data-latex="\\RightLabel{AAAA}">
                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>HHHHH</mtext>
-                                          </mstyle>
+                                          <mtext>HHHHH</mtext>
                                         </mpadded>
                                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                           <mtr>
@@ -2980,9 +2660,7 @@ describe('BussproofsRegProofs', () => {
                                                   <mtd rowalign="bottom">
                                                     <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
                                                       <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>D</mtext>
-                                                      </mstyle>
+                                                      <mtext>D</mtext>
                                                       <mspace width=".5ex"></mspace>
                                                     </mrow>
                                                   </mtd>
@@ -2990,9 +2668,7 @@ describe('BussproofsRegProofs', () => {
                                                   <mtd rowalign="bottom">
                                                     <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
                                                       <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>A1</mtext>
-                                                      </mstyle>
+                                                      <mtext>A1</mtext>
                                                       <mspace width=".5ex"></mspace>
                                                     </mrow>
                                                   </mtd>
@@ -3000,9 +2676,7 @@ describe('BussproofsRegProofs', () => {
                                                   <mtd rowalign="bottom">
                                                     <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
                                                       <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>A2</mtext>
-                                                      </mstyle>
+                                                      <mtext>A2</mtext>
                                                       <mspace width=".5ex"></mspace>
                                                     </mrow>
                                                   </mtd>
@@ -3014,18 +2688,14 @@ describe('BussproofsRegProofs', () => {
                                             <mtd>
                                               <mrow>
                                                 <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>Q</mtext>
-                                                </mstyle>
+                                                <mtext>Q</mtext>
                                                 <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
                                           </mtr>
                                         </mtable>
                                         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>11111111111111111</mtext>
-                                          </mstyle>
+                                          <mtext>11111111111111111</mtext>
                                         </mpadded>
                                       </mrow>
                                     </mrow>
@@ -3035,9 +2705,7 @@ describe('BussproofsRegProofs', () => {
                                     <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
                                       <mrow data-latex="\\LL{WWW}">
                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>BBBB</mtext>
-                                          </mstyle>
+                                          <mtext>BBBB</mtext>
                                         </mpadded>
                                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                           <mtr>
@@ -3047,9 +2715,7 @@ describe('BussproofsRegProofs', () => {
                                                   <mtd rowalign="bottom">
                                                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
                                                       <mspace width=".5ex"></mspace>
-                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                        <mtext>A</mtext>
-                                                      </mstyle>
+                                                      <mtext>A</mtext>
                                                       <mspace width=".5ex"></mspace>
                                                     </mrow>
                                                   </mtd>
@@ -3058,9 +2724,7 @@ describe('BussproofsRegProofs', () => {
                                                     <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
                                                       <mrow data-latex="\\RightLabel{MMM}">
                                                         <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>qqqq</mtext>
-                                                          </mstyle>
+                                                          <mtext>qqqq</mtext>
                                                         </mpadded>
                                                         <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
                                                           <mtr>
@@ -3070,9 +2734,7 @@ describe('BussproofsRegProofs', () => {
                                                                   <mtd rowalign="bottom">
                                                                     <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
                                                                       <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>B</mtext>
-                                                                      </mstyle>
+                                                                      <mtext>B</mtext>
                                                                       <mspace width=".5ex"></mspace>
                                                                     </mrow>
                                                                   </mtd>
@@ -3080,9 +2742,7 @@ describe('BussproofsRegProofs', () => {
                                                                   <mtd rowalign="bottom">
                                                                     <mrow data-latex="\\LL{qqqq}" semantics="bspr_axiom:true">
                                                                       <mspace width=".5ex"></mspace>
-                                                                      <mstyle displaystyle="false" scriptlevel="0">
-                                                                        <mtext>R</mtext>
-                                                                      </mstyle>
+                                                                      <mtext>R</mtext>
                                                                       <mspace width=".5ex"></mspace>
                                                                     </mrow>
                                                                   </mtd>
@@ -3094,24 +2754,20 @@ describe('BussproofsRegProofs', () => {
                                                             <mtd>
                                                               <mrow>
                                                                 <mspace width=".5ex"></mspace>
-                                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <mi data-latex="C">C</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="D">D</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="Q">Q</mi>
-                                                                  </mrow>
-                                                                </mstyle>
+                                                                <mrow data-mjx-texclass="ORD">
+                                                                  <mi data-latex="C">C</mi>
+                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                  <mi data-latex="D">D</mi>
+                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                  <mi data-latex="Q">Q</mi>
+                                                                </mrow>
                                                                 <mspace width=".5ex"></mspace>
                                                               </mrow>
                                                             </mtd>
                                                           </mtr>
                                                         </mtable>
                                                         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                          <mstyle displaystyle="false" scriptlevel="0">
-                                                            <mtext>AAAA</mtext>
-                                                          </mstyle>
+                                                          <mtext>AAAA</mtext>
                                                         </mpadded>
                                                       </mrow>
                                                       <mspace width="-3.216em"></mspace>
@@ -3125,18 +2781,14 @@ describe('BussproofsRegProofs', () => {
                                             <mtd>
                                               <mrow>
                                                 <mspace width=".5ex"></mspace>
-                                                <mstyle displaystyle="false" scriptlevel="0">
-                                                  <mtext>E</mtext>
-                                                </mstyle>
+                                                <mtext>E</mtext>
                                                 <mspace width=".5ex"></mspace>
                                               </mrow>
                                             </mtd>
                                           </mtr>
                                         </mtable>
                                         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                          <mstyle displaystyle="false" scriptlevel="0">
-                                            <mtext>MMM</mtext>
-                                          </mstyle>
+                                          <mtext>MMM</mtext>
                                         </mpadded>
                                       </mrow>
                                       <mspace width="-7.925em"></mspace>
@@ -3150,18 +2802,14 @@ describe('BussproofsRegProofs', () => {
                             <mtd>
                               <mrow>
                                 <mspace width=".5ex"></mspace>
-                                <mstyle displaystyle="false" scriptlevel="0">
-                                  <mtext>F</mtext>
-                                </mstyle>
+                                <mtext>F</mtext>
                                 <mspace width=".5ex"></mspace>
                               </mrow>
                             </mtd>
                           </mtr>
                         </mtable>
                         <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                          <mstyle displaystyle="false" scriptlevel="0">
-                            <mtext>CCCCC</mtext>
-                          </mstyle>
+                          <mtext>CCCCC</mtext>
                         </mpadded>
                       </mrow>
                     </mrow>
@@ -3173,9 +2821,7 @@ describe('BussproofsRegProofs', () => {
                 <mtd rowalign="bottom">
                   <mrow data-latex="\\LL{BBB}" semantics="bspr_axiom:true">
                     <mspace width=".5ex"></mspace>
-                    <mstyle displaystyle="false" scriptlevel="0">
-                      <mtext>M</mtext>
-                    </mstyle>
+                    <mtext>M</mtext>
                     <mspace width=".5ex"></mspace>
                   </mrow>
                 </mtd>
@@ -3187,20 +2833,18 @@ describe('BussproofsRegProofs', () => {
           <mtd>
             <mrow>
               <mspace width=".5ex"></mspace>
-              <mstyle displaystyle="false" scriptlevel="0">
-                <mrow data-mjx-texclass="ORD">
-                  <mi data-latex="N">N</mi>
-                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                  <mi data-latex="R">R</mi>
-                </mrow>
-              </mstyle>
+              <mrow data-mjx-texclass="ORD">
+                <mi data-latex="N">N</mi>
+                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                <mi data-latex="R">R</mi>
+              </mrow>
               <mspace width=".5ex"></mspace>
             </mrow>
           </mtd>
         </mtr>
       </mtable>
       <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-        <mstyle displaystyle="false" scriptlevel="0">
+        <mstyle displaystyle="false">
           <mtext>QERE</mtext>
         </mstyle>
       </mpadded>

--- a/testsuite/tests/input/tex/ConfigMacros.test.ts
+++ b/testsuite/tests/input/tex/ConfigMacros.test.ts
@@ -18,10 +18,10 @@ describe('Config Macros Active', () => {
   it('Macros Simple', () =>
     runMacroTests(
       {active: {"@": "~"}},
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"PH\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mtext data-latex=\"~\">&#xA0;</mtext>
-      <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+      <mi data-latex="A">A</mi>
+      <mtext data-latex="~">&#xA0;</mtext>
+      <mi data-latex="a">a</mi>
     </math>`,
       'A~a',
       'A@a'
@@ -32,9 +32,9 @@ describe('Config Macros Commands', () => {
   it('Commands Simple', () =>
     runMacroTests(
       {macros: {"RR": "{\\bf R}"}},
-    `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"PH\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\bf R}\">
-        <mi mathvariant=\"bold\" data-latex=\"R\">R</mi>
+    `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
+        <mi mathvariant="bold" data-latex="R">R</mi>
       </mrow>
 </math>`,
       '{\\bf R}',
@@ -42,12 +42,12 @@ describe('Config Macros Commands', () => {
   it('Commands Argument', () =>
     runMacroTests(
       {macros: {"bold": ["{\\bf #1}", 1]}},
-    `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"PH\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{\\bf bold}\">
-        <mi mathvariant=\"bold\" data-latex=\"b\">b</mi>
-        <mi mathvariant=\"bold\" data-latex=\"o\">o</mi>
-        <mi mathvariant=\"bold\" data-latex=\"l\">l</mi>
-        <mi mathvariant=\"bold\" data-latex=\"d\">d</mi>
+    `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="{\\bf bold}">
+        <mi mathvariant="bold" data-latex="b">b</mi>
+        <mi mathvariant="bold" data-latex="o">o</mi>
+        <mi mathvariant="bold" data-latex="l">l</mi>
+        <mi mathvariant="bold" data-latex="d">d</mi>
       </mrow>
     </math>`,
       '{\\bf bold}',
@@ -55,20 +55,20 @@ describe('Config Macros Commands', () => {
   it('Commands Aux Argument', () =>
     runMacroTests(
       {macros: {"foo": ["\\mbox{first } #1 \\mbox{ second } #2", 2, ["[", "]"]]}},
-    `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"PH\" display=\"block\">
-      <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"\\mbox{first }\">
+    `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+      <mstyle displaystyle="false" data-latex="\\mbox{first }">
         <mtext>first&#xA0;</mtext>
       </mstyle>
-      <mi data-latex=\"h\">h</mi>
-      <mi data-latex=\"i\">i</mi>
-      <mstyle displaystyle=\"false\" scriptlevel=\"0\" data-latex=\"\\mbox{ second }\">
+      <mi data-latex="h">h</mi>
+      <mi data-latex="i">i</mi>
+      <mstyle displaystyle="false" data-latex="\\mbox{ second }">
         <mtext>&#xA0;second&#xA0;</mtext>
       </mstyle>
-      <mi data-latex=\"t\">t</mi>
-      <mi data-latex=\"h\">h</mi>
-      <mi data-latex=\"e\">e</mi>
-      <mi data-latex=\"r\">r</mi>
-      <mi data-latex=\"e\">e</mi>
+      <mi data-latex="t">t</mi>
+      <mi data-latex="h">h</mi>
+      <mi data-latex="e">e</mi>
+      <mi data-latex="r">r</mi>
+      <mi data-latex="e">e</mi>
     </math>`,
       '\\mbox{first } hi \\mbox{ second } there',
       '\\foo[hi]{there}'));
@@ -78,10 +78,10 @@ describe('Config Macros Environment', () => {
   it('Environment Simple', () =>
     runMacroTests(
       {environments: {"myHeartEnv": ["\\heartsuit", "\\spadesuit"]}},
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{myHeartEnv}a\\end{myHeartEnv}\" display=\"block\">
-      <mi mathvariant=\"normal\" data-latex=\"\\heartsuit\">&#x2661;</mi>
-      <mi data-latex=\"a\">a</mi>
-      <mi mathvariant=\"normal\" data-latex=\"\\spadesuit\">&#x2660;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{myHeartEnv}a\\end{myHeartEnv}" display="block">
+      <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
+      <mi data-latex="a">a</mi>
+      <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
     </math>`,
       '\\begin{myHeartEnv}a\\end{myHeartEnv}',
       '\\begin{myHeartEnv}a\\end{myHeartEnv}'

--- a/testsuite/tests/input/tex/Extpfeil.test.ts
+++ b/testsuite/tests/input/tex/Extpfeil.test.ts
@@ -10,9 +10,7 @@ describe('Extpfeil', () => {
       tex2mml('\\xtwoheadrightarrow{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xtwoheadrightarrow{abcxyz}" display="block">
   <mover data-latex="\\xtwoheadrightarrow{abcxyz}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x21A0;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x21A0;</mo>
     <mpadded width="+1.556em" lspace="0.667em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -30,9 +28,7 @@ describe('Extpfeil', () => {
       tex2mml('\\xtwoheadleftarrow{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xtwoheadleftarrow{abcxyz}" display="block">
   <mover data-latex="\\xtwoheadleftarrow{abcxyz}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x219E;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x219E;</mo>
     <mpadded width="+1.667em" lspace="0.944em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -50,9 +46,7 @@ describe('Extpfeil', () => {
       tex2mml('\\xmapsto{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xmapsto{abcxyz}" display="block">
   <mover data-latex="\\xmapsto{abcxyz}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x21A6;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x21A6;</mo>
     <mpadded width="+0.722em" lspace="0.333em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -70,9 +64,7 @@ describe('Extpfeil', () => {
       tex2mml('\\xlongequal{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xlongequal{abcxyz}" display="block">
   <mover data-latex="\\xlongequal{abcxyz}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL" stretchy="true">=</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL" stretchy="true">=</mo>
     <mpadded width="+0.778em" lspace="0.389em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -90,9 +82,7 @@ describe('Extpfeil', () => {
       tex2mml('\\xtofrom{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xtofrom{abcxyz}" display="block">
   <mover data-latex="\\xtofrom{abcxyz}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x21C4;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x21C4;</mo>
     <mpadded width="+1.333em" lspace="0.667em" voffset="-.2em" height="-.2em">
       <mi data-latex="a">a</mi>
       <mi data-latex="b">b</mi>
@@ -110,9 +100,7 @@ describe('Extpfeil', () => {
       tex2mml('\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}" display="block">
   <mover data-latex="\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}">
-    <mstyle scriptlevel="0">
-      <mo data-mjx-texclass="REL">&#x21E0;</mo>
-    </mstyle>
+    <mo data-mjx-texclass="REL">&#x21E0;</mo>
     <mpadded width="+1.667em" lspace="0.556em" voffset="-.2em" height="-.2em">
       <mi data-latex="x">x</mi>
       <mi data-latex="y">y</mi>
@@ -128,8 +116,8 @@ describe('Extpfeil Errors', () => {
   it('NewextarrowArg1', () =>
     toXmlMatch(
       tex2mml('\\Newextarrow{ab}{10,20}{8672}\\ab{xyz}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Newextarrow{ab}{10,20}{8672}\\ab{xyz}\" display=\"block\">
-      <merror data-mjx-error=\"First argument to \\Newextarrow must be a control sequence name\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{ab}{10,20}{8672}\\ab{xyz}" display="block">
+      <merror data-mjx-error="First argument to \\Newextarrow must be a control sequence name">
         <mtext>First argument to \\Newextarrow must be a control sequence name</mtext>
       </merror>
     </math>`
@@ -137,8 +125,8 @@ describe('Extpfeil Errors', () => {
   it('NewextarrowArg2 One', () =>
     toXmlMatch(
       tex2mml('\\Newextarrow{\\ab}{10}{8672}\\ab{xyz}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Newextarrow{\\ab}{10}{8672}\\ab{xyz}\" display=\"block\">
-      <merror data-mjx-error=\"Second argument to \\Newextarrow must be two integers separated by a comma\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10}{8672}\\ab{xyz}" display="block">
+      <merror data-mjx-error="Second argument to \\Newextarrow must be two integers separated by a comma">
         <mtext>Second argument to \\Newextarrow must be two integers separated by a comma</mtext>
       </merror>
     </math>`
@@ -146,8 +134,8 @@ describe('Extpfeil Errors', () => {
   it('NewextarrowArg2 Two', () =>
     toXmlMatch(
       tex2mml('\\Newextarrow{\\ab}{10 20}{8672}\\ab{xyz}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Newextarrow{\\ab}{10 20}{8672}\\ab{xyz}\" display=\"block\">
-      <merror data-mjx-error=\"Second argument to \\Newextarrow must be two integers separated by a comma\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10 20}{8672}\\ab{xyz}" display="block">
+      <merror data-mjx-error="Second argument to \\Newextarrow must be two integers separated by a comma">
         <mtext>Second argument to \\Newextarrow must be two integers separated by a comma</mtext>
       </merror>
     </math>`
@@ -155,8 +143,8 @@ describe('Extpfeil Errors', () => {
   it('NewextarrowArg2 Three', () =>
     toXmlMatch(
       tex2mml('\\Newextarrow{\\ab}{aa}{8672}\\ab{xyz}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Newextarrow{\\ab}{aa}{8672}\\ab{xyz}\" display=\"block\">
-      <merror data-mjx-error=\"Second argument to \\Newextarrow must be two integers separated by a comma\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{aa}{8672}\\ab{xyz}" display="block">
+      <merror data-mjx-error="Second argument to \\Newextarrow must be two integers separated by a comma">
         <mtext>Second argument to \\Newextarrow must be two integers separated by a comma</mtext>
       </merror>
     </math>`
@@ -164,8 +152,8 @@ describe('Extpfeil Errors', () => {
   it('NewextarrowArg3', () =>
     toXmlMatch(
       tex2mml('\\Newextarrow{\\ab}{10,20}{AG}\\ab{xyz}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Newextarrow{\\ab}{10,20}{AG}\\ab{xyz}\" display=\"block\">
-      <merror data-mjx-error=\"Third argument to \\Newextarrow must be a unicode character number\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10,20}{AG}\\ab{xyz}" display="block">
+      <merror data-mjx-error="Third argument to \\Newextarrow must be a unicode character number">
         <mtext>Third argument to \\Newextarrow must be a unicode character number</mtext>
       </merror>
     </math>`

--- a/testsuite/tests/input/tex/Mhchem.test.ts
+++ b/testsuite/tests/input/tex/Mhchem.test.ts
@@ -44,9 +44,7 @@ describe('Mhchem0', () => {
     </mrow>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mn data-latex="2">2</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{CO}">
       <mi data-mjx-auto-op="false" data-latex="CO">CO</mi>
     </mrow>
@@ -99,7 +97,7 @@ describe('Mhchem0', () => {
   <mrow data-mjx-texclass="ORD" data-latex="{5.3~\\mathchoice{\\textstyle\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}}{\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}}{\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}}{\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}}}">
     <mn data-latex="5.3">75.3</mn>
     <mtext data-latex="~">&#xA0;</mtext>
-    <mstyle displaystyle="false" scriptlevel="0" data-latex="\\textstyle\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}">
+    <mstyle displaystyle="false" data-latex="\\textstyle\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}">
       <mfrac data-latex="\\frac{\\mathrm{J}}{\\mathrm{mol}\\mkern3mu \\mathrm{K}}">
         <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{J}">
           <mi mathvariant="normal" data-latex="J">J</mi>
@@ -375,9 +373,7 @@ describe('Mhchem1', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ce{2 H2O}" display="block">
   <mrow data-mjx-texclass="ORD" data-latex="{2\\,\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
     <mn data-latex="2">2</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -411,9 +407,7 @@ describe('Mhchem1', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ce{2H2O}" display="block">
   <mrow data-mjx-texclass="ORD" data-latex="{2\\,\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
     <mn data-latex="2">2</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -447,9 +441,7 @@ describe('Mhchem1', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ce{0.5 H2O}" display="block">
   <mrow data-mjx-texclass="ORD" data-latex="{0.5\\,\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
     <mn data-latex=".5">0.5</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -482,15 +474,13 @@ describe('Mhchem1', () => {
       tex2mml('\\ce{1/2 H2O}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ce{1/2 H2O}" display="block">
   <mrow data-mjx-texclass="ORD" data-latex="{\\mathchoice{\\textstyle\\frac{1}{2}}{\\frac{1}{2}}{\\frac{1}{2}}{\\frac{1}{2}}\\,\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
-    <mstyle displaystyle="false" scriptlevel="0" data-latex="\\textstyle\\frac{1}{2}">
-      <mfrac data-latex="\\frac{1}{2}">
+    <mstyle displaystyle="false" data-latex="\\textstyle\\frac{1}{2}">
+      <mfrac data-latex="\\frac{1}{2}" data-latex="\\textstyle\\frac{1}{2}">
         <mn data-latex="1">1</mn>
         <mn data-latex="2">2</mn>
       </mfrac>
     </mstyle>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -530,9 +520,7 @@ describe('Mhchem1', () => {
     </mrow>
     <mn data-latex="2">2</mn>
     <mo data-latex=")" stretchy="false">)</mo>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -566,9 +554,7 @@ describe('Mhchem1', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ce{$n$ H2O}" display="block">
   <mrow data-mjx-texclass="ORD" data-latex="{n \\,\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
     <mi data-latex="n">n</mi>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -1295,12 +1281,8 @@ describe('Mhchem2', () => {
                 <mrow data-mjx-texclass="ORD" data-latex="{\\leftharpoondown}">
                   <mo stretchy="false" data-latex="\\leftharpoondown">&#x21BD;</mo>
                 </mrow>
-                <mstyle scriptlevel="0" data-latex="\\!">
-                  <mspace width="-0.167em"></mspace>
-                </mstyle>
-                <mstyle scriptlevel="0" data-latex="\\!">
-                  <mspace width="-0.167em"></mspace>
-                </mstyle>
+                <mspace width="-0.167em" data-latex="\\!"></mspace>
+                <mspace width="-0.167em" data-latex="\\!"></mspace>
                 <mrow data-mjx-texclass="ORD" data-latex="{-}">
                   <mo data-latex="-">&#x2212;</mo>
                 </mrow>
@@ -1308,16 +1290,12 @@ describe('Mhchem2', () => {
             </mrow>
           </mrow>
           <mrow data-mjx-texclass="ORD" data-latex="{}">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle scriptlevel="0">
               <mrow data-mjx-texclass="ORD" data-latex="{-}">
                 <mo data-latex="-">&#x2212;</mo>
               </mrow>
-              <mstyle scriptlevel="0" data-latex="\\!">
-                <mspace width="-0.167em"></mspace>
-              </mstyle>
-              <mstyle scriptlevel="0" data-latex="\\!">
-                <mspace width="-0.167em"></mspace>
-              </mstyle>
+              <mspace width="-0.167em" data-latex="\\!"></mspace>
+              <mspace width="-0.167em" data-latex="\\!"></mspace>
               <mrow data-mjx-texclass="ORD" data-latex="{\\rightharpoonup}">
                 <mo stretchy="false" data-latex="\\rightharpoonup">&#x21C0;</mo>
               </mrow>
@@ -1353,16 +1331,12 @@ describe('Mhchem2', () => {
             </mrow>
           </mrow>
           <mrow data-mjx-texclass="ORD" data-latex="{}">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle scriptlevel="0">
               <mrow data-mjx-texclass="ORD" data-latex="{-}">
                 <mo data-latex="-">&#x2212;</mo>
               </mrow>
-              <mstyle scriptlevel="0" data-latex="\\!">
-                <mspace width="-0.167em"></mspace>
-              </mstyle>
-              <mstyle scriptlevel="0" data-latex="\\!">
-                <mspace width="-0.167em"></mspace>
-              </mstyle>
+              <mspace width="-0.167em" data-latex="\\!"></mspace>
+              <mspace width="-0.167em" data-latex="\\!"></mspace>
               <mrow data-mjx-texclass="ORD" data-latex="{\\rightharpoonup}">
                 <mo stretchy="false" data-latex="\\rightharpoonup">&#x21C0;</mo>
               </mrow>
@@ -1396,12 +1370,8 @@ describe('Mhchem2', () => {
                 <mrow data-mjx-texclass="ORD" data-latex="{\\leftharpoondown}">
                   <mo stretchy="false" data-latex="\\leftharpoondown">&#x21BD;</mo>
                 </mrow>
-                <mstyle scriptlevel="0" data-latex="\\!">
-                  <mspace width="-0.167em"></mspace>
-                </mstyle>
-                <mstyle scriptlevel="0" data-latex="\\!">
-                  <mspace width="-0.167em"></mspace>
-                </mstyle>
+                <mspace width="-0.167em" data-latex="\\!"></mspace>
+                <mspace width="-0.167em" data-latex="\\!"></mspace>
                 <mrow data-mjx-texclass="ORD" data-latex="{-}">
                   <mo data-latex="-">&#x2212;</mo>
                 </mrow>
@@ -1409,7 +1379,7 @@ describe('Mhchem2', () => {
             </mrow>
           </mrow>
           <mrow data-mjx-texclass="ORD" data-latex="{}">
-            <mstyle displaystyle="false" scriptlevel="0">
+            <mstyle scriptlevel="0">
               <mrow data-mjx-texclass="ORD" data-latex="\\vphantom{{-}}">
                 <mpadded width="0">
                   <mphantom>
@@ -1605,9 +1575,7 @@ describe('Mhchem3', () => {
     <mo data-latex="+">+</mo>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mn data-latex="2">2</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="INNER" data-latex-item="\\left(  \\mathrm{O}{\\vphantom{A}}_{\\smash[t]{2}} {}+{} \\mathchoice{\\textstyle\\frac{79}{21}}{\\frac{79}{21}}{\\frac{79}{21}}{\\frac{79}{21}}\\,\\mathrm{N}{\\vphantom{A}}_{\\smash[t]{2}} \\right)" data-latex="\\left(  \\mathrm{O}{\\vphantom{A}}_{\\smash[t]{2}} {}+{} \\mathchoice{\\textstyle\\frac{79}{21}}{\\frac{79}{21}}{\\frac{79}{21}}{\\frac{79}{21}}\\,\\mathrm{N}{\\vphantom{A}}_{\\smash[t]{2}} \\right)">
       <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
       <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{O}">
@@ -1634,15 +1602,13 @@ describe('Mhchem3', () => {
       <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
       <mo data-latex="+">+</mo>
       <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-      <mstyle displaystyle="false" scriptlevel="0" data-latex="\\textstyle\\frac{79}{21}">
+      <mstyle displaystyle="false" data-latex="\\textstyle\\frac{79}{21}">
         <mfrac data-latex="\\frac{79}{21}">
           <mn data-latex="79">79</mn>
           <mn data-latex="21">21</mn>
         </mfrac>
       </mstyle>
-      <mstyle scriptlevel="0" data-latex="\\,">
-        <mspace width="0.167em"></mspace>
-      </mstyle>
+      <mspace width="0.167em" data-latex="\\,"></mspace>
       <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{N}">
         <mi mathvariant="normal" data-latex="N">N</mi>
       </mrow>
@@ -3029,19 +2995,13 @@ describe('Mhchem6', () => {
         </mrow>
       </mrow>
     </msub>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="{\\cdot}">
       <mo data-latex="\\cdot">&#x22C5;</mo>
     </mrow>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mn data-latex="2">12</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -3118,19 +3078,13 @@ describe('Mhchem6', () => {
         </mrow>
       </mrow>
     </msub>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="{\\cdot}">
       <mo data-latex="\\cdot">&#x22C5;</mo>
     </mrow>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mn data-latex="2">12</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -3207,19 +3161,13 @@ describe('Mhchem6', () => {
         </mrow>
       </mrow>
     </msub>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="{\\cdot}">
       <mo data-latex="\\cdot">&#x22C5;</mo>
     </mrow>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mn data-latex="2">12</mn>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -3968,12 +3916,8 @@ describe('Mhchem8', () => {
                     <mrow data-mjx-texclass="ORD" data-latex="{\\leftharpoondown}">
                       <mo stretchy="false" data-latex="\\leftharpoondown">&#x21BD;</mo>
                     </mrow>
-                    <mstyle scriptlevel="0" data-latex="\\!">
-                      <mspace width="-0.167em"></mspace>
-                    </mstyle>
-                    <mstyle scriptlevel="0" data-latex="\\!">
-                      <mspace width="-0.167em"></mspace>
-                    </mstyle>
+                    <mspace width="-0.167em" data-latex="\\!"></mspace>
+                    <mspace width="-0.167em" data-latex="\\!"></mspace>
                     <mrow data-mjx-texclass="ORD" data-latex="{-}">
                       <mo data-latex="-">&#x2212;</mo>
                     </mrow>
@@ -3981,16 +3925,12 @@ describe('Mhchem8', () => {
                 </mrow>
               </mrow>
               <mrow data-mjx-texclass="ORD" data-latex="{}">
-                <mstyle displaystyle="false" scriptlevel="0">
+                <mstyle scriptlevel="0">
                   <mrow data-mjx-texclass="ORD" data-latex="{-}">
                     <mo data-latex="-">&#x2212;</mo>
                   </mrow>
-                  <mstyle scriptlevel="0" data-latex="\\!">
-                    <mspace width="-0.167em"></mspace>
-                  </mstyle>
-                  <mstyle scriptlevel="0" data-latex="\\!">
-                    <mspace width="-0.167em"></mspace>
-                  </mstyle>
+                  <mspace width="-0.167em" data-latex="\\!" data-latex="\\!"></mspace>
+                  <mspace width="-0.167em" data-latex="\\!"></mspace>
                   <mrow data-mjx-texclass="ORD" data-latex="{\\rightharpoonup}">
                     <mo stretchy="false" data-latex="\\rightharpoonup">&#x21C0;</mo>
                   </mrow>
@@ -4101,12 +4041,8 @@ describe('Mhchem8', () => {
                     <mrow data-mjx-texclass="ORD" data-latex="{\\leftharpoondown}">
                       <mo stretchy="false" data-latex="\\leftharpoondown">&#x21BD;</mo>
                     </mrow>
-                    <mstyle scriptlevel="0" data-latex="\\!">
-                      <mspace width="-0.167em"></mspace>
-                    </mstyle>
-                    <mstyle scriptlevel="0" data-latex="\\!">
-                      <mspace width="-0.167em"></mspace>
-                    </mstyle>
+                    <mspace width="-0.167em" data-latex="\\!"></mspace>
+                    <mspace width="-0.167em" data-latex="\\!"></mspace>
                     <mrow data-mjx-texclass="ORD" data-latex="{-}">
                       <mo data-latex="-">&#x2212;</mo>
                     </mrow>
@@ -4114,16 +4050,12 @@ describe('Mhchem8', () => {
                 </mrow>
               </mrow>
               <mrow data-mjx-texclass="ORD" data-latex="{}">
-                <mstyle displaystyle="false" scriptlevel="0">
+                <mstyle scriptlevel="0">
                   <mrow data-mjx-texclass="ORD" data-latex="{-}">
                     <mo data-latex="-">&#x2212;</mo>
                   </mrow>
-                  <mstyle scriptlevel="0" data-latex="\\!">
-                    <mspace width="-0.167em"></mspace>
-                  </mstyle>
-                  <mstyle scriptlevel="0" data-latex="\\!">
-                    <mspace width="-0.167em"></mspace>
-                  </mstyle>
+                  <mspace width="-0.167em" data-latex="\\!"></mspace>
+                  <mspace width="-0.167em" data-latex="\\!"></mspace>
                   <mrow data-mjx-texclass="ORD" data-latex="{\\rightharpoonup}">
                     <mo stretchy="false" data-latex="\\rightharpoonup">&#x21C0;</mo>
                   </mrow>
@@ -4502,7 +4434,7 @@ describe('Mhchem9', () => {
   <mrow data-mjx-texclass="ORD" data-latex="{123~\\mathchoice{\\textstyle\\frac{\\mathrm{kJ}}{\\mathrm{mol}}}{\\frac{\\mathrm{kJ}}{\\mathrm{mol}}}{\\frac{\\mathrm{kJ}}{\\mathrm{mol}}}{\\frac{\\mathrm{kJ}}{\\mathrm{mol}}}}">
     <mn data-latex="23">123</mn>
     <mtext data-latex="~">&#xA0;</mtext>
-    <mstyle displaystyle="false" scriptlevel="0" data-latex="\\textstyle\\frac{\\mathrm{kJ}}{\\mathrm{mol}}">
+    <mstyle displaystyle="false" data-latex="\\textstyle\\frac{\\mathrm{kJ}}{\\mathrm{mol}}">
       <mfrac data-latex="\\frac{\\mathrm{kJ}}{\\mathrm{mol}}">
         <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{kJ}">
           <mi data-mjx-auto-op="false" data-latex="kJ">kJ</mi>
@@ -4683,9 +4615,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}}">
       <mover data-latex="\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{I}">
             <mi mathvariant="normal" data-latex="I">I</mi>
@@ -4733,9 +4663,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}}">
       <mover data-latex="\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{I}">
             <mi mathvariant="normal" data-latex="I">I</mi>
@@ -4830,9 +4758,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow{\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}}">
       <mover data-latex="\\xrightarrow{\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
             <mi mathvariant="normal" data-latex="H">H</mi>
@@ -4880,9 +4806,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow[{{\\text{text below}}}]{{\\text{text above}}}}">
       <munderover data-latex="\\xrightarrow[{{\\text{text below}}}]{{\\text{text above}}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset=".15em" depth="-.15em">
           <mrow data-mjx-texclass="ORD" data-latex="{{\\text{text below}}}">
             <mrow data-mjx-texclass="ORD" data-latex="{\\text{text below}}">
@@ -4917,9 +4841,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow[{x_i }]{x }}">
       <munderover data-latex="\\xrightarrow[{x_i }]{x }">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset=".15em" depth="-.15em">
           <mrow data-mjx-texclass="ORD" data-latex="{x_i }">
             <msub data-latex="x_i">
@@ -4948,9 +4870,7 @@ describe('Mhchem-Ams', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ce{x Na(NH4)HPO4 -&gt;[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}" display="block">
   <mrow data-mjx-texclass="ORD" data-latex="{x\\,\\mathrm{Na}(\\mathrm{NH}{\\vphantom{A}}_{\\smash[t]{4}})\\mathrm{HPO}{\\vphantom{A}}_{\\smash[t]{4}} {}\\mathrel{\\xrightarrow{\\mathrm{\\Delta}}}{} (\\mathrm{NaPO}{\\vphantom{A}}_{\\smash[t]{3}}){\\vphantom{A}}_{\\smash[t]{x }} {}+{} x\\,\\mathrm{NH}{\\vphantom{A}}_{\\smash[t]{3}} \\uparrow{}  {}+{} x\\,\\mathrm{H}{\\vphantom{A}}_{\\smash[t]{2}}\\mathrm{O}}">
     <mi data-latex="x">x</mi>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{Na}">
       <mi data-mjx-auto-op="false" data-latex="Na">Na</mi>
     </mrow>
@@ -5001,9 +4921,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow{\\mathrm{\\Delta}}}">
       <mover data-latex="\\xrightarrow{\\mathrm{\\Delta}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{\\Delta}">
             <mi mathvariant="normal" data-latex="\\Delta">&#x394;</mi>
@@ -5058,9 +4976,7 @@ describe('Mhchem-Ams', () => {
     <mo data-latex="+">+</mo>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mi data-latex="x">x</mi>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{NH}">
       <mi data-mjx-auto-op="false" data-latex="NH">NH</mi>
     </mrow>
@@ -5088,9 +5004,7 @@ describe('Mhchem-Ams', () => {
     <mo data-latex="+">+</mo>
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mi data-latex="x">x</mi>
-    <mstyle scriptlevel="0" data-latex="\\,">
-      <mspace width="0.167em"></mspace>
-    </mstyle>
+    <mspace width="0.167em" data-latex="\\,"></mspace>
     <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{H}">
       <mi mathvariant="normal" data-latex="H">H</mi>
     </mrow>
@@ -5146,9 +5060,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}}">
       <mover data-latex="\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{I}">
             <mi mathvariant="normal" data-latex="I">I</mi>
@@ -5203,9 +5115,7 @@ describe('Mhchem-Ams', () => {
     <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
     <mrow data-mjx-texclass="REL" data-latex="\\mathrel{\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}}">
       <mover data-latex="\\xrightarrow{\\mathrm{I}{\\vphantom{A}}^{-}}">
-        <mstyle scriptlevel="0">
-          <mo data-mjx-texclass="REL">&#x2192;</mo>
-        </mstyle>
+        <mo data-mjx-texclass="REL">&#x2192;</mo>
         <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{I}">
             <mi mathvariant="normal" data-latex="I">I</mi>

--- a/testsuite/tests/input/tex/Physics.test.ts
+++ b/testsuite/tests/input/tex/Physics.test.ts
@@ -8602,23 +8602,23 @@ describe('Physics7_11', () => {
   it('Matrices_Other_8', () =>
     toXmlMatch(
       tex2mml('\\begin{smallmatrix} a & b \\\\ c & d \\end{smallmatrix}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}\" display=\"block\">
-  <mstyle scriptlevel=\"1\" data-latex-item=\"{smallmatrix}\" data-latex=\"\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}\">
-    <mtable data-mjx-smallmatrix=\"true\" columnspacing=\"0.333em\" rowspacing=\".2em\" displaystyle=\"false\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}" display="block">
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
       <mtr>
         <mtd>
-          <mi data-latex=\"a\">a</mi>
+          <mi data-latex="a">a</mi>
         </mtd>
         <mtd>
-          <mi data-latex=\"b\">b</mi>
+          <mi data-latex="b">b</mi>
         </mtd>
       </mtr>
       <mtr>
         <mtd>
-          <mi data-latex=\"c\">c</mi>
+          <mi data-latex="c">c</mi>
         </mtd>
         <mtd>
-          <mi data-latex=\"d\">d</mi>
+          <mi data-latex="d">d</mi>
         </mtd>
       </mtr>
     </mtable>
@@ -9246,24 +9246,24 @@ describe('Physics7_2', () => {
   it('Matrices_Small_1', () =>
     toXmlMatch(
       tex2mml('\\smallmatrixquantity*{a & b \\\\ c & d}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}\" display=\"block\">
-  <mstyle scriptlevel=\"1\" data-latex-item=\"{smallmatrix}\" data-latex=\"\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}\">
-    <mtable data-mjx-smallmatrix=\"true\" columnspacing=\"0.333em\" rowspacing=\".2em\" displaystyle=\"false\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}" display="block">
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
       <mtr>
         <mtd>
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"{}\"></mrow>
-          <mi data-latex=\"a\">a</mi>
+          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+          <mi data-latex="a">a</mi>
         </mtd>
         <mtd>
-          <mi data-latex=\"b\">b</mi>
+          <mi data-latex="b">b</mi>
         </mtd>
       </mtr>
       <mtr>
         <mtd>
-          <mi data-latex=\"c\">c</mi>
+          <mi data-latex="c">c</mi>
         </mtd>
         <mtd>
-          <mi data-latex=\"d\">d</mi>
+          <mi data-latex="d">d</mi>
         </mtd>
       </mtr>
     </mtable>

--- a/testsuite/tests/input/tex/Physics.test.ts
+++ b/testsuite/tests/input/tex/Physics.test.ts
@@ -1334,7 +1334,7 @@ describe('Physics2_1', () => {
     toXmlMatch(
       tex2mml('\\vb{\\mbox{ab}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vb{\\mbox{ab}}" display="block">
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\vb{\\mbox{ab}}">
+  <mstyle displaystyle="false" data-latex="\\vb{\\mbox{ab}}">
     <mtext>ab</mtext>
   </mstyle>
 </math>`
@@ -3868,26 +3868,18 @@ describe('Physics4_0', () => {
     toXmlMatch(
       tex2mml('\\qcc'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\qcc" display="block">
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mtext data-latex="\\text{c.c.}">c.c.</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
 </math>`
     ));
   it('QuickQuad_0_1', () =>
     toXmlMatch(
       tex2mml('\\qand'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\qand" display="block">
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mtext data-latex="\\text{and}">and</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
 </math>`
     ));
   it('QuickQuad_0_2', () =>
@@ -3896,9 +3888,7 @@ describe('Physics4_0', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\qc b" display="block">
   <mi data-latex="\\qqtext*{,}">a</mi>
   <mtext data-latex="\\text{,}">,</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -3907,13 +3897,9 @@ describe('Physics4_0', () => {
       tex2mml('a\\qqtext{hello}b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\qqtext{hello}b" display="block">
   <mi data-latex="\\qqtext{hello}">a</mi>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mtext data-latex="\\text{hello}">hello</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -3923,9 +3909,7 @@ describe('Physics4_0', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\qqtext*{hello}b" display="block">
   <mi data-latex="\\qqtext*{hello}">a</mi>
   <mtext data-latex="\\text{hello}">hello</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -3934,13 +3918,9 @@ describe('Physics4_0', () => {
       tex2mml('a\\qqtext ab'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\qqtext ab" display="block">
   <mi data-latex="\\qqtext a">a</mi>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mtext data-latex="\\text{a}">a</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -3950,9 +3930,7 @@ describe('Physics4_0', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\qqtext* ab" display="block">
   <mi data-latex="\\qqtext* a">a</mi>
   <mtext data-latex="\\text{a}">a</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="b">b</mi>
 </math>`
     ));
@@ -3965,13 +3943,9 @@ describe('Physics4_0', () => {
   <mi data-latex="r">r</mi>
   <mi data-latex="e">e</mi>
   <mi data-latex="\\qif">e</mi>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mtext data-latex="\\text{if}">if</mtext>
-  <mstyle scriptlevel="0" data-latex="\\quad">
-    <mspace width="1em"></mspace>
-  </mstyle>
+  <mspace width="1em" data-latex="\\quad"></mspace>
   <mi data-latex="t">t</mi>
   <mi data-latex="w">w</mi>
   <mi data-latex="o">o</mi>
@@ -5888,9 +5862,7 @@ describe('Physics6_0', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6406,9 +6378,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6434,9 +6404,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6459,9 +6427,7 @@ describe('Physics6_2', () => {
     <mi data-latex="A">A</mi>
   </mrow>
   <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
   <mrow data-mjx-texclass="ORD" data-latex="{A}">
     <mi data-latex="A">A</mi>
@@ -6481,9 +6447,7 @@ describe('Physics6_2', () => {
     </mfrac>
   </mrow>
   <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
   <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
     <mfrac data-latex="\\frac{a}{b}">
@@ -6506,9 +6470,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6528,9 +6490,7 @@ describe('Physics6_2', () => {
     <mi data-latex="a">a</mi>
   </mrow>
   <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
   <mrow data-mjx-texclass="ORD" data-latex="{a}">
     <mi data-latex="a">a</mi>
@@ -6550,9 +6510,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6578,9 +6536,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6603,9 +6559,7 @@ describe('Physics6_2', () => {
     </mfrac>
   </mrow>
   <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
   <mrow data-mjx-texclass="ORD" data-latex="{A}">
     <mi data-latex="A">A</mi>
@@ -6628,9 +6582,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6657,9 +6609,7 @@ describe('Physics6_2', () => {
     </mfrac>
   </mrow>
   <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
   <mrow data-mjx-texclass="ORD" data-latex="{\\frac{a}{b}}">
     <mfrac data-latex="\\frac{a}{b}">
@@ -6686,9 +6636,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6709,9 +6657,7 @@ describe('Physics6_2', () => {
     </mfrac>
   </mrow>
   <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  <mstyle scriptlevel="0" data-latex="\\!">
-    <mspace width="-0.167em"></mspace>
-  </mstyle>
+  <mspace width="-0.167em" data-latex="\\!"></mspace>
   <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
   <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
   <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\ketbra*{\\frac{a}{b}}{}">|</mo>
@@ -6747,9 +6693,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6772,9 +6716,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -6797,9 +6739,7 @@ describe('Physics6_2', () => {
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
-    <mstyle scriptlevel="0" data-latex="\\!">
-      <mspace width="-0.167em"></mspace>
-    </mstyle>
+    <mspace width="-0.167em" data-latex="\\!"></mspace>
     <mrow data-mjx-texclass="CLOSE"></mrow>
     <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
     <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
@@ -8662,67 +8602,71 @@ describe('Physics7_11', () => {
   it('Matrices_Other_8', () =>
     toXmlMatch(
       tex2mml('\\begin{smallmatrix} a & b \\\\ c & d \\end{smallmatrix}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}">
-    <mtr>
-      <mtd>
-        <mi data-latex="a">a</mi>
-      </mtd>
-      <mtd>
-        <mi data-latex="b">b</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="c">c</mi>
-      </mtd>
-      <mtd>
-        <mi data-latex="d">d</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}\" display=\"block\">
+  <mstyle scriptlevel=\"1\" data-latex-item=\"{smallmatrix}\" data-latex=\"\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}\">
+    <mtable data-mjx-smallmatrix=\"true\" columnspacing=\"0.333em\" rowspacing=\".2em\" displaystyle=\"false\">
+      <mtr>
+        <mtd>
+          <mi data-latex=\"a\">a</mi>
+        </mtd>
+        <mtd>
+          <mi data-latex=\"b\">b</mi>
+        </mtd>
+      </mtr>
+      <mtr>
+        <mtd>
+          <mi data-latex=\"c\">c</mi>
+        </mtd>
+        <mtd>
+          <mi data-latex=\"d\">d</mi>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Matrices_Other_9', () =>
     toXmlMatch(
       tex2mml('\\smqty{\\imat{3}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty{\\imat{3}}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\smqty{\\imat{3}}">
-    <mtr>
-      <mtd>
-        <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-        <mn data-latex="1">1</mn>
-      </mtd>
-      <mtd>
-        <mn data-latex="0">0</mn>
-      </mtd>
-      <mtd>
-        <mn data-latex="0">0</mn>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mn data-latex="0">0</mn>
-      </mtd>
-      <mtd>
-        <mn data-latex="1">1</mn>
-      </mtd>
-      <mtd>
-        <mn data-latex="0">0</mn>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mn data-latex="0">0</mn>
-      </mtd>
-      <mtd>
-        <mn data-latex="0">0</mn>
-      </mtd>
-      <mtd>
-        <mn data-latex="1">1</mn>
-      </mtd>
-    </mtr>
-  </mtable>
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smqty{\\imat{3}}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtr>
+        <mtd>
+          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+          <mn data-latex="1">1</mn>
+        </mtd>
+        <mtd>
+          <mn data-latex="0">0</mn>
+        </mtd>
+        <mtd>
+          <mn data-latex="0">0</mn>
+        </mtd>
+      </mtr>
+      <mtr>
+        <mtd>
+          <mn data-latex="0">0</mn>
+        </mtd>
+        <mtd>
+          <mn data-latex="1">1</mn>
+        </mtd>
+        <mtd>
+          <mn data-latex="0">0</mn>
+        </mtd>
+      </mtr>
+      <mtr>
+        <mtd>
+          <mn data-latex="0">0</mn>
+        </mtd>
+        <mtd>
+          <mn data-latex="0">0</mn>
+        </mtd>
+        <mtd>
+          <mn data-latex="1">1</mn>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Matrices_Other_10', () =>
@@ -9287,39 +9231,43 @@ describe('Physics7_2', () => {
     toXmlMatch(
       tex2mml('\\smallmatrixquantity{Q}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity{Q}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\smallmatrixquantity{Q}">
-    <mtr>
-      <mtd>
-        <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-        <mi data-latex="Q">Q</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smallmatrixquantity{Q}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtr>
+        <mtd>
+          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+          <mi data-latex="Q">Q</mi>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Matrices_Small_1', () =>
     toXmlMatch(
       tex2mml('\\smallmatrixquantity*{a & b \\\\ c & d}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}">
-    <mtr>
-      <mtd>
-        <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-        <mi data-latex="a">a</mi>
-      </mtd>
-      <mtd>
-        <mi data-latex="b">b</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="c">c</mi>
-      </mtd>
-      <mtd>
-        <mi data-latex="d">d</mi>
-      </mtd>
-    </mtr>
-  </mtable>
+      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}\" display=\"block\">
+  <mstyle scriptlevel=\"1\" data-latex-item=\"{smallmatrix}\" data-latex=\"\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}\">
+    <mtable data-mjx-smallmatrix=\"true\" columnspacing=\"0.333em\" rowspacing=\".2em\" displaystyle=\"false\">
+      <mtr>
+        <mtd>
+          <mrow data-mjx-texclass=\"ORD\" data-latex=\"{}\"></mrow>
+          <mi data-latex=\"a\">a</mi>
+        </mtd>
+        <mtd>
+          <mi data-latex=\"b\">b</mi>
+        </mtd>
+      </mtr>
+      <mtr>
+        <mtd>
+          <mi data-latex=\"c\">c</mi>
+        </mtd>
+        <mtd>
+          <mi data-latex=\"d\">d</mi>
+        </mtd>
+      </mtr>
+    </mtable>
+  </mstyle>
 </math>`
     ));
   it('Matrices_Small_2', () =>
@@ -9328,25 +9276,27 @@ describe('Physics7_2', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity*(a &amp; b \\\\ c &amp; d)" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right\\rgroup" data-latex="\\smallmatrixquantity*(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rgroup" data-latex="\\right\\rgroup">&#x27EF;</mo>
   </mrow>
 </math>`
@@ -9357,55 +9307,28 @@ describe('Physics7_2', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity(a &amp; b \\\\ c &amp; d)" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smallmatrixquantity(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+         </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
-  </mrow>
-</math>`
-    ));
-  it('Matrices_Small_4', () =>
-    toXmlMatch(
-      tex2mml('\\smallmatrixquantity[a & b \\\\ c & d]'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity[a &amp; b \\\\ c &amp; d]" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right]" data-latex="\\smallmatrixquantity[a &amp; b \\\\ c &amp; d]">
-    <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
-    <mo data-mjx-texclass="CLOSE" data-latex-item="\\right]" data-latex="\\right]">]</mo>
   </mrow>
 </math>`
     ));
@@ -9415,25 +9338,27 @@ describe('Physics7_2', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity|a &amp; b \\\\ c &amp; d|" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smallmatrixquantity|a &amp; b \\\\ c &amp; d|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
 </math>`
@@ -9442,34 +9367,8 @@ describe('Physics7_2', () => {
     toXmlMatch(
       tex2mml('\\smqty{a & b \\\\ c & d}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty{a &amp; b \\\\ c &amp; d}" display="block">
-  <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="\\smqty{a &amp; b \\\\ c &amp; d}">
-    <mtr>
-      <mtd>
-        <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-        <mi data-latex="a">a</mi>
-      </mtd>
-      <mtd>
-        <mi data-latex="b">b</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="c">c</mi>
-      </mtd>
-      <mtd>
-        <mi data-latex="d">d</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Matrices_Small_7', () =>
-    toXmlMatch(
-      tex2mml('\\smqty(a & b \\\\ c & d)'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)">
-    <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+  <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smqty{a &amp; b \\\\ c &amp; d}">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
       <mtr>
         <mtd>
           <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9488,6 +9387,36 @@ describe('Physics7_2', () => {
         </mtd>
       </mtr>
     </mtable>
+  </mstyle>
+</math>`
+    ));
+  it('Matrices_Small_7', () =>
+    toXmlMatch(
+      tex2mml('\\smqty(a & b \\\\ c & d)'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)" display="block">
+  <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)">
+    <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -9498,25 +9427,27 @@ describe('Physics7_2', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty*(a &amp; b \\\\ c &amp; d)" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right\\rgroup" data-latex="\\smqty*(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rgroup" data-latex="\\right\\rgroup">&#x27EF;</mo>
   </mrow>
 </math>`
@@ -9527,25 +9458,27 @@ describe('Physics7_2', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty[a &amp; b \\\\ c &amp; d]" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right]" data-latex="\\smqty[a &amp; b \\\\ c &amp; d]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right]" data-latex="\\right]">]</mo>
   </mrow>
 </math>`
@@ -9556,25 +9489,27 @@ describe('Physics7_2', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty|a &amp; b \\\\ c &amp; d|" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smqty|a &amp; b \\\\ c &amp; d|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
 </math>`
@@ -9588,26 +9523,30 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\spmqty{Q} \\smqty(R)" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right)" data-latex="\\left(\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="Q">Q</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="Q">Q</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} R\\end{smallmatrix}\\right)" data-latex="\\left(\\begin{smallmatrix}{} R\\end{smallmatrix}\\right)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="R">R</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="R">R</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -9618,26 +9557,30 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sPmqty{Q} \\smqty*(R)" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right\\rgroup" data-latex="\\left\\lgroup\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right\\rgroup">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="Q">Q</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="Q">Q</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rgroup" data-latex="\\right\\rgroup">&#x27EF;</mo>
   </mrow>
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} R\\end{smallmatrix}\\right\\rgroup" data-latex="\\left\\lgroup\\begin{smallmatrix}{} R\\end{smallmatrix}\\right\\rgroup">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="R">R</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="R">R</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rgroup" data-latex="\\right\\rgroup">&#x27EF;</mo>
   </mrow>
 </math>`
@@ -9648,26 +9591,30 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sbmqty{Q} \\smqty[R]" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right]" data-latex="\\left[\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="Q">Q</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="Q">Q</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right]" data-latex="\\right]">]</mo>
   </mrow>
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} R\\end{smallmatrix}\\right]" data-latex="\\left[\\begin{smallmatrix}{} R\\end{smallmatrix}\\right]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="R">R</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="R">R</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right]" data-latex="\\right]">]</mo>
   </mrow>
 </math>`
@@ -9678,26 +9625,30 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\svmqty{Q} \\smqty|R|" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right|" data-latex="\\left|\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="Q">Q</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="Q">Q</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} R\\end{smallmatrix}\\right|" data-latex="\\left|\\begin{smallmatrix}{} R\\end{smallmatrix}\\right|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="R">R</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="R">R</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
 </math>`
@@ -9708,25 +9659,27 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\spmqty{a &amp; b \\\\ c &amp; d}" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -9737,25 +9690,27 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sPmqty{a &amp; b \\\\ c &amp; d}" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right\\rgroup" data-latex="\\smqty*(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rgroup" data-latex="\\right\\rgroup">&#x27EF;</mo>
   </mrow>
 </math>`
@@ -9766,25 +9721,27 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sbmqty{a &amp; b \\\\ c &amp; d}" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right]" data-latex="\\smqty[a &amp; b \\\\ c &amp; d]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right]" data-latex="\\right]">]</mo>
   </mrow>
 </math>`
@@ -9795,25 +9752,27 @@ describe('Physics7_3', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\svmqty{a &amp; b \\\\ c &amp; d}" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smqty|a &amp; b \\\\ c &amp; d|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
 </math>`
@@ -9883,25 +9842,27 @@ describe('Physics7_4', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smdet{a &amp; b \\\\ c &amp; d} " display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smqty|a &amp; b \\\\ c &amp; d| ">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="b">b</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="c">c</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="d">d</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="b">b</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="c">c</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="d">d</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
 </math>`
@@ -9948,14 +9909,16 @@ describe('Physics7_4', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smdet a b" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a\\end{smallmatrix}\\right|" data-latex="\\left|\\begin{smallmatrix}{} a\\end{smallmatrix}\\right|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right|" data-latex="\\right|">|</mo>
   </mrow>
   <mi data-latex="b">b</mi>
@@ -10219,31 +10182,33 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat{1}{2}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 1\\\\ 1 &amp; 1 &amp; 1\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{1}{2}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mn data-latex="1">1</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="1">1</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="1">1</mn>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mn data-latex="1">1</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="1">1</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="1">1</mn>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mn data-latex="1">1</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="1">1</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="1">1</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mn data-latex="1">1</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="1">1</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="1">1</mn>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10254,42 +10219,44 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat{a}{3}{3}) " display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; a\\\\ a &amp; a &amp; a\\\\ a &amp; a &amp; a\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{a}{3}{3}) ">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10300,24 +10267,26 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat{a}{3}{1}) " display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\\\ a\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{a}{3}{1}) ">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10328,20 +10297,22 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat{a}{1}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; a\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{a}{1}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
         </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-        <mtd>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+          <mtd>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10352,91 +10323,93 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat*{1}{2}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left}{1}} &amp; 1_{{1}{2}} &amp; 1_{{1}{3}}\\\\ 1_{{2}{1}} &amp; 1_{{2}{2}} &amp; 1_{{2}{3}}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{1}{2}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <msub data-latex="1_{{1}{1}}">
-            <mn data-latex="1">1</mn>
-            <mrow data-mjx-texclass="ORD" data-latex="{{1}{1}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <msub data-latex="1_{{1}{1}}">
+              <mn data-latex="1">1</mn>
+              <mrow data-mjx-texclass="ORD" data-latex="{{1}{1}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="1_{{1}{2}}">
+              <mn data-latex="1">1</mn>
+              <mrow data-mjx-texclass="ORD" data-latex="{{1}{2}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="1_{{1}{2}}">
-            <mn data-latex="1">1</mn>
-            <mrow data-mjx-texclass="ORD" data-latex="{{1}{2}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="1_{{1}{3}}">
+              <mn data-latex="1">1</mn>
+              <mrow data-mjx-texclass="ORD" data-latex="{{1}{3}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
+            </msub>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <msub data-latex="1_{{2}{1}}">
+              <mn data-latex="1">1</mn>
+              <mrow data-mjx-texclass="ORD" data-latex="{{2}{1}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="1_{{1}{3}}">
-            <mn data-latex="1">1</mn>
-            <mrow data-mjx-texclass="ORD" data-latex="{{1}{3}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="1_{{2}{2}}">
+              <mn data-latex="1">1</mn>
+              <mrow data-mjx-texclass="ORD" data-latex="{{2}{2}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="1_{{2}{3}}">
+              <mn data-latex="1">1</mn>
+              <mrow data-mjx-texclass="ORD" data-latex="{{2}{3}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msub data-latex="1_{{2}{1}}">
-            <mn data-latex="1">1</mn>
-            <mrow data-mjx-texclass="ORD" data-latex="{{2}{1}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="1_{{2}{2}}">
-            <mn data-latex="1">1</mn>
-            <mrow data-mjx-texclass="ORD" data-latex="{{2}{2}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="1_{{2}{3}}">
-            <mn data-latex="1">1</mn>
-            <mrow data-mjx-texclass="ORD" data-latex="{{2}{3}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-    </mtable>
+            </msub>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10447,132 +10420,134 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat*{a}{3}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left}{1}} &amp; a_{{1}{2}} &amp; a_{{1}{3}}\\\\ a_{{2}{1}} &amp; a_{{2}{2}} &amp; a_{{2}{3}}\\\\ a_{{3}{1}} &amp; a_{{3}{2}} &amp; a_{{3}{3}}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{3}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <msub data-latex="a_{{1}{1}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{1}{1}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <msub data-latex="a_{{1}{1}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{1}{1}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{{1}{2}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{1}{2}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{{1}{2}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{1}{2}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{{1}{3}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{1}{3}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
+            </msub>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <msub data-latex="a_{{2}{1}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{2}{1}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{{1}{3}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{1}{3}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{{2}{2}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{2}{2}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{{2}{3}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{2}{3}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msub data-latex="a_{{2}{1}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{2}{1}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
+            </msub>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <msub data-latex="a_{{3}{1}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{3}{1}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                  <mn data-latex="1">1</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{{3}{2}}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{{3}{2}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                  <mn data-latex="2">2</mn>
+                </mrow>
               </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{{2}{2}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{2}{2}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{{3}{3}}">
+              <mi data-latex="a">a</mi>
+               <mrow data-mjx-texclass="ORD" data-latex="{{3}{3}}">
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
+                <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                  <mn data-latex="3">3</mn>
+                </mrow>
               </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{{2}{3}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{2}{3}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msub data-latex="a_{{3}{1}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{3}{1}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                <mn data-latex="1">1</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{{3}{2}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{3}{2}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{2}">
-                <mn data-latex="2">2</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{{3}{3}}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{{3}{3}}">
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="{3}">
-                <mn data-latex="3">3</mn>
-              </mrow>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-    </mtable>
+            </msub>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10583,39 +10558,41 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat*{a}{3}{1})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\\\ a_{2}\\\\ a_{3}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{3}{1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <msub data-latex="a_{1}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{1}">
-              <mn data-latex="1">1</mn>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msub data-latex="a_{2}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{2}">
-              <mn data-latex="2">2</mn>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <msub data-latex="a_{3}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{3}">
-              <mn data-latex="3">3</mn>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <msub data-latex="a_{1}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                <mn data-latex="1">1</mn>
+              </mrow>
+            </msub>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <msub data-latex="a_{2}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                <mn data-latex="2">2</mn>
+              </mrow>
+            </msub>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <msub data-latex="a_{3}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                <mn data-latex="3">3</mn>
+              </mrow>
+            </msub>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10626,35 +10603,37 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat*{a}{1}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; a_{2} &amp; a_{3}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{1}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <msub data-latex="a_{1}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{1}">
-              <mn data-latex="1">1</mn>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{2}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{2}">
-              <mn data-latex="2">2</mn>
-            </mrow>
-          </msub>
-        </mtd>
-        <mtd>
-          <msub data-latex="a_{3}">
-            <mi data-latex="a">a</mi>
-            <mrow data-mjx-texclass="ORD" data-latex="{3}">
-              <mn data-latex="3">3</mn>
-            </mrow>
-          </msub>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <msub data-latex="a_{1}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                <mn data-latex="1">1</mn>
+              </mrow>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{2}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{2}">
+                <mn data-latex="2">2</mn>
+              </mrow>
+            </msub>
+          </mtd>
+          <mtd>
+            <msub data-latex="a_{3}">
+              <mi data-latex="a">a</mi>
+              <mrow data-mjx-texclass="ORD" data-latex="{3}">
+                <mn data-latex="3">3</mn>
+              </mrow>
+            </msub>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10665,14 +10644,16 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat*{a}{1}{1})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{1}{1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10683,14 +10664,16 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmat*{a}{-1}{-1})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{-1}{-1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mi data-latex="a">a</mi>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mi data-latex="a">a</mi>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10701,20 +10684,22 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\zmat{1}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 0\\end{smallmatrix}\\right)" data-latex="\\smqty(\\zmat{1}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mn data-latex="0">0</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mn data-latex="0">0</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10725,31 +10710,33 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\zmat{2}{3})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 0\\\\ 0 &amp; 0 &amp; 0\\end{smallmatrix}\\right)" data-latex="\\smqty(\\zmat{2}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mn data-latex="0">0</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mn data-latex="0">0</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -10760,24 +10747,26 @@ describe('Physics7_6', () => {
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\zmat{3}{1})" display="block">
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\\\ 0\\end{smallmatrix}\\right)" data-latex="\\smqty(\\zmat{3}{1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtr>
-        <mtd>
-          <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
-          <mn data-latex="0">0</mn>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-      </mtr>
-      <mtr>
-        <mtd>
-          <mn data-latex="0">0</mn>
-        </mtd>
-      </mtr>
-    </mtable>
+    <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+        <mtr>
+          <mtd>
+            <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
+            <mn data-latex="0">0</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+            <mn data-latex="0">0</mn>
+          </mtd>
+        </mtr>
+      </mtable>
+    </mstyle>
     <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
   </mrow>
 </math>`
@@ -11702,8 +11691,8 @@ describe('Physics Errors', () => {
   it('MissingArgFor Quantity', () =>
     toXmlMatch(
       tex2mml('\\pqty'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pqty\" display=\"block\">
-      <merror data-mjx-error=\"Missing argument for \\pqty\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pqty" display="block">
+      <merror data-mjx-error="Missing argument for \\pqty">
         <mtext>Missing argument for \\pqty</mtext>
       </merror>
     </math>`
@@ -11711,8 +11700,8 @@ describe('Physics Errors', () => {
   it('MissingArgFor Eval', () =>
     toXmlMatch(
       tex2mml('\\eval'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\eval\" display=\"block\">
-      <merror data-mjx-error=\"Missing argument for \\eval\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eval" display="block">
+      <merror data-mjx-error="Missing argument for \\eval">
         <mtext>Missing argument for \\eval</mtext>
       </merror>
     </math>`
@@ -11720,8 +11709,8 @@ describe('Physics Errors', () => {
   it('MissingArgFor Commutator 1', () =>
     toXmlMatch(
       tex2mml('\\commutator\\nix'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\commutator\\nix\" display=\"block\">
-      <merror data-mjx-error=\"Missing argument for \\commutator\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\commutator\\nix" display="block">
+      <merror data-mjx-error="Missing argument for \\commutator">
         <mtext>Missing argument for \\commutator</mtext>
       </merror>
     </math>`
@@ -11729,8 +11718,8 @@ describe('Physics Errors', () => {
   it('MissingArgFor Commutator 2', () =>
     toXmlMatch(
       tex2mml('\\commutator'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\commutator\" display=\"block\">
-      <merror data-mjx-error=\"Missing argument for \\commutator\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\commutator" display="block">
+      <merror data-mjx-error="Missing argument for \\commutator">
         <mtext>Missing argument for \\commutator</mtext>
       </merror>
     </math>`
@@ -11738,8 +11727,8 @@ describe('Physics Errors', () => {
   it('InvalidNumber IdentityMatrix', () =>
     toXmlMatch(
       tex2mml('\\smqty(\\identitymatrix{a})'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smqty(\\identitymatrix{a})\" display=\"block\">
-      <merror data-mjx-error=\"Invalid number\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\identitymatrix{a})" display="block">
+      <merror data-mjx-error="Invalid number">
         <mtext>Invalid number</mtext>
       </merror>
     </math>`
@@ -11747,8 +11736,8 @@ describe('Physics Errors', () => {
   it('InvalidNumber XMatrix n', () =>
     toXmlMatch(
       tex2mml('\\smqty(\\xmatrix{a}{a}{2})'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smqty(\\xmatrix{a}{a}{2})\" display=\"block\">
-      <merror data-mjx-error=\"Invalid number\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmatrix{a}{a}{2})" display="block">
+      <merror data-mjx-error="Invalid number">
         <mtext>Invalid number</mtext>
       </merror>
     </math>`
@@ -11756,8 +11745,8 @@ describe('Physics Errors', () => {
   it('InvalidNumber XMatrix m', () =>
     toXmlMatch(
       tex2mml('\\smqty(\\xmatrix{a}{2}{a})'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smqty(\\xmatrix{a}{2}{a})\" display=\"block\">
-      <merror data-mjx-error=\"Invalid number\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmatrix{a}{2}{a})" display="block">
+      <merror data-mjx-error="Invalid number">
         <mtext>Invalid number</mtext>
       </merror>
     </math>`
@@ -11765,8 +11754,8 @@ describe('Physics Errors', () => {
   it('InvalidNumber XMatrix n+', () =>
     toXmlMatch(
       tex2mml('\\smqty(\\xmatrix{a}{2.0}{2})'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smqty(\\xmatrix{a}{2.0}{2})\" display=\"block\">
-      <merror data-mjx-error=\"Invalid number\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmatrix{a}{2.0}{2})" display="block">
+      <merror data-mjx-error="Invalid number">
         <mtext>Invalid number</mtext>
       </merror>
     </math>`
@@ -11774,8 +11763,8 @@ describe('Physics Errors', () => {
   it('InvalidNumber XMatrix m+', () =>
     toXmlMatch(
       tex2mml('\\smqty(\\xmatrix{a}{2}{2.0})'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\smqty(\\xmatrix{a}{2}{2.0})\" display=\"block\">
-      <merror data-mjx-error=\"Invalid number\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty(\\xmatrix{a}{2}{2.0})" display="block">
+      <merror data-mjx-error="Invalid number">
         <mtext>Invalid number</mtext>
       </merror>
     </math>`
@@ -11786,26 +11775,26 @@ describe('Automatic Bracing Macros Rest', () => {
   it('Quantities_Bracket', () =>
     toXmlMatch(
       tex2mml('\\bqty\\Bigg{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\bqty\\Bigg{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\Biggl[\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">[</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bqty\\Bigg{a}" display="block">
+      <mrow data-mjx-texclass="OPEN" data-latex="\\Biggl[">
+        <mo minsize="2.470em" maxsize="2.470em">[</mo>
       </mrow>
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\bqty\\Bigg{a}\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">]</mo>
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="CLOSE" data-latex="\\bqty\\Bigg{a}">
+        <mo minsize="2.470em" maxsize="2.470em">]</mo>
       </mrow>
     </math>`
     ));
   it('Quantities_Vert', () =>
     toXmlMatch(
       tex2mml('\\vqty\\Bigg{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\vqty\\Bigg{a}\" display=\"block\">
-      <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\Biggl|\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">|</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\vqty\\Bigg{a}" display="block">
+      <mrow data-mjx-texclass="OPEN" data-latex="\\Biggl|">
+        <mo minsize="2.470em" maxsize="2.470em">|</mo>
       </mrow>
-      <mi data-latex=\"a\">a</mi>
-      <mrow data-mjx-texclass=\"CLOSE\" data-latex=\"\\vqty\\Bigg{a}\">
-        <mo minsize=\"2.470em\" maxsize=\"2.470em\">|</mo>
+      <mi data-latex="a">a</mi>
+      <mrow data-mjx-texclass="CLOSE" data-latex="\\vqty\\Bigg{a}">
+        <mo minsize="2.470em" maxsize="2.470em">|</mo>
       </mrow>
     </math>`
     ));
@@ -11815,55 +11804,55 @@ describe('Vector Mo Rest', () => {
   it('dotproduct', () =>
     toXmlMatch(
       tex2mml('A \\dotproduct B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\dotproduct B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mo mathvariant=\"bold\" data-latex=\"\\dotproduct\">&#x22C5;</mo>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\dotproduct B" display="block">
+      <mi data-latex="A">A</mi>
+      <mo mathvariant="bold" data-latex="\\dotproduct">&#x22C5;</mo>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('vdot', () =>
     toXmlMatch(
       tex2mml('A \\vdot B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\vdot B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mo mathvariant=\"bold\" data-latex=\"\\vdot\">&#x22C5;</mo>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\vdot B" display="block">
+      <mi data-latex="A">A</mi>
+      <mo mathvariant="bold" data-latex="\\vdot">&#x22C5;</mo>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('cross', () =>
     toXmlMatch(
       tex2mml('A \\cross B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\cross B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mo data-latex=\"\\cross\">&#xD7;</mo>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\cross B" display="block">
+      <mi data-latex="A">A</mi>
+      <mo data-latex="\\cross">&#xD7;</mo>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('cp', () =>
     toXmlMatch(
       tex2mml('A \\cp B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\cp B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mo data-latex=\"\\cp\">&#xD7;</mo>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\cp B" display="block">
+      <mi data-latex="A">A</mi>
+      <mo data-latex="\\cp">&#xD7;</mo>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('divsymbol', () =>
     toXmlMatch(
       tex2mml('A \\divsymbol B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\divsymbol B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mo data-latex=\"\\divsymbol\">&#xF7;</mo>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\divsymbol B" display="block">
+      <mi data-latex="A">A</mi>
+      <mo data-latex="\\divsymbol">&#xF7;</mo>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('divisionsymbol', () =>
     toXmlMatch(
       tex2mml('A \\divisionsymbol B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\divisionsymbol B\" display=\"block\">
-      <mi data-latex=\"A\">A</mi>
-      <mo data-latex=\"\\divisionsymbol\">&#xF7;</mo>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\divisionsymbol B" display="block">
+      <mi data-latex="A">A</mi>
+      <mo data-latex="\\divisionsymbol">&#xF7;</mo>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
 });
@@ -11872,337 +11861,337 @@ describe('Expressions Macros Rest', () => {
   it('trace', () =>
     toXmlMatch(
       tex2mml('\\trace(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\trace(x)\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\trace(x)" display="block">
       <mi>tr</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mrow data-latex=\")\">
-        <mo data-mjx-texclass=\"OPEN\">(</mo>
-        <mi data-latex=\"x\">x</mi>
-        <mo data-mjx-texclass=\"CLOSE\">)</mo>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mrow data-latex=")">
+        <mo data-mjx-texclass="OPEN">(</mo>
+        <mi data-latex="x">x</mi>
+        <mo data-mjx-texclass="CLOSE">)</mo>
       </mrow>
     </math>`
     ));
   it('Tr', () =>
     toXmlMatch(
       tex2mml('\\Tr(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Tr(x)\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Tr(x)" display="block">
       <mi>Tr</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mrow data-latex=\")\">
-        <mo data-mjx-texclass=\"OPEN\">(</mo>
-        <mi data-latex=\"x\">x</mi>
-        <mo data-mjx-texclass=\"CLOSE\">)</mo>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mrow data-latex=")">
+        <mo data-mjx-texclass="OPEN">(</mo>
+        <mi data-latex="x">x</mi>
+        <mo data-mjx-texclass="CLOSE">)</mo>
       </mrow>
     </math>`
     ));
   it('Trace', () =>
     toXmlMatch(
       tex2mml('\\Trace(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Trace(x)\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Trace(x)" display="block">
       <mi>Tr</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mrow data-latex=\")\">
-        <mo data-mjx-texclass=\"OPEN\">(</mo>
-        <mi data-latex=\"x\">x</mi>
-        <mo data-mjx-texclass=\"CLOSE\">)</mo>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mrow data-latex=")">
+        <mo data-mjx-texclass="OPEN">(</mo>
+        <mi data-latex="x">x</mi>
+        <mo data-mjx-texclass="CLOSE">)</mo>
       </mrow>
     </math>`
     ));
   it('arcsine', () =>
     toXmlMatch(
       tex2mml('\\arcsine(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arcsine(x)\" display=\"block\">
-      <mi data-latex=\"\\arcsine\">arcsin</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arcsine(x)" display="block">
+      <mi data-latex="\\arcsine">arcsin</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('asine', () =>
     toXmlMatch(
       tex2mml('\\asine(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\asine(x)\" display=\"block\">
-      <mi data-latex=\"\\asine\">asin</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\asine(x)" display="block">
+      <mi data-latex="\\asine">asin</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('cosine', () =>
     toXmlMatch(
       tex2mml('\\cosine(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cosine(x)\" display=\"block\">
-      <mi data-latex=\"\\cosine\">cos</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cosine(x)" display="block">
+      <mi data-latex="\\cosine">cos</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('hypcosine', () =>
     toXmlMatch(
       tex2mml('\\hypcosine(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hypcosine(x)\" display=\"block\">
-      <mi data-latex=\"\\hypcosine\">cosh</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hypcosine(x)" display="block">
+      <mi data-latex="\\hypcosine">cosh</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('arccosine', () =>
     toXmlMatch(
       tex2mml('\\arccosine(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arccosine(x)\" display=\"block\">
-      <mi data-latex=\"\\arccosine\">arccos</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arccosine(x)" display="block">
+      <mi data-latex="\\arccosine">arccos</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('acosine', () =>
     toXmlMatch(
       tex2mml('\\acosine(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\acosine(x)\" display=\"block\">
-      <mi data-latex=\"\\acosine\">acos</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\acosine(x)" display="block">
+      <mi data-latex="\\acosine">acos</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('tangent', () =>
     toXmlMatch(
       tex2mml('\\tangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\tangent(x)\" display=\"block\">
-      <mi data-latex=\"\\tangent\">tan</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\tangent(x)" display="block">
+      <mi data-latex="\\tangent">tan</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('hyptangent', () =>
     toXmlMatch(
       tex2mml('\\hyptangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hyptangent(x)\" display=\"block\">
-      <mi data-latex=\"\\hyptangent\">tanh</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hyptangent(x)" display="block">
+      <mi data-latex="\\hyptangent">tanh</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('arctangent', () =>
     toXmlMatch(
       tex2mml('\\arctangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arctangent(x)\" display=\"block\">
-      <mi data-latex=\"\\arctangent\">arctan</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arctangent(x)" display="block">
+      <mi data-latex="\\arctangent">arctan</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('atangent', () =>
     toXmlMatch(
       tex2mml('\\atangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\atangent(x)\" display=\"block\">
-      <mi data-latex=\"\\atangent\">atan</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\atangent(x)" display="block">
+      <mi data-latex="\\atangent">atan</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('cosecant', () =>
     toXmlMatch(
       tex2mml('\\cosecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cosecant(x)\" display=\"block\">
-      <mi data-latex=\"\\cosecant\">csc</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cosecant(x)" display="block">
+      <mi data-latex="\\cosecant">csc</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('hypcosecant', () =>
     toXmlMatch(
       tex2mml('\\hypcosecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hypcosecant(x)\" display=\"block\">
-      <mi data-latex=\"\\hypcosecant\">csch</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hypcosecant(x)" display="block">
+      <mi data-latex="\\hypcosecant">csch</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('arccosecant', () =>
     toXmlMatch(
       tex2mml('\\arccosecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arccosecant(x)\" display=\"block\">
-      <mi data-latex=\"\\arccosecant\">arccsc</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arccosecant(x)" display="block">
+      <mi data-latex="\\arccosecant">arccsc</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('acosecant', () =>
     toXmlMatch(
       tex2mml('\\acosecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\acosecant(x)\" display=\"block\">
-      <mi data-latex=\"\\acosecant\">acsc</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\acosecant(x)" display="block">
+      <mi data-latex="\\acosecant">acsc</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('secant', () =>
     toXmlMatch(
       tex2mml('\\secant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\secant(x)\" display=\"block\">
-      <mi data-latex=\"\\secant\">sec</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\secant(x)" display="block">
+      <mi data-latex="\\secant">sec</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('hypsecant', () =>
     toXmlMatch(
       tex2mml('\\hypsecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hypsecant(x)\" display=\"block\">
-      <mi data-latex=\"\\hypsecant\">sech</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hypsecant(x)" display="block">
+      <mi data-latex="\\hypsecant">sech</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('arcsecant', () =>
     toXmlMatch(
       tex2mml('\\arcsecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arcsecant(x)\" display=\"block\">
-      <mi data-latex=\"\\arcsecant\">arcsec</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arcsecant(x)" display="block">
+      <mi data-latex="\\arcsecant">arcsec</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('asecant', () =>
     toXmlMatch(
       tex2mml('\\asecant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\asecant(x)\" display=\"block\">
-      <mi data-latex=\"\\asecant\">asec</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\asecant(x)" display="block">
+      <mi data-latex="\\asecant">asec</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('cotangent', () =>
     toXmlMatch(
       tex2mml('\\cotangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\cotangent(x)\" display=\"block\">
-      <mi data-latex=\"\\cotangent\">cot</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cotangent(x)" display="block">
+      <mi data-latex="\\cotangent">cot</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('hypcotangent', () =>
     toXmlMatch(
       tex2mml('\\hypcotangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\hypcotangent(x)\" display=\"block\">
-      <mi data-latex=\"\\hypcotangent\">coth</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hypcotangent(x)" display="block">
+      <mi data-latex="\\hypcotangent">coth</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('arccotangent', () =>
     toXmlMatch(
       tex2mml('\\arccotangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\arccotangent(x)\" display=\"block\">
-      <mi data-latex=\"\\arccotangent\">arccot</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\arccotangent(x)" display="block">
+      <mi data-latex="\\arccotangent">arccot</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('acotangent', () =>
     toXmlMatch(
       tex2mml('\\acotangent(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\acotangent(x)\" display=\"block\">
-      <mi data-latex=\"\\acotangent\">acot</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\acotangent(x)" display="block">
+      <mi data-latex="\\acotangent">acot</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('exponential', () =>
     toXmlMatch(
       tex2mml('\\exponential(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\exponential(x)\" display=\"block\">
-      <mi data-latex=\"\\exponential\">exp</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\exponential(x)" display="block">
+      <mi data-latex="\\exponential">exp</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('logarithm', () =>
     toXmlMatch(
       tex2mml('\\logarithm(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\logarithm(x)\" display=\"block\">
-      <mi data-latex=\"\\logarithm\">log</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\logarithm(x)" display="block">
+      <mi data-latex="\\logarithm">log</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('naturallogarithm', () =>
     toXmlMatch(
       tex2mml('\\naturallogarithm(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\naturallogarithm(x)\" display=\"block\">
-      <mi data-latex=\"\\naturallogarithm\">ln</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\naturallogarithm(x)" display="block">
+      <mi data-latex="\\naturallogarithm">ln</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('determinant', () =>
     toXmlMatch(
       tex2mml('\\determinant(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\determinant(x)\" display=\"block\">
-      <mi data-latex=\"\\determinant\">det</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\determinant(x)" display="block">
+      <mi data-latex="\\determinant">det</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
   it('Probability', () =>
     toXmlMatch(
       tex2mml('\\Probability(x)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\Probability(x)\" display=\"block\">
-      <mi data-latex=\"\\Probability\">Pr</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-      <mi data-latex=\"x\">x</mi>
-      <mo data-latex=\")\" stretchy=\"false\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Probability(x)" display="block">
+      <mi data-latex="\\Probability">Pr</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mo data-latex="(" stretchy="false">(</mo>
+      <mi data-latex="x">x</mi>
+      <mo data-latex=")" stretchy="false">)</mo>
     </math>`
     ));
 });
@@ -12211,32 +12200,32 @@ describe('Derivative Macros Rest', () => {
   it('differential', () =>
     toXmlMatch(
       tex2mml('\\differential'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\differential\" display=\"block\">
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\differential\">
-        <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\differential" display="block">
+      <mrow data-mjx-texclass="ORD" data-latex="\\differential">
+        <mi mathvariant="normal" data-latex="d">d</mi>
       </mrow>
     </math>`
     ));
   it('variation', () =>
     toXmlMatch(
       tex2mml('\\variation'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\variation\" display=\"block\">
-      <mi data-latex=\"\\variation\">&#x3B4;</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\variation" display="block">
+      <mi data-latex="\\variation">&#x3B4;</mi>
     </math>`
     ));
   it('derivative one arg', () =>
     toXmlMatch(
       tex2mml('\\derivative{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\derivative{x}\" display=\"block\">
-      <mfrac data-latex=\"\\derivative{x}\">
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\diffd \">
-          <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\derivative{x}" display="block">
+      <mfrac data-latex="\\derivative{x}">
+        <mrow data-mjx-texclass="ORD" data-latex="\\diffd ">
+          <mi mathvariant="normal" data-latex="d">d</mi>
         </mrow>
-        <mrow data-latex=\"\\diffd x  \">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\diffd\">
-            <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+        <mrow data-latex="\\diffd x  ">
+          <mrow data-mjx-texclass="ORD" data-latex="\\diffd">
+            <mi mathvariant="normal" data-latex="d">d</mi>
           </mrow>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12244,19 +12233,19 @@ describe('Derivative Macros Rest', () => {
   it('derivative two arg', () =>
     toXmlMatch(
       tex2mml('\\derivative{x}{y}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\derivative{x}{y}\" display=\"block\">
-      <mfrac data-latex=\"\\derivative{x}{y}\">
-        <mrow data-latex=\"\\diffd x\">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\diffd\">
-            <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\derivative{x}{y}" display="block">
+      <mfrac data-latex="\\derivative{x}{y}">
+        <mrow data-latex="\\diffd x">
+          <mrow data-mjx-texclass="ORD" data-latex="\\diffd">
+            <mi mathvariant="normal" data-latex="d">d</mi>
           </mrow>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\diffd y  \">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\diffd\">
-            <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+        <mrow data-latex="\\diffd y  ">
+          <mrow data-mjx-texclass="ORD" data-latex="\\diffd">
+            <mi mathvariant="normal" data-latex="d">d</mi>
           </mrow>
-          <mi data-latex=\"y\">y</mi>
+          <mi data-latex="y">y</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12264,35 +12253,35 @@ describe('Derivative Macros Rest', () => {
   it('derivative three arg', () =>
     toXmlMatch(
       tex2mml('\\derivative{x}{y}{z}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\derivative{x}{y}{z}\" display=\"block\">
-      <mfrac data-latex=\"\\derivative{x}{y}\">
-        <mrow data-latex=\"\\diffd x\">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\diffd\">
-            <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\derivative{x}{y}{z}" display="block">
+      <mfrac data-latex="\\derivative{x}{y}">
+        <mrow data-latex="\\diffd x">
+          <mrow data-mjx-texclass="ORD" data-latex="\\diffd">
+            <mi mathvariant="normal" data-latex="d">d</mi>
           </mrow>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\diffd y  \">
-          <mrow data-mjx-texclass=\"ORD\" data-latex=\"\\diffd\">
-            <mi mathvariant=\"normal\" data-latex=\"d\">d</mi>
+        <mrow data-latex="\\diffd y  ">
+          <mrow data-mjx-texclass="ORD" data-latex="\\diffd">
+            <mi mathvariant="normal" data-latex="d">d</mi>
           </mrow>
-          <mi data-latex=\"y\">y</mi>
+          <mi data-latex="y">y</mi>
         </mrow>
       </mfrac>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{z}\">
-        <mi data-latex=\"z\">z</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{z}">
+        <mi data-latex="z">z</mi>
       </mrow>
     </math>`
     ));
   it('partialderivative one arg', () =>
     toXmlMatch(
       tex2mml('\\partialderivative{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\partialderivative{x}\" display=\"block\">
-      <mfrac data-latex=\"\\partialderivative{x}\">
-        <mi data-latex=\"\\partial \">&#x2202;</mi>
-        <mrow data-latex=\"\\partial x  \">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\partialderivative{x}" display="block">
+      <mfrac data-latex="\\partialderivative{x}">
+        <mi data-latex="\\partial ">&#x2202;</mi>
+        <mrow data-latex="\\partial x  ">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12300,15 +12289,15 @@ describe('Derivative Macros Rest', () => {
   it('partialderivative two arg', () =>
     toXmlMatch(
       tex2mml('\\partialderivative{x}{y}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\partialderivative{x}{y}\" display=\"block\">
-      <mfrac data-latex=\"\\partialderivative{x}{y}\">
-        <mrow data-latex=\"\\partial x\">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\partialderivative{x}{y}" display="block">
+      <mfrac data-latex="\\partialderivative{x}{y}">
+        <mrow data-latex="\\partial x">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\partial y  \">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"y\">y</mi>
+        <mrow data-latex="\\partial y  ">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="y">y</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12316,22 +12305,22 @@ describe('Derivative Macros Rest', () => {
   it('partialderivative three arg', () =>
     toXmlMatch(
       tex2mml('\\partialderivative{x}{y}{z}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\partialderivative{x}{y}{z}\" display=\"block\">
-      <mfrac data-latex=\"\\partialderivative{x}{y}{z}\">
-        <mrow data-latex=\"\\partial^{2}x\">
-          <msup data-latex=\"\\partial^{2}\">
-            <mi data-latex=\"\\partial\">&#x2202;</mi>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{2}\">
-              <mn data-latex=\"2\">2</mn>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\partialderivative{x}{y}{z}" display="block">
+      <mfrac data-latex="\\partialderivative{x}{y}{z}">
+        <mrow data-latex="\\partial^{2}x">
+          <msup data-latex="\\partial^{2}">
+            <mi data-latex="\\partial">&#x2202;</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{2}">
+              <mn data-latex="2">2</mn>
             </mrow>
           </msup>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\partial y  \\partial z\">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"y\">y</mi>
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"z\">z</mi>
+        <mrow data-latex="\\partial y  \\partial z">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="y">y</mi>
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="z">z</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12339,38 +12328,38 @@ describe('Derivative Macros Rest', () => {
   it('partialderivative four arg', () =>
     toXmlMatch(
       tex2mml('\\partialderivative{x}{y}{z}{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\partialderivative{x}{y}{z}{a}\" display=\"block\">
-      <mfrac data-latex=\"\\partialderivative{x}{y}{z}\">
-        <mrow data-latex=\"\\partial^{2}x\">
-          <msup data-latex=\"\\partial^{2}\">
-            <mi data-latex=\"\\partial\">&#x2202;</mi>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{2}\">
-              <mn data-latex=\"2\">2</mn>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\partialderivative{x}{y}{z}{a}" display="block">
+      <mfrac data-latex="\\partialderivative{x}{y}{z}">
+        <mrow data-latex="\\partial^{2}x">
+          <msup data-latex="\\partial^{2}">
+            <mi data-latex="\\partial">&#x2202;</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{2}">
+              <mn data-latex="2">2</mn>
             </mrow>
           </msup>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\partial y  \\partial z\">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"y\">y</mi>
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"z\">z</mi>
+        <mrow data-latex="\\partial y  \\partial z">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="y">y</mi>
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="z">z</mi>
         </mrow>
       </mfrac>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{a}\">
-        <mi data-latex=\"a\">a</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{a}">
+        <mi data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
   it('pderivative one arg', () =>
     toXmlMatch(
       tex2mml('\\pderivative{x}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pderivative{x}\" display=\"block\">
-      <mfrac data-latex=\"\\pderivative{x}\">
-        <mi data-latex=\"\\partial \">&#x2202;</mi>
-        <mrow data-latex=\"\\partial x  \">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pderivative{x}" display="block">
+      <mfrac data-latex="\\pderivative{x}">
+        <mi data-latex="\\partial ">&#x2202;</mi>
+        <mrow data-latex="\\partial x  ">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12378,15 +12367,15 @@ describe('Derivative Macros Rest', () => {
   it('pderivative two arg', () =>
     toXmlMatch(
       tex2mml('\\pderivative{x}{y}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pderivative{x}{y}\" display=\"block\">
-      <mfrac data-latex=\"\\pderivative{x}{y}\">
-        <mrow data-latex=\"\\partial x\">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"x\">x</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pderivative{x}{y}" display="block">
+      <mfrac data-latex="\\pderivative{x}{y}">
+        <mrow data-latex="\\partial x">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\partial y  \">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"y\">y</mi>
+        <mrow data-latex="\\partial y  ">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="y">y</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12394,22 +12383,22 @@ describe('Derivative Macros Rest', () => {
   it('pderivative three arg', () =>
     toXmlMatch(
       tex2mml('\\pderivative{x}{y}{z}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pderivative{x}{y}{z}\" display=\"block\">
-      <mfrac data-latex=\"\\pderivative{x}{y}{z}\">
-        <mrow data-latex=\"\\partial^{2}x\">
-          <msup data-latex=\"\\partial^{2}\">
-            <mi data-latex=\"\\partial\">&#x2202;</mi>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{2}\">
-              <mn data-latex=\"2\">2</mn>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pderivative{x}{y}{z}" display="block">
+      <mfrac data-latex="\\pderivative{x}{y}{z}">
+        <mrow data-latex="\\partial^{2}x">
+          <msup data-latex="\\partial^{2}">
+            <mi data-latex="\\partial">&#x2202;</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{2}">
+              <mn data-latex="2">2</mn>
             </mrow>
           </msup>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\partial y  \\partial z\">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"y\">y</mi>
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"z\">z</mi>
+        <mrow data-latex="\\partial y  \\partial z">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="y">y</mi>
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="z">z</mi>
         </mrow>
       </mfrac>
     </math>`
@@ -12417,26 +12406,26 @@ describe('Derivative Macros Rest', () => {
   it('pderivative four arg', () =>
     toXmlMatch(
       tex2mml('\\pderivative{x}{y}{z}{a}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pderivative{x}{y}{z}{a}\" display=\"block\">
-      <mfrac data-latex=\"\\pderivative{x}{y}{z}\">
-        <mrow data-latex=\"\\partial^{2}x\">
-          <msup data-latex=\"\\partial^{2}\">
-            <mi data-latex=\"\\partial\">&#x2202;</mi>
-            <mrow data-mjx-texclass=\"ORD\" data-latex=\"{2}\">
-              <mn data-latex=\"2\">2</mn>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pderivative{x}{y}{z}{a}" display="block">
+      <mfrac data-latex="\\pderivative{x}{y}{z}">
+        <mrow data-latex="\\partial^{2}x">
+          <msup data-latex="\\partial^{2}">
+            <mi data-latex="\\partial">&#x2202;</mi>
+            <mrow data-mjx-texclass="ORD" data-latex="{2}">
+              <mn data-latex="2">2</mn>
             </mrow>
           </msup>
-          <mi data-latex=\"x\">x</mi>
+          <mi data-latex="x">x</mi>
         </mrow>
-        <mrow data-latex=\"\\partial y  \\partial z\">
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"y\">y</mi>
-          <mi data-latex=\"\\partial\">&#x2202;</mi>
-          <mi data-latex=\"z\">z</mi>
+        <mrow data-latex="\\partial y  \\partial z">
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="y">y</mi>
+          <mi data-latex="\\partial">&#x2202;</mi>
+          <mi data-latex="z">z</mi>
         </mrow>
       </mfrac>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{a}\">
-        <mi data-latex=\"a\">a</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{a}">
+        <mi data-latex="a">a</mi>
       </mrow>
     </math>`
     ));
@@ -12446,282 +12435,208 @@ describe('Quick Quad Macros Rest', () => {
   it('qq', () =>
     toXmlMatch(
       tex2mml('A \\qq B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qq B\" display=\"block\">
-      <mi data-latex=\"\\qq B\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{B}\">B</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qq B" display="block">
+      <mi data-latex="\\qq B">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{B}">B</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
     </math>`
     ));
   it('qcomma', () =>
     toXmlMatch(
       tex2mml('A \\qcomma B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qcomma B\" display=\"block\">
-      <mi data-latex=\"\\qqtext*{,}\">A</mi>
-      <mtext data-latex=\"\\text{,}\">,</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qcomma B" display="block">
+      <mi data-latex="\\qqtext*{,}">A</mi>
+      <mtext data-latex="\\text{,}">,</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qthen', () =>
     toXmlMatch(
       tex2mml('A \\qthen B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qthen B\" display=\"block\">
-      <mi data-latex=\"\\qthen\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{then}\">then</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qthen B" display="block">
+      <mi data-latex="\\qthen">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{then}">then</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qelse', () =>
     toXmlMatch(
       tex2mml('A \\qelse B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qelse B\" display=\"block\">
-      <mi data-latex=\"\\qelse\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{else}\">else</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qelse B" display="block">
+      <mi data-latex="\\qelse">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{else}">else</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qotherwise', () =>
     toXmlMatch(
       tex2mml('A \\qotherwise B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qotherwise B\" display=\"block\">
-      <mi data-latex=\"\\qotherwise\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{otherwise}\">otherwise</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qotherwise B" display="block">
+      <mi data-latex="\\qotherwise">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{otherwise}">otherwise</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qunless', () =>
     toXmlMatch(
       tex2mml('A \\qunless B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qunless B\" display=\"block\">
-      <mi data-latex=\"\\qunless\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{unless}\">unless</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qunless B" display="block">
+      <mi data-latex="\\qunless">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{unless}">unless</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qgiven', () =>
     toXmlMatch(
       tex2mml('A \\qgiven B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qgiven B\" display=\"block\">
-      <mi data-latex=\"\\qgiven\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{given}\">given</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qgiven B" display="block">
+      <mi data-latex="\\qgiven">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{given}">given</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qusing', () =>
     toXmlMatch(
       tex2mml('A \\qusing B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qusing B\" display=\"block\">
-      <mi data-latex=\"\\qusing\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{using}\">using</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qusing B" display="block">
+      <mi data-latex="\\qusing">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{using}">using</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qassume', () =>
     toXmlMatch(
       tex2mml('A \\qassume B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qassume B\" display=\"block\">
-      <mi data-latex=\"\\qassume\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{assume}\">assume</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qassume B" display="block">
+      <mi data-latex="\\qassume">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{assume}">assume</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qsince', () =>
     toXmlMatch(
       tex2mml('A \\qsince B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qsince B\" display=\"block\">
-      <mi data-latex=\"\\qsince\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{since}\">since</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qsince B" display="block">
+      <mi data-latex="\\qsince">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{since}">since</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qlet', () =>
     toXmlMatch(
       tex2mml('A \\qlet B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qlet B\" display=\"block\">
-      <mi data-latex=\"\\qlet\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{let}\">let</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qlet B" display="block">
+      <mi data-latex="\\qlet">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{let}">let</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qfor', () =>
     toXmlMatch(
       tex2mml('A \\qfor B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qfor B\" display=\"block\">
-      <mi data-latex=\"\\qfor\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{for}\">for</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qfor B" display="block">
+      <mi data-latex="\\qfor">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{for}">for</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qall', () =>
     toXmlMatch(
       tex2mml('A \\qall B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qall B\" display=\"block\">
-      <mi data-latex=\"\\qall\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{all}\">all</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qall B" display="block">
+      <mi data-latex="\\qall">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{all}">all</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qeven', () =>
     toXmlMatch(
       tex2mml('A \\qeven B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qeven B\" display=\"block\">
-      <mi data-latex=\"\\qeven\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{even}\">even</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qeven B" display="block">
+      <mi data-latex="\\qeven">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{even}">even</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qodd', () =>
     toXmlMatch(
       tex2mml('A \\qodd B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qodd B\" display=\"block\">
-      <mi data-latex=\"\\qodd\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{odd}\">odd</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qodd B" display="block">
+      <mi data-latex="\\qodd">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{odd}">odd</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qinteger', () =>
     toXmlMatch(
       tex2mml('A \\qinteger B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qinteger B\" display=\"block\">
-      <mi data-latex=\"\\qinteger\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{integer}\">integer</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qinteger B" display="block">
+      <mi data-latex="\\qinteger">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{integer}">integer</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qor', () =>
     toXmlMatch(
       tex2mml('A \\qor B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qor B\" display=\"block\">
-      <mi data-latex=\"\\qor\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{or}\">or</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qor B" display="block">
+      <mi data-latex="\\qor">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{or}">or</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qas', () =>
     toXmlMatch(
       tex2mml('A \\qas B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qas B\" display=\"block\">
-      <mi data-latex=\"\\qas\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{as}\">as</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qas B" display="block">
+      <mi data-latex="\\qas">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{as}">as</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
   it('qin', () =>
     toXmlMatch(
       tex2mml('A \\qin B'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"A \\qin B\" display=\"block\">
-      <mi data-latex=\"\\qin\">A</mi>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mtext data-latex=\"\\text{in}\">in</mtext>
-      <mstyle scriptlevel=\"0\" data-latex=\"\\quad\">
-        <mspace width=\"1em\"></mspace>
-      </mstyle>
-      <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="A \\qin B" display="block">
+      <mi data-latex="\\qin">A</mi>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mtext data-latex="\\text{in}">in</mtext>
+      <mspace width="1em" data-latex="\\quad"></mspace>
+      <mi data-latex="B">B</mi>
     </math>`
     ));
 });
@@ -12730,371 +12645,365 @@ describe('Bra-Ket Macros Rest', () => {
   it('innerproduct arg one', () =>
     toXmlMatch(
       tex2mml('\\innerproduct{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\innerproduct{A}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\middle\\vert{A}\\right\\rangle\" data-latex=\"\\innerproduct{A}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\innerproduct{A}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\middle\\vert{A}\\right\\rangle" data-latex="\\innerproduct{A}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\vert\" data-latex=\"\\middle\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\vert\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\vert" data-latex="\\middle\\vert">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('innerproduct arg two', () =>
     toXmlMatch(
       tex2mml('\\innerproduct{A}{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\innerproduct{A}{B}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\middle\\vert{B}\\right\\rangle\" data-latex=\"\\innerproduct{A}{B}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\innerproduct{A}{B}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\middle\\vert{B}\\right\\rangle" data-latex="\\innerproduct{A}{B}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\vert\" data-latex=\"\\middle\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\vert\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\vert" data-latex="\\middle\\vert">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('innerproduct arg three', () =>
     toXmlMatch(
       tex2mml('\\innerproduct{A}{B}{C}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\innerproduct{A}{B}{C}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\middle\\vert{B}\\right\\rangle\" data-latex=\"\\left\\langle{A}\\middle\\vert{B}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\innerproduct{A}{B}{C}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\middle\\vert{B}\\right\\rangle" data-latex="\\left\\langle{A}\\middle\\vert{B}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\vert\" data-latex=\"\\middle\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\vert\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\vert" data-latex="\\middle\\vert">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-        <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{C}">
+        <mi data-latex="C">C</mi>
       </mrow>
     </math>`
     ));
   it('ip arg one', () =>
     toXmlMatch(
       tex2mml('\\ip{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ip{A}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\middle\\vert{A}\\right\\rangle\" data-latex=\"\\ip{A}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ip{A}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\middle\\vert{A}\\right\\rangle" data-latex="\\ip{A}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\vert\" data-latex=\"\\middle\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\vert\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\vert" data-latex="\\middle\\vert">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('ip arg two', () =>
     toXmlMatch(
       tex2mml('\\ip{A}{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ip{A}{B}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\middle\\vert{B}\\right\\rangle\" data-latex=\"\\ip{A}{B}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ip{A}{B}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\middle\\vert{B}\\right\\rangle" data-latex="\\ip{A}{B}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\vert\" data-latex=\"\\middle\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\vert\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\vert" data-latex="\\middle\\vert">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('ip arg three', () =>
     toXmlMatch(
       tex2mml('\\ip{A}{B}{C}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\ip{A}{B}{C}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\middle\\vert{B}\\right\\rangle\" data-latex=\"\\left\\langle{A}\\middle\\vert{B}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ip{A}{B}{C}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\middle\\vert{B}\\right\\rangle" data-latex="\\left\\langle{A}\\middle\\vert{B}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\vert\" data-latex=\"\\middle\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\vert\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\vert" data-latex="\\middle\\vert">|</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\vert"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-        <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{C}">
+        <mi data-latex="C">C</mi>
       </mrow>
     </math>`
     ));
   it('op arg one', () =>
     toXmlMatch(
       tex2mml('\\op{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\op{A}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{A}\\right\\vert\" data-latex=\"\\op{A}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\op{A}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{A}\\right\\vert" data-latex="\\op{A}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\rangle\" data-latex=\"\\middle\\rangle\">&#x27E9;</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\rangle\"></mrow>
-        <mstyle scriptlevel=\"0\" data-latex=\"\\!\">
-          <mspace width=\"-0.167em\"></mspace>
-        </mstyle>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\langle\" data-latex=\"\\middle\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\langle\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
+        <mspace width="-0.167em" data-latex="\\!"></mspace>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
     </math>`
     ));
   it('op arg two', () =>
     toXmlMatch(
       tex2mml('\\op{A}{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\op{A}{B}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{B}\\right\\vert\" data-latex=\"\\op{A}{B}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\op{A}{B}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{B}\\right\\vert" data-latex="\\op{A}{B}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\rangle\" data-latex=\"\\middle\\rangle\">&#x27E9;</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\rangle\"></mrow>
-        <mstyle scriptlevel=\"0\" data-latex=\"\\!\">
-          <mspace width=\"-0.167em\"></mspace>
-        </mstyle>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\langle\" data-latex=\"\\middle\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\langle\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
+        <mspace width="-0.167em" data-latex="\\!"></mspace>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
     </math>`
     ));
   it('op arg three', () =>
     toXmlMatch(
       tex2mml('\\op{A}{B}{C}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\op{A}{B}{C}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{B}\\right\\vert\" data-latex=\"\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{B}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\op{A}{B}{C}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{B}\\right\\vert" data-latex="\\left\\vert{A}\\middle\\rangle\\!\\middle\\langle{B}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\rangle\" data-latex=\"\\middle\\rangle\">&#x27E9;</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\rangle\"></mrow>
-        <mstyle scriptlevel=\"0\" data-latex=\"\\!\">
-          <mspace width=\"-0.167em\"></mspace>
-        </mstyle>
-        <mrow data-mjx-texclass=\"CLOSE\"></mrow>
-        <mo data-latex-item=\"\\middle\\langle\" data-latex=\"\\middle\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"OPEN\" data-latex=\"\\middle\\langle\"></mrow>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\rangle" data-latex="\\middle\\rangle">&#x27E9;</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\rangle"></mrow>
+        <mspace width="-0.167em" data-latex="\\!"></mspace>
+        <mrow data-mjx-texclass="CLOSE"></mrow>
+        <mo data-latex-item="\\middle\\langle" data-latex="\\middle\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="OPEN" data-latex="\\middle\\langle"></mrow>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-        <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{C}">
+        <mi data-latex="C">C</mi>
       </mrow>
     </math>`
     ));
   it('expectationvalue arg one', () =>
     toXmlMatch(
       tex2mml('\\expectationvalue{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\expectationvalue{A}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle {A} \\right\\rangle\" data-latex=\"\\expectationvalue{A}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle \" data-latex=\"\\left\\langle \">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\expectationvalue{A}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle {A} \\right\\rangle" data-latex="\\expectationvalue{A}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle " data-latex="\\left\\langle ">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('expectationvalue arg two', () =>
     toXmlMatch(
       tex2mml('\\expectationvalue{A}{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\expectationvalue{A}{B}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{B}\\right\\vert\" data-latex=\"\\left\\langle{B}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\expectationvalue{A}{B}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{B}\\right\\vert" data-latex="\\left\\langle{B}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-        <mi data-latex=\"A\">A</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{A}">
+        <mi data-latex="A">A</mi>
       </mrow>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{B}\\right\\rangle\" data-latex=\"\\left\\vert{B}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{B}\\right\\rangle" data-latex="\\left\\vert{B}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('expectationvalue arg three', () =>
     toXmlMatch(
       tex2mml('\\expectationvalue{A}{B}{C}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\expectationvalue{A}{B}{C}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{B}\\right\\vert\" data-latex=\"\\left\\langle{B}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\expectationvalue{A}{B}{C}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{B}\\right\\vert" data-latex="\\left\\langle{B}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-        <mi data-latex=\"A\">A</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{A}">
+        <mi data-latex="A">A</mi>
       </mrow>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{B}\\right\\rangle\" data-latex=\"\\left\\vert{B}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{B}\\right\\rangle" data-latex="\\left\\vert{B}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-        <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{C}">
+        <mi data-latex="C">C</mi>
       </mrow>
     </math>`
     ));
   it('expval arg one', () =>
     toXmlMatch(
       tex2mml('\\expval{A}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\expval{A}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle {A} \\right\\rangle\" data-latex=\"\\expval{A}\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle \" data-latex=\"\\left\\langle \">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\expval{A}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle {A} \\right\\rangle" data-latex="\\expval{A}">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle " data-latex="\\left\\langle ">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('expval arg two', () =>
     toXmlMatch(
       tex2mml('\\expval{A}{B}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\expval{A}{B}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{B}\\right\\vert\" data-latex=\"\\left\\langle{B}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\expval{A}{B}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{B}\\right\\vert" data-latex="\\left\\langle{B}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-        <mi data-latex=\"A\">A</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{A}">
+        <mi data-latex="A">A</mi>
       </mrow>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{B}\\right\\rangle\" data-latex=\"\\left\\vert{B}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{B}\\right\\rangle" data-latex="\\left\\vert{B}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('expval arg three', () =>
     toXmlMatch(
       tex2mml('\\expval{A}{B}{C}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\expval{A}{B}{C}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{B}\\right\\vert\" data-latex=\"\\left\\langle{B}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\expval{A}{B}{C}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{B}\\right\\vert" data-latex="\\left\\langle{B}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-        <mi data-latex=\"A\">A</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{A}">
+        <mi data-latex="A">A</mi>
       </mrow>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{B}\\right\\rangle\" data-latex=\"\\left\\vert{B}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-          <mi data-latex=\"B\">B</mi>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{B}\\right\\rangle" data-latex="\\left\\vert{B}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{B}">
+          <mi data-latex="B">B</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-        <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{C}">
+        <mi data-latex="C">C</mi>
       </mrow>
     </math>`
     ));
   it('matrixelement arg three', () =>
     toXmlMatch(
       tex2mml('\\matrixelement{A}{B}{C}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\matrixelement{A}{B}{C}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\right\\vert\" data-latex=\"\\left\\langle{A}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\matrixelement{A}{B}{C}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\right\\vert" data-latex="\\left\\langle{A}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-        <mi data-latex=\"B\">B</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{B}">
+        <mi data-latex="B">B</mi>
       </mrow>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{C}\\right\\rangle\" data-latex=\"\\left\\vert{C}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-          <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{C}\\right\\rangle" data-latex="\\left\\vert{C}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{C}">
+          <mi data-latex="C">C</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
     </math>`
     ));
   it('matrixelement arg four', () =>
     toXmlMatch(
       tex2mml('\\matrixelement{A}{B}{C}{D}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\matrixelement{A}{B}{C}{D}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\langle{A}\\right\\vert\" data-latex=\"\\left\\langle{A}\\right\\vert\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\langle\" data-latex=\"\\left\\langle\">&#x27E8;</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{A}\">
-          <mi data-latex=\"A\">A</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\matrixelement{A}{B}{C}{D}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle{A}\\right\\vert" data-latex="\\left\\langle{A}\\right\\vert">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle" data-latex="\\left\\langle">&#x27E8;</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{A}">
+          <mi data-latex="A">A</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\vert\" data-latex=\"\\right\\vert\">|</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{B}\">
-        <mi data-latex=\"B\">B</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{B}">
+        <mi data-latex="B">B</mi>
       </mrow>
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left\\vert{C}\\right\\rangle\" data-latex=\"\\left\\vert{C}\\right\\rangle\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left\\vert\" data-latex=\"\\left\\vert\">|</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{C}\">
-          <mi data-latex=\"C\">C</mi>
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert{C}\\right\\rangle" data-latex="\\left\\vert{C}\\right\\rangle">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert" data-latex="\\left\\vert">|</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{C}">
+          <mi data-latex="C">C</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right\\rangle\" data-latex=\"\\right\\rangle\">&#x27E9;</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
       </mrow>
-      <mrow data-mjx-texclass=\"ORD\" data-latex=\"{D}\">
-        <mi data-latex=\"D\">D</mi>
+      <mrow data-mjx-texclass="ORD" data-latex="{D}">
+        <mi data-latex="D">D</mi>
       </mrow>
     </math>`
     ));
@@ -13104,245 +13013,245 @@ describe('Matrix Macros Rest', () => {
   it('zeromatrix', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\zeromatrix{2}{3}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\zeromatrix{2}{3}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left &amp; 0\\\\ 0 &amp; 0 &amp; 0\\end{array}\\right)\" data-latex=\"\\mqty(\\zeromatrix{2}{3})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\zeromatrix{2}{3}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 0\\\\ 0 &amp; 0 &amp; 0\\end{array}\\right)" data-latex="\\mqty(\\zeromatrix{2}{3})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('paulimatrix 0', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\paulimatrix{0}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\paulimatrix{0}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left0\\\\ 0 &amp; 1\\end{array}\\right)\" data-latex=\"\\mqty(\\paulimatrix{0})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\paulimatrix{0}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left0\\\\ 0 &amp; 1\\end{array}\\right)" data-latex="\\mqty(\\paulimatrix{0})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"1\">1</mn>
+              <mn data-latex="1">1</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"1\">1</mn>
+              <mn data-latex="1">1</mn>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('paulimatrix 1', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\paulimatrix{1}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\paulimatrix{1}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left1\\\\ 1 &amp; 0\\end{array}\\right)\" data-latex=\"\\mqty(\\paulimatrix{1})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\paulimatrix{1}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left1\\\\ 1 &amp; 0\\end{array}\\right)" data-latex="\\mqty(\\paulimatrix{1})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"1\">1</mn>
+              <mn data-latex="1">1</mn>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"1\">1</mn>
+              <mn data-latex="1">1</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('paulimatrix 2', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\paulimatrix{2}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\paulimatrix{2}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left-i\\\\ i &amp; 0\\end{array}\\right)\" data-latex=\"\\mqty(\\paulimatrix{2})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\paulimatrix{2}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left-i\\\\ i &amp; 0\\end{array}\\right)" data-latex="\\mqty(\\paulimatrix{2})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mo data-latex=\"-\">&#x2212;</mo>
-              <mi data-latex=\"i\">i</mi>
+              <mo data-latex="-">&#x2212;</mo>
+              <mi data-latex="i">i</mi>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mi data-latex=\"i\">i</mi>
+              <mi data-latex="i">i</mi>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('paulimatrix 3', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\paulimatrix{3}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\paulimatrix{3}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left0\\\\ 0 &amp; -1\\end{array}\\right)\" data-latex=\"\\mqty(\\paulimatrix{3})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\paulimatrix{3}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left0\\\\ 0 &amp; -1\\end{array}\\right)" data-latex="\\mqty(\\paulimatrix{3})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"1\">1</mn>
+              <mn data-latex="1">1</mn>
             </mtd>
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mn data-latex=\"0\">0</mn>
+              <mn data-latex="0">0</mn>
             </mtd>
             <mtd>
-              <mo data-latex=\"-\">&#x2212;</mo>
-              <mn data-latex=\"1\">1</mn>
+              <mo data-latex="-">&#x2212;</mo>
+              <mn data-latex="1">1</mn>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('paulimatrix 4', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\paulimatrix{4}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\paulimatrix{4}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\leftarray}\\right)\" data-latex=\"\\mqty(\\paulimatrix{4})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\"></mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\paulimatrix{4}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\leftarray}\\right)" data-latex="\\mqty(\\paulimatrix{4})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}"></mtable>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('diagonalmatrix', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\diagonalmatrix{0,1\\\\2&3}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\diagonalmatrix{0,1\\\\2&amp;3}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\left{0}\\\\ &amp;\\mqty{1\\\\2&amp;3}\\end{array}\\right)\" data-latex=\"\\mqty(\\diagonalmatrix{0,1\\\\2&amp;3})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\diagonalmatrix{0,1\\\\2&amp;3}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left{0}\\\\ &amp;\\mqty{1\\\\2&amp;3}\\end{array}\\right)" data-latex="\\mqty(\\diagonalmatrix{0,1\\\\2&amp;3})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-                <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+              <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+                <mtr data-latex-item="{}" data-latex="{}">
                   <mtd>
-                    <mn data-latex=\"0\">0</mn>
+                    <mn data-latex="0">0</mn>
                   </mtd>
                 </mtr>
               </mtable>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd></mtd>
             <mtd>
-              <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-                <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+              <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+                <mtr data-latex-item="{}" data-latex="{}">
                   <mtd>
-                    <mn data-latex=\"1\">1</mn>
+                    <mn data-latex="1">1</mn>
                   </mtd>
                 </mtr>
-                <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+                <mtr data-latex-item="{}" data-latex="{}">
                   <mtd>
-                    <mn data-latex=\"2\">2</mn>
+                    <mn data-latex="2">2</mn>
                   </mtd>
                   <mtd>
-                    <mn data-latex=\"3\">3</mn>
+                    <mn data-latex="3">3</mn>
                   </mtd>
                 </mtr>
               </mtable>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
   it('antidiagonalmatrix', () =>
     toXmlMatch(
       tex2mml('\\pmqty{\\antidiagonalmatrix{0,1\\\\2&3}}'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\pmqty{\\antidiagonalmatrix{0,1\\\\2&amp;3}}\" display=\"block\">
-      <mrow data-mjx-texclass=\"INNER\" data-latex-item=\"\\lefty{0}\\\\ \\mqty{1\\\\2&amp;3}\\end{array}\\right)\" data-latex=\"\\mqty(\\antidiagonalmatrix{0,1\\\\2&amp;3})\">
-        <mo data-mjx-texclass=\"OPEN\" data-latex-item=\"\\left(\" data-latex=\"\\left(\">(</mo>
-        <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmqty{\\antidiagonalmatrix{0,1\\\\2&amp;3}}" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\lefty{0}\\\\ \\mqty{1\\\\2&amp;3}\\end{array}\\right)" data-latex="\\mqty(\\antidiagonalmatrix{0,1\\\\2&amp;3})">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
+        <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd></mtd>
             <mtd>
-              <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-                <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+              <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+                <mtr data-latex-item="{}" data-latex="{}">
                   <mtd>
-                    <mn data-latex=\"0\">0</mn>
+                    <mn data-latex="0">0</mn>
                   </mtd>
                 </mtr>
               </mtable>
             </mtd>
           </mtr>
-          <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+          <mtr data-latex-item="{}" data-latex="{}">
             <mtd>
-              <mtable columnspacing=\"1em\" rowspacing=\"4pt\" columnalign=\"\" data-frame-styles=\"\" framespacing=\".5em .125em\" data-latex-item=\"{array}\" data-latex=\"{array}\">
-                <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+              <mtable columnspacing="1em" rowspacing="4pt" columnalign="" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="{array}">
+                <mtr data-latex-item="{}" data-latex="{}">
                   <mtd>
-                    <mn data-latex=\"1\">1</mn>
+                    <mn data-latex="1">1</mn>
                   </mtd>
                 </mtr>
-                <mtr data-latex-item=\"{}\" data-latex=\"{}\">
+                <mtr data-latex-item="{}" data-latex="{}">
                   <mtd>
-                    <mn data-latex=\"2\">2</mn>
+                    <mn data-latex="2">2</mn>
                   </mtd>
                   <mtd>
-                    <mn data-latex=\"3\">3</mn>
+                    <mn data-latex="3">3</mn>
                   </mtd>
                 </mtr>
               </mtable>
             </mtd>
           </mtr>
         </mtable>
-        <mo data-mjx-texclass=\"CLOSE\" data-latex-item=\"\\right)\" data-latex=\"\\right)\">)</mo>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right)" data-latex="\\right)">)</mo>
       </mrow>
     </math>`
     ));
@@ -13352,38 +13261,38 @@ describe('Rest for Completion', () => {
   it('Issue 2831', () =>
     toXmlMatch(
       tex2mml('\\exp((\\frac{a}{a}a){a})'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\exp((\\frac{a}{a}a){a})\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\exp((\\frac{a}{a}a){a})" display="block">
       <mi>exp</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mrow data-latex=\")\">
-        <mo data-mjx-texclass=\"OPEN\">(</mo>
-        <mo data-latex=\"(\" stretchy=\"false\">(</mo>
-        <mfrac data-latex=\"\\frac{a}{a}\">
-          <mi data-latex=\"a\">a</mi>
-          <mi data-latex=\"a\">a</mi>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mrow data-latex=")">
+        <mo data-mjx-texclass="OPEN">(</mo>
+        <mo data-latex="(" stretchy="false">(</mo>
+        <mfrac data-latex="\\frac{a}{a}">
+          <mi data-latex="a">a</mi>
+          <mi data-latex="a">a</mi>
         </mfrac>
-        <mi data-latex=\"a\">a</mi>
-        <mo data-latex=\")\" stretchy=\"false\">)</mo>
-        <mrow data-mjx-texclass=\"ORD\" data-latex=\"{a}\">
-          <mi data-latex=\"a\">a</mi>
+        <mi data-latex="a">a</mi>
+        <mo data-latex=")" stretchy="false">)</mo>
+        <mrow data-mjx-texclass="ORD" data-latex="{a}">
+          <mi data-latex="a">a</mi>
         </mrow>
-        <mo data-mjx-texclass=\"CLOSE\">)</mo>
+        <mo data-mjx-texclass="CLOSE">)</mo>
       </mrow>
     </math>`
     ));
   it('Issue 3000', () =>
     toXmlMatch(
       tex2mml('\\sin(1\\over2)'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\sin(1\\over2)\" display=\"block\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sin(1\\over2)" display="block">
       <mi>sin</mi>
-      <mo data-mjx-texclass=\"NONE\">&#x2061;</mo>
-      <mrow data-latex=\")\">
-        <mo data-mjx-texclass=\"OPEN\">(</mo>
-        <mfrac data-latex-item=\"\\over\">
-          <mn data-latex=\"1\">1</mn>
-          <mn data-latex=\"2\">2</mn>
+      <mo data-mjx-texclass="NONE">&#x2061;</mo>
+      <mrow data-latex=")">
+        <mo data-mjx-texclass="OPEN">(</mo>
+        <mfrac data-latex-item="\\over">
+          <mn data-latex="1">1</mn>
+          <mn data-latex="2">2</mn>
         </mfrac>
-        <mo data-mjx-texclass=\"CLOSE\">)</mo>
+        <mo data-mjx-texclass="CLOSE">)</mo>
       </mrow>
     </math>`
     ));

--- a/testsuite/tests/input/tex/Tag.test.ts
+++ b/testsuite/tests/input/tex/Tag.test.ts
@@ -8,7 +8,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('a'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a" display="block">
-  <mtable displaystyle="true" data-latex="a">
+  <mtable data-latex="a">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -24,7 +24,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -40,7 +40,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -66,7 +66,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -82,7 +82,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -98,7 +98,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\notag\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -111,7 +111,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -134,7 +134,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -147,7 +147,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -166,7 +166,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -185,7 +185,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\eqref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\eqref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -204,7 +204,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a=b\\label{A}\\\\ c&=d \\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -273,7 +273,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -289,7 +289,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -305,7 +305,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -329,7 +329,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -353,7 +353,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -369,7 +369,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -385,7 +385,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -411,7 +411,7 @@ describe('TagAll', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -435,7 +435,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -454,7 +454,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -475,7 +475,7 @@ describe('TagAll', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -507,7 +507,7 @@ describe('TagAll', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -548,7 +548,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('a\\tag{0}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\tag{0}" display="block">
-  <mtable displaystyle="true" data-latex="a\\tag{0}">
+  <mtable data-latex="a\\tag{0}">
     <mlabeledtr>
       <mtd id="mjx-eqn:0">
         <mtext data-latex="\\text{(0)}">(0)</mtext>
@@ -564,7 +564,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -577,7 +577,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{split}a\\end{split}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{split}a\\end{split}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
+  <mtable columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -590,7 +590,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -613,7 +613,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{}">a</mi>
@@ -626,7 +626,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -639,7 +639,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\notag\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -652,7 +652,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -675,7 +675,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -688,7 +688,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -704,7 +704,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -720,7 +720,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\eqref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\eqref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -781,7 +781,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -794,7 +794,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -810,7 +810,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -831,7 +831,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -855,7 +855,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -868,7 +868,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -884,7 +884,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -907,7 +907,7 @@ describe('TagNone', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -931,7 +931,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -947,7 +947,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -968,7 +968,7 @@ describe('TagNone', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -997,7 +997,7 @@ describe('TagNone', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1038,7 +1038,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1054,7 +1054,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{split}a\\end{split}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{split}a\\end{split}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
+  <mtable columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1067,7 +1067,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1093,7 +1093,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1109,7 +1109,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1125,7 +1125,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\notag\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -1138,7 +1138,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}" display="block">
-  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
+  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1161,7 +1161,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -1174,7 +1174,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1193,7 +1193,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1212,7 +1212,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\eqref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\eqref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1231,7 +1231,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a=b\\label{A}\\\\ c&=d \\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
+  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1300,7 +1300,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1316,7 +1316,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1332,7 +1332,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1356,7 +1356,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1380,7 +1380,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1396,7 +1396,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1412,7 +1412,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1438,7 +1438,7 @@ describe('TagAms', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1462,7 +1462,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1481,7 +1481,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1502,7 +1502,7 @@ describe('TagAms', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1534,7 +1534,7 @@ describe('TagAms', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>

--- a/testsuite/tests/input/tex/Unicode.test.ts
+++ b/testsuite/tests/input/tex/Unicode.test.ts
@@ -53,7 +53,7 @@ describe('Unicode', () => {
     toXmlMatch(
       tex2mml('\\mbox{A}\\unicode{65}{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mbox{A}\\unicode{65}{B}" display="block">
-  <mstyle displaystyle="false" scriptlevel="0" data-latex="\\mbox{A}">
+  <mstyle displaystyle="false" data-latex="\\mbox{A}">
     <mtext>A</mtext>
   </mstyle>
   <mtext data-latex="\\unicode{65}">A</mtext>


### PR DESCRIPTION
This PR fixes the tests to handle the changes from #1146 that resolved mathjax/MathJax#3300.  These are mostly changes for the removal of `mstyle` elements that are no longer needed, or the removal of some `displaystyle` or `scriptlevel` attributes that are redundant.

Some `newcommand` tests still fail, but they will pass with the PR that updates the `\let` command (I'm preparing it now).