### PR TITLE
Add ability to filter SRE and LaTeX attributes from SVG image

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -649,7 +649,7 @@ export class Menu {
             this.checkbox('BreakInline', 'Allow In-line Breaks', 'breakInline'),
           ]),
           this.rule(),
-          this.submenu('MathmlIncludes', 'MathML Includes', [
+          this.submenu('MathmlIncludes', 'MathML/SVG has', [
             this.checkbox('showSRE', 'Semantic attributes', 'showSRE'),
             this.checkbox('showTex', 'LaTeX attributes', 'showTex'),
             this.checkbox('texHints', 'TeX hints', 'texHints'),
@@ -1496,6 +1496,23 @@ export class Menu {
     svg = svg
       .replace(/ (?:role|focusable)=".*?"/g, '')
       .replace(/"currentColor"/g, '"black"');
+    if (!this.settings.showSRE) {
+      svg = svg.replace(
+        / (?:data-semantic-.*?|role|aria-(?:level|posinset|setsize|owns))=".*?"/g,
+        ''
+      );
+    }
+    if (!this.settings.showTex) {
+      svg = svg.replace(/ data-latex(?:-item)?=".*?"/g, '');
+    }
+    if (!this.settings.texHints) {
+      svg = svg
+        .replace(
+          / data-mjx-(?:texclass|alternate|variant|smallmatrix|mathaccent|auto-op|script-align|vbox)=".*?"/g,
+          ''
+        )
+        .replace(/ data-mml-node="TeXAtom"/g, '');
+    }
     return `${XMLDECLARATION}\n${svg}`;
   }
 


### PR DESCRIPTION
This PR allows you to filter attributes from the SVG image generated by the contextual menu "Show As" or "Copy to Clipboard" submenus.  It uses the settings from the "MathML includes" menu, renamed as "MathML/SVG has" (to not make it wider than it was).

This makes it easier to make cleaner SVG images.