### PR TITLE
Map \perp to U+27C2 rather than U+22A5 (issue mathjax/MathJax#3322)

### DIFF
--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -6532,7 +6532,9 @@ describe('Mathchar0mo', () => {
     toXmlMatch(
       tex2mml('\\perp'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\perp" display="block">
-      <mo data-latex="\\perp">&#x22A5;</mo>
+      <mrow data-mjx-texclass="ORD">
+        <mo data-latex="\\perp">&#x27C2;</mo>
+      </mrow>
     </math>`
     ));
   it('equiv', () =>

--- a/ts/input/tex/base/BaseMappings.ts
+++ b/ts/input/tex/base/BaseMappings.ts
@@ -261,7 +261,7 @@ new sm.CharacterMap('mathchar0mo', ParseMethods.mathchar0mo, {
   ll: '\u226A',
   sim: '\u223C',
   simeq: '\u2243',
-  perp: '\u22A5',
+  perp: '\u27C2',
   equiv: '\u2261',
   asymp: '\u224D',
   smile: '\u2323',


### PR DESCRIPTION
This PR changes the unicode value assigned to the `\perp` macro.

Resolves issue mathjax/MathJax#3322.