### PR TITLE
Update newcommand to handle delimiters vs macros better, and add tests

### DIFF
--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -69,11 +69,11 @@ describe('Newcommand', () => {
       tex2mml(
         '\\newenvironment{argument}[1][a]{\\textbf{Argument #1:}}{aa}\\begin{argument}b\\end{argument}'
       ),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\newenvironment{argument}[1][a]{\\textbf{Argument #1:}}{aa}\\begin{argument}b\\end{argument}\" display=\"block\">
-      <mtext mathvariant=\"bold\" data-latex=\"\\textbf{Argument a:}\">Argument a:</mtext>
-      <mi data-latex=\"b\">b</mi>
-      <mi data-latex=\"a\">a</mi>
-      <mi data-latex=\"a\">a</mi>
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\newenvironment{argument}[1][a]{\\textbf{Argument #1:}}{aa}\\begin{argument}b\\end{argument}" display="block">
+      <mtext mathvariant="bold" data-latex="\\textbf{Argument a:}">Argument a:</mtext>
+      <mi data-latex="b">b</mi>
+      <mi data-latex="a">a</mi>
+      <mi data-latex="a">a</mi>
     </math>`
     ));
   it('Newenvironment Arg Optional', () =>
@@ -773,12 +773,168 @@ describe('NewcommandError', () => {
   it('Missing End Error', () =>
     toXmlMatch(
       tex2mml('\\newenvironment{env}{aa}{bb}\\begin{env}cc'),
-      `<math xmlns=\"http://www.w3.org/1998/Math/MathML\" data-latex=\"\\newenvironment{env}{aa}{bb}\\begin{env}cc\" display=\"block\">
-      <merror data-mjx-error=\"Missing \\end{env}\">
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\newenvironment{env}{aa}{bb}\\begin{env}cc" display="block">
+      <merror data-mjx-error="Missing \\end{env}">
         <mtext>Missing \\end{env}</mtext>
       </merror>
     </math>`
     ));
+});
+
+describe('Newcommand Overrides', () => {
+  beforeEach(() => setupTex(['base', 'newcommand']));
+  it('Let def macro be undefined', () =>
+     toXmlMatch(
+       tex2mml('\\def\\test{error} \\let\\test=\\undefined \\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\test{error} \\let\\test=\\undefined \\test" display="block">
+      <merror data-mjx-error="Undefined control sequence \\test">
+        <mtext>Undefined control sequence \\test</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Let existing macro be undefined', () =>
+     toXmlMatch(
+       tex2mml('\\let\\sqrt=\\undefined \\sqrt{x}'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\sqrt=\\undefined \\sqrt{x}" display="block">
+      <merror data-mjx-error="Undefined control sequence \\sqrt">
+        <mtext>Undefined control sequence \\sqrt</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Let existing delimiter be undefined', () =>
+     toXmlMatch(
+       tex2mml('\\let\\|=\\undefined \\left\\| X \\right\\|'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\|=\\undefined \\left\\| X \\right\\|" display="block">
+      <merror data-mjx-error="Missing or unrecognized delimiter for \\left">
+        <mtext>Missing or unrecognized delimiter for \\left</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Let after def of existing macro be undefined', () =>
+     toXmlMatch(
+       tex2mml('\\def\\sqrt{X} \\let\\sqrt=\\undefined \\sqrt{x}'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\sqrt{X} \\let\\sqrt=\\undefined \\sqrt{x}" display="block">
+      <merror data-mjx-error="Undefined control sequence \\sqrt">
+        <mtext>Undefined control sequence \\sqrt</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Def overrides let delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\let\\test=\\| \\def\\test{x} \\left\\test X \\right\\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\test=\\| \\def\\test{x} \\left\\test X \\right\\test" display="block">
+      <merror data-mjx-error="Missing or unrecognized delimiter for \\left">
+        <mtext>Missing or unrecognized delimiter for \\left</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Def overrides let delimiter as macro', () =>
+     toXmlMatch(
+       tex2mml('\\let\\test=\\| \\def\\test{x} \\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\test=\\| \\def\\test{x} \\test" display="block">
+      <mi data-latex="x">x</mi>
+    </math>`
+     ));
+  it('Def overrides existing delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\def\\|{x} \\left\\| X \\right\\|'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\|{x} \\left\\| X \\right\\|" display="block">
+      <merror data-mjx-error="Missing or unrecognized delimiter for \\left">
+        <mtext>Missing or unrecognized delimiter for \\left</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Def overrides existing delimiter as macro', () =>
+     toXmlMatch(
+       tex2mml('\\def\\|{x} \\|'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\|{x} \\|" display="block">
+      <mi data-latex="x">x</mi>
+    </math>`
+     ));
+  it('Let overrides def macro', () =>
+     toXmlMatch(
+       tex2mml('\\def\\test{x} \\let\\test=\\| \\test X \\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\test{x} \\let\\test=\\| \\test X \\test" display="block">
+      <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\test">&#x2016;</mo>
+      <mi data-latex="X">X</mi>
+      <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\test">&#x2016;</mo>
+    </math>`
+     ));
+  it('Let overrides def macro as delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\def\\test{x} \\let\\test=\\| \\left\\test X \\right\\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\test{x} \\let\\test=\\| \\left\\test X \\right\\test" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\test X \\right\\test" data-latex="\\def\\test{x} \\let\\test=\\| \\left\\test X \\right\\test">
+        <mo data-mjx-texclass="OPEN" symmetric="true" data-latex-item="\\left\\test " data-latex="\\left\\test ">&#x2016;</mo>
+        <mi data-latex="X">X</mi>
+        <mo data-mjx-texclass="CLOSE" symmetric="true" data-latex-item="\\right\\test" data-latex="\\right\\test">&#x2016;</mo>
+      </mrow>
+    </math>`
+     ));
+  it('Let overrides existing macro', () =>
+     toXmlMatch(
+       tex2mml('\\let\\sqrt=\\| \\sqrt X'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\sqrt=\\| \\sqrt X" display="block">
+      <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\sqrt">&#x2016;</mo>
+      <mi data-latex="X">X</mi>
+    </math>`
+     ));
+  it('Let overrides existing macro as delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\let\\sqrt=\\| \\left\\sqrt X \\right\\sqrt'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\sqrt=\\| \\left\\sqrt X \\right\\sqrt" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\sqrt X \\right\\sqrt" data-latex="\\let\\sqrt=\\| \\left\\sqrt X \\right\\sqrt">
+        <mo data-mjx-texclass="OPEN" symmetric="true" data-latex-item="\\left\\sqrt " data-latex="\\left\\sqrt ">&#x2016;</mo>
+        <mi data-latex="X">X</mi>
+        <mo data-mjx-texclass="CLOSE" symmetric="true" data-latex-item="\\right\\sqrt" data-latex="\\right\\sqrt">&#x2016;</mo>
+      </mrow>
+    </math>`
+     ));
+  it('Let overrides delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\let\\|=\\sqrt \\left\\| X \\right\\|'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\|=\\sqrt \\left\\| X \\right\\|" display="block">
+      <merror data-mjx-error="Missing or unrecognized delimiter for \\left">
+        <mtext>Missing or unrecognized delimiter for \\left</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Let overrides delimiter as macro', () =>
+     toXmlMatch(
+       tex2mml('\\let\\|=\\sqrt \\| X'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\|=\\sqrt \\| X" display="block">
+      <msqrt data-latex="\\let\\|=\\sqrt \\| X">
+        <mi data-latex="X">X</mi>
+      </msqrt>
+    </math>`
+     ));
+  it('Let of character macro overrides delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\let\\|=\\alpha \\left\\| X \\right\\|'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\|=\\alpha \\left\\| X \\right\\|" display="block">
+      <merror data-mjx-error="Missing or unrecognized delimiter for \\left">
+        <mtext>Missing or unrecognized delimiter for \\left</mtext>
+      </merror>
+    </math>`
+     ));
+  it('Let of character creates delimiter', () =>
+     toXmlMatch(
+       tex2mml('\\let\\test=< \\left\\test X \\right\\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\test=&lt; \\left\\test X \\right\\test" display="block">
+      <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\test X \\right\\test" data-latex="\\let\\test=&lt; \\left\\test X \\right\\test">
+        <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\test " data-latex="\\left\\test ">&#x27E8;</mo>
+        <mi data-latex="X">X</mi>
+        <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\test" data-latex="\\right\\test">&#x27E8;</mo>
+      </mrow>
+    </math>`
+     ));
+  it('Let of character overrides def', () =>
+     toXmlMatch(
+       tex2mml('\\def\\test{X}\\let\\test=< \\test'),
+       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\test{X}\\let\\test=&lt; \\test" display="block">
+      <mo fence="false" stretchy="false" data-latex="\\def\\test{X}\\let\\test=&lt; \\test">&#x27E8;</mo>
+    </math>`
+     ));
 });
 
 afterAll(() => getTokens('newcommand'));

--- a/testsuite/tsconfig.json
+++ b/testsuite/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./js",
-    "moduleResolution": "node",
     "paths": {
       "#js/*": ["../mjs/*"],
       "#source/*": ["../components/mjs/*"],

--- a/ts/input/tex/MapHandler.ts
+++ b/ts/input/tex/MapHandler.ts
@@ -22,7 +22,7 @@
  */
 
 import { HandlerType } from './HandlerTypes.js';
-import { AbstractTokenMap, TokenMap } from './TokenMap.js';
+import { AbstractTokenMap, TokenMap, CharacterMap } from './TokenMap.js';
 import { ParseInput, ParseResult, ParseMethod } from './Types.js';
 import { PrioritizedList } from '../../util/PrioritizedList.js';
 import { FunctionList } from '../../util/FunctionList.js';
@@ -58,6 +58,8 @@ export const MapHandler = {
  * Class of token mappings that are active in a configuration.
  */
 export class SubHandler {
+  public static FALLBACK = Symbol('fallback');
+
   private _configuration: PrioritizedList<TokenMap> =
     new PrioritizedList<TokenMap>();
   private _fallback: FunctionList = new FunctionList();
@@ -96,6 +98,9 @@ export class SubHandler {
   public parse(input: ParseInput): ParseResult {
     for (const { item: map } of this._configuration) {
       const result = map.parse(input);
+      if (result === SubHandler.FALLBACK) {
+        break;
+      }
       if (result) {
         return result;
       }
@@ -149,6 +154,9 @@ export class SubHandler {
   public applicable(token: string): TokenMap {
     for (const { item: map } of this._configuration) {
       if (map.contains(token)) {
+        if (map instanceof CharacterMap && map.lookup(token).char === null) {
+          return null;
+        }
         return map;
       }
     }

--- a/ts/input/tex/Types.ts
+++ b/ts/input/tex/Types.ts
@@ -32,7 +32,7 @@ export type Attributes = Record<string, Args>;
 export type Environment = Record<string, Args>;
 
 export type ParseInput = [TexParser, string];
-export type ParseResult = void | boolean | StackItem;
+export type ParseResult = void | boolean | StackItem | symbol;
 
 export type ParseMethod = (
   parser: TexParser,


### PR DESCRIPTION
This PR fixes some problems with the `newcommand` package where definitions for macros and delimiters don't always stay synchronized (e.g., `\let\|=\sqrt \left\| X \right\|` should produce an error but doesn't currently).

In order to manage this, the `addMacro()` and `addDelimiter()` methods in `NewcommandUtil` are modified to keep the macro and delimiter mappings in sync.  One approach would have been to delete a delimiter when a corresponding macro is defined, for instance; but we don't want to remove delimiters from the main `delimiter` mapping, as that is global, and might be in use by other TeX input jax.  Had we done this, changes in one TeX input jax would affect all others.  In particular, with the jest tests, where the TeX input has is re-instantiated for each test, would see previous tests affect later ones, for example.

In order to avoid that problem, we the ability to have definitions that force the parsing of macros and delimiters to terminate and drop directly to the fallback method.  For macros, if the parse function returns a new special symbol, that causes the parse loop to terminate early and go to the fallback method.  For delimiters, if the character is `null`, that terminates the lookup in the `applicable()` method.  These are the changes in the `MapHandler.ts` file.

The structure of the `Let()` method in `NewcommandMethods.ts` is reorganized a bit to break out the various cases for the defining control sequence (macro vs. character vs. delimiter), and to include a new case where the macro becomes undefined (in the past, `\def\test{\text{Wrong!}} \let\test=\undefined \test` would produce `Wrong!` rather than an undefined macro error, as it should). 

The case for a CharacterMap now excludes DelimiterMap, since something like `\let\test=<` would find the delimiter definition and use that to create `\test` as a macro rather than a delimiter.  For example, `\def\test{X}\let\test=< \test` used to produce `X` rather than `⟨`.

Finally, 17 new tests are added to check for the various interactions of macros and delimiters.  With this PR, together with `fix/3300-tests` all the tests should now pass.