### PR TITLE
Use Info's keydown() method to handle ctrl-A (it wasn't working this way).

### DIFF
--- a/ts/ui/menu/SelectableInfo.ts
+++ b/ts/ui/menu/SelectableInfo.ts
@@ -30,18 +30,18 @@ import { Info, HtmlClasses } from './mj-context-menu.js';
  */
 export class SelectableInfo extends Info {
   /**
-   * Add a keypress event to handle "select all" so that only
-   * the info-box's text is selected (not the whole page)
+   * Handle "select all" so that only the info-box's text is selected
+   * (not the whole page)
    *
    * @override
    */
-  public addEvents(element: HTMLElement) {
-    element.addEventListener('keypress', (event: KeyboardEvent) => {
-      if (event.key === 'a' && (event.ctrlKey || event.metaKey)) {
-        this.selectAll();
-        this.stop(event);
-      }
-    });
+  public keydown(event: KeyboardEvent) {
+    if (event.key === 'a' && (event.ctrlKey || event.metaKey)) {
+      this.selectAll();
+      this.stop(event);
+      return;
+    }
+    super.keydown(event);
   }
 
   /**


### PR DESCRIPTION
This PR changes from overriding `addEvents()` to overriding `keydown()` to handle the select-all action.  It wasn't working (at least for me in Firefox), and the lack of a `super.addEvents(element)` was preventing other handlers from being added, like the one for ESC to close the dialog.