### PR TITLE
Make bboldx delimiters be plain characters, as in the actual package.

### DIFF
--- a/ts/input/tex/bboldx/BboldxConfiguration.ts
+++ b/ts/input/tex/bboldx/BboldxConfiguration.ts
@@ -39,10 +39,6 @@ Configuration.create('text-bboldx', {
       'text-bboldx-mathchar0miBold',
       'text-bboldx-delimiterBold',
     ],
-    [HandlerType.DELIMITER]: [
-      'text-bboldx-delimiterNormal',
-      'text-bboldx-delimiterBold',
-    ],
   },
 });
 
@@ -59,7 +55,6 @@ export const BboldxConfiguration = Configuration.create('bboldx', {
       'bboldx-mathchar0miBold',
       'bboldx-delimiterBold',
     ],
-    [HandlerType.DELIMITER]: ['bboldx-delimiterNormal', 'bboldx-delimiterBold'],
   },
   [ConfigurationType.OPTIONS]: {
     bboldx: {

--- a/ts/input/tex/bboldx/BboldxMappings.ts
+++ b/ts/input/tex/bboldx/BboldxMappings.ts
@@ -71,13 +71,13 @@ new CharacterMap('bboldx-mathchar0miNormal', BboldxMethods.mathchar0miNormal, {
 /**
  * Macros for delimiters.
  */
-new DelimiterMap('bboldx-delimiterNormal', BboldxMethods.delimiterNormal, {
-  '\\bbLparen': '\u0028',
-  '\\bbRparen': '\u0029',
-  '\\bbLbrack': '\u005B',
-  '\\bbRbrack': '\u005D',
-  '\\bbLangle': '\u2329',
-  '\\bbRangle': '\u232A',
+new CharacterMap('bboldx-delimiterNormal', BboldxMethods.delimiterNormal, {
+  bbLparen: '\u0028',
+  bbRparen: '\u0029',
+  bbLbrack: '\u005B',
+  bbRbrack: '\u005D',
+  bbLangle: '\u2329',
+  bbRangle: '\u232A',
 });
 
 /**
@@ -127,13 +127,13 @@ new CharacterMap('bboldx-mathchar0miBold', BboldxMethods.mathchar0miBold, {
 /**
  * Macros for delimiters.
  */
-new DelimiterMap('bboldx-delimiterBold', BboldxMethods.delimiterBold, {
-  '\\bfbbLparen': '\u0028',
-  '\\bfbbRparen': '\u0029',
-  '\\bfbbLbrack': '\u005B',
-  '\\bfbbRbrack': '\u005D',
-  '\\bfbbLangle': '\u2329',
-  '\\bfbbRangle': '\u232A',
+new CharacterMap('bboldx-delimiterBold', BboldxMethods.delimiterBold, {
+  bfbbLparen: '\u0028',
+  bfbbRparen: '\u0029',
+  bfbbLbrack: '\u005B',
+  bfbbRbrack: '\u005D',
+  bfbbLangle: '\u2329',
+  bfbbRangle: '\u232A',
 });
 
 new CommandMap('bboldx', {

--- a/ts/input/tex/bboldx/BboldxMappings.ts
+++ b/ts/input/tex/bboldx/BboldxMappings.ts
@@ -21,7 +21,7 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import { CommandMap, CharacterMap, DelimiterMap } from '../TokenMap.js';
+import { CommandMap, CharacterMap } from '../TokenMap.js';
 import { BboldxMethods } from './BboldxMethods.js';
 
 /**
@@ -207,7 +207,7 @@ new CharacterMap(
 /**
  * Macros for delimiters.
  */
-new DelimiterMap('text-bboldx-delimiterNormal', BboldxMethods.delimiterNormal, {
+new CharacterMap('text-bboldx-delimiterNormal', BboldxMethods.delimiterNormal, {
   '\\txtbbLparen': '\u0028',
   '\\txtbbRparen': '\u0029',
   '\\txtbbLbrack': '\u005B',
@@ -263,7 +263,7 @@ new CharacterMap('text-bboldx-mathchar0miBold', BboldxMethods.mathchar0miBold, {
 /**
  * Macros for delimiters.
  */
-new DelimiterMap('text-bboldx-delimiterBold', BboldxMethods.delimiterBold, {
+new CharacterMap('text-bboldx-delimiterBold', BboldxMethods.delimiterBold, {
   '\\txtbfbbLparen': '\u0028',
   '\\txtbfbbRparen': '\u0029',
   '\\txtbfbbLbrack': '\u005B',

--- a/ts/input/tex/bboldx/BboldxMappings.ts
+++ b/ts/input/tex/bboldx/BboldxMappings.ts
@@ -208,12 +208,12 @@ new CharacterMap(
  * Macros for delimiters.
  */
 new CharacterMap('text-bboldx-delimiterNormal', BboldxMethods.delimiterNormal, {
-  '\\txtbbLparen': '\u0028',
-  '\\txtbbRparen': '\u0029',
-  '\\txtbbLbrack': '\u005B',
-  '\\txtbbRbrack': '\u005D',
-  '\\txtbbLangle': '\u2329',
-  '\\txtbbRangle': '\u232A',
+  txtbbLparen: '\u0028',
+  txtbbRparen: '\u0029',
+  txtbbLbrack: '\u005B',
+  txtbbRbrack: '\u005D',
+  txtbbLangle: '\u2329',
+  txtbbRangle: '\u232A',
 });
 
 /**
@@ -264,12 +264,12 @@ new CharacterMap('text-bboldx-mathchar0miBold', BboldxMethods.mathchar0miBold, {
  * Macros for delimiters.
  */
 new CharacterMap('text-bboldx-delimiterBold', BboldxMethods.delimiterBold, {
-  '\\txtbfbbLparen': '\u0028',
-  '\\txtbfbbRparen': '\u0029',
-  '\\txtbfbbLbrack': '\u005B',
-  '\\txtbfbbRbrack': '\u005D',
-  '\\txtbfbbLangle': '\u2329',
-  '\\txtbfbbRangle': '\u232A',
+  txtbfbbLparen: '\u0028',
+  txtbfbbRparen: '\u0029',
+  txtbfbbLbrack: '\u005B',
+  txtbfbbRbrack: '\u005D',
+  txtbfbbLangle: '\u2329',
+  txtbfbbRangle: '\u232A',
 });
 
 new CommandMap('text-bboldx', {

--- a/ts/input/tex/bboldx/BboldxMethods.ts
+++ b/ts/input/tex/bboldx/BboldxMethods.ts
@@ -73,14 +73,14 @@ export const BboldxMethods = {
   },
 
   /**
-   * Handle bboldx delimiters as mi in normal variant.
+   * Handle bboldx delimiters as mo in normal variant.
    *
    * @param {TexParser} parser The current tex parser.
    * @param {Token} delim The parsed token.
    */
   delimiterNormal: function (parser: TexParser, delim: Token) {
     const font = getBbxFont(parser, '-bboldx', '-bboldx-light', '-bboldx-bold');
-    const def = { fence: false, stretchy: false, mathvariant: font };
+    const def = { stretchy: false, mathvariant: font };
     const node = parser.create('token', 'mo', def, delim.char);
     parser.Push(node);
   },
@@ -103,14 +103,14 @@ export const BboldxMethods = {
   },
 
   /**
-   * Handle bboldx delimiters as mi in bold variant.
+   * Handle bboldx delimiters as mo in bold variant.
    *
    * @param {TexParser} parser The current tex parser.
    * @param {Token} delim The parsed token.
    */
   delimiterBold: function (parser: TexParser, delim: Token) {
     const font = getBbxFont(parser, '-bboldx-bold', '-bboldx', '-bboldx-bold');
-    const def = { fence: false, stretchy: false, mathvariant: font };
+    const def = { stretchy: false, mathvariant: font };
     const node = parser.create('token', 'mo', def, delim.char);
     parser.Push(node);
   },


### PR DESCRIPTION
This PR makes the bboldx delimiters into plain characters, as they are in the actual TeX package.

Since the characters used are actual parentheses, brackets, and angles, but just in a different variant, they obtain their TeX class (and other properties) from the operator dictionary.  So the open ones have TeX class OPEN, and the closes have TeX class CLOSE, as expected.

I'm not sure whey the `fence` property was being set to `false`, as the operator dictionary says they should be `true`, so I've removed that.  If there is a reason for it, I can put that back.