### PR TITLE
Rename loader.preLoad() to loader.preLoaded() to make it clear tht this doesn't do any loading itself.

### DIFF
--- a/components/mjs/a11y/util.js
+++ b/components/mjs/a11y/util.js
@@ -9,7 +9,7 @@ import base from 'speech-rule-engine/lib/mathmaps/base.json' with {type: 'json'}
 import en from 'speech-rule-engine/lib/mathmaps/en.json' with {type: 'json'};
 import nemeth from 'speech-rule-engine/lib/mathmaps/nemeth.json' with {type: 'json'};
 
-Loader.preLoad(
+Loader.preLoaded(
   'a11y/sre',
   'a11y/semantic-enrich',
   'a11y/explorer'

--- a/components/mjs/input/tex/tex.js
+++ b/components/mjs/input/tex/tex.js
@@ -3,7 +3,7 @@ import './lib/tex.js';
 import {registerTeX} from './register.js';
 import {Loader} from '#js/components/loader.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'input/tex-base',
   '[tex]/ams',
   '[tex]/newcommand',

--- a/components/mjs/mml-chtml-nofont/mml-chtml-nofont.js
+++ b/components/mjs/mml-chtml-nofont/mml-chtml-nofont.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/mml',

--- a/components/mjs/mml-chtml/mml-chtml.js
+++ b/components/mjs/mml-chtml/mml-chtml.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/mml',

--- a/components/mjs/mml-svg-nofont/mml-svg-nofont.js
+++ b/components/mjs/mml-svg-nofont/mml-svg-nofont.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/mml',

--- a/components/mjs/mml-svg/mml-svg.js
+++ b/components/mjs/mml-svg/mml-svg.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/mml',

--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -43,7 +43,7 @@ combineDefaults(MathJax.config, 'output', {font: 'mathjax-newcm'});
 /*
  * Mark the preloaded components
  */
-Loader.preLoad('loader', 'startup', 'core', 'adaptors/liteDOM');
+Loader.preLoaded('loader', 'startup', 'core', 'adaptors/liteDOM');
 
 if (path.basename(dir) === 'node-main') {
   CONFIG.paths.esm = CONFIG.paths.mathjax;

--- a/components/mjs/output/util.js
+++ b/components/mjs/output/util.js
@@ -78,12 +78,12 @@ export const OutputUtil = {
 
   },
 
-  loadFont(startup, jax, font, preload) {
+  loadFont(startup, jax, font, preloaded) {
     if (!MathJax.loader) {
       return startup;
     }
-    if (preload) {
-      MathJax.loader.preLoad(`[${font}]/${jax}`);
+    if (preloaded) {
+      MathJax.loader.preLoaded(`[${font}]/${jax}`);
     }
     return Package.loadPromise(`output/${jax}`).then(startup);
   }

--- a/components/mjs/startup/init.js
+++ b/components/mjs/startup/init.js
@@ -4,7 +4,7 @@ import {combineDefaults} from '#js/components/global.js';
 import {dependencies, paths, provides, compatibility} from '../dependencies.js';
 import {Loader, CONFIG} from '#js/components/loader.js';
 
-Loader.preLoad('loader', 'startup');
+Loader.preLoaded('loader', 'startup');
 
 combineDefaults(MathJax.config.loader, 'dependencies', dependencies);
 combineDefaults(MathJax.config.loader, 'paths', paths);

--- a/components/mjs/tex-chtml-nofont/tex-chtml-nofont.js
+++ b/components/mjs/tex-chtml-nofont/tex-chtml-nofont.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'core',
   'input/tex',
   'output/chtml',

--- a/components/mjs/tex-chtml/tex-chtml.js
+++ b/components/mjs/tex-chtml/tex-chtml.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/tex',

--- a/components/mjs/tex-mml-chtml-nofont/tex-mml-chtml-nofont.js
+++ b/components/mjs/tex-mml-chtml-nofont/tex-mml-chtml-nofont.js
@@ -7,7 +7,7 @@ import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/tex', 'input/mml',

--- a/components/mjs/tex-mml-chtml/tex-mml-chtml.js
+++ b/components/mjs/tex-mml-chtml/tex-mml-chtml.js
@@ -7,7 +7,7 @@ import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/tex', 'input/mml',

--- a/components/mjs/tex-mml-svg-nofont/tex-mml-svg-nofont.js
+++ b/components/mjs/tex-mml-svg-nofont/tex-mml-svg-nofont.js
@@ -7,7 +7,7 @@ import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/tex', 'input/mml',

--- a/components/mjs/tex-mml-svg/tex-mml-svg.js
+++ b/components/mjs/tex-mml-svg/tex-mml-svg.js
@@ -7,7 +7,7 @@ import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/tex', 'input/mml',

--- a/components/mjs/tex-svg-nofont/tex-svg-nofont.js
+++ b/components/mjs/tex-svg-nofont/tex-svg-nofont.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'core',
   'input/tex',
   'output/svg',

--- a/components/mjs/tex-svg/tex-svg.js
+++ b/components/mjs/tex-svg/tex-svg.js
@@ -6,7 +6,7 @@ import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
 import {checkSre} from '../a11y/util.js';
 
-Loader.preLoad(
+Loader.preLoaded(
   'loader', 'startup',
   'core',
   'input/tex',

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -84,7 +84,7 @@ export interface MathJaxObject extends MJObject {
   loader: {
     ready: (...names: string[]) => Promise<string[]>; // Get a promise for when all the named packages are loaded
     load: (...names: string[]) => Promise<string>; // Load the packages and return a promise for when ready
-    preLoad: (...names: string[]) => void; // Indicate that packages are already loaded by hand
+    preLoaded: (...names: string[]) => void; // Indicate that packages are already loaded by hand
     defaultReady: () => void; // The function performed when all packages are loaded
     getRoot: () => string; // Find the root URL for the MathJax files
     checkVersion: (name: string, version: string) => boolean; // Check the version of an extension
@@ -218,7 +218,7 @@ export const Loader = {
    *
    * @param {string[]} names  The packages to load
    */
-  preLoad(...names: string[]) {
+  preLoaded(...names: string[]) {
     for (const name of names) {
       let extension = Package.packages.get(name);
       if (!extension) {


### PR DESCRIPTION
This PR renames the `loader.preLoad()` method to `loader.preLoaded()` to make it clear that this function doesn't do any actual loading of files itself, but rather just tells the loader that you have preloaded some files.  There is no functionality difference, but the name has always been more confusing than it should be.

It would be possible to have `loader.preLoad()` call `loader.preLoaded()` for backward compatibility.  Do you thin that is necessary?