### PR TITLE
Fix more problems from #1146

### DIFF
--- a/testsuite/tests/input/tex/Ams.test.ts
+++ b/testsuite/tests/input/tex/Ams.test.ts
@@ -556,7 +556,7 @@ describe('Ams Environments', () => {
       tex2mml('\\begin{subarray}{c}a\\end{subarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{subarray}{c}a\\end{subarray}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{subarray}" data-latex="\\begin{subarray}{c}a\\end{subarray}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em">
       <mtr data-latex-item="{c}" data-latex="{c}">
         <mtd>
           <mi data-latex="a">a</mi>
@@ -571,7 +571,7 @@ describe('Ams Environments', () => {
       tex2mml('\\begin{smallmatrix}a\\end{smallmatrix}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mi data-latex="a">a</mi>
@@ -585,7 +585,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{align} a&=b \\\\ c&=d \\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -617,7 +617,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{align*} a&=b \\\\ c&=d \\end{align*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -649,7 +649,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b \\\\ c \\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -672,7 +672,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -697,7 +697,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{split} r&=s\\\\ & =t \\end{split} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -707,7 +707,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
+          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
             <mtr>
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -753,7 +753,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather} a=b \\\\ c=d \\end{gather}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}" display="block">
-  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
+  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -775,7 +775,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather*} a=b \\\\ c=d \\end{gather*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}" display="block">
-  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
+  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -797,7 +797,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat}{2} a&=b \\\\ c&=d \\end{alignat}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
     <mtr data-latex-item="{2}" data-latex="{2}">
       <mtd>
         <mi data-latex="a">a</mi>
@@ -829,7 +829,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat*}{2} a&=b \\\\ c&=d \\end{alignat*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
     <mtr data-latex-item="{2}" data-latex="{2}">
       <mtd>
         <mi data-latex="a">a</mi>
@@ -863,7 +863,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{alignedat}{2} r&=s\\\\ & =t \\end{alignedat} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -873,7 +873,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
+          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
             <mtr data-latex-item="{2}" data-latex="{2}">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -921,7 +921,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{aligned} r&=s\\\\ & =t \\end{aligned} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -931,7 +931,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
+          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -979,7 +979,7 @@ describe('Ams Environments', () => {
         '\\begin{align*} a&=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -989,7 +989,7 @@ describe('Ams Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
+          <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1040,7 +1040,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray} a & = & b\\\\ c & = & d \\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}" display="block">
-  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
+  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1076,7 +1076,7 @@ describe('Ams Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray*} a & = & b\\\\ c & = & d \\end{eqnarray*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}" display="block">
-  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
+  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1117,7 +1117,7 @@ describe('Ams Labelled Environments', () => {
       tex2mml('\\begin{subarray}{c}a\\end{subarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{subarray}{c}a\\end{subarray}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{subarray}" data-latex="\\begin{subarray}{c}a\\end{subarray}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em">
       <mtr data-latex-item="{c}" data-latex="{c}">
         <mtd>
           <mi data-latex="a">a</mi>
@@ -1132,7 +1132,7 @@ describe('Ams Labelled Environments', () => {
       tex2mml('\\begin{smallmatrix}a\\end{smallmatrix}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix}a\\end{smallmatrix}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mi data-latex="a">a</mi>
@@ -1146,7 +1146,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{align} a&=b \\\\ c&=d \\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} a&amp;=b \\\\ c&amp;=d \\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1184,7 +1184,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{align*} a&=b \\\\ c&=d \\end{align*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1216,7 +1216,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b \\\\ c \\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b \\\\ c \\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1242,7 +1242,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline*}" data-latex="\\begin{multline*} a\\\\ b \\\\ c \\end{multline*}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1267,7 +1267,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{split} r&=s\\\\ & =t \\end{split} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{split} r&amp;=s\\\\ &amp; =t \\end{split} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1277,7 +1277,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
+          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{split}" data-latex="{split}">
             <mtr>
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1323,7 +1323,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather} a=b \\\\ c=d \\end{gather}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}" display="block">
-  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
+  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather} a=b \\\\ c=d \\end{gather}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1351,7 +1351,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather*} a=b \\\\ c=d \\end{gather*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}" display="block">
-  <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
+  <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather*}" data-latex="\\begin{gather*} a=b \\\\ c=d \\end{gather*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1373,7 +1373,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat}{2} a&=b \\\\ c&=d \\end{alignat}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat}" data-latex="\\begin{alignat}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat}">
     <mlabeledtr data-latex-item="{2}" data-latex="{2}">
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1411,7 +1411,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{alignat*}{2} a&=b \\\\ c&=d \\end{alignat*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignat*}" data-latex="\\begin{alignat*}{2} a&amp;=b \\\\ c&amp;=d \\end{alignat*}">
     <mtr data-latex-item="{2}" data-latex="{2}">
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1445,7 +1445,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{alignedat}{2} r&=s\\\\ & =t \\end{alignedat} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{alignedat}{2} r&amp;=s\\\\ &amp; =t \\end{alignedat} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1455,7 +1455,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
+          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{alignedat}" data-latex="{alignedat}">
             <mtr data-latex-item="{2}" data-latex="{2}">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1503,7 +1503,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{aligned} r&=s\\\\ & =t \\end{aligned} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{aligned} r&amp;=s\\\\ &amp; =t \\end{aligned} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1513,7 +1513,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
+          <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{aligned}" data-latex="{aligned}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1561,7 +1561,7 @@ describe('Ams Labelled Environments', () => {
         '\\begin{align*} a&=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&=d \\end{align*}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align*}" data-latex="\\begin{align*} a&amp;=b \\begin{gathered} r=s\\\\  =t \\end{gathered} \\\\ c&amp;=d \\end{align*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1571,7 +1571,7 @@ describe('Ams Labelled Environments', () => {
           <mi></mi>
           <mo data-latex="=">=</mo>
           <mi data-latex="b">b</mi>
-          <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
+          <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gathered}" data-latex="{gathered}">
             <mtr data-latex-item=" " data-latex=" ">
               <mtd>
                 <mi data-latex="r">r</mi>
@@ -1608,7 +1608,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{equation} a \\end{equation}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation} a \\end{equation}" display="block">
-  <mtable data-latex-item="{equation}" data-latex="\\begin{equation} a \\end{equation}">
+  <mtable displaystyle="true" data-latex-item="{equation}" data-latex="\\begin{equation} a \\end{equation}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1631,7 +1631,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray} a & = & b\\\\ c & = & d \\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}" display="block">
-  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
+  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1673,7 +1673,7 @@ describe('Ams Labelled Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray*} a & = & b\\\\ c & = & d \\end{eqnarray*}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}" display="block">
-  <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
+  <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray*}" data-latex="\\begin{eqnarray*} a &amp; = &amp; b\\\\ c &amp; = &amp; d \\end{eqnarray*}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1874,7 +1874,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1897,7 +1897,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveleft a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1920,7 +1920,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1943,7 +1943,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveleft c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1966,7 +1966,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}\\shoveright a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="right">
         <mi data-latex="a">a</mi>
@@ -1989,7 +1989,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2012,7 +2012,7 @@ describe('MultlineShove', () => {
     toXmlMatch(
       tex2mml('\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\ b\\\\\\shoveright c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2037,7 +2037,7 @@ describe('MultlineShove', () => {
         '\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveright\\shoveleft b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2062,7 +2062,7 @@ describe('MultlineShove', () => {
         '\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline} a\\\\\\shoveleft\\shoveright b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -2126,7 +2126,7 @@ describe('Ams Complex', () => {
         '\\begin{align}\\dot{x} & = \\sigma(y-x) \\\\\\dot{y} & = \\rho x - y - xz \\\\\\dot{z} & = -\\beta z + xy\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}\\dot{x} &amp; = \\sigma(y-x) \\\\\\dot{y} &amp; = \\rho x - y - xz \\\\\\dot{z} &amp; = -\\beta z + xy\\end{align}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}\\dot{x} &amp; = \\sigma(y-x) \\\\\\dot{y} &amp; = \\rho x - y - xz \\\\\\dot{z} &amp; = -\\beta z + xy\\end{align}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}\\dot{x} &amp; = \\sigma(y-x) \\\\\\dot{y} &amp; = \\rho x - y - xz \\\\\\dot{z} &amp; = -\\beta z + xy\\end{align}">
     <mtr>
       <mtd>
         <mrow data-mjx-texclass="ORD" data-latex="\\dot{x}">
@@ -2203,7 +2203,7 @@ describe('Ams Complex', () => {
         '\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} & = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} & = 0 \\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} &amp; = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} &amp; = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} &amp; = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} &amp; = 0 \\end{align}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} &amp; = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} &amp; = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} &amp; = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} &amp; = 0 \\end{align}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align} \\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} &amp; = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\  \\nabla \\cdot \\vec{\\mathbf{E}} &amp; = 4 \\pi \\rho \\\\  \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} &amp; = \\vec{\\mathbf{0}} \\\\  \\nabla \\cdot \\vec{\\mathbf{B}} &amp; = 0 \\end{align}">
     <mtr>
       <mtd>
         <mi mathvariant="normal" data-latex="\\nabla">&#x2207;</mi>

--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -9,7 +9,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -79,7 +79,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @<<< B @>>> C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -142,7 +142,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>b> B\\\\@VlVrV @AlArA\\\\C @<a<b< D\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -234,7 +234,7 @@ describe('AmsCD', () => {
         '\\begin{CD}A @>>> B@>\\text{very long label}>>C\\\\@VVV @VVV @VVV\\\\D @>>> E@>>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -314,7 +314,7 @@ describe('AmsCD', () => {
         '\\begin{CD}A @>>> B @>{\\text{very long label}}>> C \\\\@VVV @VVV @VVV \\\\D @>>> E @>{\\phantom{\\text{very long label}}}>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -402,7 +402,7 @@ describe('AmsCD', () => {
         '\\begin{CD}A @>>> B @>{\\text{very long label}}>> C \\\\@VVV @VVV @VVV \\\\D @>>> E @>{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -500,7 +500,7 @@ describe('AmsCD', () => {
         '\\minCDarrowwidth{5cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -572,7 +572,7 @@ describe('AmsCD', () => {
         '\\minCDarrowheight{4cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -644,7 +644,7 @@ describe('AmsCD', () => {
         '\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
     <mtr>
       <mtd>
         <mi data-latex="A">A</mi>
@@ -714,7 +714,7 @@ describe('AmsCD', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @Ra>> BaD\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}" display="block">
-      <mtable columnspacing="5pt" rowspacing="5pt" data-latex-item="{CD}" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}">
+      <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}">
         <mtr>
           <mtd>
             <mi data-latex="A">A</mi>

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -2302,7 +2302,7 @@ describe('Matrix', () => {
     toXmlMatch(
       tex2mml('\\eqalignno{a&b&c}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalignno{a&amp;b&amp;c}" display="block">
-  <mtable rowspacing=".5em" columnspacing="0.278em" columnalign="right left" data-latex="\\eqalignno{a&amp;b&amp;c}">
+  <mtable rowspacing=".5em" columnspacing="0.278em" displaystyle="true" columnalign="right left" data-latex="\\eqalignno{a&amp;b&amp;c}">
     <mlabeledtr data-latex-item="{" data-latex="{">
       <mtd>
         <mi data-latex="c">c</mi>
@@ -2321,7 +2321,7 @@ describe('Matrix', () => {
     toXmlMatch(
       tex2mml('\\leqalignno{a&b&c}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\leqalignno{a&amp;b&amp;c}" display="block">
-      <mtable rowspacing=".5em" columnspacing="0.278em" side="left" columnalign="right left" data-latex="\\leqalignno{a&amp;b&amp;c}">
+      <mtable rowspacing=".5em" columnspacing="0.278em" side="left" displaystyle="true" columnalign="right left" data-latex="\\leqalignno{a&amp;b&amp;c}">
         <mlabeledtr data-latex-item="{" data-latex="{">
           <mtd>
             <mi data-latex="c">c</mi>
@@ -2340,7 +2340,7 @@ describe('Matrix', () => {
     toXmlMatch(
       tex2mml('\\eqalign{a&b&c}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalign{a&amp;b&amp;c}" display="block">
-      <mtable rowspacing=".5em" columnspacing="0.278em" columnalign="right left" data-latex="\\eqalign{a&amp;b&amp;c}">
+      <mtable rowspacing=".5em" columnspacing="0.278em" displaystyle="true" columnalign="right left" data-latex="\\eqalign{a&amp;b&amp;c}">
         <mtr data-latex-item="{" data-latex="{">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -2359,7 +2359,7 @@ describe('Matrix', () => {
     toXmlMatch(
       tex2mml('\\displaylines{a\\\\ b}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\displaylines{a\\\\ b}" display="block">
-      <mtable rowspacing=".5em" columnspacing="1em" data-latex="\\displaylines{a\\\\ b}">
+      <mtable rowspacing=".5em" columnspacing="1em" displaystyle="true" data-latex="\\displaylines{a\\\\ b}">
         <mtr data-latex-item="{" data-latex="{">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -2776,7 +2776,7 @@ describe('Array', () => {
     toXmlMatch(
       tex2mml('\\eqalignno{a &  & {\\hbox{(3)}}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}}" display="block">
-  <mtable rowspacing=".5em" columnspacing="0.278em" columnalign="right left" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}}">
+  <mtable rowspacing=".5em" columnspacing="0.278em" displaystyle="true" columnalign="right left" data-latex="\\eqalignno{a &amp;  &amp; {\\hbox{(3)}}}">
     <mlabeledtr data-latex-item="{" data-latex="{">
       <mtd>
         <mrow data-mjx-texclass="ORD" data-latex="{\\hbox{(3)}}">
@@ -4208,7 +4208,7 @@ describe('Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&=&b\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a&amp;=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4333,7 +4333,7 @@ describe('Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{darray}{c}a\\end{darray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{c}a\\end{darray}" display="block">
-      <mtable columnspacing="1em" rowspacing="4pt" data-latex-item="{darray}" data-latex="\\begin{darray}{c}a\\end{darray}">
+      <mtable columnspacing="1em" rowspacing="4pt" displaystyle="true" data-latex-item="{darray}" data-latex="\\begin{darray}{c}a\\end{darray}">
         <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4346,7 +4346,7 @@ describe('Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{darray}{c}a\\\\b\\end{darray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{c}a\\\\b\\end{darray}" display="block">
-      <mtable columnspacing="1em" rowspacing="4pt" data-latex-item="{darray}" data-latex="\\begin{darray}{c}a\\\\b\\end{darray}">
+      <mtable columnspacing="1em" rowspacing="4pt" displaystyle="true" data-latex-item="{darray}" data-latex="\\begin{darray}{c}a\\\\b\\end{darray}">
         <mtr data-latex-item="{c}" data-latex="{c}">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4364,7 +4364,7 @@ describe('Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{darray}{rcl}a&=&b\\end{darray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}" display="block">
-      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-latex-item="{darray}" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" displaystyle="true" data-latex-item="{darray}" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\end{darray}">
         <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4383,7 +4383,7 @@ describe('Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{darray}{rcl}a&=&b\\\\c&=&d\\end{darray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}" display="block">
-      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" data-latex-item="{darray}" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}">
+      <mtable columnspacing="1em" rowspacing="4pt" columnalign="right center left" displaystyle="true" data-latex-item="{darray}" data-latex="\\begin{darray}{rcl}a&amp;=&amp;b\\\\c&amp;=&amp;d\\end{darray}">
         <mtr data-latex-item="{rcl}" data-latex="{rcl}">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4464,7 +4464,7 @@ describe('BreakAlign', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{c}{t}a&=&b\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{c}{t}a&amp;=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd data-vertical-align="top">
             <mi data-latex="a">a</mi>
@@ -4486,7 +4486,7 @@ describe('BreakAlign', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a&\\breakAlign{c}{t}=&b\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a&amp;\\breakAlign{c}{t}=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4508,7 +4508,7 @@ describe('BreakAlign', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{r}{t}a&=&b\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\end{eqnarray}">
         <mtr data-break-align="top">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4530,7 +4530,7 @@ describe('BreakAlign', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{r}{t}a&=&b\\\\\\breakAlign{r}{t}c&=&d\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{t}a&amp;=&amp;b\\\\\\breakAlign{r}{t}c&amp;=&amp;d\\end{eqnarray}">
         <mtr data-break-align="top">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4566,7 +4566,7 @@ describe('BreakAlign', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{r}{tbmc}a&=&b\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-break-align="bottom middle top" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{r}{tbmc}a&amp;=&amp;b\\end{eqnarray}">
         <mtr data-break-align="top bottom middle center">
           <mtd>
             <mi data-latex="a">a</mi>
@@ -4588,7 +4588,7 @@ describe('BreakAlign', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}\\breakAlign{t}{t}a&=&b\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left" columnspacing="0em 0.278em" rowspacing="3pt" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}\\breakAlign{t}{t}a&amp;=&amp;b\\end{eqnarray}">
         <mtr>
           <mtd>
             <mi data-latex="a">a</mi>
@@ -9058,7 +9058,7 @@ describe('Referencing', () => {
     toXmlMatch(
       tex2mml('a\\label{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}" display="block">
-      <mtable data-latex="a\\label{A}">
+      <mtable displaystyle="true" data-latex="a\\label{A}">
         <mlabeledtr>
           <mtd id="mjx-eqn:A">
             <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -9074,7 +9074,7 @@ describe('Referencing', () => {
     toXmlMatch(
       tex2mml('a\\label{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{}" display="block">
-      <mtable data-latex="a\\label{}">
+      <mtable displaystyle="true" data-latex="a\\label{}">
         <mlabeledtr>
           <mtd id="mjx-eqn:1">
             <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -9090,7 +9090,7 @@ describe('Referencing', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}" display="block">
-      <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a\\label{A}\\\\c\\label{B}\\end{eqnarray}">
         <mlabeledtr>
           <mtd id="mjx-eqn:A">
             <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -9132,7 +9132,7 @@ describe('Referencing', () => {
     toXmlMatch(
       tex2mml('a\\label{A}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}\\ref{A}" display="block">
-      <mtable data-latex="a\\label{A}\\ref{A}">
+      <mtable displaystyle="true" data-latex="a\\label{A}\\ref{A}">
         <mlabeledtr>
           <mtd id="mjx-eqn:A">
             <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -9151,7 +9151,7 @@ describe('Referencing', () => {
     toXmlMatch(
       tex2mml('a\\label{A}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\label{A}\\ref{B}" display="block">
-      <mtable data-latex="a\\label{A}\\ref{B}">
+      <mtable displaystyle="true" data-latex="a\\label{A}\\ref{B}">
         <mlabeledtr>
           <mtd id="mjx-eqn:A">
             <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -9170,7 +9170,7 @@ describe('Referencing', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}" display="block">
-      <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}a\\\\c\\nonumber\\end{eqnarray}">
         <mlabeledtr>
           <mtd id="mjx-eqn:1">
             <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -10035,7 +10035,7 @@ describe('Complete Array', () => {
     toXmlMatch(
       tex2mml('\\begin{eqnarray}{rcl}a & b \\\\d&c&c&c \\\\\\end{eqnarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}" display="block">
-      <mtable columnalign="right center left right" columnspacing="0em 0.278em 0em" rowspacing="3pt" data-break-align="bottom middle top bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}">
+      <mtable displaystyle="true" columnalign="right center left right" columnspacing="0em 0.278em 0em" rowspacing="3pt" data-break-align="bottom middle top bottom" data-latex-item="{eqnarray}" data-latex="\\begin{eqnarray}{rcl}a &amp; b \\\\d&amp;c&amp;c&amp;c \\\\\\end{eqnarray}">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{r c l}">
@@ -10225,7 +10225,7 @@ describe('User Defined Environments', () => {
       tex2mml('\\begin{smallmatrix} a & b \\\\ c & d \\end{smallmatrix}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}" display="block">
       <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}">
-        <mtable data-mjx-smallmatrix="true" columnspacing="1" rowspacing=".2em" displaystyle="false">
+        <mtable data-mjx-smallmatrix="true" columnspacing="1" rowspacing=".2em">
           <mtr>
             <mtd>
               <mi data-latex="a">a</mi>
@@ -10279,7 +10279,7 @@ describe('User Defined Environments', () => {
       tex2mml('\\begin{crampedsubarray}{cc} a & b \\\\ c & d \\end{crampedsubarray}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{crampedsubarray}{cc} a &amp; b \\\\ c &amp; d \\end{crampedsubarray}" display="block">
       <mstyle scriptlevel="1" data-latex-item="{crampedsubarray}" data-latex="\\begin{crampedsubarray}{cc} a &amp; b \\\\ c &amp; d \\end{crampedsubarray}">
-        <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" columnalign="center center" data-cramped="true" displaystyle="false">
+        <mtable data-mjx-smallmatrix="true" columnspacing="0em" rowspacing="0.1em" columnalign="center center" data-cramped="true">
           <mtr data-latex-item="{cc}" data-latex="{cc}">
             <mtd>
               <mi data-latex="a">a</mi>
@@ -10304,7 +10304,7 @@ describe('User Defined Environments', () => {
     toXmlMatch(
       tex2mml('\\begin{gather}a\\end{gather}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{gather}a\\end{gather}" display="block">
-      <mtable columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather}a\\end{gather}">
+      <mtable displaystyle="true" columnspacing="1em" rowspacing="3pt" data-break-align="middle" data-latex-item="{gather}" data-latex="\\begin{gather}a\\end{gather}">
         <mtr>
           <mtd>
             <mi data-latex="a">a</mi>

--- a/testsuite/tests/input/tex/Physics.test.ts
+++ b/testsuite/tests/input/tex/Physics.test.ts
@@ -8604,7 +8604,7 @@ describe('Physics7_11', () => {
       tex2mml('\\begin{smallmatrix} a & b \\\\ c & d \\end{smallmatrix}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\begin{smallmatrix} a &amp; b \\\\ c &amp; d \\end{smallmatrix}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mi data-latex="a">a</mi>
@@ -8630,7 +8630,7 @@ describe('Physics7_11', () => {
       tex2mml('\\smqty{\\imat{3}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty{\\imat{3}}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smqty{\\imat{3}}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9232,7 +9232,7 @@ describe('Physics7_2', () => {
       tex2mml('\\smallmatrixquantity{Q}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity{Q}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smallmatrixquantity{Q}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9248,7 +9248,7 @@ describe('Physics7_2', () => {
       tex2mml('\\smallmatrixquantity*{a & b \\\\ c & d}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smallmatrixquantity*{a &amp; b \\\\ c &amp; d}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9277,7 +9277,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right\\rgroup" data-latex="\\smallmatrixquantity*(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9308,7 +9308,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smallmatrixquantity(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9339,7 +9339,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smallmatrixquantity|a &amp; b \\\\ c &amp; d|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9368,7 +9368,7 @@ describe('Physics7_2', () => {
       tex2mml('\\smqty{a & b \\\\ c & d}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\smqty{a &amp; b \\\\ c &amp; d}" display="block">
   <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="\\smqty{a &amp; b \\\\ c &amp; d}">
-    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+    <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
       <mtr>
         <mtd>
           <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9397,7 +9397,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9428,7 +9428,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right\\rgroup" data-latex="\\smqty*(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9459,7 +9459,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right]" data-latex="\\smqty[a &amp; b \\\\ c &amp; d]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9490,7 +9490,7 @@ describe('Physics7_2', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smqty|a &amp; b \\\\ c &amp; d|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9524,7 +9524,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right)" data-latex="\\left(\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9538,7 +9538,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} R\\end{smallmatrix}\\right)" data-latex="\\left(\\begin{smallmatrix}{} R\\end{smallmatrix}\\right)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9558,7 +9558,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right\\rgroup" data-latex="\\left\\lgroup\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right\\rgroup">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9572,7 +9572,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} R\\end{smallmatrix}\\right\\rgroup" data-latex="\\left\\lgroup\\begin{smallmatrix}{} R\\end{smallmatrix}\\right\\rgroup">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9592,7 +9592,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right]" data-latex="\\left[\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9606,7 +9606,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} R\\end{smallmatrix}\\right]" data-latex="\\left[\\begin{smallmatrix}{} R\\end{smallmatrix}\\right]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9626,7 +9626,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right|" data-latex="\\left|\\begin{smallmatrix}{} Q\\end{smallmatrix}\\right|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9640,7 +9640,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} R\\end{smallmatrix}\\right|" data-latex="\\left|\\begin{smallmatrix}{} R\\end{smallmatrix}\\right|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9660,7 +9660,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left(\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right)" data-latex="\\smqty(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9691,7 +9691,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\lgroup\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right\\rgroup" data-latex="\\smqty*(a &amp; b \\\\ c &amp; d)">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\lgroup" data-latex="\\left\\lgroup">&#x27EE;</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9722,7 +9722,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left[\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right]" data-latex="\\smqty[a &amp; b \\\\ c &amp; d]">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left[" data-latex="\\left[">[</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9753,7 +9753,7 @@ describe('Physics7_3', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smqty|a &amp; b \\\\ c &amp; d|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9843,7 +9843,7 @@ describe('Physics7_4', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a &amp; b \\\\ c &amp; d\\end{smallmatrix}\\right|" data-latex="\\smqty|a &amp; b \\\\ c &amp; d| ">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -9910,7 +9910,7 @@ describe('Physics7_4', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left|\\begin{smallmatrix}{} a\\end{smallmatrix}\\right|" data-latex="\\left|\\begin{smallmatrix}{} a\\end{smallmatrix}\\right|">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left|" data-latex="\\left|">|</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10183,7 +10183,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 1\\\\ 1 &amp; 1 &amp; 1\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{1}{2}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10220,7 +10220,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; a\\\\ a &amp; a &amp; a\\\\ a &amp; a &amp; a\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{a}{3}{3}) ">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10268,7 +10268,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\\\ a\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{a}{3}{1}) ">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10298,7 +10298,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; a\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat{a}{1}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10324,7 +10324,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left}{1}} &amp; 1_{{1}{2}} &amp; 1_{{1}{3}}\\\\ 1_{{2}{1}} &amp; 1_{{2}{2}} &amp; 1_{{2}{3}}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{1}{2}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10421,7 +10421,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left}{1}} &amp; a_{{1}{2}} &amp; a_{{1}{3}}\\\\ a_{{2}{1}} &amp; a_{{2}{2}} &amp; a_{{2}{3}}\\\\ a_{{3}{1}} &amp; a_{{3}{2}} &amp; a_{{3}{3}}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{3}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10559,7 +10559,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\\\ a_{2}\\\\ a_{3}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{3}{1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10604,7 +10604,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; a_{2} &amp; a_{3}\\end{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{1}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10645,7 +10645,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{1}{1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10665,7 +10665,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left{smallmatrix}\\right)" data-latex="\\smqty(\\xmat*{a}{-1}{-1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10685,7 +10685,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 0\\end{smallmatrix}\\right)" data-latex="\\smqty(\\zmat{1}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10711,7 +10711,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left &amp; 0\\\\ 0 &amp; 0 &amp; 0\\end{smallmatrix}\\right)" data-latex="\\smqty(\\zmat{2}{3})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>
@@ -10748,7 +10748,7 @@ describe('Physics7_6', () => {
   <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\\\ 0\\end{smallmatrix}\\right)" data-latex="\\smqty(\\zmat{3}{1})">
     <mo data-mjx-texclass="OPEN" data-latex-item="\\left(" data-latex="\\left(">(</mo>
     <mstyle scriptlevel="1" data-latex-item="{smallmatrix}" data-latex="{smallmatrix}">
-      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em" displaystyle="false">
+      <mtable data-mjx-smallmatrix="true" columnspacing="0.333em" rowspacing=".2em">
         <mtr>
           <mtd>
             <mrow data-mjx-texclass="ORD" data-latex="{}"></mrow>

--- a/testsuite/tests/input/tex/Tag.test.ts
+++ b/testsuite/tests/input/tex/Tag.test.ts
@@ -8,7 +8,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('a'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a" display="block">
-  <mtable data-latex="a">
+  <mtable displaystyle="true"  data-latex="a">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -24,7 +24,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -40,7 +40,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -66,7 +66,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -82,7 +82,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -98,7 +98,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\notag\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -111,7 +111,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -134,7 +134,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -147,7 +147,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -166,7 +166,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -185,7 +185,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\eqref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\eqref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -204,7 +204,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a=b\\label{A}\\\\ c&=d \\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -273,7 +273,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -289,7 +289,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -305,7 +305,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -329,7 +329,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -353,7 +353,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -369,7 +369,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -385,7 +385,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -411,7 +411,7 @@ describe('TagAll', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -435,7 +435,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -454,7 +454,7 @@ describe('TagAll', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -475,7 +475,7 @@ describe('TagAll', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -507,7 +507,7 @@ describe('TagAll', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -548,7 +548,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('a\\tag{0}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\tag{0}" display="block">
-  <mtable data-latex="a\\tag{0}">
+  <mtable displaystyle="true" data-latex="a\\tag{0}">
     <mlabeledtr>
       <mtd id="mjx-eqn:0">
         <mtext data-latex="\\text{(0)}">(0)</mtext>
@@ -564,7 +564,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -577,7 +577,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{split}a\\end{split}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{split}a\\end{split}" display="block">
-  <mtable columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -590,7 +590,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -613,7 +613,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{}">a</mi>
@@ -626,7 +626,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -639,7 +639,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\notag\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -652,7 +652,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -675,7 +675,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -688,7 +688,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -704,7 +704,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -720,7 +720,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\eqref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\eqref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -781,7 +781,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -794,7 +794,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -810,7 +810,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -831,7 +831,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -855,7 +855,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -868,7 +868,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -884,7 +884,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -907,7 +907,7 @@ describe('TagNone', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -931,7 +931,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\label{A}">a</mi>
@@ -947,7 +947,7 @@ describe('TagNone', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -968,7 +968,7 @@ describe('TagNone', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -997,7 +997,7 @@ describe('TagNone', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1038,7 +1038,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1054,7 +1054,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{split}a\\end{split}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{split}a\\end{split}" display="block">
-  <mtable columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="0em" rowspacing="3pt" data-break-align="bottom" data-latex-item="{split}" data-latex="\\begin{split}a\\end{split}">
     <mtr>
       <mtd>
         <mi data-latex="a">a</mi>
@@ -1067,7 +1067,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1093,7 +1093,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1109,7 +1109,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1125,7 +1125,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\notag\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -1138,7 +1138,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}" display="block">
-  <mtable rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
+  <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\begin{multline}a\\\\ b\\\\ c\\notag\\end{multline}">
     <mtr>
       <mtd columnalign="left">
         <mi data-latex="a">a</mi>
@@ -1161,7 +1161,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\notag\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\notag\\end{align}">
     <mtr>
       <mtd>
         <mi data-latex="\\notag">a</mi>
@@ -1174,7 +1174,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1193,7 +1193,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1212,7 +1212,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\eqref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\eqref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1231,7 +1231,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a=b\\label{A}\\\\ c&=d \\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}" display="block">
-  <mtable columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" data-latex-item="{align}" data-latex="\\begin{align}a=b\\label{A}\\\\ c&amp;=d \\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1300,7 +1300,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:1">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1316,7 +1316,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1332,7 +1332,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1356,7 +1356,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\\\b\\tag{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1380,7 +1380,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1396,7 +1396,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1412,7 +1412,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1438,7 +1438,7 @@ describe('TagAms', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1462,7 +1462,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(1)}">(1)</mtext>
@@ -1481,7 +1481,7 @@ describe('TagAms', () => {
     toXmlMatch(
       tex2mml('\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\end{align}\\ref{A}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1502,7 +1502,7 @@ describe('TagAms', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>
@@ -1534,7 +1534,7 @@ describe('TagAms', () => {
         '\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}a\\tag{A}\\label{A}\\\\b\\tag{B}\\label{B}\\end{align}\\ref{A}\\ref{B}" display="block">
-  <mtable columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
+  <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="{align}">
     <mlabeledtr>
       <mtd id="mjx-eqn:A">
         <mtext data-latex="\\text{(A)}">(A)</mtext>

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -773,8 +773,14 @@ export abstract class AbstractMmlNode
         delete attributes[key];
       }
     }
-    this.attributes.setInherited('displaystyle', display);
-    this.attributes.setInherited('scriptlevel', level);
+    const displaystyle = this.attributes.getExplicit('displaystyle');
+    if (displaystyle === undefined) {
+      this.attributes.setInherited('displaystyle', display);
+    }
+    const scriptlevel = this.attributes.getExplicit('scriptlevel');
+    if (scriptlevel === undefined) {
+      this.attributes.setInherited('scriptlevel', level);
+    }
     if (prime) {
       this.setProperty('texprimestyle', prime);
     }

--- a/ts/core/MmlTree/MmlNodes/mstyle.ts
+++ b/ts/core/MmlTree/MmlNodes/mstyle.ts
@@ -61,6 +61,20 @@ export class MmlMstyle extends AbstractMmlLayoutNode {
   }
 
   /**
+   * @override
+   */
+  public setInheritedAttributes(
+    attributes: AttributeList = {},
+    display: boolean = false,
+    level: number = 0,
+    prime: boolean = false
+  ) {
+    this.attributes.setInherited('displaystyle', display);
+    this.attributes.setInherited('scriptlevel', level);
+    super.setInheritedAttributes(attributes, display, level, prime);
+  }
+
+  /**
    * Handle scriptlevel changes, and add mstyle attributes to the ones being inherited.
    *
    * @override


### PR DESCRIPTION
The changes in #1146 caused an unintended consequence of not making some tables be in display style, and I accidentally "fixed" the tests to match the wrong results during the massive update I did on the test output.  This PR fixes that problem with tables and returns the tests to their proper values.


