### PR TITLE
Update test framework

### DIFF
--- a/testsuite/package.json
+++ b/testsuite/package.json
@@ -9,10 +9,12 @@
   "imports": {
     "#js/*": "../mjs/*",
     "#source/*": "../components/mjs/*",
-    "#helpers": "./src/index.ts"
+    "#src/*": "./src/*",
+    "#helpers": "./js/src/index.js"
   },
   "dependencies": {
     "@jest/globals": "^29.7.0",
+    "@mathjax/mathjax-bbm-font-extension": "0.4.2-beta.8",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",

--- a/testsuite/pnpm-lock.yaml
+++ b/testsuite/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
+      '@mathjax/mathjax-bbm-font-extension':
+        specifier: 0.4.2-beta.8
+        version: 0.4.2-beta.8
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -298,6 +301,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@mathjax/mathjax-bbm-font-extension@0.4.2-beta.8':
+    resolution: {integrity: sha512-FU/M4IJ6dRCRxxfnxRSAwWgEEvcpgqqzupiSe3JW8TCl2zR0co3zaYtO1oaHGrmmlqAkARPRJnpxViIWhfPr6A==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1653,6 +1659,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@mathjax/mathjax-bbm-font-extension@0.4.2-beta.8': {}
 
   '@sinclair/typebox@0.27.8': {}
 

--- a/testsuite/src/index.ts
+++ b/testsuite/src/index.ts
@@ -1,2 +1,2 @@
-export * from './setupTex';
-export * from './xmlMatch';
+export * from './setupTex.js';
+export * from './xmlMatch.js';

--- a/testsuite/src/setupTex.ts
+++ b/testsuite/src/setupTex.ts
@@ -63,7 +63,7 @@ export function trapOutput(method: string, code: () => void) {
 }
 
 /**
- * Trap errors produces while running code.
+ * Trap errors produced while running code.
  * @param code The code to run.
  * @return The error message produced.
  */
@@ -76,7 +76,7 @@ export function trapErrors(code: () => void) {
 }
 
 /**
- * Trap errors produces while running code.
+ * Trap errors produced while running code.
  * @param code The code to run.
  * @return The error message produced.
  */
@@ -89,7 +89,7 @@ export async function trapAsyncErrors(code: () => Promise<void>) {
 }
 
 /**
- * When true, errors with throw rather than poroduce merror elements.
+ * When true, errors will throw rather than produce merror elements.
  */
 let reportErrors = false;
 

--- a/testsuite/src/setupTex.ts
+++ b/testsuite/src/setupTex.ts
@@ -326,12 +326,8 @@ export async function setupComponents(config: any) {
   MathJax.config.loader.require = (file: string) => {
     return new Promise((ok, fail) => import(file).then(ok).catch(e => fail(e)));
   }
-  if (!config.startup) {
-    config.startup = {};
-  }
-  if (config.startup.typeset === undefined) {
-    config.startup.typeset = false;
-  }
+  config.startup ??= {};
+  config.startup.typeset ??= false;
   config = Object.assign({}, throwCompileErrors, config);
   componentPromise = init(config);
 }

--- a/testsuite/src/setupTex.ts
+++ b/testsuite/src/setupTex.ts
@@ -1,43 +1,342 @@
-import {TeX} from '#js/input/tex';
-import {AbstractParseMap, RegExpMap} from '#js/input/tex/TokenMap';
-import {ConfigurationHandler} from '#js/input/tex/Configuration';
+import {TeX} from '#js/input/tex.js';
+import {AbstractParseMap, RegExpMap, CommandMap} from '#js/input/tex/TokenMap.js';
+import {ConfigurationHandler} from '#js/input/tex/Configuration.js';
 import {HandlerType, ConfigurationType} from '#js/input/tex/HandlerTypes.js';
 import {MapHandler} from '#js/input/tex/MapHandler.js';
-import {HTMLDocument} from '#js/handlers/html/HTMLDocument';
-import {liteAdaptor} from '#js/adaptors/liteAdaptor';
-import {STATE} from '#js/core/MathItem';
-import {SerializedMmlVisitor} from '#js/core/MmlTree/SerializedMmlVisitor';
-import {MmlNode} from '#js/core/MmlTree/MmlNode';
-import {tmpJsonFile} from './constants';
+import {HTMLDocument} from '#js/handlers/html/HTMLDocument.js';
+import {RegisterHTMLHandler} from '#js/handlers/html.js';
+import {liteAdaptor} from '#js/adaptors/liteAdaptor.js';
+import {MathItem, STATE} from '#js/core/MathItem.js';
+import {SerializedMmlVisitor} from '#js/core/MmlTree/SerializedMmlVisitor.js';
+import {MmlNode} from '#js/core/MmlTree/MmlNode.js';
+import {mathjax} from '#js/mathjax.js';
+import {OptionList} from '#js/util/Options.js';
+import {tmpJsonFile} from '#src/constants.js';
 import * as fs from 'fs';
+import {init} from '#source/node-main/node-main.mjs';
+import {expect} from '@jest/globals';
 
+declare const MathJax: any;
+type MATHITEM = MathItem<any, any, any>;
+type PackageList = (string | [string, number])[];
+
+/**
+ * The various conversion functions (set up in setupTex... function below).
+ */
 let convert: (tex: string, display: boolean) => string;
+let render: (text: string, display: boolean) => string;
+let typeset: (text: string, display: boolean) => Promise<string>;
+let page: (text: string) => Promise<string[]>;
 
-export function setupTex(packages: string[] = ['base'], options = {}) {
+/**
+ * A promise that resolves when the components are loaded and set up.
+ */
+let componentPromise: Promise<string[]>;
+
+/**
+ * Get the adaptor, and register HTML documents.
+ */
+const adaptor = liteAdaptor();
+const handler = RegisterHTMLHandler(adaptor);
+
+/**
+ * A vistor to convert MmlNodes to serialized MathML.
+ */
+const visitor = new SerializedMmlVisitor();
+export const toMathML = ((node: MmlNode) => visitor.visitTree(node));
+
+/*********************************************************************/
+
+/**
+ * Trap output produced while running code.
+ * @param method The console method to trap.
+ * @param code The code to run.
+ * @return The output sent to the given method.
+ */
+export function trapOutput(method: string, code: () => void) {
+  const saved = (console as any)[method];
+  let message = '';
+  (console as any)[method] = (...msg: any[]) => {message += (message ? '\n' : '') + msg.join(' ')};
+  code();
+  (console as any)[method] = saved;
+  return message;
+}
+
+/**
+ * Trap errors produces while running code.
+ * @param code The code to run.
+ * @return The error message produced.
+ */
+export function trapErrors(code: () => void) {
+  let message = '(no error)';
+  reportErrors = true;
+  try {code()} catch (e) {message = e.message}
+  reportErrors = false;
+  return message;
+}
+
+/**
+ * Trap errors produces while running code.
+ * @param code The code to run.
+ * @return The error message produced.
+ */
+export async function trapAsyncErrors(code: () => Promise<void>) {
+  let message = '(no error)';
+  reportErrors = true;
+  await code().catch((e) => {message = e.message});
+  reportErrors = false;
+  return message;
+}
+
+/**
+ * When true, errors with throw rather than poroduce merror elements.
+ */
+let reportErrors = false;
+
+/**
+ * Configuration that causes TeX errors to throw rather than
+ * generate merror elements, so we can trap them with trapErrors().
+ */
+export const throwTexErrors = {
+  formatError(jax: any, err: Error) {
+    if (reportErrors) throw err;
+    return jax.formatError(err);
+  }
+}
+
+/**
+ * Configuration that causes compile errors to throw rather than
+ * generate merror elements, so we can trap them with trapErrors().
+ */
+export const throwCompileErrors = {
+  options: {
+    compileError(jax: any, math: any, err: Error) {
+      if (reportErrors) throw err;
+      return jax.compileError(math, err);
+    }
+  }
+}
+
+/**
+ * Trap TeX processing errors and return an expect() result
+ * @param string The TeX string to process
+ * @param display True for display style, false for in-line
+ * @param typeset The function used to typeset the TeX (tex2mml, typeset2mml, etc)
+ */
+export function expectTexError(
+  tex: string,
+  display: boolean = true,
+  fn: (((tex: string, display?: boolean) => any) | ((tex: string) => any)) = tex2mml,
+): any {
+  return expect(trapErrors(() => fn(tex, display)));
+}
+
+/**
+ * Trap TeX processing errors and return an expect() result
+ * @param string The TeX string to process
+ * @param display True for display style, false for in-line
+ * @param typeset The function used to typeset the TeX (tex2mml, typeset2mml, etc)
+ */
+export function expectTypesetError(
+  tex: string,
+  display: boolean = true,
+  fn: (((tex: string, display?: boolean) => Promise<any>) | ((tex: string) => Promise<any>)) = typeset2mml,
+): any {
+  return expect(trapAsyncErrors(() => fn(tex, display))).resolves;
+}
+
+/*********************************************************************/
+
+/**
+ * Set up TeX input packages and options for tex2mml(), and create the convert() function,
+ *   which uses MathDocument.convert() to compile the TeX.
+ *
+ * @param {string[]} packages    The TeX packages to configure
+ * @param {OptionList} options   The TeX options to include
+ */
+export function setupTex(packages: PackageList = ['base'], options: OptionList = {}) {
+  const parserOptions = Object.assign({}, {packages}, throwTexErrors, options);
+  const tex = new TeX(parserOptions);
+  const html = new HTMLDocument('', adaptor, {InputJax: tex});
+  convert = (expr: string, display: boolean) =>
+    toMathML(html.convert(expr, {display: display, end: STATE.CONVERT}));
+}
+
+/**
+ * Set up TeX input packages and options for render2mml(), and create the render() function,
+ *   which uses MathDocument.findMath().compile() to compile the TeX from within a document.
+ *
+ * @param {string[]} packages    The TeX packages to configure
+ * @param {OptionList} options   The TeX options to include
+ */
+export function setupTexRender(packages: PackageList = ['base'], options: OptionList = {}) {
+  const parserOptions = Object.assign(
+    {},
+    {packages: packages, inlineMath: {'[+]': [['$', '$']]}},
+    throwTexErrors,
+    options
+  );
+  const tex = new TeX(parserOptions);
+  render = (text: string, display: boolean) => {
+    const delim = display ? '$$' : '$';
+    const document = `<html><head></head><body>${delim}${text}${delim}</body></html>`;
+    const html = mathjax.document(document, {InputJax: tex});
+    html.findMath().compile();
+    return toMathML((Array.from(html.math)[0] as MATHITEM).root);
+  }
+}
+
+/**
+ * Set up TeX input packages and options for typeset2mml(), and create the typeset() function,
+ *   which uses MathDocument.findMath().compile() wrapped in handleRetriesFor() to
+ *   compile the TeX from within a document asynchronously.
+ *
+ * @param {string[]} packages    The TeX packages to configure
+ * @param {OptionList} options   The TeX options to include
+ */
+export function setupTexTypeset(packages: PackageList = ['base'], options: OptionList = {}) {
+  MathJax.config.tex = Object.assign(
+    {},
+    {packages: packages, inlineMath: {'[+]': [['$', '$']]}},
+    throwTexErrors,
+    options
+  );
+  typeset = async (text: string, display: boolean) => {
+    await componentPromise;
+    const delim = display ? '$$' : '$';
+    MathJax.config.startup.document =
+      `<html><head></head><body>${delim}${text}${delim}</body></html>`;
+    MathJax.startup.getComponents();
+    const mathdoc = MathJax.startup.document;
+    await mathjax.handleRetriesFor(() => mathdoc.findMath().compile());
+    return toMathML((Array.from(mathdoc.math) as MATHITEM[])[0].root);
+  }
+}
+
+/**
+ * Set up TeX input packages and options for page2mml(), and create the page() function,
+ *   which uses MathDocument.findMath().compile() wrapped in handleRetriesFor() to
+ *   compile a pagefrom within a document asynchronously, and test an array of results,
+ *   one for each expression in the page.
+ *
+ * @param {string[]} packages    The TeX packages to configure
+ * @param {OptionList} options   The TeX options to include
+ */
+export function setupTexPage(packages: PackageList = ['base'], options: OptionList = {}) {
+  MathJax.config.tex = Object.assign(
+    {},
+    {packages: packages, inlineMath: {'[+]': [['$', '$']]}},
+    throwTexErrors,
+    options
+  );
+  page = async (text: string) => {
+    await componentPromise;
+    MathJax.config.startup.document =
+      `<html><head></head><body>${text}</body></html>`;
+    MathJax.startup.getComponents();
+    const mathdoc = MathJax.startup.document;
+    await mathjax.handleRetriesFor(() => mathdoc.findMath().compile());
+    const math = Array.from(mathdoc.math) as MATHITEM[];
+    return math.map((mi) => toMathML(mi.root));
+  }
+}
+
+import {SVG} from '#js/output/svg.js';
+
+/**
+ * Set up TeX input packages and options for tex2mml(), and create the convert() function,
+ *   which uses MathDocument.convert() to typeset the Tex, with an SVG output jax available.
+ *
+ * @param {string[]} packages    The TeX packages to configure
+ * @param {OptionList} options   The TeX options to include
+ */
+export function setupTexWithOutput(packages: string[] = ['base'], options: OptionList = {}) {
   const parserOptions = Object.assign({}, {packages: packages}, options);
   const tex = new TeX(parserOptions);
-  const html = new HTMLDocument('', liteAdaptor(), {InputJax: tex});
+  const html = new HTMLDocument('', adaptor, {InputJax: tex, OutputJax: new SVG()});
   const visitor = new SerializedMmlVisitor();
   const toMathML = ((node: MmlNode) => visitor.visitTree(node));
   convert = (expr: string, display: boolean) =>
     toMathML(html.convert(expr, {display: display, end: STATE.CONVERT}));
 }
 
-import {SVG} from '#js/output/svg';
+/*********************************************************************/
 
-export function setupTexWithOutput(packages: string[] = ['base'], options = {}) {
-  const parserOptions = Object.assign({}, {packages: packages}, options);
-  const tex = new TeX(parserOptions);
-  const html = new HTMLDocument('', liteAdaptor(), {InputJax: tex, OutputJax: new SVG()});
-  const visitor = new SerializedMmlVisitor();
-  const toMathML = ((node: MmlNode) => visitor.visitTree(node));
-  convert = (expr: string, display: boolean) =>
-    toMathML(html.convert(expr, {display: display, end: STATE.CONVERT}));
-}
-
-export function tex2mml(tex: string, display: boolean = true) {
+/**
+ * Convert TeX to MathML using MathDocument.convert
+ *
+ * @param {string} tex        The math to convert
+ * @param {boolean} display   True for display math, false for in-line math
+ * @returns {string}          The MathML for the TeX expression
+ */
+export function tex2mml(tex: string, display: boolean = true): string {
   return convert(tex, display);
 };
+
+/**
+ * Convert TeX to MathML using MathDocument.findMath().compile() on a document
+ *   (allows embedded HTML tags when texhtml is present).
+ *
+ * @param {string} tex        The math to convert
+ * @param {boolean} display   True for display math, false for in-line math
+ * @returns {string}          The MathML for the TeX expression
+ */
+export function render2mml(tex: string, display: boolean = true): string {
+  return render(tex, display);
+}
+
+/**
+ * Convert TeX to MathML using MathDocument.findMath().compile() wrapped in
+ * handleRetriesFor() on a document (allows retries to be processed).
+ *
+ * @param {string} tex          The math to convert
+ * @param {boolean} display     True for display math, false for in-line math
+ * @returns {Promise<string>}   A promise for the MathML for the TeX expression
+ */
+export function typeset2mml(tex: string, display: boolean = true): Promise<string> {
+  return typeset(tex, display);
+}
+
+/**
+ * Convert TeX to MathML using MathDocument.findMath().compile() wrapped in
+ * handleRetriesFor() on a whole document (allowing retries to be processed).
+ * Returns an array of MathML, one for each expression in the page
+ *
+ * @param {string} text           The serialized HTML document to process.
+ * @returns {Promise<string[]>}   A promise for the array of MathML from the document
+ */
+export function page2mml(text: string): Promise<string[]> {
+  return page(text);
+}
+
+/*********************************************************************/
+
+/**
+ * Initialize the component framework (for typeset2mml() and
+ * page2mml()), setting a promise for when that is complete (the
+ * conversion functions with for that promise to resolve).
+ * @param config The MathJax configuration
+ */
+export async function setupComponents(config: any) {
+  mathjax.handlers.unregister(handler);
+  //
+  // Jest import() doesn't return a promise that is an instance of Promise,
+  //   so wrap it in a real promise, so Package will properly identify it.
+  //
+  MathJax.config.loader.require = (file: string) => {
+    return new Promise((ok, fail) => import(file).then(ok).catch(e => fail(e)));
+  }
+  if (!config.startup) {
+    config.startup = {};
+  }
+  if (config.startup.typeset === undefined) {
+    config.startup.typeset = false;
+  }
+  config = Object.assign({}, throwCompileErrors, config);
+  componentPromise = init(config);
+}
+
+/*********************************************************************/
 
 // Machinery for measuring the completeness of our macro tests.
 
@@ -129,6 +428,11 @@ export function getTokens(configuration: string) {
   });
   fs.appendFileSync(tmpJsonFile, ',' + JSON.stringify(outJSON, null, 2));
 }
+
+//
+// Force the original lookup to be called (so we get coverage for it) before we change it.
+//
+(function () {new CommandMap('', {}).lookup('x')})();
 
 // A prototype extension for the macro table lookups.
 AbstractParseMap.prototype.lookup = function(token: string) {

--- a/testsuite/src/texReporter.js
+++ b/testsuite/src/texReporter.js
@@ -42,7 +42,7 @@ export default class TexReporter {
 }
 
 /**
- * Convert the array of configurations to a array of rows of data,
+ * Convert the array of configurations to an array of rows of data,
  * sorted by package name.
  * @param coverage The coverage data from the json file
  * @return The array of rows of data
@@ -161,9 +161,9 @@ function getColor(actual, size) {
 }
 
 /**
- * Add color escape seuences, if needed
+ * Add color escape sequences, if needed
  * @param cell The cell contents
- * @param color The color number to use in the scape sequence
+ * @param color The color number to use in the escape sequence
  * @return The cell contents with color sequences
  */
 function colorize(cell, color) {

--- a/testsuite/src/xmlMatch.ts
+++ b/testsuite/src/xmlMatch.ts
@@ -2,7 +2,12 @@ import { expect } from '@jest/globals';
 import { xml2json } from 'xml-js';
 
 expect.extend({
-  // An xml matcher via deep equality on JSON objects.
+  /**
+   * An xml matcher via deep equality on JSON objects.
+   *
+   * @param {string} received  The string received from the tests
+   * @param {string} expected  The string expected to be produced by the tests
+   */
   toBeXmlMatch(received: string, expected: string) {
     const recJson = xml2json(received);
     const exptJson = xml2json(expected)
@@ -13,15 +18,24 @@ expect.extend({
   },
 });
 
+/**
+ * Compares a result to an expected result.
+ *
+ * @param {string} received  The string received from the tests
+ * @param {string} expected  The string expected to be produced by the tests
+ */
 export function toXmlMatch(received: string, expected: string) {
   // This is slightly awkward way of getting around ts-jest problems with custom
   // matcher extensions.
   (expect(received) as any).toBeXmlMatch(expected);
 }
 
-//
-// Compares an array of results to an array of expected results.
-//
+/**
+ * Compares an array of results to an array of expected results.
+ *
+ * @param {string[]} received  An array of strings received from the tests
+ * @param {string[]} expected  The array of string expected to be produced by the tests
+ */
 export function toXmlArrayMatch(received: string[], expected: string[]) {
   const r = received.length;
   const e = expected.length;

--- a/testsuite/src/xmlMatch.ts
+++ b/testsuite/src/xmlMatch.ts
@@ -18,3 +18,15 @@ export function toXmlMatch(received: string, expected: string) {
   // matcher extensions.
   (expect(received) as any).toBeXmlMatch(expected);
 }
+
+//
+// Compares an array of results to an array of expected results.
+//
+export function toXmlArrayMatch(received: string[], expected: string[]) {
+  const r = received.length;
+  const e = expected.length;
+  expect(`${r} MathML string${r === 1 ? '' : 's'}`).toBe(`${e} MathML string${e === 1 ? '' : 's'}`);
+  for (let i = 0; i < received.length; i++) {
+    toXmlMatch(`<!--${i+1}-->\n${received[i]}`, `<!--${i+1}-->\n${expected[i]}`);
+  }
+}

--- a/testsuite/tsconfig.json
+++ b/testsuite/tsconfig.json
@@ -3,13 +3,15 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./js",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "paths": {
       "#js/*": ["../mjs/*"],
       "#source/*": ["../components/mjs/*"],
+      "#src/*": ["./src/*"],
       "#helpers": ["./src/index.js"]
     },
-    "lib": ["es2017"]
+    "lib": ["es2022"]
   },
   "include": ["./tests/**/*.ts", "./src/*.ts"]
 }


### PR DESCRIPTION
This is the first in a series of PRs that I'm going to be making that add or updates tests for the TeX input jax and its packages.  I have broken down the PRs into separate pieces by tex package, to make them easier to review.  But some rely on some of the open PRs (like `rename-stylelist`, or `woff2`, or `begingroup`) in order to run, and I have not merged those into these branches, other than the `mhchem-stretchies` branch, which is merged into the `test-mhchem` PR that I will be making.  So you may not be able to test these individually without merging some of the other branches.  Many of these PRs include changes to the ts/input/tex package files to either fix bugs that I found while making the tests, or to remove unreachable code that was identified by jest during testing.  I will try to explain those changes in the PRs themselves.

In addition, the `test-tex` PR includes changes to the main ts/input/tex files along with miscellaneous tests to fill out the coverage for lines from those files that weren't run by other tests.  But the changes in these files may be needed by other PRs, so yo umight want to merge that into a test branch, along with this PR, and use that as a basis for runing the tests in the other PRs, if you want to do that.

To get the complete coverage, you will need to merge all these test PRs together, and merge in all the pending PRs of mine in order to for them all to run properly.  Note that the testsuite/package.json file has been updated, so you should to an `pnpm install` in the `testsuites` directory to get the added font package that is needed for one of the tests.

Merging the pending PRs will cause merge conflicts in several cases.  If you want to merge them into your test branch, you should always keep the changes from the `test-...` branches, and discard the changes in the older PRs, as the test branches are the most up-to-date.  I will update either these or the older PRs to resolve conflicts once one or the other is merged.

-----

This PR adds new functionality to the test framework.  In particular:

* New functions are added in `setupTex.js` that provide for component-based tests, like those needed for the `require` and `autoload` packages.  You use `setupComponents()` (once per file) to specify the needed MathJax configuration (loading the needed components), and then `setupTexTypeset()` or `setupTexPage()` to configure the TeX input jax on a per-test basis.  The tests then use `async` functions along with `await typeset2mml()` or `await page2mml()` to perform the tests.  Traditional tests and component-based tests can both be used int he same file.
* A new `render2mml()` function and associated `setupTexRender()` use an `HTMLDocument.render()` call rather than `HTMLDocument.convert()` call to do the typesetting.  This is needed for the `texhtml` tests, in order to have actual `<tex-html>` DOM elements to work with rather than just LaTeX text.
* New functions `trapErrors()`, `trapAsyncErrors()`, and `trapOutput()` are provided that can be used to test for TeX syntax errors, or for `console` messages.  The first two are accomplished by overriding the `formatError()` option of the TeX input jax and the `compileError()` option of the `MathDocument` to throw errors rather than generate their ususal `merror` elements, and trapping those errors to retrieve their messages.  The latter is done by temporarily overriding the `console.log` or `console.warn` methods to capture their output so it can be tested.
* Error trapping is made even easier by new functions `expectTexError()` and `expectTypesetError()`, which wrap the appropriate typesetting calls inside `expect()` calls.
* Configuration snippets for the error trapping are also made available, in case they are needed in a more sophisticated testing setting.

* A new `toXmlArrayMatch()` is added to `xmlMatch.ts` that matches an array of XML strings to an array of expected strings.  This is for use with `page2mml()`, which produces an array of XML, one for each MathItem in the page.

* The `texReporter` output is now colorized like that in the main jest file output, and all the tables are combine into a single one, similar to the jest output.  The "Missing" column is clipped to the width of the terminal window, as it is in the jest output.

Finally, the tsconfig file is modified and `.js` is added to the imports to avoid typescript errors.