### PR TITLE
include a11y in default settings, and fix a number of problems with changing menu values.  (mathjax/MathJax#3310)

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -223,6 +223,9 @@ export class SpeechExplorer
    * @override
    */
   public FocusIn(event: FocusEvent) {
+    if (this.item.outputData.nofocus) {
+      return;
+    }
     if (this.mousedown) {
       this.mousedown = false;
       return;

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -342,12 +342,13 @@ export abstract class Startup {
   public static typesetPromise(elements: any[]): Promise<void> {
     Startup.document.options.elements = elements;
     Startup.document.reset();
-    return Startup.mathjax.handleRetriesFor(() => {
+    Startup.rerenderPromise = Startup.promise = Startup.mathjax.handleRetriesFor(() => {
       Startup.document.render();
       const promise = Promise.all(Startup.document.renderPromises);
       Startup.document.renderPromises = [];
       return promise;
     });
+    return Startup.promise;
   }
 
   /**

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -342,12 +342,13 @@ export abstract class Startup {
   public static typesetPromise(elements: any[]): Promise<void> {
     Startup.document.options.elements = elements;
     Startup.document.reset();
-    Startup.rerenderPromise = Startup.promise = Startup.mathjax.handleRetriesFor(() => {
-      Startup.document.render();
-      const promise = Promise.all(Startup.document.renderPromises);
-      Startup.document.renderPromises = [];
-      return promise;
-    });
+    Startup.rerenderPromise = Startup.promise =
+      Startup.mathjax.handleRetriesFor(() => {
+        Startup.document.render();
+        const promise = Promise.all(Startup.document.renderPromises);
+        Startup.document.renderPromises = [];
+        return promise;
+      });
     return Startup.promise;
   }
 

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -405,11 +405,7 @@ export abstract class CommonOutputJax<
       this.getLinebreakWidth();
     }
     const inlineMarked = !!math.root.getProperty('inlineMarked');
-    if (
-      this.options.linebreaks.inline &&
-      !math.display &&
-      !inlineMarked
-    ) {
+    if (this.options.linebreaks.inline && !math.display && !inlineMarked) {
       this.markInlineBreaks(math.root.childNodes?.[0]);
       math.root.setProperty('inlineMarked', true);
     } else if (!this.options.linebreaks.inline && inlineMarked) {

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -404,13 +404,17 @@ export abstract class CommonOutputJax<
     if (linebreak) {
       this.getLinebreakWidth();
     }
+    const inlineMarked = !!math.root.getProperty('inlineMarked');
     if (
       this.options.linebreaks.inline &&
       !math.display &&
-      !math.outputData.inlineMarked
+      !inlineMarked
     ) {
       this.markInlineBreaks(math.root.childNodes?.[0]);
-      math.outputData.inlineMarked = true;
+      math.root.setProperty('inlineMarked', true);
+    } else if (!this.options.linebreaks.inline && inlineMarked) {
+      this.unmarkInlineBreaks(math.root);
+      math.root.setProperty('inlineMarked', false);
     }
     math.root.setTeXclass(null);
     const wrapper = this.factory.wrap(math.root);
@@ -586,6 +590,21 @@ export abstract class CommonOutputJax<
       marked = true;
     }
     return marked;
+  }
+
+  /**
+   * @param {MmlNode} node   The node where inline breaks are to be removed
+   */
+  public unmarkInlineBreaks(node: MmlNode) {
+    if (!node) return;
+    node.removeProperty('forcebreak');
+    node.removeProperty('breakable');
+    if (node.getProperty('process-breaks')) {
+      node.removeProperty('process-breaks');
+      for (const child of node.childNodes) {
+        this.unmarkInlineBreaks(child);
+      }
+    }
   }
 
   /**

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1220,12 +1220,12 @@ export class CommonWrapper<
       return ['left', 0];
     }
     if (!align || align === 'auto') {
-      align = this.jax.math.outputData.inlineMarked
+      align = this.jax.math.root.getProperty('inlineMarked')
         ? 'left'
         : this.jax.options.displayAlign;
     }
     if (!shift || shift === 'auto') {
-      shift = this.jax.math.outputData.inlineMarked
+      shift = this.jax.math.root.getProperty('inlineMarked')
         ? '0'
         : this.jax.options.displayIndent;
     }

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -56,11 +56,6 @@ export class MJContextMenu extends ContextMenu {
   public mathItem: MathItem<HTMLElement, Text, Document> = null;
 
   /**
-   * True when the menu is posted while the explorer is in operation
-   */
-  public refocus: boolean = false;
-
-  /**
    * The document options
    */
   public settings: OptionList;
@@ -85,8 +80,6 @@ export class MJContextMenu extends ContextMenu {
    */
   public post(x?: any, y?: number) {
     if (this.mathItem) {
-      this.refocus =
-        document.activeElement.nodeName.toLowerCase() !== 'mjx-container';
       if (y !== undefined) {
         this.getOriginalMenu();
         this.getSemanticsMenu();
@@ -106,20 +99,8 @@ export class MJContextMenu extends ContextMenu {
    * @override
    */
   public unpost() {
-    this.mathItem = null;
-    if (this.refocus) {
-      super.unpost();
-      return;
-    }
-    //
-    // Prevent store.active.focus() from refocusing the menu in super.unpost()
-    //   (no pretty way to do it without making changes to mj-context-menu)
-    //
-    const store = this.store;
-    const active = store.active;
-    (store as any)._active = document.body;
     super.unpost();
-    store.active = active;
+    this.mathItem.outputData.nofocus = false;
   }
 
   /*======================================================================*/

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -85,7 +85,8 @@ export class MJContextMenu extends ContextMenu {
    */
   public post(x?: any, y?: number) {
     if (this.mathItem) {
-      this.refocus = document.activeElement.nodeName.toLowerCase() !== 'mjx-container';
+      this.refocus =
+        document.activeElement.nodeName.toLowerCase() !== 'mjx-container';
       if (y !== undefined) {
         this.getOriginalMenu();
         this.getSemanticsMenu();

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -56,6 +56,11 @@ export class MJContextMenu extends ContextMenu {
   public mathItem: MathItem<HTMLElement, Text, Document> = null;
 
   /**
+   * True when the menu is posted while the explorer is in operation
+   */
+  public refocus: boolean = false;
+
+  /**
    * The document options
    */
   public settings: OptionList;
@@ -80,6 +85,7 @@ export class MJContextMenu extends ContextMenu {
    */
   public post(x?: any, y?: number) {
     if (this.mathItem) {
+      this.refocus = document.activeElement.nodeName.toLowerCase() !== 'mjx-container';
       if (y !== undefined) {
         this.getOriginalMenu();
         this.getSemanticsMenu();
@@ -99,9 +105,20 @@ export class MJContextMenu extends ContextMenu {
    * @override
    */
   public unpost() {
-    super.unpost();
-    this.mathItem?.typesetRoot?.blur();
     this.mathItem = null;
+    if (this.refocus) {
+      super.unpost();
+      return;
+    }
+    //
+    // Prevent store.active.focus() from refocusing the menu in super.unpost()
+    //   (no pretty way to do it without making changes to mj-context-menu)
+    //
+    const store = this.store;
+    const active = store.active;
+    (store as any)._active = document.body;
+    super.unpost();
+    store.active = active;
   }
 
   /*======================================================================*/

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -499,11 +499,11 @@ export class Menu {
     this.jax[jax.name] = jax;
     this.settings.renderer = jax.name;
     this.settings.scale = jax.options.scale;
-    this.defaultSettings = Object.assign({}, this.settings);
     this.settings.overflow =
       jax.options.displayOverflow.substring(0, 1).toUpperCase() +
       jax.options.displayOverflow.substring(1).toLowerCase();
     this.settings.breakInline = jax.options.linebreaks.inline;
+    this.defaultSettings = Object.assign({}, this.document.options.a11y, this.settings);
   }
 
   /**
@@ -1019,7 +1019,9 @@ export class Menu {
    */
   protected setOverflow(overflow: string) {
     this.document.outputJax.options.displayOverflow = overflow.toLowerCase();
-    this.document.rerender();
+    if (!Menu.loading) {
+      this.document.rerender();
+    }
   }
 
   /**
@@ -1027,7 +1029,9 @@ export class Menu {
    */
   protected setInlineBreaks(breaks: boolean) {
     this.document.outputJax.options.linebreaks.inline = breaks;
-    this.document.rerender();
+    if (!Menu.loading) {
+      this.document.rerender();
+    }
   }
 
   /**
@@ -1035,7 +1039,9 @@ export class Menu {
    */
   protected setScale(scale: string) {
     this.document.outputJax.options.scale = parseFloat(scale);
-    this.document.rerender();
+    if (!Menu.loading) {
+      this.document.rerender();
+    }
   }
 
   /**
@@ -1277,15 +1283,17 @@ export class Menu {
     Menu.loading++; // pretend we're loading, to suppress rerendering for each variable change
     const pool = this.menu.pool;
     const settings = this.defaultSettings;
-    for (const name of Object.keys(this.settings) as (keyof MenuSettings)[]) {
+    for (const name of Object.keys(settings) as (keyof MenuSettings)[]) {
       const variable = pool.lookup(name);
       if (variable) {
-        variable.setValue(settings[name] as string | boolean);
-        const item = (variable as any).items[0];
-        if (item) {
-          item.executeCallbacks_();
+        if (variable.getValue() !== settings[name]) {
+          variable.setValue(settings[name] as string | boolean);
+          const item = (variable as any).items[0];
+          if (item) {
+            item.executeCallbacks_();
+          }
         }
-      } else {
+      } else if (Object.hasOwn(this.settings, name)) {
         (this.settings as any)[name] = settings[name];
       }
     }
@@ -1366,6 +1374,13 @@ export class Menu {
       this.document = startup.document = startup.getDocument();
       this.document.menu = this;
       this.setA11y(this.settings);
+      this.defaultSettings =
+        Object.assign(
+          {},
+          this.document.options.a11y,
+          MathJax.config?.options?.a11y || {},
+          this.defaultSettings
+        );
       this.document.outputJax.reset();
       this.transferMathList(document);
       this.document.processed = document.processed;
@@ -1468,11 +1483,8 @@ export class Menu {
     math.root = root.copy(true);
     math.root.setInheritedAttributes({}, math.display, 0, false);
     if (breaks) {
-      math.root.walkTree((n) => {
-        n.removeProperty('process-breaks');
-        n.removeProperty('forcebreak');
-        n.removeProperty('breakable');
-      });
+      jax.unmarkInlineBreaks(math.root);
+      math.root.setProperty('inlineMarked', false);
     }
     const promise = mathjax.handleRetriesFor(() => {
       jax.toDOM(math, div, jax.document);
@@ -1554,6 +1566,7 @@ export class Menu {
    * @param {number=} start   The state at which to start rerendering
    */
   protected rerender(start: number = STATE.TYPESET) {
+    this.menu.refocus = false;
     this.rerenderStart = Math.min(start, this.rerenderStart);
     const startup = MathJax.startup;
     if (!Menu.loading && startup.rerenderPromise) {

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -503,7 +503,11 @@ export class Menu {
       jax.options.displayOverflow.substring(0, 1).toUpperCase() +
       jax.options.displayOverflow.substring(1).toLowerCase();
     this.settings.breakInline = jax.options.linebreaks.inline;
-    this.defaultSettings = Object.assign({}, this.document.options.a11y, this.settings);
+    this.defaultSettings = Object.assign(
+      {},
+      this.document.options.a11y,
+      this.settings
+    );
   }
 
   /**
@@ -1374,13 +1378,12 @@ export class Menu {
       this.document = startup.document = startup.getDocument();
       this.document.menu = this;
       this.setA11y(this.settings);
-      this.defaultSettings =
-        Object.assign(
-          {},
-          this.document.options.a11y,
-          MathJax.config?.options?.a11y || {},
-          this.defaultSettings
-        );
+      this.defaultSettings = Object.assign(
+        {},
+        this.document.options.a11y,
+        MathJax.config?.options?.a11y || {},
+        this.defaultSettings
+      );
       this.document.outputJax.reset();
       this.transferMathList(document);
       this.document.processed = document.processed;

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1638,7 +1638,10 @@ export class Menu {
     const element = math.typesetRoot;
     element.addEventListener(
       'contextmenu',
-      () => (this.menu.mathItem = math, math.outputData.nofocus = true),
+      () => {
+        this.menu.mathItem = math;
+        math.outputData.nofocus = true;
+      },
       true
     );
     element.addEventListener(

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1569,7 +1569,6 @@ export class Menu {
    * @param {number=} start   The state at which to start rerendering
    */
   protected rerender(start: number = STATE.TYPESET) {
-    this.menu.refocus = false;
     this.rerenderStart = Math.min(start, this.rerenderStart);
     const startup = MathJax.startup;
     if (!Menu.loading && startup.rerenderPromise) {
@@ -1639,7 +1638,7 @@ export class Menu {
     const element = math.typesetRoot;
     element.addEventListener(
       'contextmenu',
-      () => (this.menu.mathItem = math),
+      () => (this.menu.mathItem = math, math.outputData.nofocus = true),
       true
     );
     element.addEventListener(

--- a/ts/ui/menu/MenuUtil.ts
+++ b/ts/ui/menu/MenuUtil.ts
@@ -21,12 +21,13 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import {context} from '../../util/context.js';
+import { context } from '../../util/context.js';
 
 /**
  * True when platform is a Mac (so we can enable CMD menu item for zoom trigger)
  */
-export const isMac = context.window?.navigator?.platform?.substring(0, 3) === 'Mac';
+export const isMac =
+  context.window?.navigator?.platform?.substring(0, 3) === 'Mac';
 
 /**
  * @param {string} text   The text to be copied to the clipboard


### PR DESCRIPTION
This PR fixes a number of problems that occur when menu values are changed, and in particular, when the menu values are reset to their defaults.

The fixes include the following:

1.  Resetting the menu to default values should force the math to be retypeset, but instead caused the math to disappear.  This was due to the initial typesetting not setting the `MathJax.startup.rerenderPromise`, so that has been added, here.

2.  Turning off inline breaking would not remove the current inline breaks.  This was due to the fact the inline breaks are handled via properties of the internal MathML nodes, and they were not being cleared.  This PR adds code to clear those properties.  It also moves the marker that the math has inline breaks from the `outputData` object (which is cleared when the state is set to before the math is rendered, so the flag was being lost) to a property of the top-level math node.

3.  In the past, a menu that is produced by a mouse click (rather than pressing space on a focused expression) could cause the expression to become focused even when it has been re-rendered, which could leave the expression in a partially active state.  We add a `refocus` property to the `MJContextMenu` class to track whether we should refocus the expression or not.  This requires a little trickery because there is no easy way to tell `mj-context-menu` not to call `store.active.focus()` during the `unpost()` method for the menu.  A better solution would be to add a feature to `mj-context-menu` to control that (say via an argument to `unpost()`)

4.  The `a11y` options weren't being reset by the "reset to defaults" menu item because the values being reset where based on the keys of the `menu.settings`object.  This PR changes that to use the `defaultSettings` keys instead, and to include the `a11y` values in the `defaultSettings` object.  Because the explorer can be loaded dynamically (if it is not included in the combined component, or if individual components are loaded separately), the `defaultSettings` may need to be augmented when the explorer is loaded.

5.  Finally, the reset code was changed to only reset the values that have changed, and to prevent multiple re-renderings of the document during the reset.

This resolves issue mathjax/MathJax#3310, and fixes several other items not indicated there.