### PR TITLE
Normalize format for tests and convert error tests to trapped errors

### DIFF
--- a/testsuite/tests/input/tex/Action.test.ts
+++ b/testsuite/tests/input/tex/Action.test.ts
@@ -4,38 +4,59 @@ import '#js/input/tex/action/ActionConfiguration';
 
 beforeEach(() => setupTex(['base', 'action']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Action', () => {
-  it('TextTip', () =>
+
+  /********************************************************************************/
+
+  it('TextTip', () => {
     toXmlMatch(
       tex2mml('\\texttip{A}{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texttip{A}{B}" display="block">
-  <maction actiontype="tooltip" data-latex="\\mathtip{A}{\\text{B}}">
-    <mi data-latex="A">A</mi>
-    <mtext data-latex="\\text{B}">B</mtext>
-  </maction>
-</math>`
-    ));
-  it('MathTip', () =>
+         <maction actiontype="tooltip" data-latex="\\mathtip{A}{\\text{B}}">
+      <mi data-latex="A">A</mi>
+      <mtext data-latex="\\text{B}">B</mtext>
+    </maction>
+  </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MathTip', () => {
     toXmlMatch(
       tex2mml('\\mathtip{A}{B}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathtip{A}{B}" display="block">
-  <maction actiontype="tooltip" data-latex="\\mathtip{A}{B}">
-    <mi data-latex="A">A</mi>
-    <mi data-latex="B">B</mi>
-  </maction>
-</math>`
-    ));
-  it('Toggle', () =>
+         <maction actiontype="tooltip" data-latex="\\mathtip{A}{B}">
+           <mi data-latex="A">A</mi>
+           <mi data-latex="B">B</mi>
+         </maction>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Toggle', () => {
     toXmlMatch(
       tex2mml('\\toggle A B C \\endtoggle'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\toggle A B C \\endtoggle" display="block">
-  <maction data-latex="\\toggle A B C \\endtoggle">
-    <mi data-latex="A">A</mi>
-    <mi data-latex="B">B</mi>
-    <mi data-latex="C">C</mi>
-  </maction>
-</math>`
-    ));
+         <maction data-latex="\\toggle A B C \\endtoggle">
+           <mi data-latex="A">A</mi>
+           <mi data-latex="B">B</mi>
+           <mi data-latex="C">C</mi>
+         </maction>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('action'));

--- a/testsuite/tests/input/tex/Bbox.test.ts
+++ b/testsuite/tests/input/tex/Bbox.test.ts
@@ -1,106 +1,131 @@
 import { afterAll, beforeEach, describe, it } from '@jest/globals';
-import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
 import '#js/input/tex/bbox/BboxConfiguration';
 
 beforeEach(() => setupTex(['base', 'bbox']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Bbox', () => {
-  it('Bbox-Background', () =>
+
+  /********************************************************************************/
+
+  it('Bbox-Background', () => {
     toXmlMatch(
       tex2mml('\\bbox[yellow]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[yellow]{a}" display="block">
-  <mstyle mathbackground="yellow" data-latex="\\bbox[yellow]{a}">
-    <mi data-latex="a">a</mi>
-  </mstyle>
-</math>`
-    ));
-  it('Bbox-Padding', () =>
+         <mstyle mathbackground="yellow" data-latex="\\bbox[yellow]{a}">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Padding', () => {
     toXmlMatch(
       tex2mml('\\bbox[5px]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[5px]{a}" display="block">
-  <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px" data-latex="\\bbox[5px]{a}">
-    <mi data-latex="a">a</mi>
-  </mpadded>
-</math>`
-    ));
-  it('Bbox-Frame', () =>
+         <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px" data-latex="\\bbox[5px]{a}">
+           <mi data-latex="a">a</mi>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Frame', () => {
     toXmlMatch(
       tex2mml('\\bbox[border:5px solid red]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[border:5px solid red]{a}" display="block">
-  <mstyle style="border:5px solid red" data-latex="\\bbox[border:5px solid red]{a}">
-    <mi data-latex="a">a</mi>
-  </mstyle>
-</math>`
-    ));
-  it('Bbox-Background-Padding', () =>
+         <mstyle style="border:5px solid red" data-latex="\\bbox[border:5px solid red]{a}">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Background-Padding', () => {
     toXmlMatch(
       tex2mml('\\bbox[yellow,5px]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[yellow,5px]{a}" display="block">
-  <mstyle mathbackground="yellow" data-latex="\\bbox[yellow,5px]{a}">
-    <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px">
-      <mi data-latex="a">a</mi>
-    </mpadded>
-  </mstyle>
-</math>`
-    ));
-  it('Bbox-Padding-Frame', () =>
+         <mstyle mathbackground="yellow" data-latex="\\bbox[yellow,5px]{a}">
+           <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px">
+             <mi data-latex="a">a</mi>
+           </mpadded>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Padding-Frame', () => {
     toXmlMatch(
       tex2mml('\\bbox[5px,border:2px solid red]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[5px,border:2px solid red]{a}" display="block">
-  <mstyle style="border:2px solid red" data-latex="\\bbox[5px,border:2px solid red]{a}">
-    <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px">
-      <mi data-latex="a">a</mi>
-    </mpadded>
-  </mstyle>
-</math>`
-    ));
-  it('Bbox-Background-Padding-Frame', () =>
+         <mstyle style="border:2px solid red" data-latex="\\bbox[5px,border:2px solid red]{a}">
+           <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px">
+             <mi data-latex="a">a</mi>
+           </mpadded>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Background-Padding-Frame', () => {
     toXmlMatch(
       tex2mml('\\bbox[yellow,5px,border:2px solid red]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[yellow,5px,border:2px solid red]{a}" display="block">
-  <mstyle mathbackground="yellow" style="border:2px solid red" data-latex="\\bbox[yellow,5px,border:2px solid red]{a}">
-    <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px">
-      <mi data-latex="a">a</mi>
-    </mpadded>
-  </mstyle>
-</math>`
-    ));
-  it('Bbox-Background-Error', () =>
-    toXmlMatch(
-      tex2mml('\\bbox[yellow,green]{a}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[yellow,green]{a}" display="block">
-  <merror data-mjx-error="Background specified twice in \\bbox">
-    <mtext>Background specified twice in \\bbox</mtext>
-  </merror>
-</math>`
-    ));
-  it('Bbox-Padding-Error', () =>
-    toXmlMatch(
-      tex2mml('\\bbox[5px,6px]{a}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[5px,6px]{a}" display="block">
-  <merror data-mjx-error="Padding specified twice in \\bbox">
-    <mtext>Padding specified twice in \\bbox</mtext>
-  </merror>
-</math>`
-    ));
-  it('Bbox-Frame-Error', () =>
-    toXmlMatch(
-      tex2mml('\\bbox[border:2px solid red,border:2px solid green]{a}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[border:2px solid red,border:2px solid green]{a}" display="block">
-  <merror data-mjx-error="Style specified twice in \\bbox">
-    <mtext>Style specified twice in \\bbox</mtext>
-  </merror>
-</math>`
-    ));
-  it('Bbox-General-Error', () =>
-    toXmlMatch(
-      tex2mml('\\bbox[22-11=color]{a}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bbox[22-11=color]{a}" display="block">
-  <merror data-mjx-error="&quot;22-11=color&quot; doesn\'t look like a color, a padding dimension, or a style">
-    <mtext>&quot;22-11=color&quot; doesn\'t look like a color, a padding dimension, or a style</mtext>
-  </merror>
-</math>`
-    ));
+         <mstyle mathbackground="yellow" style="border:2px solid red" data-latex="\\bbox[yellow,5px,border:2px solid red]{a}">
+           <mpadded height="+5px" depth="+5px" lspace="5px" width="+10px">
+             <mi data-latex="a">a</mi>
+           </mpadded>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Background-Error', () => {
+    expectTexError('\\bbox[yellow,green]{a}')
+      .toBe('Background specified twice in \\bbox');
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Padding-Error', () => {
+    expectTexError('\\bbox[5px,6px]{a}')
+      .toBe('Padding specified twice in \\bbox');
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-Frame-Error', () => {
+    expectTexError('\\bbox[border:2px solid red,border:2px solid green]{a}')
+      .toBe('Style specified twice in \\bbox');
+  });
+
+  /********************************************************************************/
+
+  it('Bbox-General-Error', () => {
+    expectTexError('\\bbox[22-11=color]{a}')
+      .toBe(`"22-11=color" doesn't look like a color, a padding dimension, or a style`);
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('bbox'));

--- a/testsuite/tests/input/tex/Braket.test.ts
+++ b/testsuite/tests/input/tex/Braket.test.ts
@@ -1,546 +1,673 @@
 import { afterAll, beforeEach, describe, it } from '@jest/globals';
-import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
 import '#js/input/tex/braket/BraketConfiguration';
 
 beforeEach(() => setupTex(['base', 'braket']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Braket', () => {
-  it('Braket-bra', () =>
+
+  /********************************************************************************/
+
+  it('Braket-bra', () => {
     toXmlMatch(
       tex2mml('\\bra{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bra{x}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\langle {x} \\vert}">
-    <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{x}">
-      <mi data-latex="x">x</mi>
-    </mrow>
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-bra-large', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\langle {x} \\vert}">
+           <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{x}">
+             <mi data-latex="x">x</mi>
+           </mrow>
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-bra-large', () => {
     toXmlMatch(
       tex2mml('\\bra{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bra{\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\langle {\\frac{x}{y}} \\vert}">
-    <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
-      <mfrac data-latex="\\frac{x}{y}">
-        <mi data-latex="x">x</mi>
-        <mi data-latex="y">y</mi>
-      </mfrac>
-    </mrow>
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bra', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\langle {\\frac{x}{y}} \\vert}">
+           <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
+             <mfrac data-latex="\\frac{x}{y}">
+               <mi data-latex="x">x</mi>
+               <mi data-latex="y">y</mi>
+             </mfrac>
+           </mrow>
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bra', () => {
     toXmlMatch(
       tex2mml('\\Bra{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Bra{\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\left\\langle {\\frac{x}{y}} \\right\\vert}">
-    <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle {\\frac{x}{y}} \\right\\vert" data-latex="\\left\\langle {\\frac{x}{y}} \\right\\vert">
-      <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle " data-latex="\\left\\langle ">&#x27E8;</mo>
-      <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
-        <mfrac data-latex="\\frac{x}{y}">
-          <mi data-latex="x">x</mi>
-          <mi data-latex="y">y</mi>
-        </mfrac>
-      </mrow>
-      <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
-    </mrow>
-  </mrow>
-</math>`
-    ));
-  it('Braket-ket', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\left\\langle {\\frac{x}{y}} \\right\\vert}">
+           <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle {\\frac{x}{y}} \\right\\vert" data-latex="\\left\\langle {\\frac{x}{y}} \\right\\vert">
+             <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle " data-latex="\\left\\langle ">&#x27E8;</mo>
+             <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
+               <mfrac data-latex="\\frac{x}{y}">
+                 <mi data-latex="x">x</mi>
+                 <mi data-latex="y">y</mi>
+               </mfrac>
+             </mrow>
+             <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-ket', () => {
     toXmlMatch(
       tex2mml('\\ket{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ket{x}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\vert {x} \\rangle}">
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{x}">
-      <mi data-latex="x">x</mi>
-    </mrow>
-    <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-ket-large', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\vert {x} \\rangle}">
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{x}">
+             <mi data-latex="x">x</mi>
+           </mrow>
+           <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-ket-large', () => {
     toXmlMatch(
       tex2mml('\\ket{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ket{\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\vert {\\frac{x}{y}} \\rangle}">
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
-      <mfrac data-latex="\\frac{x}{y}">
-        <mi data-latex="x">x</mi>
-        <mi data-latex="y">y</mi>
-      </mfrac>
-    </mrow>
-    <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Ket', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\vert {\\frac{x}{y}} \\rangle}">
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
+             <mfrac data-latex="\\frac{x}{y}">
+               <mi data-latex="x">x</mi>
+               <mi data-latex="y">y</mi>
+             </mfrac>
+           </mrow>
+           <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Ket', () => {
     toXmlMatch(
       tex2mml('\\Ket{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Ket{\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\left\\vert {\\frac{x}{y}} \\right\\rangle}">
-    <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert {\\frac{x}{y}} \\right\\rangle" data-latex="\\left\\vert {\\frac{x}{y}} \\right\\rangle">
-      <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert " data-latex="\\left\\vert ">|</mo>
-      <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
-        <mfrac data-latex="\\frac{x}{y}">
-          <mi data-latex="x">x</mi>
-          <mi data-latex="y">y</mi>
-        </mfrac>
-      </mrow>
-      <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
-    </mrow>
-  </mrow>
-</math>`
-    ));
-  it('Braket-braket', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\left\\vert {\\frac{x}{y}} \\right\\rangle}">
+           <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert {\\frac{x}{y}} \\right\\rangle" data-latex="\\left\\vert {\\frac{x}{y}} \\right\\rangle">
+             <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert " data-latex="\\left\\vert ">|</mo>
+             <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
+               <mfrac data-latex="\\frac{x}{y}">
+                 <mi data-latex="x">x</mi>
+                 <mi data-latex="y">y</mi>
+               </mfrac>
+             </mrow>
+             <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-braket', () => {
     toXmlMatch(
       tex2mml('\\braket{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket{x}" display="block">
-  <mrow data-latex="\\braket{x}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mi data-latex="x">x</mi>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-braket-large', () =>
+         <mrow data-latex="\\braket{x}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mi data-latex="x">x</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-braket-large', () => {
     toXmlMatch(
       tex2mml('\\braket{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket{\\frac{x}{y}}" display="block">
-  <mrow data-latex="\\braket{\\frac{x}{y}}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Braket', () =>
+         <mrow data-latex="\\braket{\\frac{x}{y}}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Braket', () => {
     toXmlMatch(
       tex2mml('\\Braket{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Braket{\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}}">
-    <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-ketbra', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}}">
+           <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-ketbra', () => {
     toXmlMatch(
       tex2mml('\\ketbra{x}{y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ketbra{x}{y}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\vert {x} \\rangle\\langle {y} \\vert}">
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{x}">
-      <mi data-latex="x">x</mi>
-    </mrow>
-    <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-    <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{y}">
-      <mi data-latex="y">y</mi>
-    </mrow>
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-ketbra-large', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\vert {x} \\rangle\\langle {y} \\vert}">
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{x}">
+             <mi data-latex="x">x</mi>
+           </mrow>
+           <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
+           <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{y}">
+             <mi data-latex="y">y</mi>
+           </mrow>
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-ketbra-large', () => {
     toXmlMatch(
       tex2mml('\\ketbra{\\frac{x}{y}}{z}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ketbra{\\frac{x}{y}}{z}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\vert {\\frac{x}{y}} \\rangle\\langle {z} \\vert}">
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
-      <mfrac data-latex="\\frac{x}{y}">
-        <mi data-latex="x">x</mi>
-        <mi data-latex="y">y</mi>
-      </mfrac>
-    </mrow>
-    <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
-    <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
-    <mrow data-mjx-texclass="ORD" data-latex="{z}">
-      <mi data-latex="z">z</mi>
-    </mrow>
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Ketbra', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\vert {\\frac{x}{y}} \\rangle\\langle {z} \\vert}">
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
+             <mfrac data-latex="\\frac{x}{y}">
+               <mi data-latex="x">x</mi>
+               <mi data-latex="y">y</mi>
+             </mfrac>
+           </mrow>
+           <mo fence="false" stretchy="false" data-latex="\\rangle">&#x27E9;</mo>
+           <mo fence="false" stretchy="false" data-latex="\\langle">&#x27E8;</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{z}">
+             <mi data-latex="z">z</mi>
+           </mrow>
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\vert">|</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Ketbra', () => {
     toXmlMatch(
       tex2mml('\\Ketbra{\\frac{x}{y}}{z}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Ketbra{\\frac{x}{y}}{z}" display="block">
-  <mrow data-mjx-texclass="ORD" data-latex="{\\left\\vert {\\frac{x}{y}} \\right\\rangle\\left\\langle {z} \\right\\vert}">
-    <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert {\\frac{x}{y}} \\right\\rangle" data-latex="\\left\\vert {\\frac{x}{y}} \\right\\rangle">
-      <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert " data-latex="\\left\\vert ">|</mo>
-      <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
-        <mfrac data-latex="\\frac{x}{y}">
-          <mi data-latex="x">x</mi>
-          <mi data-latex="y">y</mi>
-        </mfrac>
-      </mrow>
-      <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
-    </mrow>
-    <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle {z} \\right\\vert" data-latex="\\left\\langle {z} \\right\\vert">
-      <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle " data-latex="\\left\\langle ">&#x27E8;</mo>
-      <mrow data-mjx-texclass="ORD" data-latex="{z}">
-        <mi data-latex="z">z</mi>
-      </mrow>
-      <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
-    </mrow>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Set-small', () =>
+         <mrow data-mjx-texclass="ORD" data-latex="{\\left\\vert {\\frac{x}{y}} \\right\\rangle\\left\\langle {z} \\right\\vert}">
+           <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\vert {\\frac{x}{y}} \\right\\rangle" data-latex="\\left\\vert {\\frac{x}{y}} \\right\\rangle">
+             <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\vert " data-latex="\\left\\vert ">|</mo>
+             <mrow data-mjx-texclass="ORD" data-latex="{\\frac{x}{y}}">
+               <mfrac data-latex="\\frac{x}{y}">
+                 <mi data-latex="x">x</mi>
+                 <mi data-latex="y">y</mi>
+               </mfrac>
+             </mrow>
+             <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\rangle" data-latex="\\right\\rangle">&#x27E9;</mo>
+           </mrow>
+           <mrow data-mjx-texclass="INNER" data-latex-item="\\left\\langle {z} \\right\\vert" data-latex="\\left\\langle {z} \\right\\vert">
+             <mo data-mjx-texclass="OPEN" data-latex-item="\\left\\langle " data-latex="\\left\\langle ">&#x27E8;</mo>
+             <mrow data-mjx-texclass="ORD" data-latex="{z}">
+               <mi data-latex="z">z</mi>
+             </mrow>
+             <mo data-mjx-texclass="CLOSE" data-latex-item="\\right\\vert" data-latex="\\right\\vert">|</mo>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Set-small', () => {
     toXmlMatch(
       tex2mml('\\set{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\set{x}" display="block">
-      <mrow data-latex="\\set{x}">
-        <mo data-mjx-texclass="OPEN" stretchy="false">{</mo>
-        <mi data-latex="x">x</mi>
-        <mo data-mjx-texclass="CLOSE" stretchy="false">}</mo>
-      </mrow>
-    </math>`
-    ));
-  it('Braket-Set', () =>
+         <mrow data-latex="\\set{x}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">{</mo>
+           <mi data-latex="x">x</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Set', () => {
     toXmlMatch(
       tex2mml('\\Set{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{x}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Set{x}">
-    <mo data-mjx-texclass="OPEN">{</mo>
-    <mspace width="0.167em"></mspace>
-    <mi data-latex="x">x</mi>
-    <mspace width="0.167em"></mspace>
-    <mo data-mjx-texclass="CLOSE">}</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Set-large', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Set{x}">
+           <mo data-mjx-texclass="OPEN">{</mo>
+           <mspace width="0.167em"></mspace>
+           <mi data-latex="x">x</mi>
+           <mspace width="0.167em"></mspace>
+           <mo data-mjx-texclass="CLOSE">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Set-large', () => {
     toXmlMatch(
       tex2mml('\\Set{\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Set{\\frac{x}{y}}">
-    <mo data-mjx-texclass="OPEN">{</mo>
-    <mspace width="0.167em"></mspace>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mspace width="0.167em"></mspace>
-    <mo data-mjx-texclass="CLOSE">}</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Set-Bar', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Set{\\frac{x}{y}}">
+           <mo data-mjx-texclass="OPEN">{</mo>
+           <mspace width="0.167em"></mspace>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mspace width="0.167em"></mspace>
+           <mo data-mjx-texclass="CLOSE">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Set-Bar', () => {
     toXmlMatch(
       tex2mml('\\Set{x|\\frac{x}{y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{x|\\frac{x}{y}}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Set{x|\\frac{x}{y}}">
-    <mo data-mjx-texclass="OPEN">{</mo>
-    <mspace width="0.167em"></mspace>
-    <mi data-latex="x">x</mi>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mspace width="0.167em"></mspace>
-    <mo data-mjx-texclass="CLOSE">}</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Set-over', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Set{x|\\frac{x}{y}}">
+           <mo data-mjx-texclass="OPEN">{</mo>
+           <mspace width="0.167em"></mspace>
+           <mi data-latex="x">x</mi>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mspace width="0.167em"></mspace>
+           <mo data-mjx-texclass="CLOSE">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Set-over', () => {
     toXmlMatch(
       tex2mml('\\Set{x\\over y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{x\\over y}" display="block">
-      <mrow data-mjx-texclass="INNER" data-latex="\\Set{x\\over y}">
-        <mo data-mjx-texclass="OPEN">{</mo>
-        <mspace width="0.167em"></mspace>
-        <mfrac data-latex-item="\\over">
-          <mi data-latex="x">x</mi>
-          <mi data-latex="y">y</mi>
-        </mfrac>
-        <mspace width="0.167em"></mspace>
-        <mo data-mjx-texclass="CLOSE">}</mo>
-      </mrow>
-    </math>`
-    ));
-  it('Braket-bar-small', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Set{x\\over y}">
+           <mo data-mjx-texclass="OPEN">{</mo>
+           <mspace width="0.167em"></mspace>
+           <mfrac data-latex-item="\\over">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mspace width="0.167em"></mspace>
+           <mo data-mjx-texclass="CLOSE">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-bar-small', () => {
     toXmlMatch(
       tex2mml('\\braket{x|y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket{x|y}" display="block">
-  <mrow data-latex="\\braket{x|y}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mi data-latex="x">x</mi>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-bar-large', () =>
+         <mrow data-latex="\\braket{x|y}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mi data-latex="x">x</mi>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-bar-large', () => {
     toXmlMatch(
       tex2mml('\\braket{\\frac{x}{y}|z}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket{\\frac{x}{y}|z}" display="block">
-  <mrow data-latex="\\braket{\\frac{x}{y}|z}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
-    <mi data-latex="z">z</mi>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar', () =>
+         <mrow data-latex="\\braket{\\frac{x}{y}|z}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
+           <mi data-latex="z">z</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar', () => {
     toXmlMatch(
       tex2mml('\\Braket{\\frac{x}{y}|z}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Braket{\\frac{x}{y}|z}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}|z}">
-    <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="z">z</mi>
-    <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar1', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}|z}">
+           <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="z">z</mi>
+           <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar1', () => {
     toXmlMatch(
       tex2mml('\\Braket{\\frac{x}{y}||z||y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Braket{\\frac{x}{y}||z||y}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}||z||y}">
-    <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="z">z</mi>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar2', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}||z||y}">
+           <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="z">z</mi>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar2', () => {
     toXmlMatch(
       tex2mml('\\Braket{\\frac{x}{y}\\||z||y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Braket{\\frac{x}{y}\\||z||y}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}\\||z||y}">
-    <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="z">z</mi>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar3', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}\\||z||y}">
+           <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="z">z</mi>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar3', () => {
     toXmlMatch(
       tex2mml('\\Braket{\\frac{x}{y}|||z||y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Braket{\\frac{x}{y}|||z||y}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}|||z||y}">
-    <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="z">z</mi>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar4', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}|||z||y}">
+           <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="z">z</mi>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar4', () => {
     toXmlMatch(
       tex2mml('\\Braket{\\frac{x}{y}|||z|||y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Braket{\\frac{x}{y}|||z|||y}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}|||z|||y}">
-    <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="z">z</mi>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar-Set', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Braket{\\frac{x}{y}|||z|||y}">
+           <mo data-mjx-texclass="OPEN">&#x27E8;</mo>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="z">z</mi>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">|</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="CLOSE">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar-Set', () => {
     toXmlMatch(
       tex2mml('\\Set{\\frac{x}{y}||y||z}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{\\frac{x}{y}||y||z}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Set{\\frac{x}{y}||y||z}">
-    <mo data-mjx-texclass="OPEN">{</mo>
-    <mspace width="0.167em"></mspace>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-    <mi data-latex="z">z</mi>
-    <mspace width="0.167em"></mspace>
-    <mo data-mjx-texclass="CLOSE">}</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Bar-Set2', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Set{\\frac{x}{y}||y||z}">
+           <mo data-mjx-texclass="OPEN">{</mo>
+           <mspace width="0.167em"></mspace>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+           <mi data-latex="z">z</mi>
+           <mspace width="0.167em"></mspace>
+           <mo data-mjx-texclass="CLOSE">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Bar-Set2', () => {
     toXmlMatch(
       tex2mml('\\Set{\\frac{x}{y}\\||y\\||z}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Set{\\frac{x}{y}\\||y\\||z}" display="block">
-  <mrow data-mjx-texclass="INNER" data-latex="\\Set{\\frac{x}{y}\\||y\\||z}">
-    <mo data-mjx-texclass="OPEN">{</mo>
-    <mspace width="0.167em"></mspace>
-    <mfrac data-latex="\\frac{x}{y}">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-    </mfrac>
-    <mrow data-mjx-texclass="CLOSE"></mrow>
-    <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
-    <mrow data-mjx-texclass="OPEN"></mrow>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-    <mi data-latex="y">y</mi>
-    <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\|">&#x2016;</mo>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-    <mi data-latex="z">z</mi>
-    <mspace width="0.167em"></mspace>
-    <mo data-mjx-texclass="CLOSE">}</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-Space', () =>
+         <mrow data-mjx-texclass="INNER" data-latex="\\Set{\\frac{x}{y}\\||y\\||z}">
+           <mo data-mjx-texclass="OPEN">{</mo>
+           <mspace width="0.167em"></mspace>
+           <mfrac data-latex="\\frac{x}{y}">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+           </mfrac>
+           <mrow data-mjx-texclass="CLOSE"></mrow>
+           <mo data-mjx-texclass="BIN" data-braketbar="true">&#x2016;</mo>
+           <mrow data-mjx-texclass="OPEN"></mrow>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+           <mi data-latex="y">y</mi>
+           <mo data-mjx-texclass="ORD" fence="false" stretchy="false" data-latex="\\|">&#x2016;</mo>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+           <mi data-latex="z">z</mi>
+           <mspace width="0.167em"></mspace>
+           <mo data-mjx-texclass="CLOSE">}</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Space', () => {
     toXmlMatch(
       tex2mml('\\braket {a|b}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket {a|b}" display="block">
-  <mrow data-latex="\\braket {a|b}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mi data-latex="a">a</mi>
-    <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
-    <mi data-latex="b">b</mi>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-No-Braces-Simple', () =>
+         <mrow data-latex="\\braket {a|b}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mi data-latex="a">a</mi>
+           <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
+           <mi data-latex="b">b</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-No-Braces-Simple', () => {
     toXmlMatch(
       tex2mml('\\braket a|b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket a|b" display="block">
-  <mrow data-latex="a">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mi>a</mi>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-  <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-  <mi data-latex="b">b</mi>
-</math>`
-    ));
-  it('Braket-No-Braces-Complex', () =>
+         <mrow data-latex="a">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mi>a</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+         <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+         <mi data-latex="b">b</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-No-Braces-Complex', () => {
     toXmlMatch(
       tex2mml('\\braket \\frac{a}{c}|b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket \\frac{a}{c}|b" display="block">
-  <mrow data-latex="\\frac{a}{c}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mfrac>
-      <mi data-latex="a">a</mi>
-      <mi data-latex="c">c</mi>
-    </mfrac>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-  <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
-  <mi data-latex="b">b</mi>
-</math>`
-    ));
-  it('Braket-Nested', () =>
+         <mrow data-latex="\\frac{a}{c}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mfrac>
+             <mi data-latex="a">a</mi>
+             <mi data-latex="c">c</mi>
+           </mfrac>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+         <mo data-mjx-texclass="ORD" stretchy="false" data-latex="|">|</mo>
+         <mi data-latex="b">b</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-Nested', () => {
     toXmlMatch(
       tex2mml('\\braket {\\braket{a|b}c}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket {\\braket{a|b}c}" display="block">
-  <mrow data-latex="\\braket {\\braket{a|b}c}">
-    <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-    <mrow data-latex="{}">
-      <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
-      <mi data-latex="a">a</mi>
-      <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
-      <mi data-latex="b">b</mi>
-      <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-    </mrow>
-    <mi data-latex="c">c</mi>
-    <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
-  </mrow>
-</math>`
-    ));
-  it('Braket-error', () =>
-    toXmlMatch(
-      tex2mml('\\braket'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\braket" display="block">
-      <merror data-mjx-error="Missing argument for \\braket">
-        <mtext>Missing argument for \\braket</mtext>
-      </merror>
-    </math>`
-    ));
+         <mrow data-latex="\\braket {\\braket{a|b}c}">
+           <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+           <mrow data-latex="{}">
+             <mo data-mjx-texclass="OPEN" stretchy="false">&#x27E8;</mo>
+             <mi data-latex="a">a</mi>
+             <mo data-mjx-texclass="ORD" stretchy="false" data-braketbar="true" data-latex="|">|</mo>
+             <mi data-latex="b">b</mi>
+             <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+           </mrow>
+           <mi data-latex="c">c</mi>
+           <mo data-mjx-texclass="CLOSE" stretchy="false">&#x27E9;</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Braket-error', () => {
+    expectTexError('\\braket')
+      .toBe('Missing argument for \\braket');
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('braket'));

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -5,2853 +5,2972 @@ import '#js/input/tex/ams/AmsConfiguration';
 
 beforeEach(() => setupTexWithOutput(['base', 'ams', 'bussproofs']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('BussproofsRegInf', () => {
-  it('Single Axiom', () =>
+
+  /********************************************************************************/
+
+  it('Single Axiom', () => {
     toXmlMatch(
       tex2mml('\\begin{prooftree}\\AxiomC{A}\\end{prooftree}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_axiom:true;bspr_proof:true">
-    <mspace width=".5ex"></mspace>
-    <mstyle displaystyle="false">
-      <mtext>A</mtext>
-    </mstyle>
-    <mspace width=".5ex"></mspace>
-  </mrow>
-</math>`
-    ));
-  it('Unary Inference', () =>
+         <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_axiom:true;bspr_proof:true">
+           <mspace width=".5ex"></mspace>
+           <mstyle displaystyle="false">
+             <mtext>A</mtext>
+           </mstyle>
+           <mspace width=".5ex"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Unary Inference', () => {
     toXmlMatch(
       tex2mml('\\begin{prooftree}\\AxiomC{A}\\UnaryInfC{B}\\end{prooftree}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\UnaryInfC{B}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:1;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>B</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Binary Inference', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:1;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>B</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Binary Inference', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\BinaryInfC{C}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\BinaryInfC{C}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\BinaryInfC{C}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:2;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>C</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Trinary Inference', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\BinaryInfC{C}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:2;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>B</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>C</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Trinary Inference', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\TrinaryInfC{D}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\TrinaryInfC{D}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\TrinaryInfC{D}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:3;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>C</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>D</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Quaternary Inference', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\TrinaryInfC{D}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:3;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>B</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>C</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>D</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Quaternary Inference', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\QuaternaryInfC{E}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\QuaternaryInfC{E}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\QuaternaryInfC{E}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:4;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>C</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>D</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>E</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Quinary Inference', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\QuaternaryInfC{E}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:4;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>B</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>C</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>D</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>E</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Quinary Inference', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\AxiomC{E}\\QuinaryInfC{F}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\AxiomC{E}\\QuinaryInfC{F}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\AxiomC{E}\\QuinaryInfC{F}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:5;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>C</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>D</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AxiomC{E}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>E</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>F</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Label Left', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{A}\\AxiomC{B}\\AxiomC{C}\\AxiomC{D}\\AxiomC{E}\\QuinaryInfC{F}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:5;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>B</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{C}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>C</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>D</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AxiomC{E}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>E</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>F</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Label Left', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" display="block">
-      <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
-        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false">
-            <mtext>L</mtext>
-          </mstyle>
-        </mpadded>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>A</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mrow>
-    </math>`
-    ));
-  it('Label Right', () =>
+         <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
+           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+             <mstyle displaystyle="false">
+               <mtext>L</mtext>
+             </mstyle>
+           </mpadded>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>A</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>B</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Label Right', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
-      <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>A</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false">
-            <mtext>R</mtext>
-          </mstyle>
-        </mpadded>
-      </mrow>
-    </math>`
-    ));
-  it('Label Both', () =>
+         <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>A</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>B</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+             <mstyle displaystyle="false">
+               <mtext>R</mtext>
+             </mstyle>
+           </mpadded>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Label Both', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" display="block">
-      <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
-        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false">
-            <mtext>L</mtext>
-          </mstyle>
-        </mpadded>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>A</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false">
-            <mtext>R</mtext>
-          </mstyle>
-        </mpadded>
-      </mrow>
-    </math>`
-    ));
-  it('Single Axiom Abbr', () =>
+         <mrow data-latex="\\begin{prooftree}\\AxiomC{A}\\LeftLabel{L}\\RightLabel{R}\\UnaryInfC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
+           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+             <mstyle displaystyle="false">
+               <mtext>L</mtext>
+             </mstyle>
+           </mpadded>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>A</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>B</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+             <mstyle displaystyle="false">
+               <mtext>R</mtext>
+             </mstyle>
+           </mpadded>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Single Axiom Abbr', () => {
     toXmlMatch(
       tex2mml('\\begin{prooftree}\\AXC{A}\\end{prooftree}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\end{prooftree}" display="block">
-  <mrow data-latex="\\begin{prooftree}\\AXC{A}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_axiom:true;bspr_proof:true">
-    <mspace width=".5ex"></mspace>
-    <mstyle displaystyle="false">
-      <mtext>A</mtext>
-    </mstyle>
-    <mspace width=".5ex"></mspace>
-  </mrow>
-</math>`
-    ));
-  it('Unary Inference Abbr', () =>
+         <mrow data-latex="\\begin{prooftree}\\AXC{A}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_axiom:true;bspr_proof:true">
+           <mspace width=".5ex"></mspace>
+           <mstyle displaystyle="false">
+             <mtext>A</mtext>
+           </mstyle>
+           <mspace width=".5ex"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Unary Inference Abbr', () => {
     toXmlMatch(
       tex2mml('\\begin{prooftree}\\AXC{A}\\UIC{B}\\end{prooftree}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\UIC{B}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AXC{A}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:1;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>B</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Binary Inference Abbr', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AXC{A}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:1;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>B</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Binary Inference Abbr', () => {
     toXmlMatch(
       tex2mml('\\begin{prooftree}\\AXC{A}\\AXC{B}\\BIC{C}\\end{prooftree}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\AXC{B}\\BIC{C}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AXC{A}\\AXC{B}\\BIC{C}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:2;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AXC{B}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>C</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Trinary Inference Abbr', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AXC{A}\\AXC{B}\\BIC{C}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:2;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AXC{B}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>B</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>C</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Trinary Inference Abbr', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\AXC{B}\\AXC{C}\\TIC{D}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\AXC{B}\\AXC{C}\\TIC{D}\\end{prooftree}" display="block">
-  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AXC{A}\\AXC{B}\\AXC{C}\\TIC{D}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:3;bspr_proof:true">
-    <mtr>
-      <mtd>
-        <mtable framespacing="0 0">
-          <mtr>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>A</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AXC{B}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-            <mtd></mtd>
-            <mtd rowalign="bottom">
-              <mrow data-latex="\\AXC{C}" semantics="bspr_axiom:true">
-                <mspace width=".5ex"></mspace>
-                <mtext>C</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mspace width=".5ex"></mspace>
-          <mtext>D</mtext>
-          <mspace width=".5ex"></mspace>
-        </mrow>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Label Left Abbr', () =>
+         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AXC{A}\\AXC{B}\\AXC{C}\\TIC{D}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down;bspr_inference:3;bspr_proof:true">
+           <mtr>
+             <mtd>
+               <mtable framespacing="0 0">
+                 <mtr>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AXC{A}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>A</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AXC{B}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>B</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                   <mtd></mtd>
+                   <mtd rowalign="bottom">
+                     <mrow data-latex="\\AXC{C}" semantics="bspr_axiom:true">
+                       <mspace width=".5ex"></mspace>
+                       <mtext>C</mtext>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mspace width=".5ex"></mspace>
+                 <mtext>D</mtext>
+                 <mspace width=".5ex"></mspace>
+               </mrow>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Label Left Abbr', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" display="block">
-      <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
-        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false">
-            <mtext>L</mtext>
-          </mstyle>
-        </mpadded>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>A</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mrow>
-    </math>`
-    ));
-  it('Label Right Abbr', () =>
+         <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:left;bspr_inference:1;bspr_proof:true">
+           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+             <mstyle displaystyle="false">
+               <mtext>L</mtext>
+             </mstyle>
+           </mpadded>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\LeftLabel{L}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>A</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>B</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Label Right Abbr', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
-      <mrow data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>A</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false">
-            <mtext>R</mtext>
-          </mstyle>
-        </mpadded>
-      </mrow>
-    </math>`
-    ));
-  it('Label Both Abbr', () =>
+         <mrow data-latex="\\begin{prooftree}\\AXC{A}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:right;bspr_inference:1;bspr_proof:true">
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>A</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>B</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+             <mstyle displaystyle="false">
+               <mtext>R</mtext>
+             </mstyle>
+           </mpadded>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Label Both Abbr', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" display="block">
-      <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
-        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-          <mstyle displaystyle="false">
-            <mtext>L</mtext>
-          </mstyle>
-        </mpadded>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>A</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>B</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-          <mstyle displaystyle="false">
-            <mtext>R</mtext>
-          </mstyle>
-        </mpadded>
-      </mrow>
-    </math>`
-    ));
+         <mrow data-latex="\\begin{prooftree}\\AXC{A}\\LeftLabel{L}\\RightLabel{R}\\UIC{B}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_labelledRule:both;bspr_inference:1;bspr_proof:true">
+           <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+             <mstyle displaystyle="false">
+               <mtext>L</mtext>
+             </mstyle>
+           </mpadded>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\RightLabel{R}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>A</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>B</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+             <mstyle displaystyle="false">
+               <mtext>R</mtext>
+             </mstyle>
+           </mpadded>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('BussproofsRegProofs', () => {
-  it('Simple Proof', () =>
+
+  /********************************************************************************/
+
+  it('Simple Proof', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:2;bspr_proof:true">
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>D</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                  <mtd></mtd>
-                  <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2">
-                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
-                        <mtr>
-                          <mtd>
-                            <mtable framespacing="0 0">
-                              <mtr>
-                                <mtd rowalign="bottom">
-                                  <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                    <mspace width=".5ex"></mspace>
-                                    <mtext>A</mtext>
-                                    <mspace width=".5ex"></mspace>
-                                  </mrow>
-                                </mtd>
-                                <mtd></mtd>
-                                <mtd rowalign="bottom">
-                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
-                                    <mtr>
-                                      <mtd>
-                                        <mtable framespacing="0 0">
-                                          <mtr>
-                                            <mtd rowalign="bottom">
-                                              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                <mspace width=".5ex"></mspace>
-                                                <mtext>B</mtext>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                            <mtd></mtd>
-                                            <mtd rowalign="bottom">
-                                              <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                <mspace width=".5ex"></mspace>
-                                                <mtext>R</mtext>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                      </mtd>
-                                    </mtr>
-                                    <mtr>
-                                      <mtd>
-                                        <mrow>
-                                          <mspace width=".5ex"></mspace>
-                                          <mrow data-mjx-texclass="ORD">
-                                            <mi data-latex="C">C</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="D">D</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="Q">Q</mi>
-                                          </mrow>
-                                          <mspace width=".5ex"></mspace>
-                                        </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                          </mtd>
-                        </mtr>
-                        <mtr>
-                          <mtd>
-                            <mrow>
-                              <mspace width=".5ex"></mspace>
-                              <mtext>E</mtext>
-                              <mspace width=".5ex"></mspace>
-                            </mrow>
-                          </mtd>
-                        </mtr>
-                      </mtable>
-                      <mspace width="-3.795em"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>F</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mspace width="3.795em"></mspace>
-      </mrow>
-    </math>`
-    ));
-  it('Simple Proof Noise', () =>
+         <mrow semantics="bspr_inference:2;bspr_proof:true">
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>D</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                     <mtd></mtd>
+                     <mtd rowalign="bottom">
+                       <mrow semantics="bspr_inference:2">
+                         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
+                           <mtr>
+                             <mtd>
+                               <mtable framespacing="0 0">
+                                 <mtr>
+                                   <mtd rowalign="bottom">
+                                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                       <mspace width=".5ex"></mspace>
+                                       <mtext>A</mtext>
+                                       <mspace width=".5ex"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                   <mtd></mtd>
+                                   <mtd rowalign="bottom">
+                                     <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
+                                       <mtr>
+                                         <mtd>
+                                           <mtable framespacing="0 0">
+                                             <mtr>
+                                               <mtd rowalign="bottom">
+                                                 <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                   <mspace width=".5ex"></mspace>
+                                                   <mtext>B</mtext>
+                                                   <mspace width=".5ex"></mspace>
+                                                 </mrow>
+                                               </mtd>
+                                               <mtd></mtd>
+                                               <mtd rowalign="bottom">
+                                                 <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                   <mspace width=".5ex"></mspace>
+                                                   <mtext>R</mtext>
+                                                   <mspace width=".5ex"></mspace>
+                                                 </mrow>
+                                               </mtd>
+                                             </mtr>
+                                           </mtable>
+                                         </mtd>
+                                       </mtr>
+                                       <mtr>
+                                         <mtd>
+                                           <mrow>
+                                             <mspace width=".5ex"></mspace>
+                                             <mrow data-mjx-texclass="ORD">
+                                               <mi data-latex="C">C</mi>
+                                               <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                               <mi data-latex="D">D</mi>
+                                               <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                               <mi data-latex="Q">Q</mi>
+                                             </mrow>
+                                             <mspace width=".5ex"></mspace>
+                                           </mrow>
+                                         </mtd>
+                                       </mtr>
+                                     </mtable>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                             </mtd>
+                           </mtr>
+                           <mtr>
+                             <mtd>
+                               <mrow>
+                                 <mspace width=".5ex"></mspace>
+                                 <mtext>E</mtext>
+                                 <mspace width=".5ex"></mspace>
+                               </mrow>
+                             </mtd>
+                           </mtr>
+                         </mtable>
+                         <mspace width="-3.795em"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>F</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mspace width="3.795em"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Simple Proof Noise', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" display="block">
-      <mrow data-latex-item="{prooftree}" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" semantics="bspr_proof:true">
-        <mrow data-mjx-texclass="ORD">
-          <mo>$</mo>
-        </mrow>
-        <mi>&#x3B1;</mi>
-        <mrow data-mjx-texclass="ORD">
-          <mo>$</mo>
-        </mrow>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down;bspr_inference:2">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>D</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                  <mtd></mtd>
-                  <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2">
-                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
-                        <mtr>
-                          <mtd>
-                            <mtable framespacing="0 0">
-                              <mtr>
-                                <mtd rowalign="bottom">
-                                  <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                    <mspace width=".5ex"></mspace>
-                                    <mtext>A</mtext>
-                                    <mspace width=".5ex"></mspace>
-                                  </mrow>
-                                </mtd>
-                                <mtd></mtd>
-                                <mtd rowalign="bottom">
-                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
-                                    <mtr>
-                                      <mtd>
-                                        <mtable framespacing="0 0">
-                                          <mtr>
-                                            <mtd rowalign="bottom">
-                                              <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                <mspace width=".5ex"></mspace>
-                                                <mtext>B</mtext>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                            <mtd></mtd>
-                                            <mtd rowalign="bottom">
-                                              <mrow data-latex="$" semantics="bspr_axiom:true">
-                                                <mspace width=".5ex"></mspace>
-                                                <mtext>R</mtext>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                      </mtd>
-                                    </mtr>
-                                    <mtr>
-                                      <mtd>
-                                        <mrow>
-                                          <mspace width=".5ex"></mspace>
-                                          <mrow data-mjx-texclass="ORD">
-                                            <mi data-latex="C">C</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="D">D</mi>
-                                            <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                            <mi data-latex="Q">Q</mi>
-                                          </mrow>
-                                          <mspace width=".5ex"></mspace>
-                                        </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                          </mtd>
-                        </mtr>
-                        <mtr>
-                          <mtd>
-                            <mrow>
-                              <mspace width=".5ex"></mspace>
-                              <mtext>E</mtext>
-                              <mspace width=".5ex"></mspace>
-                            </mrow>
-                          </mtd>
-                        </mtr>
-                      </mtable>
-                      <mspace width="-3.795em"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mtext>F</mtext>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mspace width="3.795em"></mspace>
-      </mrow>
-    </math>`
-    ));
-  it('Simple Proof Large', () =>
+         <mrow data-latex-item="{prooftree}" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}$\\alpha$\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\end{prooftree}" semantics="bspr_proof:true">
+           <mrow data-mjx-texclass="ORD">
+             <mo>$</mo>
+           </mrow>
+           <mi>&#x3B1;</mi>
+           <mrow data-mjx-texclass="ORD">
+             <mo>$</mo>
+           </mrow>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down;bspr_inference:2">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>D</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                     <mtd></mtd>
+                     <mtd rowalign="bottom">
+                       <mrow semantics="bspr_inference:2">
+                         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
+                           <mtr>
+                             <mtd>
+                               <mtable framespacing="0 0">
+                                 <mtr>
+                                   <mtd rowalign="bottom">
+                                     <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                       <mspace width=".5ex"></mspace>
+                                       <mtext>A</mtext>
+                                       <mspace width=".5ex"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                   <mtd></mtd>
+                                   <mtd rowalign="bottom">
+                                     <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
+                                       <mtr>
+                                         <mtd>
+                                           <mtable framespacing="0 0">
+                                             <mtr>
+                                               <mtd rowalign="bottom">
+                                                 <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                   <mspace width=".5ex"></mspace>
+                                                   <mtext>B</mtext>
+                                                   <mspace width=".5ex"></mspace>
+                                                 </mrow>
+                                               </mtd>
+                                               <mtd></mtd>
+                                               <mtd rowalign="bottom">
+                                                 <mrow data-latex="$" semantics="bspr_axiom:true">
+                                                   <mspace width=".5ex"></mspace>
+                                                   <mtext>R</mtext>
+                                                   <mspace width=".5ex"></mspace>
+                                                 </mrow>
+                                               </mtd>
+                                             </mtr>
+                                           </mtable>
+                                         </mtd>
+                                       </mtr>
+                                       <mtr>
+                                         <mtd>
+                                           <mrow>
+                                             <mspace width=".5ex"></mspace>
+                                             <mrow data-mjx-texclass="ORD">
+                                               <mi data-latex="C">C</mi>
+                                               <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                               <mi data-latex="D">D</mi>
+                                               <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                               <mi data-latex="Q">Q</mi>
+                                             </mrow>
+                                             <mspace width=".5ex"></mspace>
+                                           </mrow>
+                                         </mtd>
+                                       </mtr>
+                                     </mtable>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                             </mtd>
+                           </mtr>
+                           <mtr>
+                             <mtd>
+                               <mrow>
+                                 <mspace width=".5ex"></mspace>
+                                 <mtext>E</mtext>
+                                 <mspace width=".5ex"></mspace>
+                               </mrow>
+                             </mtd>
+                           </mtr>
+                         </mtable>
+                         <mspace width="-3.795em"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mtext>F</mtext>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mspace width="3.795em"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Simple Proof Large', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:2;bspr_proof:true">
-        <mspace width="8.227em"></mspace>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2">
-                      <mspace width="-4.953em"></mspace>
-                      <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down">
-                        <mtr>
-                          <mtd>
-                            <mtable framespacing="0 0">
-                              <mtr>
-                                <mtd rowalign="bottom">
-                                  <mrow semantics="bspr_inference:3">
-                                    <mspace width="-3.274em"></mspace>
-                                    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\TrinaryInfC{Q}" semantics="bspr_inferenceRule:down">
-                                      <mtr>
-                                        <mtd>
-                                          <mtable framespacing="0 0">
-                                            <mtr>
-                                              <mtd rowalign="bottom">
-                                                <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>D</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                              <mtd></mtd>
-                                              <mtd rowalign="bottom">
-                                                <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>A1</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                              <mtd></mtd>
-                                              <mtd rowalign="bottom">
-                                                <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>A2</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                        </mtd>
-                                      </mtr>
-                                      <mtr>
-                                        <mtd>
-                                          <mrow>
-                                            <mspace width=".5ex"></mspace>
-                                            <mtext>Q</mtext>
-                                            <mspace width=".5ex"></mspace>
-                                          </mrow>
-                                        </mtd>
-                                      </mtr>
-                                    </mtable>
-                                  </mrow>
-                                </mtd>
-                                <mtd></mtd>
-                                <mtd rowalign="bottom">
-                                  <mrow semantics="bspr_inference:2">
-                                    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
-                                      <mtr>
-                                        <mtd>
-                                          <mtable framespacing="0 0">
-                                            <mtr>
-                                              <mtd rowalign="bottom">
-                                                <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>A</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                              <mtd></mtd>
-                                              <mtd rowalign="bottom">
-                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mtable framespacing="0 0">
-                                                        <mtr>
-                                                          <mtd rowalign="bottom">
-                                                            <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mtext>B</mtext>
-                                                              <mspace width=".5ex"></mspace>
-                                                            </mrow>
-                                                          </mtd>
-                                                          <mtd></mtd>
-                                                          <mtd rowalign="bottom">
-                                                            <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mtext>R</mtext>
-                                                              <mspace width=".5ex"></mspace>
-                                                            </mrow>
-                                                          </mtd>
-                                                        </mtr>
-                                                      </mtable>
-                                                    </mtd>
-                                                  </mtr>
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mrow data-mjx-texclass="ORD">
-                                                          <mi data-latex="C">C</mi>
-                                                          <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                          <mi data-latex="D">D</mi>
-                                                          <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                          <mi data-latex="Q">Q</mi>
-                                                        </mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                        </mtd>
-                                      </mtr>
-                                      <mtr>
-                                        <mtd>
-                                          <mrow>
-                                            <mspace width=".5ex"></mspace>
-                                            <mtext>E</mtext>
-                                            <mspace width=".5ex"></mspace>
-                                          </mrow>
-                                        </mtd>
-                                      </mtr>
-                                    </mtable>
-                                    <mspace width="-3.795em"></mspace>
-                                  </mrow>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                          </mtd>
-                        </mtr>
-                        <mtr>
-                          <mtd>
-                            <mrow>
-                              <mspace width=".5ex"></mspace>
-                              <mtext>F</mtext>
-                              <mspace width=".5ex"></mspace>
-                            </mrow>
-                          </mtd>
-                        </mtr>
-                      </mtable>
-                    </mrow>
-                  </mtd>
-                  <mtd>
-                    <mspace width="3.795em"></mspace>
-                  </mtd>
-                  <mtd rowalign="bottom">
-                    <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                      <mspace width=".5ex"></mspace>
-                      <mtext>M</mtext>
-                      <mspace width=".5ex"></mspace>
-                    </mrow>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mrow data-mjx-texclass="ORD">
-                  <mi data-latex="N">N</mi>
-                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                  <mi data-latex="R">R</mi>
-                </mrow>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-      </mrow>
-    </math>`
-    ));
-  it('Simple Proofs Right Labels', () =>
+         <mrow semantics="bspr_inference:2;bspr_proof:true">
+           <mspace width="8.227em"></mspace>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\BinaryInfC{E}\\BinaryInfC{F}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow semantics="bspr_inference:2">
+                         <mspace width="-4.953em"></mspace>
+                         <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{F}" semantics="bspr_inferenceRule:down">
+                           <mtr>
+                             <mtd>
+                               <mtable framespacing="0 0">
+                                 <mtr>
+                                   <mtd rowalign="bottom">
+                                     <mrow semantics="bspr_inference:3">
+                                       <mspace width="-3.274em"></mspace>
+                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\TrinaryInfC{Q}" semantics="bspr_inferenceRule:down">
+                                         <mtr>
+                                           <mtd>
+                                             <mtable framespacing="0 0">
+                                               <mtr>
+                                                 <mtd rowalign="bottom">
+                                                   <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>D</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                                 <mtd></mtd>
+                                                 <mtd rowalign="bottom">
+                                                   <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>A1</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                                 <mtd></mtd>
+                                                 <mtd rowalign="bottom">
+                                                   <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>A2</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                           </mtd>
+                                         </mtr>
+                                         <mtr>
+                                           <mtd>
+                                             <mrow>
+                                               <mspace width=".5ex"></mspace>
+                                               <mtext>Q</mtext>
+                                               <mspace width=".5ex"></mspace>
+                                             </mrow>
+                                           </mtd>
+                                         </mtr>
+                                       </mtable>
+                                     </mrow>
+                                   </mtd>
+                                   <mtd></mtd>
+                                   <mtd rowalign="bottom">
+                                     <mrow semantics="bspr_inference:2">
+                                       <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{E}" semantics="bspr_inferenceRule:down">
+                                         <mtr>
+                                           <mtd>
+                                             <mtable framespacing="0 0">
+                                               <mtr>
+                                                 <mtd rowalign="bottom">
+                                                   <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>A</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                                 <mtd></mtd>
+                                                 <mtd rowalign="bottom">
+                                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}" semantics="bspr_inferenceRule:down;bspr_inference:2">
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mtable framespacing="0 0">
+                                                           <mtr>
+                                                             <mtd rowalign="bottom">
+                                                               <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                 <mspace width=".5ex"></mspace>
+                                                                 <mtext>B</mtext>
+                                                                 <mspace width=".5ex"></mspace>
+                                                               </mrow>
+                                                             </mtd>
+                                                             <mtd></mtd>
+                                                             <mtd rowalign="bottom">
+                                                               <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                 <mspace width=".5ex"></mspace>
+                                                                 <mtext>R</mtext>
+                                                                 <mspace width=".5ex"></mspace>
+                                                               </mrow>
+                                                             </mtd>
+                                                           </mtr>
+                                                         </mtable>
+                                                       </mtd>
+                                                     </mtr>
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mrow data-mjx-texclass="ORD">
+                                                             <mi data-latex="C">C</mi>
+                                                             <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                             <mi data-latex="D">D</mi>
+                                                             <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                             <mi data-latex="Q">Q</mi>
+                                                           </mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                           </mtd>
+                                         </mtr>
+                                         <mtr>
+                                           <mtd>
+                                             <mrow>
+                                               <mspace width=".5ex"></mspace>
+                                               <mtext>E</mtext>
+                                               <mspace width=".5ex"></mspace>
+                                             </mrow>
+                                           </mtd>
+                                         </mtr>
+                                       </mtable>
+                                       <mspace width="-3.795em"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                             </mtd>
+                           </mtr>
+                           <mtr>
+                             <mtd>
+                               <mrow>
+                                 <mspace width=".5ex"></mspace>
+                                 <mtext>F</mtext>
+                                 <mspace width=".5ex"></mspace>
+                               </mrow>
+                             </mtd>
+                           </mtr>
+                         </mtable>
+                       </mrow>
+                     </mtd>
+                     <mtd>
+                       <mspace width="3.795em"></mspace>
+                     </mtd>
+                     <mtd rowalign="bottom">
+                       <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                         <mspace width=".5ex"></mspace>
+                         <mtext>M</mtext>
+                         <mspace width=".5ex"></mspace>
+                       </mrow>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mrow data-mjx-texclass="ORD">
+                     <mi data-latex="N">N</mi>
+                     <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                     <mi data-latex="R">R</mi>
+                   </mrow>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Simple Proofs Right Labels', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:right">
-        <mspace width="8.227em"></mspace>
-        <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-            <mtr>
-              <mtd>
-                <mtable framespacing="0 0">
-                  <mtr>
-                    <mtd rowalign="bottom">
-                      <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                        <mspace width="-8.227em"></mspace>
-                        <mrow>
-                          <mspace width="3.274em"></mspace>
-                          <mrow data-latex="\\RightLabel{QERE}">
-                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                              <mtr>
-                                <mtd>
-                                  <mtable framespacing="0 0">
-                                    <mtr>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:3">
-                                          <mspace width="-3.274em"></mspace>
-                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
-                                            <mtr>
-                                              <mtd>
-                                                <mtable framespacing="0 0">
-                                                  <mtr>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>D</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A1</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A2</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                              </mtd>
-                                            </mtr>
-                                            <mtr>
-                                              <mtd>
-                                                <mrow>
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>Q</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                        </mrow>
-                                      </mtd>
-                                      <mtd></mtd>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                          <mrow data-latex="\\RightLabel{CCCCC}">
-                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                              <mtr>
-                                                <mtd>
-                                                  <mtable framespacing="0 0">
-                                                    <mtr>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                          <mspace width=".5ex"></mspace>
-                                                          <mtext>A</mtext>
-                                                          <mspace width=".5ex"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                      <mtd></mtd>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                          <mrow data-latex="\\RightLabel{BBB}">
-                                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                              <mtr>
-                                                                <mtd>
-                                                                  <mtable framespacing="0 0">
-                                                                    <mtr>
-                                                                      <mtd rowalign="bottom">
-                                                                        <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                          <mspace width=".5ex"></mspace>
-                                                                          <mtext>B</mtext>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                        </mrow>
-                                                                      </mtd>
-                                                                      <mtd></mtd>
-                                                                      <mtd rowalign="bottom">
-                                                                        <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                          <mspace width=".5ex"></mspace>
-                                                                          <mtext>R</mtext>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                        </mrow>
-                                                                      </mtd>
-                                                                    </mtr>
-                                                                  </mtable>
-                                                                </mtd>
-                                                              </mtr>
-                                                              <mtr>
-                                                                <mtd>
-                                                                  <mrow>
-                                                                    <mspace width=".5ex"></mspace>
-                                                                    <mrow data-mjx-texclass="ORD">
-                                                                      <mi data-latex="C">C</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="D">D</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="Q">Q</mi>
-                                                                    </mrow>
-                                                                    <mspace width=".5ex"></mspace>
-                                                                  </mrow>
-                                                                </mtd>
-                                                              </mtr>
-                                                            </mtable>
-                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                              <mtext>AAAA</mtext>
-                                                            </mpadded>
-                                                          </mrow>
-                                                          <mspace width="-3.216em"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                    </mtr>
-                                                  </mtable>
-                                                </mtd>
-                                              </mtr>
-                                              <mtr>
-                                                <mtd>
-                                                  <mrow>
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mtext>E</mtext>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                              <mtext>BBB</mtext>
-                                            </mpadded>
-                                          </mrow>
-                                          <mspace width="-6.134em"></mspace>
-                                        </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                              <mtr>
-                                <mtd>
-                                  <mrow>
-                                    <mspace width=".5ex"></mspace>
-                                    <mtext>F</mtext>
-                                    <mspace width=".5ex"></mspace>
-                                  </mrow>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                              <mtext>CCCCC</mtext>
-                            </mpadded>
-                          </mrow>
-                        </mrow>
-                      </mrow>
-                    </mtd>
-                    <mtd>
-                      <mspace width="3.185em"></mspace>
-                    </mtd>
-                    <mtd rowalign="bottom">
-                      <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                        <mspace width=".5ex"></mspace>
-                        <mtext>M</mtext>
-                        <mspace width=".5ex"></mspace>
-                      </mrow>
-                    </mtd>
-                  </mtr>
-                </mtable>
-              </mtd>
-            </mtr>
-            <mtr>
-              <mtd>
-                <mrow>
-                  <mspace width=".5ex"></mspace>
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="N">N</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="R">R</mi>
-                  </mrow>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-            <mstyle displaystyle="false">
-              <mtext>QERE</mtext>
-            </mstyle>
-          </mpadded>
-        </mrow>
-      </mrow>
-    </math>`
-    ));
-  it('Simple Proofs Left Labels', () =>
+         <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:right">
+           <mspace width="8.227em"></mspace>
+           <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+               <mtr>
+                 <mtd>
+                   <mtable framespacing="0 0">
+                     <mtr>
+                       <mtd rowalign="bottom">
+                         <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                           <mspace width="-8.227em"></mspace>
+                           <mrow>
+                             <mspace width="3.274em"></mspace>
+                             <mrow data-latex="\\RightLabel{QERE}">
+                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                 <mtr>
+                                   <mtd>
+                                     <mtable framespacing="0 0">
+                                       <mtr>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:3">
+                                             <mspace width="-3.274em"></mspace>
+                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
+                                               <mtr>
+                                                 <mtd>
+                                                   <mtable framespacing="0 0">
+                                                     <mtr>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>D</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A1</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A2</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                 </mtd>
+                                               </mtr>
+                                               <mtr>
+                                                 <mtd>
+                                                   <mrow>
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>Q</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                           </mrow>
+                                         </mtd>
+                                         <mtd></mtd>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                             <mrow data-latex="\\RightLabel{CCCCC}">
+                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mtable framespacing="0 0">
+                                                       <mtr>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>A</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                         <mtd></mtd>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                             <mrow data-latex="\\RightLabel{BBB}">
+                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                 <mtr>
+                                                                   <mtd>
+                                                                     <mtable framespacing="0 0">
+                                                                       <mtr>
+                                                                         <mtd rowalign="bottom">
+                                                                           <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mtext>B</mtext>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                         <mtd></mtd>
+                                                                         <mtd rowalign="bottom">
+                                                                           <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mtext>R</mtext>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                     </mtable>
+                                                                   </mtd>
+                                                                 </mtr>
+                                                                 <mtr>
+                                                                   <mtd>
+                                                                     <mrow>
+                                                                       <mspace width=".5ex"></mspace>
+                                                                       <mrow data-mjx-texclass="ORD">
+                                                                         <mi data-latex="C">C</mi>
+                                                                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                         <mi data-latex="D">D</mi>
+                                                                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                         <mi data-latex="Q">Q</mi>
+                                                                       </mrow>
+                                                                       <mspace width=".5ex"></mspace>
+                                                                     </mrow>
+                                                                   </mtd>
+                                                                 </mtr>
+                                                               </mtable>
+                                                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                 <mtext>AAAA</mtext>
+                                                               </mpadded>
+                                                             </mrow>
+                                                             <mspace width="-3.216em"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                   </mtd>
+                                                 </mtr>
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mrow>
+                                                       <mspace width=".5ex"></mspace>
+                                                       <mtext>E</mtext>
+                                                       <mspace width=".5ex"></mspace>
+                                                     </mrow>
+                                                   </mtd>
+                                                 </mtr>
+                                               </mtable>
+                                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                 <mtext>BBB</mtext>
+                                               </mpadded>
+                                             </mrow>
+                                             <mspace width="-6.134em"></mspace>
+                                           </mrow>
+                                         </mtd>
+                                       </mtr>
+                                     </mtable>
+                                   </mtd>
+                                 </mtr>
+                                 <mtr>
+                                   <mtd>
+                                     <mrow>
+                                       <mspace width=".5ex"></mspace>
+                                       <mtext>F</mtext>
+                                       <mspace width=".5ex"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                 <mtext>CCCCC</mtext>
+                               </mpadded>
+                             </mrow>
+                           </mrow>
+                         </mrow>
+                       </mtd>
+                       <mtd>
+                         <mspace width="3.185em"></mspace>
+                       </mtd>
+                       <mtd rowalign="bottom">
+                         <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                           <mspace width=".5ex"></mspace>
+                           <mtext>M</mtext>
+                           <mspace width=".5ex"></mspace>
+                         </mrow>
+                       </mtd>
+                     </mtr>
+                   </mtable>
+                 </mtd>
+               </mtr>
+               <mtr>
+                 <mtd>
+                   <mrow>
+                     <mspace width=".5ex"></mspace>
+                     <mrow data-mjx-texclass="ORD">
+                       <mi data-latex="N">N</mi>
+                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                       <mi data-latex="R">R</mi>
+                     </mrow>
+                     <mspace width=".5ex"></mspace>
+                   </mrow>
+                 </mtd>
+               </mtr>
+             </mtable>
+             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+               <mstyle displaystyle="false">
+                 <mtext>QERE</mtext>
+               </mstyle>
+             </mpadded>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Simple Proofs Left Labels', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:left">
-        <mspace width="3.835em"></mspace>
-        <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-          <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-            <mstyle displaystyle="false">
-              <mtext>QERE</mtext>
-            </mstyle>
-          </mpadded>
-          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-            <mtr>
-              <mtd>
-                <mtable framespacing="0 0">
-                  <mtr>
-                    <mtd rowalign="bottom">
-                      <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                        <mspace width="-6.927em"></mspace>
-                        <mrow>
-                          <mspace width="-0.551em"></mspace>
-                          <mrow data-latex="\\LeftLabel{QERE}">
-                            <mspace width="0.551em"></mspace>
-                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                              <mtext>CCCCC</mtext>
-                            </mpadded>
-                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                              <mtr>
-                                <mtd>
-                                  <mtable framespacing="0 0">
-                                    <mtr>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:3">
-                                          <mspace width="-3.274em"></mspace>
-                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\LeftLabel{AAAA}" semantics="bspr_inferenceRule:down">
-                                            <mtr>
-                                              <mtd>
-                                                <mtable framespacing="0 0">
-                                                  <mtr>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>D</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A1</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A2</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                              </mtd>
-                                            </mtr>
-                                            <mtr>
-                                              <mtd>
-                                                <mrow>
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>Q</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                        </mrow>
-                                      </mtd>
-                                      <mtd></mtd>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                                          <mrow data-latex="\\LeftLabel{CCCCC}">
-                                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                              <mtext>BBB</mtext>
-                                            </mpadded>
-                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                              <mtr>
-                                                <mtd>
-                                                  <mtable framespacing="0 0">
-                                                    <mtr>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                          <mspace width=".5ex"></mspace>
-                                                          <mtext>A</mtext>
-                                                          <mspace width=".5ex"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                      <mtd></mtd>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow data-latex="\\LeftLabel{BBB}" semantics="bspr_labelledRule:left;bspr_inference:2">
-                                                          <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                                            <mtext>AAAA</mtext>
-                                                          </mpadded>
-                                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                            <mtr>
-                                                              <mtd>
-                                                                <mtable framespacing="0 0">
-                                                                  <mtr>
-                                                                    <mtd rowalign="bottom">
-                                                                      <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                        <mspace width=".5ex"></mspace>
-                                                                        <mtext>B</mtext>
-                                                                        <mspace width=".5ex"></mspace>
-                                                                      </mrow>
-                                                                    </mtd>
-                                                                    <mtd></mtd>
-                                                                    <mtd rowalign="bottom">
-                                                                      <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                        <mspace width=".5ex"></mspace>
-                                                                        <mtext>R</mtext>
-                                                                        <mspace width=".5ex"></mspace>
-                                                                      </mrow>
-                                                                    </mtd>
-                                                                  </mtr>
-                                                                </mtable>
-                                                              </mtd>
-                                                            </mtr>
-                                                            <mtr>
-                                                              <mtd>
-                                                                <mrow>
-                                                                  <mspace width=".5ex"></mspace>
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <mi data-latex="C">C</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="D">D</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="Q">Q</mi>
-                                                                  </mrow>
-                                                                  <mspace width=".5ex"></mspace>
-                                                                </mrow>
-                                                              </mtd>
-                                                            </mtr>
-                                                          </mtable>
-                                                        </mrow>
-                                                      </mtd>
-                                                    </mtr>
-                                                  </mtable>
-                                                </mtd>
-                                              </mtr>
-                                              <mtr>
-                                                <mtd>
-                                                  <mrow>
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mtext>E</mtext>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mrow>
-                                          <mspace width="-5.403em"></mspace>
-                                        </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                              <mtr>
-                                <mtd>
-                                  <mrow>
-                                    <mspace width=".5ex"></mspace>
-                                    <mtext>F</mtext>
-                                    <mspace width=".5ex"></mspace>
-                                  </mrow>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                          </mrow>
-                        </mrow>
-                      </mrow>
-                    </mtd>
-                    <mtd>
-                      <mspace width="5.403em"></mspace>
-                    </mtd>
-                    <mtd rowalign="bottom">
-                      <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                        <mspace width=".5ex"></mspace>
-                        <mtext>M</mtext>
-                        <mspace width=".5ex"></mspace>
-                      </mrow>
-                    </mtd>
-                  </mtr>
-                </mtable>
-              </mtd>
-            </mtr>
-            <mtr>
-              <mtd>
-                <mrow>
-                  <mspace width=".5ex"></mspace>
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="N">N</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="R">R</mi>
-                  </mrow>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-        </mrow>
-      </mrow>
-    </math>`
-    ));
-  it('Simple Proofs Mixed Labels', () =>
+         <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:left">
+           <mspace width="3.835em"></mspace>
+           <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\LeftLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\LeftLabel{QERE}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+               <mstyle displaystyle="false">
+                 <mtext>QERE</mtext>
+               </mstyle>
+             </mpadded>
+             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+               <mtr>
+                 <mtd>
+                   <mtable framespacing="0 0">
+                     <mtr>
+                       <mtd rowalign="bottom">
+                         <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                           <mspace width="-6.927em"></mspace>
+                           <mrow>
+                             <mspace width="-0.551em"></mspace>
+                             <mrow data-latex="\\LeftLabel{QERE}">
+                               <mspace width="0.551em"></mspace>
+                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                 <mtext>CCCCC</mtext>
+                               </mpadded>
+                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                 <mtr>
+                                   <mtd>
+                                     <mtable framespacing="0 0">
+                                       <mtr>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:3">
+                                             <mspace width="-3.274em"></mspace>
+                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\LeftLabel{AAAA}" semantics="bspr_inferenceRule:down">
+                                               <mtr>
+                                                 <mtd>
+                                                   <mtable framespacing="0 0">
+                                                     <mtr>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>D</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A1</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A2</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                 </mtd>
+                                               </mtr>
+                                               <mtr>
+                                                 <mtd>
+                                                   <mrow>
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>Q</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                           </mrow>
+                                         </mtd>
+                                         <mtd></mtd>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                                             <mrow data-latex="\\LeftLabel{CCCCC}">
+                                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                 <mtext>BBB</mtext>
+                                               </mpadded>
+                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mtable framespacing="0 0">
+                                                       <mtr>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>A</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                         <mtd></mtd>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\LeftLabel{BBB}" semantics="bspr_labelledRule:left;bspr_inference:2">
+                                                             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                               <mtext>AAAA</mtext>
+                                                             </mpadded>
+                                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                               <mtr>
+                                                                 <mtd>
+                                                                   <mtable framespacing="0 0">
+                                                                     <mtr>
+                                                                       <mtd rowalign="bottom">
+                                                                         <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                           <mspace width=".5ex"></mspace>
+                                                                           <mtext>B</mtext>
+                                                                           <mspace width=".5ex"></mspace>
+                                                                         </mrow>
+                                                                       </mtd>
+                                                                       <mtd></mtd>
+                                                                       <mtd rowalign="bottom">
+                                                                         <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                           <mspace width=".5ex"></mspace>
+                                                                           <mtext>R</mtext>
+                                                                           <mspace width=".5ex"></mspace>
+                                                                         </mrow>
+                                                                       </mtd>
+                                                                     </mtr>
+                                                                   </mtable>
+                                                                 </mtd>
+                                                               </mtr>
+                                                               <mtr>
+                                                                 <mtd>
+                                                                   <mrow>
+                                                                     <mspace width=".5ex"></mspace>
+                                                                     <mrow data-mjx-texclass="ORD">
+                                                                       <mi data-latex="C">C</mi>
+                                                                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                       <mi data-latex="D">D</mi>
+                                                                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                       <mi data-latex="Q">Q</mi>
+                                                                     </mrow>
+                                                                     <mspace width=".5ex"></mspace>
+                                                                   </mrow>
+                                                                 </mtd>
+                                                               </mtr>
+                                                             </mtable>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                   </mtd>
+                                                 </mtr>
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mrow>
+                                                       <mspace width=".5ex"></mspace>
+                                                       <mtext>E</mtext>
+                                                       <mspace width=".5ex"></mspace>
+                                                     </mrow>
+                                                   </mtd>
+                                                 </mtr>
+                                               </mtable>
+                                             </mrow>
+                                             <mspace width="-5.403em"></mspace>
+                                           </mrow>
+                                         </mtd>
+                                       </mtr>
+                                     </mtable>
+                                   </mtd>
+                                 </mtr>
+                                 <mtr>
+                                   <mtd>
+                                     <mrow>
+                                       <mspace width=".5ex"></mspace>
+                                       <mtext>F</mtext>
+                                       <mspace width=".5ex"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                             </mrow>
+                           </mrow>
+                         </mrow>
+                       </mtd>
+                       <mtd>
+                         <mspace width="5.403em"></mspace>
+                       </mtd>
+                       <mtd rowalign="bottom">
+                         <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                           <mspace width=".5ex"></mspace>
+                           <mtext>M</mtext>
+                           <mspace width=".5ex"></mspace>
+                         </mrow>
+                       </mtd>
+                     </mtr>
+                   </mtable>
+                 </mtd>
+               </mtr>
+               <mtr>
+                 <mtd>
+                   <mrow>
+                     <mspace width=".5ex"></mspace>
+                     <mrow data-mjx-texclass="ORD">
+                       <mi data-latex="N">N</mi>
+                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                       <mi data-latex="R">R</mi>
+                     </mrow>
+                     <mspace width=".5ex"></mspace>
+                   </mrow>
+                 </mtd>
+               </mtr>
+             </mtable>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Simple Proofs Mixed Labels', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
-        <mspace width="4.379em"></mspace>
-        <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-          <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-            <mstyle displaystyle="false">
-              <mtext>DD</mtext>
-            </mstyle>
-          </mpadded>
-          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-            <mtr>
-              <mtd>
-                <mtable framespacing="0 0">
-                  <mtr>
-                    <mtd rowalign="bottom">
-                      <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                        <mspace width="-6.123em"></mspace>
-                        <mrow>
-                          <mspace width="-0.551em"></mspace>
-                          <mrow data-latex="\\LeftLabel{DD}">
-                            <mspace width="0.551em"></mspace>
-                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                              <mtext>CCCCC</mtext>
-                            </mpadded>
-                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                              <mtr>
-                                <mtd>
-                                  <mtable framespacing="0 0">
-                                    <mtr>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:3">
-                                          <mspace width="-3.274em"></mspace>
-                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
-                                            <mtr>
-                                              <mtd>
-                                                <mtable framespacing="0 0">
-                                                  <mtr>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>D</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A1</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A2</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                              </mtd>
-                                            </mtr>
-                                            <mtr>
-                                              <mtd>
-                                                <mrow>
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>Q</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                        </mrow>
-                                      </mtd>
-                                      <mtd></mtd>
-                                      <mtd rowalign="bottom">
-                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
-                                          <mrow data-latex="\\LeftLabel{CCCCC}">
-                                            <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                              <mtext>BBB</mtext>
-                                            </mpadded>
-                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                              <mtr>
-                                                <mtd>
-                                                  <mtable framespacing="0 0">
-                                                    <mtr>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                          <mspace width=".5ex"></mspace>
-                                                          <mtext>A</mtext>
-                                                          <mspace width=".5ex"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                      <mtd></mtd>
-                                                      <mtd rowalign="bottom">
-                                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                          <mrow data-latex="\\LeftLabel{BBB}">
-                                                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                              <mtr>
-                                                                <mtd>
-                                                                  <mtable framespacing="0 0">
-                                                                    <mtr>
-                                                                      <mtd rowalign="bottom">
-                                                                        <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                          <mspace width=".5ex"></mspace>
-                                                                          <mtext>B</mtext>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                        </mrow>
-                                                                      </mtd>
-                                                                      <mtd></mtd>
-                                                                      <mtd rowalign="bottom">
-                                                                        <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                          <mspace width=".5ex"></mspace>
-                                                                          <mtext>R</mtext>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                        </mrow>
-                                                                      </mtd>
-                                                                    </mtr>
-                                                                  </mtable>
-                                                                </mtd>
-                                                              </mtr>
-                                                              <mtr>
-                                                                <mtd>
-                                                                  <mrow>
-                                                                    <mspace width=".5ex"></mspace>
-                                                                    <mrow data-mjx-texclass="ORD">
-                                                                      <mi data-latex="C">C</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="D">D</mi>
-                                                                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                      <mi data-latex="Q">Q</mi>
-                                                                    </mrow>
-                                                                    <mspace width=".5ex"></mspace>
-                                                                  </mrow>
-                                                                </mtd>
-                                                              </mtr>
-                                                            </mtable>
-                                                            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                              <mtext>AAAA</mtext>
-                                                            </mpadded>
-                                                          </mrow>
-                                                          <mspace width="-3.216em"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                    </mtr>
-                                                  </mtable>
-                                                </mtd>
-                                              </mtr>
-                                              <mtr>
-                                                <mtd>
-                                                  <mrow>
-                                                    <mspace width=".5ex"></mspace>
-                                                    <mtext>E</mtext>
-                                                    <mspace width=".5ex"></mspace>
-                                                  </mrow>
-                                                </mtd>
-                                              </mtr>
-                                            </mtable>
-                                          </mrow>
-                                          <mspace width="-3.795em"></mspace>
-                                        </mrow>
-                                      </mtd>
-                                    </mtr>
-                                  </mtable>
-                                </mtd>
-                              </mtr>
-                              <mtr>
-                                <mtd>
-                                  <mrow>
-                                    <mspace width=".5ex"></mspace>
-                                    <mtext>F</mtext>
-                                    <mspace width=".5ex"></mspace>
-                                  </mrow>
-                                </mtd>
-                              </mtr>
-                            </mtable>
-                          </mrow>
-                        </mrow>
-                      </mrow>
-                    </mtd>
-                    <mtd>
-                      <mspace width="7.01em"></mspace>
-                    </mtd>
-                    <mtd rowalign="bottom">
-                      <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                        <mspace width=".5ex"></mspace>
-                        <mtext>M</mtext>
-                        <mspace width=".5ex"></mspace>
-                      </mrow>
-                    </mtd>
-                  </mtr>
-                </mtable>
-              </mtd>
-            </mtr>
-            <mtr>
-              <mtd>
-                <mrow>
-                  <mspace width=".5ex"></mspace>
-                  <mrow data-mjx-texclass="ORD">
-                    <mi data-latex="N">N</mi>
-                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                    <mi data-latex="R">R</mi>
-                  </mrow>
-                  <mspace width=".5ex"></mspace>
-                </mrow>
-              </mtd>
-            </mtr>
-          </mtable>
-          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-            <mstyle displaystyle="false">
-              <mtext>QERE</mtext>
-            </mstyle>
-          </mpadded>
-        </mrow>
-      </mrow>
-    </math>`
-    ));
-  it('Proof Very Right Label', () =>
+         <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
+           <mspace width="4.379em"></mspace>
+           <mrow data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBB}\\BinaryInfC{E}\\LeftLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\LeftLabel{DD}\\AxiomC{M}\\BinaryInfC{$N \\rightarrow R$}\\LeftLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+               <mstyle displaystyle="false">
+                 <mtext>DD</mtext>
+               </mstyle>
+             </mpadded>
+             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+               <mtr>
+                 <mtd>
+                   <mtable framespacing="0 0">
+                     <mtr>
+                       <mtd rowalign="bottom">
+                         <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                           <mspace width="-6.123em"></mspace>
+                           <mrow>
+                             <mspace width="-0.551em"></mspace>
+                             <mrow data-latex="\\LeftLabel{DD}">
+                               <mspace width="0.551em"></mspace>
+                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                 <mtext>CCCCC</mtext>
+                               </mpadded>
+                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                 <mtr>
+                                   <mtd>
+                                     <mtable framespacing="0 0">
+                                       <mtr>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:3">
+                                             <mspace width="-3.274em"></mspace>
+                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\RightLabel{AAAA}" semantics="bspr_inferenceRule:down">
+                                               <mtr>
+                                                 <mtd>
+                                                   <mtable framespacing="0 0">
+                                                     <mtr>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>D</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A1</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A2</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                 </mtd>
+                                               </mtr>
+                                               <mtr>
+                                                 <mtd>
+                                                   <mrow>
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>Q</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                           </mrow>
+                                         </mtd>
+                                         <mtd></mtd>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:left">
+                                             <mrow data-latex="\\LeftLabel{CCCCC}">
+                                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                 <mtext>BBB</mtext>
+                                               </mpadded>
+                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mtable framespacing="0 0">
+                                                       <mtr>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>A</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                         <mtd></mtd>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                             <mrow data-latex="\\LeftLabel{BBB}">
+                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                 <mtr>
+                                                                   <mtd>
+                                                                     <mtable framespacing="0 0">
+                                                                       <mtr>
+                                                                         <mtd rowalign="bottom">
+                                                                           <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mtext>B</mtext>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                         <mtd></mtd>
+                                                                         <mtd rowalign="bottom">
+                                                                           <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mtext>R</mtext>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                     </mtable>
+                                                                   </mtd>
+                                                                 </mtr>
+                                                                 <mtr>
+                                                                   <mtd>
+                                                                     <mrow>
+                                                                       <mspace width=".5ex"></mspace>
+                                                                       <mrow data-mjx-texclass="ORD">
+                                                                         <mi data-latex="C">C</mi>
+                                                                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                         <mi data-latex="D">D</mi>
+                                                                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                         <mi data-latex="Q">Q</mi>
+                                                                       </mrow>
+                                                                       <mspace width=".5ex"></mspace>
+                                                                     </mrow>
+                                                                   </mtd>
+                                                                 </mtr>
+                                                               </mtable>
+                                                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                 <mtext>AAAA</mtext>
+                                                               </mpadded>
+                                                             </mrow>
+                                                             <mspace width="-3.216em"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                   </mtd>
+                                                 </mtr>
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mrow>
+                                                       <mspace width=".5ex"></mspace>
+                                                       <mtext>E</mtext>
+                                                       <mspace width=".5ex"></mspace>
+                                                     </mrow>
+                                                   </mtd>
+                                                 </mtr>
+                                               </mtable>
+                                             </mrow>
+                                             <mspace width="-3.795em"></mspace>
+                                           </mrow>
+                                         </mtd>
+                                       </mtr>
+                                     </mtable>
+                                   </mtd>
+                                 </mtr>
+                                 <mtr>
+                                   <mtd>
+                                     <mrow>
+                                       <mspace width=".5ex"></mspace>
+                                       <mtext>F</mtext>
+                                       <mspace width=".5ex"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                             </mrow>
+                           </mrow>
+                         </mrow>
+                       </mtd>
+                       <mtd>
+                         <mspace width="7.01em"></mspace>
+                       </mtd>
+                       <mtd rowalign="bottom">
+                         <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                           <mspace width=".5ex"></mspace>
+                           <mtext>M</mtext>
+                           <mspace width=".5ex"></mspace>
+                         </mrow>
+                       </mtd>
+                     </mtr>
+                   </mtable>
+                 </mtd>
+               </mtr>
+               <mtr>
+                 <mtd>
+                   <mrow>
+                     <mspace width=".5ex"></mspace>
+                     <mrow data-mjx-texclass="ORD">
+                       <mi data-latex="N">N</mi>
+                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                       <mi data-latex="R">R</mi>
+                     </mrow>
+                     <mspace width=".5ex"></mspace>
+                   </mrow>
+                 </mtd>
+               </mtr>
+             </mtable>
+             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+               <mstyle displaystyle="false">
+                 <mtext>QERE</mtext>
+               </mstyle>
+             </mpadded>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Proof Very Right Label', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:2;bspr_proof:true">
-        <mspace width="9.835em"></mspace>
-        <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
-          <mtr>
-            <mtd>
-              <mtable framespacing="0 0">
-                <mtr>
-                  <mtd rowalign="bottom">
-                    <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                      <mspace width="-9.835em"></mspace>
-                      <mrow>
-                        <mspace width="3.274em"></mspace>
-                        <mrow data-latex="\\RightLabel{QERE}">
-                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                            <mtr>
-                              <mtd>
-                                <mtable framespacing="0 0">
-                                  <mtr>
-                                    <mtd rowalign="bottom">
-                                      <mrow semantics="bspr_inference:3;bspr_labelledRule:right">
-                                        <mspace width="-3.274em"></mspace>
-                                        <mrow data-latex="\\RightLabel{Nowhere}">
-                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                            <mtr>
-                                              <mtd>
-                                                <mtable framespacing="0 0">
-                                                  <mtr>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>D</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A1</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\RightLabel{AAAA}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A2</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                              </mtd>
-                                            </mtr>
-                                            <mtr>
-                                              <mtd>
-                                                <mrow>
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>Q</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                            <mtext>AAAA</mtext>
-                                          </mpadded>
-                                        </mrow>
-                                      </mrow>
-                                    </mtd>
-                                    <mtd></mtd>
-                                    <mtd rowalign="bottom">
-                                      <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                        <mrow data-latex="\\RightLabel{CCCCC}">
-                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                            <mtr>
-                                              <mtd>
-                                                <mtable framespacing="0 0">
-                                                  <mtr>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>A</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                    <mtd></mtd>
-                                                    <mtd rowalign="bottom">
-                                                      <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                        <mrow data-latex="\\RightLabel{BBB}">
-                                                          <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                            <mtr>
-                                                              <mtd>
-                                                                <mtable framespacing="0 0">
-                                                                  <mtr>
-                                                                    <mtd rowalign="bottom">
-                                                                      <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                        <mspace width=".5ex"></mspace>
-                                                                        <mtext>B</mtext>
-                                                                        <mspace width=".5ex"></mspace>
-                                                                      </mrow>
-                                                                    </mtd>
-                                                                    <mtd></mtd>
-                                                                    <mtd rowalign="bottom">
-                                                                      <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
-                                                                        <mspace width=".5ex"></mspace>
-                                                                        <mtext>R</mtext>
-                                                                        <mspace width=".5ex"></mspace>
-                                                                      </mrow>
-                                                                    </mtd>
-                                                                  </mtr>
-                                                                </mtable>
-                                                              </mtd>
-                                                            </mtr>
-                                                            <mtr>
-                                                              <mtd>
-                                                                <mrow>
-                                                                  <mspace width=".5ex"></mspace>
-                                                                  <mrow data-mjx-texclass="ORD">
-                                                                    <mi data-latex="C">C</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="D">D</mi>
-                                                                    <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                    <mi data-latex="Q">Q</mi>
-                                                                  </mrow>
-                                                                  <mspace width=".5ex"></mspace>
-                                                                </mrow>
-                                                              </mtd>
-                                                            </mtr>
-                                                          </mtable>
-                                                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                            <mtext>Nowhere</mtext>
-                                                          </mpadded>
-                                                        </mrow>
-                                                        <mspace width="-4.023em"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                              </mtd>
-                                            </mtr>
-                                            <mtr>
-                                              <mtd>
-                                                <mrow>
-                                                  <mspace width=".5ex"></mspace>
-                                                  <mtext>E</mtext>
-                                                  <mspace width=".5ex"></mspace>
-                                                </mrow>
-                                              </mtd>
-                                            </mtr>
-                                          </mtable>
-                                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                            <mtext>BBB</mtext>
-                                          </mpadded>
-                                        </mrow>
-                                        <mspace width="-6.135em"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                              </mtd>
-                            </mtr>
-                            <mtr>
-                              <mtd>
-                                <mrow>
-                                  <mspace width=".5ex"></mspace>
-                                  <mtext>F</mtext>
-                                  <mspace width=".5ex"></mspace>
-                                </mrow>
-                              </mtd>
-                            </mtr>
-                          </mtable>
-                          <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                            <mtext>CCCCC</mtext>
-                          </mpadded>
-                        </mrow>
-                      </mrow>
-                    </mrow>
-                  </mtd>
-                  <mtd>
-                    <mspace width="3.993em"></mspace>
-                  </mtd>
-                  <mtd rowalign="bottom">
-                    <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down;bspr_inference:1">
-                      <mtr>
-                        <mtd>
-                          <mtable framespacing="0 0">
-                            <mtr>
-                              <mtd rowalign="bottom">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down;bspr_inference:1">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
-                                              <mrow data-latex="\\UnaryInfC{More and more}">
-                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mtable framespacing="0 0">
-                                                        <mtr>
-                                                          <mtd rowalign="bottom">
-                                                            <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mtext>M</mtext>
-                                                              <mspace width=".5ex"></mspace>
-                                                            </mrow>
-                                                          </mtd>
-                                                        </mtr>
-                                                      </mtable>
-                                                    </mtd>
-                                                  </mtr>
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mtext>More and more</mtext>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                  <mtext>QERE</mtext>
-                                                </mpadded>
-                                              </mrow>
-                                              <mspace width="-3.092em"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mtext>More and more</mtext>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                              </mtd>
-                            </mtr>
-                          </mtable>
-                        </mtd>
-                      </mtr>
-                      <mtr>
-                        <mtd>
-                          <mrow>
-                            <mspace width=".5ex"></mspace>
-                            <mtext>More and more</mtext>
-                            <mspace width=".5ex"></mspace>
-                          </mrow>
-                        </mtd>
-                      </mtr>
-                    </mtable>
-                  </mtd>
-                </mtr>
-              </mtable>
-            </mtd>
-          </mtr>
-          <mtr>
-            <mtd>
-              <mrow>
-                <mspace width=".5ex"></mspace>
-                <mrow data-mjx-texclass="ORD">
-                  <mi data-latex="N">N</mi>
-                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                  <mi data-latex="R">R</mi>
-                </mrow>
-                <mspace width=".5ex"></mspace>
-              </mrow>
-            </mtd>
-          </mtr>
-        </mtable>
-        <mspace width="3.091em"></mspace>
-      </mrow>
-    </math>`
-    ));
-  it('Proof Complex', () =>
+         <mrow semantics="bspr_inference:2;bspr_proof:true">
+           <mspace width="9.835em"></mspace>
+           <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\begin{prooftree}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\RightLabel{AAAA}\\TrinaryInfC{Q}\\RightLabel{Nowhere}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\RightLabel{BBB}\\BinaryInfC{E}\\RightLabel{CCCCC}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\UnaryInfC{More and more}\\BinaryInfC{$N \\rightarrow R$}\\end{prooftree}" data-latex-item="{prooftree}" semantics="bspr_inferenceRule:down">
+             <mtr>
+               <mtd>
+                 <mtable framespacing="0 0">
+                   <mtr>
+                     <mtd rowalign="bottom">
+                       <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                         <mspace width="-9.835em"></mspace>
+                         <mrow>
+                           <mspace width="3.274em"></mspace>
+                           <mrow data-latex="\\RightLabel{QERE}">
+                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                               <mtr>
+                                 <mtd>
+                                   <mtable framespacing="0 0">
+                                     <mtr>
+                                       <mtd rowalign="bottom">
+                                         <mrow semantics="bspr_inference:3;bspr_labelledRule:right">
+                                           <mspace width="-3.274em"></mspace>
+                                           <mrow data-latex="\\RightLabel{Nowhere}">
+                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                               <mtr>
+                                                 <mtd>
+                                                   <mtable framespacing="0 0">
+                                                     <mtr>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>D</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A1</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\RightLabel{AAAA}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A2</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                 </mtd>
+                                               </mtr>
+                                               <mtr>
+                                                 <mtd>
+                                                   <mrow>
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>Q</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                               <mtext>AAAA</mtext>
+                                             </mpadded>
+                                           </mrow>
+                                         </mrow>
+                                       </mtd>
+                                       <mtd></mtd>
+                                       <mtd rowalign="bottom">
+                                         <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                           <mrow data-latex="\\RightLabel{CCCCC}">
+                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                               <mtr>
+                                                 <mtd>
+                                                   <mtable framespacing="0 0">
+                                                     <mtr>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>A</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                       <mtd></mtd>
+                                                       <mtd rowalign="bottom">
+                                                         <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                           <mrow data-latex="\\RightLabel{BBB}">
+                                                             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                               <mtr>
+                                                                 <mtd>
+                                                                   <mtable framespacing="0 0">
+                                                                     <mtr>
+                                                                       <mtd rowalign="bottom">
+                                                                         <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                           <mspace width=".5ex"></mspace>
+                                                                           <mtext>B</mtext>
+                                                                           <mspace width=".5ex"></mspace>
+                                                                         </mrow>
+                                                                       </mtd>
+                                                                       <mtd></mtd>
+                                                                       <mtd rowalign="bottom">
+                                                                         <mrow data-latex="\\AxiomC{R}" semantics="bspr_axiom:true">
+                                                                           <mspace width=".5ex"></mspace>
+                                                                           <mtext>R</mtext>
+                                                                           <mspace width=".5ex"></mspace>
+                                                                         </mrow>
+                                                                       </mtd>
+                                                                     </mtr>
+                                                                   </mtable>
+                                                                 </mtd>
+                                                               </mtr>
+                                                               <mtr>
+                                                                 <mtd>
+                                                                   <mrow>
+                                                                     <mspace width=".5ex"></mspace>
+                                                                     <mrow data-mjx-texclass="ORD">
+                                                                       <mi data-latex="C">C</mi>
+                                                                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                       <mi data-latex="D">D</mi>
+                                                                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                       <mi data-latex="Q">Q</mi>
+                                                                     </mrow>
+                                                                     <mspace width=".5ex"></mspace>
+                                                                   </mrow>
+                                                                 </mtd>
+                                                               </mtr>
+                                                             </mtable>
+                                                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                               <mtext>Nowhere</mtext>
+                                                             </mpadded>
+                                                           </mrow>
+                                                           <mspace width="-4.023em"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                 </mtd>
+                                               </mtr>
+                                               <mtr>
+                                                 <mtd>
+                                                   <mrow>
+                                                     <mspace width=".5ex"></mspace>
+                                                     <mtext>E</mtext>
+                                                     <mspace width=".5ex"></mspace>
+                                                   </mrow>
+                                                 </mtd>
+                                               </mtr>
+                                             </mtable>
+                                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                               <mtext>BBB</mtext>
+                                             </mpadded>
+                                           </mrow>
+                                           <mspace width="-6.135em"></mspace>
+                                         </mrow>
+                                       </mtd>
+                                     </mtr>
+                                   </mtable>
+                                 </mtd>
+                               </mtr>
+                               <mtr>
+                                 <mtd>
+                                   <mrow>
+                                     <mspace width=".5ex"></mspace>
+                                     <mtext>F</mtext>
+                                     <mspace width=".5ex"></mspace>
+                                   </mrow>
+                                 </mtd>
+                               </mtr>
+                             </mtable>
+                             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                               <mtext>CCCCC</mtext>
+                             </mpadded>
+                           </mrow>
+                         </mrow>
+                       </mrow>
+                     </mtd>
+                     <mtd>
+                       <mspace width="3.993em"></mspace>
+                     </mtd>
+                     <mtd rowalign="bottom">
+                       <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down;bspr_inference:1">
+                         <mtr>
+                           <mtd>
+                             <mtable framespacing="0 0">
+                               <mtr>
+                                 <mtd rowalign="bottom">
+                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" data-latex="\\UnaryInfC{More and more}" semantics="bspr_inferenceRule:down;bspr_inference:1">
+                                     <mtr>
+                                       <mtd>
+                                         <mtable framespacing="0 0">
+                                           <mtr>
+                                             <mtd rowalign="bottom">
+                                               <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                                 <mrow data-latex="\\UnaryInfC{More and more}">
+                                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mtable framespacing="0 0">
+                                                           <mtr>
+                                                             <mtd rowalign="bottom">
+                                                               <mrow data-latex="\\AxiomC{M}" semantics="bspr_axiom:true">
+                                                                 <mspace width=".5ex"></mspace>
+                                                                 <mtext>M</mtext>
+                                                                 <mspace width=".5ex"></mspace>
+                                                               </mrow>
+                                                             </mtd>
+                                                           </mtr>
+                                                         </mtable>
+                                                       </mtd>
+                                                     </mtr>
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mtext>More and more</mtext>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                     <mtext>QERE</mtext>
+                                                   </mpadded>
+                                                 </mrow>
+                                                 <mspace width="-3.092em"></mspace>
+                                               </mrow>
+                                             </mtd>
+                                           </mtr>
+                                         </mtable>
+                                       </mtd>
+                                     </mtr>
+                                     <mtr>
+                                       <mtd>
+                                         <mrow>
+                                           <mspace width=".5ex"></mspace>
+                                           <mtext>More and more</mtext>
+                                           <mspace width=".5ex"></mspace>
+                                         </mrow>
+                                       </mtd>
+                                     </mtr>
+                                   </mtable>
+                                 </mtd>
+                               </mtr>
+                             </mtable>
+                           </mtd>
+                         </mtr>
+                         <mtr>
+                           <mtd>
+                             <mrow>
+                               <mspace width=".5ex"></mspace>
+                               <mtext>More and more</mtext>
+                               <mspace width=".5ex"></mspace>
+                             </mrow>
+                           </mtd>
+                         </mtr>
+                       </mtable>
+                     </mtd>
+                   </mtr>
+                 </mtable>
+               </mtd>
+             </mtr>
+             <mtr>
+               <mtd>
+                 <mrow>
+                   <mspace width=".5ex"></mspace>
+                   <mrow data-mjx-texclass="ORD">
+                     <mi data-latex="N">N</mi>
+                     <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                     <mi data-latex="R">R</mi>
+                   </mrow>
+                   <mspace width=".5ex"></mspace>
+                 </mrow>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mspace width="3.091em"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Proof Complex', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
-        <mrow>
-          <mspace width="13.248em"></mspace>
-          <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" data-latex-item="{prooftree}">
-            <mspace width="-1.155em"></mspace>
-            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-              <mtr>
-                <mtd>
-                  <mtable framespacing="0 0">
-                    <mtr>
-                      <mtd rowalign="bottom">
-                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                          <mrow>
-                            <mspace width="-13.248em"></mspace>
-                            <mrow>
-                              <mspace width="9.11em"></mspace>
-                              <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                              <mspace width="-9.11em"></mspace>
-                                              <mrow>
-                                                <mspace width="3.592em"></mspace>
-                                                <mrow data-latex="\\BIC{$R$}">
-                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                    <mtr>
-                                                      <mtd>
-                                                        <mtable framespacing="0 0">
-                                                          <mtr>
-                                                            <mtd rowalign="bottom">
-                                                              <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                                <mspace width="-3.592em"></mspace>
-                                                                <mrow data-latex="\\BIC{$Q^2$}">
-                                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                                    <mtr>
-                                                                      <mtd>
-                                                                        <mtable framespacing="0 0">
-                                                                          <mtr>
-                                                                            <mtd rowalign="bottom">
-                                                                              <mrow data-latex="\\UIC{$P$}" semantics="bspr_labelledRule:right;bspr_inference:0">
-                                                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                                                  <mtr>
-                                                                                    <mtd>
-                                                                                      <mtable framespacing="0 0">
-                                                                                        <mtr>
-                                                                                          <mtd rowalign="bottom">
-                                                                                            <mrow data-latex="\\RL{$Hyp^{1}$}" semantics="bspr_axiom:true"></mrow>
-                                                                                          </mtd>
-                                                                                        </mtr>
-                                                                                      </mtable>
-                                                                                    </mtd>
-                                                                                  </mtr>
-                                                                                  <mtr>
-                                                                                    <mtd>
-                                                                                      <mrow>
-                                                                                        <mspace width=".5ex"></mspace>
-                                                                                        <mrow data-mjx-texclass="ORD">
-                                                                                          <mi data-latex="P">P</mi>
-                                                                                        </mrow>
-                                                                                        <mspace width=".5ex"></mspace>
-                                                                                      </mrow>
-                                                                                    </mtd>
-                                                                                  </mtr>
-                                                                                </mtable>
-                                                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                                  <mrow data-mjx-texclass="ORD">
-                                                                                    <mi data-latex="H">H</mi>
-                                                                                    <mi data-latex="y">y</mi>
-                                                                                    <msup data-latex="p^{1}">
-                                                                                      <mi data-latex="p">p</mi>
-                                                                                      <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                                                                                        <mn data-latex="1">1</mn>
-                                                                                      </mrow>
-                                                                                    </msup>
-                                                                                  </mrow>
-                                                                                </mpadded>
-                                                                              </mrow>
-                                                                            </mtd>
-                                                                            <mtd></mtd>
-                                                                            <mtd rowalign="bottom">
-                                                                              <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
-                                                                                <mspace width=".5ex"></mspace>
-                                                                                <mrow data-mjx-texclass="ORD">
-                                                                                  <mi data-latex="P">P</mi>
-                                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                                  <mi data-latex="Q">Q</mi>
-                                                                                </mrow>
-                                                                                <mspace width=".5ex"></mspace>
-                                                                              </mrow>
-                                                                            </mtd>
-                                                                          </mtr>
-                                                                        </mtable>
-                                                                      </mtd>
-                                                                    </mtr>
-                                                                    <mtr>
-                                                                      <mtd>
-                                                                        <mrow>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                          <mrow data-mjx-texclass="ORD">
-                                                                            <msup data-latex="Q^2 ">
-                                                                              <mi data-latex="Q">Q</mi>
-                                                                              <mn data-latex="2">2</mn>
-                                                                            </msup>
-                                                                          </mrow>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                        </mrow>
-                                                                      </mtd>
-                                                                    </mtr>
-                                                                  </mtable>
-                                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                    <mrow data-mjx-texclass="ORD">
-                                                                      <msub data-latex="\\rightarrow_E">
-                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                        <mi data-latex="E">E</mi>
-                                                                      </msub>
-                                                                    </mrow>
-                                                                  </mpadded>
-                                                                </mrow>
-                                                              </mrow>
-                                                            </mtd>
-                                                            <mtd></mtd>
-                                                            <mtd rowalign="bottom">
-                                                              <mrow data-latex="\\RL{$\\rightarrow_E$}" semantics="bspr_axiom:true">
-                                                                <mspace width=".5ex"></mspace>
-                                                                <mrow data-mjx-texclass="ORD">
-                                                                  <mi data-latex="Q">Q</mi>
-                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                  <mi data-latex="R">R</mi>
-                                                                </mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                              </mrow>
-                                                            </mtd>
-                                                          </mtr>
-                                                        </mtable>
-                                                      </mtd>
-                                                    </mtr>
-                                                    <mtr>
-                                                      <mtd>
-                                                        <mrow>
-                                                          <mspace width=".5ex"></mspace>
-                                                          <mrow data-mjx-texclass="ORD">
-                                                            <mi data-latex="R">R</mi>
-                                                          </mrow>
-                                                          <mspace width=".5ex"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                    </mtr>
-                                                  </mtable>
-                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                    <mrow data-mjx-texclass="ORD">
-                                                      <msub data-latex="\\rightarrow_E">
-                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                        <mi data-latex="E">E</mi>
-                                                      </msub>
-                                                    </mrow>
-                                                  </mpadded>
-                                                </mrow>
-                                              </mrow>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
-                                              <mrow data-latex="\\RL{$\\wedge_I$}">
-                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mtable framespacing="0 0">
-                                                        <mtr>
-                                                          <mtd rowalign="bottom">
-                                                            <mrow data-latex="\\RL{Rit$^2$}" semantics="bspr_axiom:true">
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mrow data-mjx-texclass="ORD">
-                                                                <mi data-latex="Q">Q</mi>
-                                                              </mrow>
-                                                              <mspace width=".5ex"></mspace>
-                                                            </mrow>
-                                                          </mtd>
-                                                        </mtr>
-                                                      </mtable>
-                                                    </mtd>
-                                                  </mtr>
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mrow data-mjx-texclass="ORD">
-                                                          <mi data-latex="Q">Q</mi>
-                                                        </mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                  <mstyle>
-                                                    <mtext>Rit</mtext>
-                                                    <mrow data-mjx-texclass="ORD">
-                                                      <msup data-latex="^2 ">
-                                                        <mi></mi>
-                                                        <mn data-latex="2">2</mn>
-                                                      </msup>
-                                                    </mrow>
-                                                  </mstyle>
-                                                </mpadded>
-                                              </mrow>
-                                              <mspace width="-2.055em"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mrow data-mjx-texclass="ORD">
-                                          <mi data-latex="Q">Q</mi>
-                                          <mo data-latex="\\wedge">&#x2227;</mo>
-                                          <mi data-latex="R">R</mi>
-                                        </mrow>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                  <mrow data-mjx-texclass="ORD">
-                                    <msub data-latex="\\wedge_I">
-                                      <mo data-latex="\\wedge">&#x2227;</mo>
-                                      <mi data-latex="I">I</mi>
-                                    </msub>
-                                  </mrow>
-                                </mpadded>
-                              </mrow>
-                            </mrow>
-                          </mrow>
-                          <mspace width="-5.455em"></mspace>
-                        </mrow>
-                      </mtd>
-                    </mtr>
-                  </mtable>
-                </mtd>
-              </mtr>
-              <mtr>
-                <mtd>
-                  <mrow>
-                    <mspace width=".5ex"></mspace>
-                    <mrow data-mjx-texclass="ORD">
-                      <mi data-latex="P">P</mi>
-                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                      <mi data-latex="Q">Q</mi>
-                      <mo data-latex="\\wedge">&#x2227;</mo>
-                      <mi data-latex="R">R</mi>
-                    </mrow>
-                    <mspace width=".5ex"></mspace>
-                  </mrow>
-                </mtd>
-              </mtr>
-            </mtable>
-            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-              <mstyle displaystyle="false">
-                <mrow data-mjx-texclass="ORD">
-                  <msup data-latex="{\\rightarrow_I}^1 ">
-                    <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
-                      <msub data-latex="\\rightarrow_I">
-                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                        <mi data-latex="I">I</mi>
-                      </msub>
-                    </mrow>
-                    <mn data-latex="1">1</mn>
-                  </msup>
-                </mrow>
-              </mstyle>
-            </mpadded>
-          </mrow>
-        </mrow>
-        <mspace width="2.952em"></mspace>
-      </mrow>
-    </math>`
-    ));
-  it('Proof Mixing Order', () =>
+         <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+           <mrow>
+             <mspace width="13.25em"></mspace>
+             <mrow data-latex="\\begin{prooftree}\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" data-latex-item="{prooftree}">
+               <mspace width="-1.155em"></mspace>
+               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                 <mtr>
+                   <mtd>
+                     <mtable framespacing="0 0">
+                       <mtr>
+                         <mtd rowalign="bottom">
+                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                             <mrow>
+                               <mspace width="-13.25em"></mspace>
+                               <mrow>
+                                 <mspace width="9.111em"></mspace>
+                                 <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
+                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                     <mtr>
+                                       <mtd>
+                                         <mtable framespacing="0 0">
+                                           <mtr>
+                                             <mtd rowalign="bottom">
+                                               <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                 <mspace width="-9.111em"></mspace>
+                                                 <mrow>
+                                                   <mspace width="3.592em"></mspace>
+                                                   <mrow data-latex="\\BIC{$R$}">
+                                                     <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                       <mtr>
+                                                         <mtd>
+                                                           <mtable framespacing="0 0">
+                                                             <mtr>
+                                                               <mtd rowalign="bottom">
+                                                                 <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                                   <mspace width="-3.592em"></mspace>
+                                                                   <mrow data-latex="\\BIC{$Q^2$}">
+                                                                     <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                       <mtr>
+                                                                         <mtd>
+                                                                           <mtable framespacing="0 0">
+                                                                             <mtr>
+                                                                               <mtd rowalign="bottom">
+                                                                                 <mrow data-latex="\\UIC{$P$}" semantics="bspr_labelledRule:right;bspr_inference:0">
+                                                                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                                     <mtr>
+                                                                                       <mtd>
+                                                                                         <mtable framespacing="0 0">
+                                                                                           <mtr>
+                                                                                             <mtd rowalign="bottom">
+                                                                                               <mrow data-latex="\\RL{$Hyp^{1}$}" semantics="bspr_axiom:true"></mrow>
+                                                                                             </mtd>
+                                                                                           </mtr>
+                                                                                         </mtable>
+                                                                                       </mtd>
+                                                                                     </mtr>
+                                                                                     <mtr>
+                                                                                       <mtd>
+                                                                                         <mrow>
+                                                                                           <mspace width=".5ex"></mspace>
+                                                                                           <mrow data-mjx-texclass="ORD">
+                                                                                             <mi data-latex="P">P</mi>
+                                                                                           </mrow>
+                                                                                           <mspace width=".5ex"></mspace>
+                                                                                         </mrow>
+                                                                                       </mtd>
+                                                                                     </mtr>
+                                                                                   </mtable>
+                                                                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                                     <mrow data-mjx-texclass="ORD">
+                                                                                       <mi data-latex="H">H</mi>
+                                                                                       <mi data-latex="y">y</mi>
+                                                                                       <msup data-latex="p^{1}">
+                                                                                         <mi data-latex="p">p</mi>
+                                                                                         <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                                                                                           <mn data-latex="1">1</mn>
+                                                                                         </mrow>
+                                                                                       </msup>
+                                                                                     </mrow>
+                                                                                   </mpadded>
+                                                                                 </mrow>
+                                                                               </mtd>
+                                                                               <mtd></mtd>
+                                                                               <mtd rowalign="bottom">
+                                                                                 <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
+                                                                                   <mspace width=".5ex"></mspace>
+                                                                                   <mrow data-mjx-texclass="ORD">
+                                                                                     <mi data-latex="P">P</mi>
+                                                                                     <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                                     <mi data-latex="Q">Q</mi>
+                                                                                   </mrow>
+                                                                                   <mspace width=".5ex"></mspace>
+                                                                                 </mrow>
+                                                                               </mtd>
+                                                                             </mtr>
+                                                                           </mtable>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                       <mtr>
+                                                                         <mtd>
+                                                                           <mrow>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mrow data-mjx-texclass="ORD">
+                                                                               <msup data-latex="Q^2 ">
+                                                                                 <mi data-latex="Q">Q</mi>
+                                                                                 <mn data-latex="2">2</mn>
+                                                                               </msup>
+                                                                             </mrow>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                     </mtable>
+                                                                     <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                       <mrow data-mjx-texclass="ORD">
+                                                                         <msub data-latex="\\rightarrow_E">
+                                                                           <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                           <mi data-latex="E">E</mi>
+                                                                         </msub>
+                                                                       </mrow>
+                                                                     </mpadded>
+                                                                   </mrow>
+                                                                 </mrow>
+                                                               </mtd>
+                                                               <mtd></mtd>
+                                                               <mtd rowalign="bottom">
+                                                                 <mrow data-latex="\\RL{$\\rightarrow_E$}" semantics="bspr_axiom:true">
+                                                                   <mspace width=".5ex"></mspace>
+                                                                   <mrow data-mjx-texclass="ORD">
+                                                                     <mi data-latex="Q">Q</mi>
+                                                                     <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                     <mi data-latex="R">R</mi>
+                                                                   </mrow>
+                                                                   <mspace width=".5ex"></mspace>
+                                                                 </mrow>
+                                                               </mtd>
+                                                             </mtr>
+                                                           </mtable>
+                                                         </mtd>
+                                                       </mtr>
+                                                       <mtr>
+                                                         <mtd>
+                                                           <mrow>
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mrow data-mjx-texclass="ORD">
+                                                               <mi data-latex="R">R</mi>
+                                                             </mrow>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                     <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                       <mrow data-mjx-texclass="ORD">
+                                                         <msub data-latex="\\rightarrow_E">
+                                                           <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                           <mi data-latex="E">E</mi>
+                                                         </msub>
+                                                       </mrow>
+                                                     </mpadded>
+                                                   </mrow>
+                                                 </mrow>
+                                               </mrow>
+                                             </mtd>
+                                             <mtd></mtd>
+                                             <mtd rowalign="bottom">
+                                               <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                                 <mrow data-latex="\\RL{$\\wedge_I$}">
+                                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mtable framespacing="0 0">
+                                                           <mtr>
+                                                             <mtd rowalign="bottom">
+                                                               <mrow data-latex="\\RL{Rit$^2$}" semantics="bspr_axiom:true">
+                                                                 <mspace width=".5ex"></mspace>
+                                                                 <mrow data-mjx-texclass="ORD">
+                                                                   <mi data-latex="Q">Q</mi>
+                                                                 </mrow>
+                                                                 <mspace width=".5ex"></mspace>
+                                                               </mrow>
+                                                             </mtd>
+                                                           </mtr>
+                                                         </mtable>
+                                                       </mtd>
+                                                     </mtr>
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mrow data-mjx-texclass="ORD">
+                                                             <mi data-latex="Q">Q</mi>
+                                                           </mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                     <mstyle>
+                                                       <mtext>Rit</mtext>
+                                                       <mrow data-mjx-texclass="ORD">
+                                                         <msup data-latex="^2 ">
+                                                           <mi></mi>
+                                                           <mn data-latex="2">2</mn>
+                                                         </msup>
+                                                       </mrow>
+                                                     </mstyle>
+                                                   </mpadded>
+                                                 </mrow>
+                                                 <mspace width="-2.055em"></mspace>
+                                               </mrow>
+                                             </mtd>
+                                           </mtr>
+                                         </mtable>
+                                       </mtd>
+                                     </mtr>
+                                     <mtr>
+                                       <mtd>
+                                         <mrow>
+                                           <mspace width=".5ex"></mspace>
+                                           <mrow data-mjx-texclass="ORD">
+                                             <mi data-latex="Q">Q</mi>
+                                             <mo data-latex="\\wedge">&#x2227;</mo>
+                                             <mi data-latex="R">R</mi>
+                                           </mrow>
+                                           <mspace width=".5ex"></mspace>
+                                         </mrow>
+                                       </mtd>
+                                     </mtr>
+                                   </mtable>
+                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                     <mrow data-mjx-texclass="ORD">
+                                       <msub data-latex="\\wedge_I">
+                                         <mo data-latex="\\wedge">&#x2227;</mo>
+                                         <mi data-latex="I">I</mi>
+                                       </msub>
+                                     </mrow>
+                                   </mpadded>
+                                 </mrow>
+                               </mrow>
+                             </mrow>
+                             <mspace width="-5.456em"></mspace>
+                           </mrow>
+                         </mtd>
+                       </mtr>
+                     </mtable>
+                   </mtd>
+                 </mtr>
+                 <mtr>
+                   <mtd>
+                     <mrow>
+                       <mspace width=".5ex"></mspace>
+                       <mrow data-mjx-texclass="ORD">
+                         <mi data-latex="P">P</mi>
+                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                         <mi data-latex="Q">Q</mi>
+                         <mo data-latex="\\wedge">&#x2227;</mo>
+                         <mi data-latex="R">R</mi>
+                       </mrow>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                 <mstyle displaystyle="false">
+                   <mrow data-mjx-texclass="ORD">
+                     <msup data-latex="{\\rightarrow_I}^1 ">
+                       <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
+                         <msub data-latex="\\rightarrow_I">
+                           <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                           <mi data-latex="I">I</mi>
+                         </msub>
+                       </mrow>
+                       <mn data-latex="1">1</mn>
+                     </msup>
+                   </mrow>
+                 </mstyle>
+               </mpadded>
+             </mrow>
+           </mrow>
+           <mspace width="2.953em"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Proof Mixing Order', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" display="block">
-      <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
-        <mrow>
-          <mspace width="13.248em"></mspace>
-          <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" data-latex-item="{prooftree}">
-            <mspace width="-1.155em"></mspace>
-            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-              <mtr>
-                <mtd>
-                  <mtable framespacing="0 0">
-                    <mtr>
-                      <mtd rowalign="bottom">
-                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                          <mrow>
-                            <mspace width="-13.248em"></mspace>
-                            <mrow>
-                              <mspace width="9.11em"></mspace>
-                              <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
-                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                  <mtr>
-                                    <mtd>
-                                      <mtable framespacing="0 0">
-                                        <mtr>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                              <mspace width="-9.11em"></mspace>
-                                              <mrow>
-                                                <mspace width="3.592em"></mspace>
-                                                <mrow data-latex="\\BIC{$R$}">
-                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                    <mtr>
-                                                      <mtd>
-                                                        <mtable framespacing="0 0">
-                                                          <mtr>
-                                                            <mtd rowalign="bottom">
-                                                              <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
-                                                                <mspace width="-3.592em"></mspace>
-                                                                <mrow data-latex="\\alwaysRootAtBottom">
-                                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
-                                                                    <mtr>
-                                                                      <mtd>
-                                                                        <mrow>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                          <mrow data-mjx-texclass="ORD">
-                                                                            <msup data-latex="Q^2 ">
-                                                                              <mi data-latex="Q">Q</mi>
-                                                                              <mn data-latex="2">2</mn>
-                                                                            </msup>
-                                                                          </mrow>
-                                                                          <mspace width=".5ex"></mspace>
-                                                                        </mrow>
-                                                                      </mtd>
-                                                                    </mtr>
-                                                                    <mtr>
-                                                                      <mtd>
-                                                                        <mtable framespacing="0 0">
-                                                                          <mtr>
-                                                                            <mtd rowalign="top">
-                                                                              <mrow data-latex="\\UIC{$P$}" semantics="bspr_labelledRule:right;bspr_inference:0">
-                                                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
-                                                                                  <mtr>
-                                                                                    <mtd>
-                                                                                      <mrow>
-                                                                                        <mspace width=".5ex"></mspace>
-                                                                                        <mrow data-mjx-texclass="ORD">
-                                                                                          <mi data-latex="P">P</mi>
-                                                                                        </mrow>
-                                                                                        <mspace width=".5ex"></mspace>
-                                                                                      </mrow>
-                                                                                    </mtd>
-                                                                                  </mtr>
-                                                                                  <mtr>
-                                                                                    <mtd>
-                                                                                      <mtable framespacing="0 0">
-                                                                                        <mtr>
-                                                                                          <mtd rowalign="top">
-                                                                                            <mrow data-latex="\\RL{$Hyp^{1}$}" semantics="bspr_axiom:true"></mrow>
-                                                                                          </mtd>
-                                                                                        </mtr>
-                                                                                      </mtable>
-                                                                                    </mtd>
-                                                                                  </mtr>
-                                                                                </mtable>
-                                                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                                  <mrow data-mjx-texclass="ORD">
-                                                                                    <mi data-latex="H">H</mi>
-                                                                                    <mi data-latex="y">y</mi>
-                                                                                    <msup data-latex="p^{1}">
-                                                                                      <mi data-latex="p">p</mi>
-                                                                                      <mrow data-mjx-texclass="ORD" data-latex="{1}">
-                                                                                        <mn data-latex="1">1</mn>
-                                                                                      </mrow>
-                                                                                    </msup>
-                                                                                  </mrow>
-                                                                                </mpadded>
-                                                                              </mrow>
-                                                                            </mtd>
-                                                                            <mtd></mtd>
-                                                                            <mtd rowalign="top">
-                                                                              <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
-                                                                                <mspace width=".5ex"></mspace>
-                                                                                <mrow data-mjx-texclass="ORD">
-                                                                                  <mi data-latex="P">P</mi>
-                                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                                  <mi data-latex="Q">Q</mi>
-                                                                                </mrow>
-                                                                                <mspace width=".5ex"></mspace>
-                                                                              </mrow>
-                                                                            </mtd>
-                                                                          </mtr>
-                                                                        </mtable>
-                                                                      </mtd>
-                                                                    </mtr>
-                                                                  </mtable>
-                                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                                    <mrow data-mjx-texclass="ORD">
-                                                                      <msub data-latex="\\rightarrow_E">
-                                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                        <mi data-latex="E">E</mi>
-                                                                      </msub>
-                                                                    </mrow>
-                                                                  </mpadded>
-                                                                </mrow>
-                                                              </mrow>
-                                                            </mtd>
-                                                            <mtd></mtd>
-                                                            <mtd rowalign="bottom">
-                                                              <mrow data-latex="\\RL{$\\rightarrow_E$}" semantics="bspr_axiom:true">
-                                                                <mspace width=".5ex"></mspace>
-                                                                <mrow data-mjx-texclass="ORD">
-                                                                  <mi data-latex="Q">Q</mi>
-                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                  <mi data-latex="R">R</mi>
-                                                                </mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                              </mrow>
-                                                            </mtd>
-                                                          </mtr>
-                                                        </mtable>
-                                                      </mtd>
-                                                    </mtr>
-                                                    <mtr>
-                                                      <mtd>
-                                                        <mrow>
-                                                          <mspace width=".5ex"></mspace>
-                                                          <mrow data-mjx-texclass="ORD">
-                                                            <mi data-latex="R">R</mi>
-                                                          </mrow>
-                                                          <mspace width=".5ex"></mspace>
-                                                        </mrow>
-                                                      </mtd>
-                                                    </mtr>
-                                                  </mtable>
-                                                  <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                    <mrow data-mjx-texclass="ORD">
-                                                      <msub data-latex="\\rightarrow_E">
-                                                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                        <mi data-latex="E">E</mi>
-                                                      </msub>
-                                                    </mrow>
-                                                  </mpadded>
-                                                </mrow>
-                                              </mrow>
-                                            </mrow>
-                                          </mtd>
-                                          <mtd></mtd>
-                                          <mtd rowalign="bottom">
-                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
-                                              <mrow data-latex="\\RL{$\\wedge_I$}">
-                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mtable framespacing="0 0">
-                                                        <mtr>
-                                                          <mtd rowalign="bottom">
-                                                            <mrow data-latex="\\RL{Rit$^2$}" semantics="bspr_axiom:true">
-                                                              <mspace width=".5ex"></mspace>
-                                                              <mrow data-mjx-texclass="ORD">
-                                                                <mi data-latex="Q">Q</mi>
-                                                              </mrow>
-                                                              <mspace width=".5ex"></mspace>
-                                                            </mrow>
-                                                          </mtd>
-                                                        </mtr>
-                                                      </mtable>
-                                                    </mtd>
-                                                  </mtr>
-                                                  <mtr>
-                                                    <mtd>
-                                                      <mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                        <mrow data-mjx-texclass="ORD">
-                                                          <mi data-latex="Q">Q</mi>
-                                                        </mrow>
-                                                        <mspace width=".5ex"></mspace>
-                                                      </mrow>
-                                                    </mtd>
-                                                  </mtr>
-                                                </mtable>
-                                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                  <mstyle>
-                                                    <mtext>Rit</mtext>
-                                                    <mrow data-mjx-texclass="ORD">
-                                                      <msup data-latex="^2 ">
-                                                        <mi></mi>
-                                                        <mn data-latex="2">2</mn>
-                                                      </msup>
-                                                    </mrow>
-                                                  </mstyle>
-                                                </mpadded>
-                                              </mrow>
-                                              <mspace width="-2.055em"></mspace>
-                                            </mrow>
-                                          </mtd>
-                                        </mtr>
-                                      </mtable>
-                                    </mtd>
-                                  </mtr>
-                                  <mtr>
-                                    <mtd>
-                                      <mrow>
-                                        <mspace width=".5ex"></mspace>
-                                        <mrow data-mjx-texclass="ORD">
-                                          <mi data-latex="Q">Q</mi>
-                                          <mo data-latex="\\wedge">&#x2227;</mo>
-                                          <mi data-latex="R">R</mi>
-                                        </mrow>
-                                        <mspace width=".5ex"></mspace>
-                                      </mrow>
-                                    </mtd>
-                                  </mtr>
-                                </mtable>
-                                <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                  <mrow data-mjx-texclass="ORD">
-                                    <msub data-latex="\\wedge_I">
-                                      <mo data-latex="\\wedge">&#x2227;</mo>
-                                      <mi data-latex="I">I</mi>
-                                    </msub>
-                                  </mrow>
-                                </mpadded>
-                              </mrow>
-                            </mrow>
-                          </mrow>
-                          <mspace width="-5.455em"></mspace>
-                        </mrow>
-                      </mtd>
-                    </mtr>
-                  </mtable>
-                </mtd>
-              </mtr>
-              <mtr>
-                <mtd>
-                  <mrow>
-                    <mspace width=".5ex"></mspace>
-                    <mrow data-mjx-texclass="ORD">
-                      <mi data-latex="P">P</mi>
-                      <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                      <mi data-latex="Q">Q</mi>
-                      <mo data-latex="\\wedge">&#x2227;</mo>
-                      <mi data-latex="R">R</mi>
-                    </mrow>
-                    <mspace width=".5ex"></mspace>
-                  </mrow>
-                </mtd>
-              </mtr>
-            </mtable>
-            <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-              <mstyle displaystyle="false">
-                <mrow data-mjx-texclass="ORD">
-                  <msup data-latex="{\\rightarrow_I}^1 ">
-                    <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
-                      <msub data-latex="\\rightarrow_I">
-                        <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                        <mi data-latex="I">I</mi>
-                      </msub>
-                    </mrow>
-                    <mn data-latex="1">1</mn>
-                  </msup>
-                </mrow>
-              </mstyle>
-            </mpadded>
-          </mrow>
-        </mrow>
-        <mspace width="2.952em"></mspace>
-      </mrow>
-    </math>`
-    ));
-  it('Extreme', () =>
+         <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+           <mrow>
+             <mspace width="13.25em"></mspace>
+             <mrow data-latex="\\begin{prooftree}\\alwaysRootAtTop\\AXC{}\\RL{$Hyp^{1}$}\\UIC{$P$}\\AXC{$P\\rightarrow Q$}\\RL{$\\rightarrow_E$}\\solidLine\\BIC{$Q^2$}\\alwaysRootAtBottom\\AXC{$Q\\rightarrow R$} \\RL{$\\rightarrow_E$} \\BIC{$R$} \\AXC{$Q$}\\RL{Rit$^2$} \\UIC{$Q$}\\RL{$\\wedge_I$}\\BIC{$Q\\wedge R$}\\RL{\${\\rightarrow_I}^1$}\\UIC{$P\\rightarrow Q\\wedge R$}\\end{prooftree}" data-latex-item="{prooftree}">
+               <mspace width="-1.155em"></mspace>
+               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                 <mtr>
+                   <mtd>
+                     <mtable framespacing="0 0">
+                       <mtr>
+                         <mtd rowalign="bottom">
+                           <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                             <mrow>
+                               <mspace width="-13.25em"></mspace>
+                               <mrow>
+                                 <mspace width="9.111em"></mspace>
+                                 <mrow data-latex="\\RL{\${\\rightarrow_I}^1$}">
+                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                     <mtr>
+                                       <mtd>
+                                         <mtable framespacing="0 0">
+                                           <mtr>
+                                             <mtd rowalign="bottom">
+                                               <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                 <mspace width="-9.111em"></mspace>
+                                                 <mrow>
+                                                   <mspace width="3.592em"></mspace>
+                                                   <mrow data-latex="\\BIC{$R$}">
+                                                     <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                       <mtr>
+                                                         <mtd>
+                                                           <mtable framespacing="0 0">
+                                                             <mtr>
+                                                               <mtd rowalign="bottom">
+                                                                 <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                                   <mspace width="-3.592em"></mspace>
+                                                                   <mrow data-latex="\\alwaysRootAtBottom">
+                                                                     <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
+                                                                       <mtr>
+                                                                         <mtd>
+                                                                           <mrow>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mrow data-mjx-texclass="ORD">
+                                                                               <msup data-latex="Q^2 ">
+                                                                                 <mi data-latex="Q">Q</mi>
+                                                                                 <mn data-latex="2">2</mn>
+                                                                               </msup>
+                                                                             </mrow>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                       <mtr>
+                                                                         <mtd>
+                                                                           <mtable framespacing="0 0">
+                                                                             <mtr>
+                                                                               <mtd rowalign="top">
+                                                                                 <mrow data-latex="\\UIC{$P$}" semantics="bspr_labelledRule:right;bspr_inference:0">
+                                                                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:up">
+                                                                                     <mtr>
+                                                                                       <mtd>
+                                                                                         <mrow>
+                                                                                           <mspace width=".5ex"></mspace>
+                                                                                           <mrow data-mjx-texclass="ORD">
+                                                                                             <mi data-latex="P">P</mi>
+                                                                                           </mrow>
+                                                                                           <mspace width=".5ex"></mspace>
+                                                                                         </mrow>
+                                                                                       </mtd>
+                                                                                     </mtr>
+                                                                                     <mtr>
+                                                                                       <mtd>
+                                                                                         <mtable framespacing="0 0">
+                                                                                           <mtr>
+                                                                                             <mtd rowalign="top">
+                                                                                               <mrow data-latex="\\RL{$Hyp^{1}$}" semantics="bspr_axiom:true"></mrow>
+                                                                                             </mtd>
+                                                                                           </mtr>
+                                                                                         </mtable>
+                                                                                       </mtd>
+                                                                                     </mtr>
+                                                                                   </mtable>
+                                                                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                                     <mrow data-mjx-texclass="ORD">
+                                                                                       <mi data-latex="H">H</mi>
+                                                                                       <mi data-latex="y">y</mi>
+                                                                                       <msup data-latex="p^{1}">
+                                                                                         <mi data-latex="p">p</mi>
+                                                                                         <mrow data-mjx-texclass="ORD" data-latex="{1}">
+                                                                                           <mn data-latex="1">1</mn>
+                                                                                         </mrow>
+                                                                                       </msup>
+                                                                                     </mrow>
+                                                                                   </mpadded>
+                                                                                 </mrow>
+                                                                               </mtd>
+                                                                               <mtd></mtd>
+                                                                               <mtd rowalign="top">
+                                                                                 <mrow data-latex="\\solidLine" semantics="bspr_axiom:true">
+                                                                                   <mspace width=".5ex"></mspace>
+                                                                                   <mrow data-mjx-texclass="ORD">
+                                                                                     <mi data-latex="P">P</mi>
+                                                                                     <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                                     <mi data-latex="Q">Q</mi>
+                                                                                   </mrow>
+                                                                                   <mspace width=".5ex"></mspace>
+                                                                                 </mrow>
+                                                                               </mtd>
+                                                                             </mtr>
+                                                                           </mtable>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                     </mtable>
+                                                                     <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                       <mrow data-mjx-texclass="ORD">
+                                                                         <msub data-latex="\\rightarrow_E">
+                                                                           <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                           <mi data-latex="E">E</mi>
+                                                                         </msub>
+                                                                       </mrow>
+                                                                     </mpadded>
+                                                                   </mrow>
+                                                                 </mrow>
+                                                               </mtd>
+                                                               <mtd></mtd>
+                                                               <mtd rowalign="bottom">
+                                                                 <mrow data-latex="\\RL{$\\rightarrow_E$}" semantics="bspr_axiom:true">
+                                                                   <mspace width=".5ex"></mspace>
+                                                                   <mrow data-mjx-texclass="ORD">
+                                                                     <mi data-latex="Q">Q</mi>
+                                                                     <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                     <mi data-latex="R">R</mi>
+                                                                   </mrow>
+                                                                   <mspace width=".5ex"></mspace>
+                                                                 </mrow>
+                                                               </mtd>
+                                                             </mtr>
+                                                           </mtable>
+                                                         </mtd>
+                                                       </mtr>
+                                                       <mtr>
+                                                         <mtd>
+                                                           <mrow>
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mrow data-mjx-texclass="ORD">
+                                                               <mi data-latex="R">R</mi>
+                                                             </mrow>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                     <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                       <mrow data-mjx-texclass="ORD">
+                                                         <msub data-latex="\\rightarrow_E">
+                                                           <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                           <mi data-latex="E">E</mi>
+                                                         </msub>
+                                                       </mrow>
+                                                     </mpadded>
+                                                   </mrow>
+                                                 </mrow>
+                                               </mrow>
+                                             </mtd>
+                                             <mtd></mtd>
+                                             <mtd rowalign="bottom">
+                                               <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                                 <mrow data-latex="\\RL{$\\wedge_I$}">
+                                                   <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mtable framespacing="0 0">
+                                                           <mtr>
+                                                             <mtd rowalign="bottom">
+                                                               <mrow data-latex="\\RL{Rit$^2$}" semantics="bspr_axiom:true">
+                                                                 <mspace width=".5ex"></mspace>
+                                                                 <mrow data-mjx-texclass="ORD">
+                                                                   <mi data-latex="Q">Q</mi>
+                                                                 </mrow>
+                                                                 <mspace width=".5ex"></mspace>
+                                                               </mrow>
+                                                             </mtd>
+                                                           </mtr>
+                                                         </mtable>
+                                                       </mtd>
+                                                     </mtr>
+                                                     <mtr>
+                                                       <mtd>
+                                                         <mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                           <mrow data-mjx-texclass="ORD">
+                                                             <mi data-latex="Q">Q</mi>
+                                                           </mrow>
+                                                           <mspace width=".5ex"></mspace>
+                                                         </mrow>
+                                                       </mtd>
+                                                     </mtr>
+                                                   </mtable>
+                                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                     <mstyle>
+                                                       <mtext>Rit</mtext>
+                                                       <mrow data-mjx-texclass="ORD">
+                                                         <msup data-latex="^2 ">
+                                                           <mi></mi>
+                                                           <mn data-latex="2">2</mn>
+                                                         </msup>
+                                                       </mrow>
+                                                     </mstyle>
+                                                   </mpadded>
+                                                 </mrow>
+                                                 <mspace width="-2.055em"></mspace>
+                                               </mrow>
+                                             </mtd>
+                                           </mtr>
+                                         </mtable>
+                                       </mtd>
+                                     </mtr>
+                                     <mtr>
+                                       <mtd>
+                                         <mrow>
+                                           <mspace width=".5ex"></mspace>
+                                           <mrow data-mjx-texclass="ORD">
+                                             <mi data-latex="Q">Q</mi>
+                                             <mo data-latex="\\wedge">&#x2227;</mo>
+                                             <mi data-latex="R">R</mi>
+                                           </mrow>
+                                           <mspace width=".5ex"></mspace>
+                                         </mrow>
+                                       </mtd>
+                                     </mtr>
+                                   </mtable>
+                                   <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                     <mrow data-mjx-texclass="ORD">
+                                       <msub data-latex="\\wedge_I">
+                                         <mo data-latex="\\wedge">&#x2227;</mo>
+                                         <mi data-latex="I">I</mi>
+                                       </msub>
+                                     </mrow>
+                                   </mpadded>
+                                 </mrow>
+                               </mrow>
+                             </mrow>
+                             <mspace width="-5.456em"></mspace>
+                           </mrow>
+                         </mtd>
+                       </mtr>
+                     </mtable>
+                   </mtd>
+                 </mtr>
+                 <mtr>
+                   <mtd>
+                     <mrow>
+                       <mspace width=".5ex"></mspace>
+                       <mrow data-mjx-texclass="ORD">
+                         <mi data-latex="P">P</mi>
+                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                         <mi data-latex="Q">Q</mi>
+                         <mo data-latex="\\wedge">&#x2227;</mo>
+                         <mi data-latex="R">R</mi>
+                       </mrow>
+                       <mspace width=".5ex"></mspace>
+                     </mrow>
+                   </mtd>
+                 </mtr>
+               </mtable>
+               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                 <mstyle displaystyle="false">
+                   <mrow data-mjx-texclass="ORD">
+                     <msup data-latex="{\\rightarrow_I}^1 ">
+                       <mrow data-mjx-texclass="ORD" data-latex="{\\rightarrow_I}">
+                         <msub data-latex="\\rightarrow_I">
+                           <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                           <mi data-latex="I">I</mi>
+                         </msub>
+                       </mrow>
+                       <mn data-latex="1">1</mn>
+                     </msup>
+                   </mrow>
+                 </mstyle>
+               </mpadded>
+             </mrow>
+           </mrow>
+           <mspace width="2.953em"></mspace>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Extreme', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{$C \\rightarrow D \\rightarrow Q$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{$N \\rightarrow R$}\\RightLabel{Nowhere}\\end{prooftree}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" display="block">
-  <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
-    <mspace width="16.317em"></mspace>
-    <mrow data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
-      <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-        <mstyle displaystyle="false">
-          <mtext>BBB</mtext>
-        </mstyle>
-      </mpadded>
-      <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-        <mtr>
-          <mtd>
-            <mtable framespacing="0 0">
-              <mtr>
-                <mtd rowalign="bottom">
-                  <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
-                    <mspace width="-18.656em"></mspace>
-                    <mrow>
-                      <mspace width="3.94em"></mspace>
-                      <mrow data-latex="\\RightLabel{QERE}">
-                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                          <mtext>WWW</mtext>
-                        </mpadded>
-                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                          <mtr>
-                            <mtd>
-                              <mtable framespacing="0 0">
-                                <mtr>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:3;bspr_labelledRule:both">
-                                      <mspace width="-7.239em"></mspace>
-                                      <mrow data-latex="\\RightLabel{AAAA}">
-                                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                          <mtext>HHHHH</mtext>
-                                        </mpadded>
-                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                          <mtr>
-                                            <mtd>
-                                              <mtable framespacing="0 0">
-                                                <mtr>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mtext>D</mtext>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                  <mtd></mtd>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mtext>A1</mtext>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                  <mtd></mtd>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mtext>A2</mtext>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                            </mtd>
-                                          </mtr>
-                                          <mtr>
-                                            <mtd>
-                                              <mrow>
-                                                <mspace width=".5ex"></mspace>
-                                                <mtext>Q</mtext>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                          <mtext>11111111111111111</mtext>
-                                        </mpadded>
-                                      </mrow>
-                                    </mrow>
-                                  </mtd>
-                                  <mtd></mtd>
-                                  <mtd rowalign="bottom">
-                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
-                                      <mrow data-latex="\\LL{WWW}">
-                                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                          <mtext>BBBB</mtext>
-                                        </mpadded>
-                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                          <mtr>
-                                            <mtd>
-                                              <mtable framespacing="0 0">
-                                                <mtr>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
-                                                      <mspace width=".5ex"></mspace>
-                                                      <mtext>A</mtext>
-                                                      <mspace width=".5ex"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                  <mtd></mtd>
-                                                  <mtd rowalign="bottom">
-                                                    <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
-                                                      <mrow data-latex="\\RightLabel{MMM}">
-                                                        <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
-                                                          <mtext>qqqq</mtext>
-                                                        </mpadded>
-                                                        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mtable framespacing="0 0">
-                                                                <mtr>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mtext>B</mtext>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                  <mtd></mtd>
-                                                                  <mtd rowalign="bottom">
-                                                                    <mrow data-latex="\\LL{qqqq}" semantics="bspr_axiom:true">
-                                                                      <mspace width=".5ex"></mspace>
-                                                                      <mtext>R</mtext>
-                                                                      <mspace width=".5ex"></mspace>
-                                                                    </mrow>
-                                                                  </mtd>
-                                                                </mtr>
-                                                              </mtable>
-                                                            </mtd>
-                                                          </mtr>
-                                                          <mtr>
-                                                            <mtd>
-                                                              <mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                                <mrow data-mjx-texclass="ORD">
-                                                                  <mi data-latex="C">C</mi>
-                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                  <mi data-latex="D">D</mi>
-                                                                  <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                                                                  <mi data-latex="Q">Q</mi>
-                                                                </mrow>
-                                                                <mspace width=".5ex"></mspace>
-                                                              </mrow>
-                                                            </mtd>
-                                                          </mtr>
-                                                        </mtable>
-                                                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                                          <mtext>AAAA</mtext>
-                                                        </mpadded>
-                                                      </mrow>
-                                                      <mspace width="-3.216em"></mspace>
-                                                    </mrow>
-                                                  </mtd>
-                                                </mtr>
-                                              </mtable>
-                                            </mtd>
-                                          </mtr>
-                                          <mtr>
-                                            <mtd>
-                                              <mrow>
-                                                <mspace width=".5ex"></mspace>
-                                                <mtext>E</mtext>
-                                                <mspace width=".5ex"></mspace>
-                                              </mrow>
-                                            </mtd>
-                                          </mtr>
-                                        </mtable>
-                                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                                          <mtext>MMM</mtext>
-                                        </mpadded>
-                                      </mrow>
-                                      <mspace width="-7.925em"></mspace>
-                                    </mrow>
-                                  </mtd>
-                                </mtr>
-                              </mtable>
-                            </mtd>
-                          </mtr>
-                          <mtr>
-                            <mtd>
-                              <mrow>
-                                <mspace width=".5ex"></mspace>
-                                <mtext>F</mtext>
-                                <mspace width=".5ex"></mspace>
-                              </mrow>
-                            </mtd>
-                          </mtr>
-                        </mtable>
-                        <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-                          <mtext>CCCCC</mtext>
-                        </mpadded>
-                      </mrow>
-                    </mrow>
-                  </mrow>
-                </mtd>
-                <mtd>
-                  <mspace width="4.349em"></mspace>
-                </mtd>
-                <mtd rowalign="bottom">
-                  <mrow data-latex="\\LL{BBB}" semantics="bspr_axiom:true">
-                    <mspace width=".5ex"></mspace>
-                    <mtext>M</mtext>
-                    <mspace width=".5ex"></mspace>
-                  </mrow>
-                </mtd>
-              </mtr>
-            </mtable>
-          </mtd>
-        </mtr>
-        <mtr>
-          <mtd>
-            <mrow>
-              <mspace width=".5ex"></mspace>
-              <mrow data-mjx-texclass="ORD">
-                <mi data-latex="N">N</mi>
-                <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
-                <mi data-latex="R">R</mi>
-              </mrow>
-              <mspace width=".5ex"></mspace>
-            </mrow>
-          </mtd>
-        </mtr>
-      </mtable>
-      <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
-        <mstyle displaystyle="false">
-          <mtext>QERE</mtext>
-        </mstyle>
-      </mpadded>
-    </mrow>
-  </mrow>
-</math>`
-    ));
+         <mrow semantics="bspr_inference:2;bspr_proof:true;bspr_labelledRule:both">
+           <mspace width="16.317em"></mspace>
+           <mrow data-latex="\\begin{prooftree}\\LL{HHHHH}\\RL{11111111111111111}\\AxiomC{D}\\AxiomC{A1}\\AxiomC{A2}\\TrinaryInfC{Q}\\RightLabel{AAAA}\\AxiomC{A}\\AxiomC{B}\\AxiomC{R}\\LL{qqqq}\\BinaryInfC{\$C \\rightarrow D \\rightarrow Q\$}\\LeftLabel{BBBB}\\RightLabel{MMM}\\BinaryInfC{E}\\RightLabel{CCCCC}\\LL{WWW}\\BinaryInfC{F}\\RightLabel{QERE}\\AxiomC{M}\\LL{BBB}\\BinaryInfC{\$N \\rightarrow R\$}\\RightLabel{Nowhere}\\end{prooftree}" data-latex-item="{prooftree}">
+             <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+               <mstyle displaystyle="false">
+                 <mtext>BBB</mtext>
+               </mstyle>
+             </mpadded>
+             <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+               <mtr>
+                 <mtd>
+                   <mtable framespacing="0 0">
+                     <mtr>
+                       <mtd rowalign="bottom">
+                         <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
+                           <mspace width="-18.656em"></mspace>
+                           <mrow>
+                             <mspace width="3.94em"></mspace>
+                             <mrow data-latex="\\RightLabel{QERE}">
+                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                 <mtext>WWW</mtext>
+                               </mpadded>
+                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                 <mtr>
+                                   <mtd>
+                                     <mtable framespacing="0 0">
+                                       <mtr>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:3;bspr_labelledRule:both">
+                                             <mspace width="-7.239em"></mspace>
+                                             <mrow data-latex="\\RightLabel{AAAA}">
+                                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                 <mtext>HHHHH</mtext>
+                                               </mpadded>
+                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mtable framespacing="0 0">
+                                                       <mtr>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{D}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>D</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                         <mtd></mtd>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{A1}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>A1</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                         <mtd></mtd>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{A2}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>A2</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                   </mtd>
+                                                 </mtr>
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mrow>
+                                                       <mspace width=".5ex"></mspace>
+                                                       <mtext>Q</mtext>
+                                                       <mspace width=".5ex"></mspace>
+                                                     </mrow>
+                                                   </mtd>
+                                                 </mtr>
+                                               </mtable>
+                                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                 <mtext>11111111111111111</mtext>
+                                               </mpadded>
+                                             </mrow>
+                                           </mrow>
+                                         </mtd>
+                                         <mtd></mtd>
+                                         <mtd rowalign="bottom">
+                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
+                                             <mrow data-latex="\\LL{WWW}">
+                                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                 <mtext>BBBB</mtext>
+                                               </mpadded>
+                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mtable framespacing="0 0">
+                                                       <mtr>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow data-latex="\\AxiomC{A}" semantics="bspr_axiom:true">
+                                                             <mspace width=".5ex"></mspace>
+                                                             <mtext>A</mtext>
+                                                             <mspace width=".5ex"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                         <mtd></mtd>
+                                                         <mtd rowalign="bottom">
+                                                           <mrow semantics="bspr_inference:2;bspr_labelledRule:both">
+                                                             <mrow data-latex="\\RightLabel{MMM}">
+                                                               <mpadded height=".25em" depth="+.25em" width="+.5ex" voffset="-.25em" semantics="bspr_prooflabel:left">
+                                                                 <mtext>qqqq</mtext>
+                                                               </mpadded>
+                                                               <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                 <mtr>
+                                                                   <mtd>
+                                                                     <mtable framespacing="0 0">
+                                                                       <mtr>
+                                                                         <mtd rowalign="bottom">
+                                                                           <mrow data-latex="\\AxiomC{B}" semantics="bspr_axiom:true">
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mtext>B</mtext>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                         <mtd></mtd>
+                                                                         <mtd rowalign="bottom">
+                                                                           <mrow data-latex="\\LL{qqqq}" semantics="bspr_axiom:true">
+                                                                             <mspace width=".5ex"></mspace>
+                                                                             <mtext>R</mtext>
+                                                                             <mspace width=".5ex"></mspace>
+                                                                           </mrow>
+                                                                         </mtd>
+                                                                       </mtr>
+                                                                     </mtable>
+                                                                   </mtd>
+                                                                 </mtr>
+                                                                 <mtr>
+                                                                   <mtd>
+                                                                     <mrow>
+                                                                       <mspace width=".5ex"></mspace>
+                                                                       <mrow data-mjx-texclass="ORD">
+                                                                         <mi data-latex="C">C</mi>
+                                                                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                         <mi data-latex="D">D</mi>
+                                                                         <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                                                                         <mi data-latex="Q">Q</mi>
+                                                                       </mrow>
+                                                                       <mspace width=".5ex"></mspace>
+                                                                     </mrow>
+                                                                   </mtd>
+                                                                 </mtr>
+                                                               </mtable>
+                                                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                                 <mtext>AAAA</mtext>
+                                                               </mpadded>
+                                                             </mrow>
+                                                             <mspace width="-3.216em"></mspace>
+                                                           </mrow>
+                                                         </mtd>
+                                                       </mtr>
+                                                     </mtable>
+                                                   </mtd>
+                                                 </mtr>
+                                                 <mtr>
+                                                   <mtd>
+                                                     <mrow>
+                                                       <mspace width=".5ex"></mspace>
+                                                       <mtext>E</mtext>
+                                                       <mspace width=".5ex"></mspace>
+                                                     </mrow>
+                                                   </mtd>
+                                                 </mtr>
+                                               </mtable>
+                                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                                 <mtext>MMM</mtext>
+                                               </mpadded>
+                                             </mrow>
+                                             <mspace width="-7.925em"></mspace>
+                                           </mrow>
+                                         </mtd>
+                                       </mtr>
+                                     </mtable>
+                                   </mtd>
+                                 </mtr>
+                                 <mtr>
+                                   <mtd>
+                                     <mrow>
+                                       <mspace width=".5ex"></mspace>
+                                       <mtext>F</mtext>
+                                       <mspace width=".5ex"></mspace>
+                                     </mrow>
+                                   </mtd>
+                                 </mtr>
+                               </mtable>
+                               <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+                                 <mtext>CCCCC</mtext>
+                               </mpadded>
+                             </mrow>
+                           </mrow>
+                         </mrow>
+                       </mtd>
+                       <mtd>
+                         <mspace width="4.349em"></mspace>
+                       </mtd>
+                       <mtd rowalign="bottom">
+                         <mrow data-latex="\\LL{BBB}" semantics="bspr_axiom:true">
+                           <mspace width=".5ex"></mspace>
+                           <mtext>M</mtext>
+                           <mspace width=".5ex"></mspace>
+                         </mrow>
+                       </mtd>
+                     </mtr>
+                   </mtable>
+                 </mtd>
+               </mtr>
+               <mtr>
+                 <mtd>
+                   <mrow>
+                     <mspace width=".5ex"></mspace>
+                     <mrow data-mjx-texclass="ORD">
+                       <mi data-latex="N">N</mi>
+                       <mo stretchy="false" data-latex="\\rightarrow">&#x2192;</mo>
+                       <mi data-latex="R">R</mi>
+                     </mrow>
+                     <mspace width=".5ex"></mspace>
+                   </mrow>
+                 </mtd>
+               </mtr>
+             </mtable>
+             <mpadded height="-.25em" depth="+.25em" width="+.5ex" voffset="-.25em" lspace=".5ex" semantics="bspr_prooflabel:right">
+               <mstyle displaystyle="false">
+                 <mtext>QERE</mtext>
+               </mstyle>
+             </mpadded>
+           </mrow>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('bussproofs'));

--- a/testsuite/tests/input/tex/Cancel.test.ts
+++ b/testsuite/tests/input/tex/Cancel.test.ts
@@ -4,89 +4,130 @@ import '#js/input/tex/cancel/CancelConfiguration';
 
 beforeEach(() => setupTex(['base', 'cancel']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Cancel', () => {
-  it('Cancel', () =>
+
+  /********************************************************************************/
+
+  it('Cancel', () => {
     toXmlMatch(
       tex2mml('\\cancel{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cancel{x}" display="block">
-  <menclose notation="updiagonalstrike" data-latex="\\cancel{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('BCancel', () =>
+         <menclose notation="updiagonalstrike" data-latex="\\cancel{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('BCancel', () => {
     toXmlMatch(
       tex2mml('\\bcancel{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\bcancel{x}" display="block">
-  <menclose notation="downdiagonalstrike" data-latex="\\bcancel{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('XCancel', () =>
+         <menclose notation="downdiagonalstrike" data-latex="\\bcancel{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('XCancel', () => {
     toXmlMatch(
       tex2mml('\\xcancel{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xcancel{x}" display="block">
-  <menclose notation="updiagonalstrike downdiagonalstrike" data-latex="\\xcancel{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('CancelTo', () =>
+         <menclose notation="updiagonalstrike downdiagonalstrike" data-latex="\\xcancel{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('CancelTo', () => {
     toXmlMatch(
       tex2mml('\\cancelto{x}{y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cancelto{x}{y}" display="block">
-  <msup data-latex="\\cancelto{x}{y}">
-    <menclose notation="updiagonalstrike updiagonalarrow northeastarrow">
-      <mi data-latex="y">y</mi>
-    </menclose>
-    <mpadded depth="-.1em" height="+.1em" voffset=".1em">
-      <mi data-latex="x">x</mi>
-    </mpadded>
-  </msup>
-</math>`
-    ));
-  it('Cancel Attr', () =>
+         <msup data-latex="\\cancelto{x}{y}">
+           <menclose notation="updiagonalstrike updiagonalarrow northeastarrow">
+             <mi data-latex="y">y</mi>
+           </menclose>
+           <mpadded depth="-.1em" height="+.1em" voffset=".1em">
+             <mi data-latex="x">x</mi>
+           </mpadded>
+         </msup>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Cancel Attr', () => {
     toXmlMatch(
       tex2mml('\\cancel[color=red]{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cancel[color=red]{x}" display="block">
-  <menclose color="red" notation="updiagonalstrike" data-latex="\\cancel[color=red]{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Cancel Attrs', () =>
+         <menclose color="red" notation="updiagonalstrike" data-latex="\\cancel[color=red]{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Cancel Attrs', () => {
     toXmlMatch(
       tex2mml('\\cancel[mathcolor=green,mathbackground=yellow]{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cancel[mathcolor=green,mathbackground=yellow]{x}" display="block">
-  <menclose mathcolor="green" mathbackground="yellow" notation="updiagonalstrike" data-latex="\\cancel[mathcolor=green,mathbackground=yellow]{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Cancel Attr Not Allowed', () =>
+         <menclose mathcolor="green" mathbackground="yellow" notation="updiagonalstrike" data-latex="\\cancel[mathcolor=green,mathbackground=yellow]{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Cancel Attr Not Allowed', () => {
     toXmlMatch(
       tex2mml('\\cancel[nothing=green]{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cancel[nothing=green]{x}" display="block">
-  <menclose notation="updiagonalstrike" data-latex="\\cancel[nothing=green]{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('CancelTo Attrs', () =>
+         <menclose notation="updiagonalstrike" data-latex="\\cancel[nothing=green]{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('CancelTo Attrs', () => {
     toXmlMatch(
       tex2mml('\\cancelto[data-padding=5,data-arrowhead=15]{x}{y}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cancelto[data-padding=5,data-arrowhead=15]{x}{y}" display="block">
-  <msup data-latex="\\cancelto[data-padding=5,data-arrowhead=15]{x}{y}">
-    <menclose data-padding="5" data-arrowhead="15" notation="updiagonalstrike updiagonalarrow northeastarrow">
-      <mi data-latex="y">y</mi>
-    </menclose>
-    <mpadded depth="-.1em" height="+.1em" voffset=".1em">
-      <mi data-latex="x">x</mi>
-    </mpadded>
-  </msup>
-</math>`
-    ));
+         <msup data-latex="\\cancelto[data-padding=5,data-arrowhead=15]{x}{y}">
+           <menclose data-padding="5" data-arrowhead="15" notation="updiagonalstrike updiagonalarrow northeastarrow">
+             <mi data-latex="y">y</mi>
+           </menclose>
+           <mpadded depth="-.1em" height="+.1em" voffset=".1em">
+             <mi data-latex="x">x</mi>
+           </mpadded>
+         </msup>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('cancel'));

--- a/testsuite/tests/input/tex/Colorv2.test.ts
+++ b/testsuite/tests/input/tex/Colorv2.test.ts
@@ -4,43 +4,81 @@ import '#js/input/tex/colorv2/ColorV2Configuration';
 
 beforeEach(() => setupTex(['base', 'colorv2']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('ColorV2', () => {
-  it('Color Open', () =>
+
+  /********************************************************************************/
+
+  it('Color Open', () => {
     toXmlMatch(
       tex2mml('\\color{red}{ab}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color{red}{ab}" display="block">
-  <mstyle mathcolor="red" data-latex="\\color{red}{ab}">
-    <mi data-latex="a">a</mi>
-    <mi data-latex="b">b</mi>
-  </mstyle>
-</math>`
-    ));
-  it('Color Enclosed', () =>
+         <mstyle mathcolor="red" data-latex="\\color{red}{ab}">
+           <mi data-latex="a">a</mi>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Color Enclosed', () => {
     toXmlMatch(
       tex2mml('\\color{red}ab'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color{red}ab" display="block">
-  <mstyle mathcolor="red" data-latex="\\color{red}a">
-    <mi data-latex="a">a</mi>
-  </mstyle>
-  <mi data-latex="b">b</mi>
-</math>`
-    ));
-  it('Color Frac', () =>
+         <mstyle mathcolor="red" data-latex="\\color{red}a">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+         <mi data-latex="b">b</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Color Frac', () => {
     toXmlMatch(
       tex2mml('\\frac{{\\cal \\color{red}{X}}}{\\color{blue}{\\sf y}}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\frac{{\\cal \\color{red}{X}}}{\\color{blue}{\\sf y}}" display="block">
-  <mfrac data-latex="\\frac{{\\cal \\color{red}{X}}}{\\color{blue}{\\sf y}}">
-    <mrow data-mjx-texclass="ORD" data-latex="{\\cal \\color{red}{X}}">
-      <mstyle mathcolor="red" data-latex="\\color{red}{X}">
-        <mi data-mjx-variant="-tex-calligraphic" mathvariant="script" data-latex="X">X</mi>
-      </mstyle>
-    </mrow>
-    <mstyle mathcolor="blue" data-latex="\\color{blue}{\\sf y}">
-      <mi mathvariant="sans-serif" data-latex="\\sf y">y</mi>
-    </mstyle>
-  </mfrac>
-</math>`
-    ));
+         <mfrac data-latex="\\frac{{\\cal \\color{red}{X}}}{\\color{blue}{\\sf y}}">
+           <mrow data-mjx-texclass="ORD" data-latex="{\\cal \\color{red}{X}}">
+             <mstyle mathcolor="red" data-latex="\\color{red}{X}">
+               <mi data-mjx-variant="-tex-calligraphic" mathvariant="script" data-latex="X">X</mi>
+             </mstyle>
+           </mrow>
+           <mstyle mathcolor="blue" data-latex="\\color{blue}{\\sf y}">
+             <mi mathvariant="sans-serif" data-latex="\\sf y">y</mi>
+           </mstyle>
+         </mfrac>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Color Nested', () => {
+    toXmlMatch(
+      tex2mml('\\color{red}{a\\color{blue}{b}c}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color{red}{a\\color{blue}{b}c}" display="block">
+         <mstyle mathcolor="red" data-latex="\\color{red}{a\\color{blue}{b}c}">
+           <mi data-latex="a">a</mi>
+           <mstyle mathcolor="blue" data-latex="\\color{blue}{b}">
+             <mi data-latex="b">b</mi>
+           </mstyle>
+           <mi data-latex="c">c</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('colorv2'));

--- a/testsuite/tests/input/tex/ConfigMacros.test.ts
+++ b/testsuite/tests/input/tex/ConfigMacros.test.ts
@@ -14,76 +14,120 @@ function runMacroTests(
   toXmlMatch(tex2mml(macro), expected.replace('PH', macro));
 }
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Config Macros Active', () => {
-  it('Macros Simple', () =>
+
+  /********************************************************************************/
+
+  it('Macros Simple', () => {
     runMacroTests(
       {active: {"@": "~"}},
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-      <mi data-latex="A">A</mi>
-      <mtext data-latex="~">&#xA0;</mtext>
-      <mi data-latex="a">a</mi>
-    </math>`,
+         <mi data-latex="A">A</mi>
+         <mtext data-latex="~">&#xA0;</mtext>
+         <mi data-latex="a">a</mi>
+       </math>`,
       'A~a',
       'A@a'
-    ));
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 describe('Config Macros Commands', () => {
-  it('Commands Simple', () =>
+
+  /********************************************************************************/
+
+  it('Commands Simple', () => {
     runMacroTests(
       {macros: {"RR": "{\\bf R}"}},
-    `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-      <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
-        <mi mathvariant="bold" data-latex="R">R</mi>
-      </mrow>
-</math>`,
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{\\bf R}">
+           <mi mathvariant="bold" data-latex="R">R</mi>
+         </mrow>
+      </math>`,
       '{\\bf R}',
-      '\\RR'));
-  it('Commands Argument', () =>
+      '\\RR'
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Commands Argument', () => {
     runMacroTests(
       {macros: {"bold": ["{\\bf #1}", 1]}},
-    `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-      <mrow data-mjx-texclass="ORD" data-latex="{\\bf bold}">
-        <mi mathvariant="bold" data-latex="b">b</mi>
-        <mi mathvariant="bold" data-latex="o">o</mi>
-        <mi mathvariant="bold" data-latex="l">l</mi>
-        <mi mathvariant="bold" data-latex="d">d</mi>
-      </mrow>
-    </math>`,
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{\\bf bold}">
+           <mi mathvariant="bold" data-latex="b">b</mi>
+           <mi mathvariant="bold" data-latex="o">o</mi>
+           <mi mathvariant="bold" data-latex="l">l</mi>
+           <mi mathvariant="bold" data-latex="d">d</mi>
+         </mrow>
+       </math>`,
       '{\\bf bold}',
-      '\\bold{bold}'));
-  it('Commands Aux Argument', () =>
+      '\\bold{bold}'
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Commands Aux Argument', () => {
     runMacroTests(
       {macros: {"foo": ["\\mbox{first } #1 \\mbox{ second } #2", 2, ["[", "]"]]}},
-    `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
-      <mstyle displaystyle="false" data-latex="\\mbox{first }">
-        <mtext>first&#xA0;</mtext>
-      </mstyle>
-      <mi data-latex="h">h</mi>
-      <mi data-latex="i">i</mi>
-      <mstyle displaystyle="false" data-latex="\\mbox{ second }">
-        <mtext>&#xA0;second&#xA0;</mtext>
-      </mstyle>
-      <mi data-latex="t">t</mi>
-      <mi data-latex="h">h</mi>
-      <mi data-latex="e">e</mi>
-      <mi data-latex="r">r</mi>
-      <mi data-latex="e">e</mi>
-    </math>`,
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="PH" display="block">
+         <mstyle displaystyle="false" data-latex="\\mbox{first }">
+           <mtext>first&#xA0;</mtext>
+         </mstyle>
+         <mi data-latex="h">h</mi>
+         <mi data-latex="i">i</mi>
+         <mstyle displaystyle="false" data-latex="\\mbox{ second }">
+           <mtext>&#xA0;second&#xA0;</mtext>
+         </mstyle>
+         <mi data-latex="t">t</mi>
+         <mi data-latex="h">h</mi>
+         <mi data-latex="e">e</mi>
+         <mi data-latex="r">r</mi>
+         <mi data-latex="e">e</mi>
+       </math>`,
       '\\mbox{first } hi \\mbox{ second } there',
-      '\\foo[hi]{there}'));
+      '\\foo[hi]{there}'
+    );
+  });
+
+  /********************************************************************************/
+
 });
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Config Macros Environment', () => {
-  it('Environment Simple', () =>
+
+  /********************************************************************************/
+
+  it('Environment Simple', () => {
     runMacroTests(
       {environments: {"myHeartEnv": ["\\heartsuit", "\\spadesuit"]}},
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{myHeartEnv}a\\end{myHeartEnv}" display="block">
-      <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
-      <mi data-latex="a">a</mi>
-      <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
-    </math>`,
+         <mi mathvariant="normal" data-latex="\\heartsuit">&#x2661;</mi>
+         <mi data-latex="a">a</mi>
+         <mi mathvariant="normal" data-latex="\\spadesuit">&#x2660;</mi>
+       </math>`,
       '\\begin{myHeartEnv}a\\end{myHeartEnv}',
       '\\begin{myHeartEnv}a\\end{myHeartEnv}'
-    ));
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/testsuite/tests/input/tex/Enclose.test.ts
+++ b/testsuite/tests/input/tex/Enclose.test.ts
@@ -4,61 +4,94 @@ import '#js/input/tex/enclose/EncloseConfiguration';
 
 beforeEach(() => setupTex(['base', 'enclose']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Enclose', () => {
-  it('Enclose 1', () =>
+
+  /********************************************************************************/
+
+  it('Enclose 1', () => {
     toXmlMatch(
       tex2mml('\\enclose{updiagonalstrike}{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\enclose{updiagonalstrike}{x}" display="block">
-  <menclose notation="updiagonalstrike" data-latex="\\enclose{updiagonalstrike}{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Enclose 2', () =>
+         <menclose notation="updiagonalstrike" data-latex="\\enclose{updiagonalstrike}{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Enclose 2', () => {
     toXmlMatch(
       tex2mml('\\enclose{circle}{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\enclose{circle}{x}" display="block">
-  <menclose notation="circle" data-latex="\\enclose{circle}{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Enclose 3', () =>
+         <menclose notation="circle" data-latex="\\enclose{circle}{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Enclose 3', () => {
     toXmlMatch(
       tex2mml('\\enclose{horizontalstrike}{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\enclose{horizontalstrike}{x}" display="block">
-  <menclose notation="horizontalstrike" data-latex="\\enclose{horizontalstrike}{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Enclose Attr 2', () =>
+         <menclose notation="horizontalstrike" data-latex="\\enclose{horizontalstrike}{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Enclose Attr 2', () => {
     toXmlMatch(
       tex2mml('\\enclose{updiagonalarrow}[mathbackground=red]{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\enclose{updiagonalarrow}[mathbackground=red]{x}" display="block">
-  <menclose mathbackground="red" notation="updiagonalarrow" data-latex="\\enclose{updiagonalarrow}[mathbackground=red]{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Enclose Attr 1', () =>
+         <menclose mathbackground="red" notation="updiagonalarrow" data-latex="\\enclose{updiagonalarrow}[mathbackground=red]{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Enclose Attr 1', () => {
     toXmlMatch(
       tex2mml('\\enclose{horizontalstrike}[data-thickness=5]{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\enclose{horizontalstrike}[data-thickness=5]{x}" display="block">
-  <menclose data-thickness="5" notation="horizontalstrike" data-latex="\\enclose{horizontalstrike}[data-thickness=5]{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
-  it('Enclose Attrs', () =>
+         <menclose data-thickness="5" notation="horizontalstrike" data-latex="\\enclose{horizontalstrike}[data-thickness=5]{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Enclose Attrs', () => {
     toXmlMatch(
       tex2mml('\\enclose{circle}[data-thickness=10,data-padding=5]{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\enclose{circle}[data-thickness=10,data-padding=5]{x}" display="block">
-  <menclose data-thickness="10" data-padding="5" notation="circle" data-latex="\\enclose{circle}[data-thickness=10,data-padding=5]{x}">
-    <mi data-latex="x">x</mi>
-  </menclose>
-</math>`
-    ));
+         <menclose data-thickness="10" data-padding="5" notation="circle" data-latex="\\enclose{circle}[data-thickness=10,data-padding=5]{x}">
+           <mi data-latex="x">x</mi>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('enclose'));

--- a/testsuite/tests/input/tex/Extpfeil.test.ts
+++ b/testsuite/tests/input/tex/Extpfeil.test.ts
@@ -1,163 +1,192 @@
 import { afterAll, beforeEach, describe, it } from '@jest/globals';
-import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
 import '#js/input/tex/extpfeil/ExtpfeilConfiguration';
 
 beforeEach(() => setupTex(['base', 'extpfeil']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Extpfeil', () => {
-  it('Xtwoheadrightarrow', () =>
+
+  /********************************************************************************/
+
+  it('Xtwoheadrightarrow', () => {
     toXmlMatch(
       tex2mml('\\xtwoheadrightarrow{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xtwoheadrightarrow{abcxyz}" display="block">
-  <mover data-latex="\\xtwoheadrightarrow{abcxyz}">
-    <mo data-mjx-texclass="REL">&#x21A0;</mo>
-    <mpadded width="+1.556em" lspace="0.667em" voffset="-.2em" height="-.2em">
-      <mi data-latex="a">a</mi>
-      <mi data-latex="b">b</mi>
-      <mi data-latex="c">c</mi>
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-      <mi data-latex="z">z</mi>
-      <mspace depth=".2em"></mspace>
-    </mpadded>
-  </mover>
-</math>`
-    ));
-  it('Xtwoheadleftarrow', () =>
+         <mover data-latex="\\xtwoheadrightarrow{abcxyz}">
+           <mo data-mjx-texclass="REL">&#x21A0;</mo>
+           <mpadded width="+1.556em" lspace="0.667em" voffset="-.2em" height="-.2em">
+             <mi data-latex="a">a</mi>
+             <mi data-latex="b">b</mi>
+             <mi data-latex="c">c</mi>
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+             <mi data-latex="z">z</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </mover>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Xtwoheadleftarrow', () => {
     toXmlMatch(
       tex2mml('\\xtwoheadleftarrow{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xtwoheadleftarrow{abcxyz}" display="block">
-  <mover data-latex="\\xtwoheadleftarrow{abcxyz}">
-    <mo data-mjx-texclass="REL">&#x219E;</mo>
-    <mpadded width="+1.667em" lspace="0.944em" voffset="-.2em" height="-.2em">
-      <mi data-latex="a">a</mi>
-      <mi data-latex="b">b</mi>
-      <mi data-latex="c">c</mi>
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-      <mi data-latex="z">z</mi>
-      <mspace depth=".2em"></mspace>
-    </mpadded>
-  </mover>
-</math>`
-    ));
-  it('Xmapsto', () =>
+         <mover data-latex="\\xtwoheadleftarrow{abcxyz}">
+           <mo data-mjx-texclass="REL">&#x219E;</mo>
+           <mpadded width="+1.667em" lspace="0.944em" voffset="-.2em" height="-.2em">
+             <mi data-latex="a">a</mi>
+             <mi data-latex="b">b</mi>
+             <mi data-latex="c">c</mi>
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+             <mi data-latex="z">z</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </mover>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Xmapsto', () => {
     toXmlMatch(
       tex2mml('\\xmapsto{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xmapsto{abcxyz}" display="block">
-  <mover data-latex="\\xmapsto{abcxyz}">
-    <mo data-mjx-texclass="REL">&#x21A6;</mo>
-    <mpadded width="+0.722em" lspace="0.333em" voffset="-.2em" height="-.2em">
-      <mi data-latex="a">a</mi>
-      <mi data-latex="b">b</mi>
-      <mi data-latex="c">c</mi>
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-      <mi data-latex="z">z</mi>
-      <mspace depth=".2em"></mspace>
-    </mpadded>
-  </mover>
-</math>`
-    ));
-  it('Xlongequal', () =>
+         <mover data-latex="\\xmapsto{abcxyz}">
+           <mo data-mjx-texclass="REL">&#x21A6;</mo>
+           <mpadded width="+0.722em" lspace="0.333em" voffset="-.2em" height="-.2em">
+             <mi data-latex="a">a</mi>
+             <mi data-latex="b">b</mi>
+             <mi data-latex="c">c</mi>
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+             <mi data-latex="z">z</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </mover>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Xlongequal', () => {
     toXmlMatch(
       tex2mml('\\xlongequal{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xlongequal{abcxyz}" display="block">
-  <mover data-latex="\\xlongequal{abcxyz}">
-    <mo data-mjx-texclass="REL" stretchy="true">=</mo>
-    <mpadded width="+0.778em" lspace="0.389em" voffset="-.2em" height="-.2em">
-      <mi data-latex="a">a</mi>
-      <mi data-latex="b">b</mi>
-      <mi data-latex="c">c</mi>
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-      <mi data-latex="z">z</mi>
-      <mspace depth=".2em"></mspace>
-    </mpadded>
-  </mover>
-</math>`
-    ));
-  it('Xtofrom', () =>
+         <mover data-latex="\\xlongequal{abcxyz}">
+           <mo data-mjx-texclass="REL" stretchy="true">=</mo>
+           <mpadded width="+0.778em" lspace="0.389em" voffset="-.2em" height="-.2em">
+             <mi data-latex="a">a</mi>
+             <mi data-latex="b">b</mi>
+             <mi data-latex="c">c</mi>
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+             <mi data-latex="z">z</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </mover>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Xtofrom', () => {
     toXmlMatch(
       tex2mml('\\xtofrom{abcxyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xtofrom{abcxyz}" display="block">
-  <mover data-latex="\\xtofrom{abcxyz}">
-    <mo data-mjx-texclass="REL">&#x21C4;</mo>
-    <mpadded width="+1.333em" lspace="0.667em" voffset="-.2em" height="-.2em">
-      <mi data-latex="a">a</mi>
-      <mi data-latex="b">b</mi>
-      <mi data-latex="c">c</mi>
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-      <mi data-latex="z">z</mi>
-      <mspace depth=".2em"></mspace>
-    </mpadded>
-  </mover>
-</math>`
-    ));
-  it('Newextarrow', () =>
+         <mover data-latex="\\xtofrom{abcxyz}">
+           <mo data-mjx-texclass="REL">&#x21C4;</mo>
+           <mpadded width="+1.333em" lspace="0.667em" voffset="-.2em" height="-.2em">
+             <mi data-latex="a">a</mi>
+             <mi data-latex="b">b</mi>
+             <mi data-latex="c">c</mi>
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+             <mi data-latex="z">z</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </mover>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Newextarrow', () => {
     toXmlMatch(
       tex2mml('\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}" display="block">
-  <mover data-latex="\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}">
-    <mo data-mjx-texclass="REL">&#x21E0;</mo>
-    <mpadded width="+1.667em" lspace="0.556em" voffset="-.2em" height="-.2em">
-      <mi data-latex="x">x</mi>
-      <mi data-latex="y">y</mi>
-      <mi data-latex="z">z</mi>
-      <mspace depth=".2em"></mspace>
-    </mpadded>
-  </mover>
-</math>`
-    ));
+         <mover data-latex="\\Newextarrow{\\ab}{10,20}{8672}\\ab{xyz}">
+           <mo data-mjx-texclass="REL">&#x21E0;</mo>
+           <mpadded width="+1.667em" lspace="0.556em" voffset="-.2em" height="-.2em">
+             <mi data-latex="x">x</mi>
+             <mi data-latex="y">y</mi>
+             <mi data-latex="z">z</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </mover>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Extpfeil Errors', () => {
-  it('NewextarrowArg1', () =>
-    toXmlMatch(
-      tex2mml('\\Newextarrow{ab}{10,20}{8672}\\ab{xyz}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{ab}{10,20}{8672}\\ab{xyz}" display="block">
-      <merror data-mjx-error="First argument to \\Newextarrow must be a control sequence name">
-        <mtext>First argument to \\Newextarrow must be a control sequence name</mtext>
-      </merror>
-    </math>`
-    ));
-  it('NewextarrowArg2 One', () =>
-    toXmlMatch(
-      tex2mml('\\Newextarrow{\\ab}{10}{8672}\\ab{xyz}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10}{8672}\\ab{xyz}" display="block">
-      <merror data-mjx-error="Second argument to \\Newextarrow must be two integers separated by a comma">
-        <mtext>Second argument to \\Newextarrow must be two integers separated by a comma</mtext>
-      </merror>
-    </math>`
-    ));
-  it('NewextarrowArg2 Two', () =>
-    toXmlMatch(
-      tex2mml('\\Newextarrow{\\ab}{10 20}{8672}\\ab{xyz}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10 20}{8672}\\ab{xyz}" display="block">
-      <merror data-mjx-error="Second argument to \\Newextarrow must be two integers separated by a comma">
-        <mtext>Second argument to \\Newextarrow must be two integers separated by a comma</mtext>
-      </merror>
-    </math>`
-    ));
-  it('NewextarrowArg2 Three', () =>
-    toXmlMatch(
-      tex2mml('\\Newextarrow{\\ab}{aa}{8672}\\ab{xyz}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{aa}{8672}\\ab{xyz}" display="block">
-      <merror data-mjx-error="Second argument to \\Newextarrow must be two integers separated by a comma">
-        <mtext>Second argument to \\Newextarrow must be two integers separated by a comma</mtext>
-      </merror>
-    </math>`
-    ));
-  it('NewextarrowArg3', () =>
-    toXmlMatch(
-      tex2mml('\\Newextarrow{\\ab}{10,20}{AG}\\ab{xyz}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Newextarrow{\\ab}{10,20}{AG}\\ab{xyz}" display="block">
-      <merror data-mjx-error="Third argument to \\Newextarrow must be a unicode character number">
-        <mtext>Third argument to \\Newextarrow must be a unicode character number</mtext>
-      </merror>
-    </math>`
-    ));
+
+  /********************************************************************************/
+
+  it('NewextarrowArg1', () => {
+    expectTexError('\\Newextarrow{ab}{10,20}{8672}\\ab{xyz}')
+      .toBe('First argument to \\Newextarrow must be a control sequence name');
+  });
+
+  /********************************************************************************/
+
+  it('NewextarrowArg2 One', () => {
+    expectTexError('\\Newextarrow{\\ab}{10}{8672}\\ab{xyz}')
+      .toBe('Second argument to \\Newextarrow must be two integers separated by a comma');
+  });
+
+  /********************************************************************************/
+
+  it('NewextarrowArg2 Two', () => {
+    expectTexError('\\Newextarrow{\\ab}{10 20}{8672}\\ab{xyz}')
+      .toBe('Second argument to \\Newextarrow must be two integers separated by a comma');
+  });
+
+  /********************************************************************************/
+
+  it('NewextarrowArg2 Three', () => {
+    expectTexError('\\Newextarrow{\\ab}{aa}{8672}\\ab{xyz}')
+      .toBe('Second argument to \\Newextarrow must be two integers separated by a comma');
+  });
+
+  /********************************************************************************/
+
+  it('NewextarrowArg3', () => {
+    expectTexError('\\Newextarrow{\\ab}{10,20}{AG}\\ab{xyz}')
+      .toBe('Third argument to \\Newextarrow must be a unicode character number');
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('extpfeil'));

--- a/testsuite/tests/input/tex/Noerrors.test.ts
+++ b/testsuite/tests/input/tex/Noerrors.test.ts
@@ -4,511 +4,744 @@ import '#js/input/tex/noerrors/NoErrorsConfiguration';
 
 beforeEach(() => setupTex(['base', 'noerrors']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('NoError', () => {
-  it('Ampersand-error', () =>
+
+  /********************************************************************************/
+
+  it('Ampersand-error', () => {
     toXmlMatch(
       tex2mml('&'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="&amp;" display="block">
-  <merror data-mjx-error="Misplaced &amp;" title="Misplaced &amp;">
-    <mtext>&amp;</mtext>
-  </merror>
-</math>`
-    ));
-  it('Argument-error', () =>
+         <merror data-mjx-error="Misplaced &amp;" title="Misplaced &amp;">
+           <mtext>&amp;</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Argument-error', () => {
     toXmlMatch(
       tex2mml('\\frac{b}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\frac{b}" display="block">
-  <merror data-mjx-error="Missing argument for \\frac" title="Missing argument for \\frac">
-    <mtext>\\frac{b}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Undefined-CS', () =>
+         <merror data-mjx-error="Missing argument for \\frac" title="Missing argument for \\frac">
+           <mtext>\\frac{b}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Undefined-CS', () => {
     toXmlMatch(
       tex2mml('\\nonsense'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\nonsense" display="block">
-  <merror data-mjx-error="Undefined control sequence \\nonsense" title="Undefined control sequence \\nonsense">
-    <mtext>\\nonsense</mtext>
-  </merror>
-</math>`
-    ));
-  it('Undefined-Env', () =>
+         <merror data-mjx-error="Undefined control sequence \\nonsense" title="Undefined control sequence \\nonsense">
+           <mtext>\\nonsense</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Undefined-Env', () => {
     toXmlMatch(
       tex2mml('\\begin{nonsense} a \\end{nonsense}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{nonsense} a \\end{nonsense}" display="block">
-  <merror data-mjx-error="Unknown environment \'nonsense\'" title="Unknown environment \'nonsense\'">
-    <mtext>\\begin{nonsense} a \\end{nonsense}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Double-super-error', () =>
+         <merror data-mjx-error="Unknown environment \'nonsense\'" title="Unknown environment \'nonsense\'">
+           <mtext>\\begin{nonsense} a \\end{nonsense}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Double-super-error', () => {
     toXmlMatch(
       tex2mml('x^2^3'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x^2^3" display="block">
-  <merror data-mjx-error="Double exponent: use braces to clarify" title="Double exponent: use braces to clarify">
-    <mtext>x^2^3</mtext>
-  </merror>
-</math>`
-    ));
-  it('Double-over-error', () =>
+         <merror data-mjx-error="Double exponent: use braces to clarify" title="Double exponent: use braces to clarify">
+           <mtext>x^2^3</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Double-over-error', () => {
     toXmlMatch(
       tex2mml('\\sum^2^3'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sum^2^3" display="block">
-  <merror data-mjx-error="Double exponent: use braces to clarify" title="Double exponent: use braces to clarify">
-    <mtext>\\sum^2^3</mtext>
-  </merror>
-</math>`
-    ));
-  it('Limits Error', () =>
+         <merror data-mjx-error="Double exponent: use braces to clarify" title="Double exponent: use braces to clarify">
+           <mtext>\\sum^2^3</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Limits Error', () => {
     toXmlMatch(
       tex2mml('+\\limits^2'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="+\\limits^2" display="block">
-  <merror data-mjx-error="\\limits is allowed only on operators" title="\\limits is allowed only on operators">
-    <mtext>+\\limits^2</mtext>
-  </merror>
-</math>`
-    ));
-  it('Double sub error', () =>
+         <merror data-mjx-error="\\limits is allowed only on operators" title="\\limits is allowed only on operators">
+           <mtext>+\\limits^2</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Double sub error', () => {
     toXmlMatch(
       tex2mml('x_2_3'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x_2_3" display="block">
-  <merror data-mjx-error="Double subscripts: use braces to clarify" title="Double subscripts: use braces to clarify">
-    <mtext>x_2_3</mtext>
-  </merror>
-</math>`
-    ));
-  it('Double under error', () =>
+         <merror data-mjx-error="Double subscripts: use braces to clarify" title="Double subscripts: use braces to clarify">
+           <mtext>x_2_3</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Double under error', () => {
     toXmlMatch(
       tex2mml('\\sum_2_3'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sum_2_3" display="block">
-  <merror data-mjx-error="Double subscripts: use braces to clarify" title="Double subscripts: use braces to clarify">
-    <mtext>\\sum_2_3</mtext>
-  </merror>
-</math>`
-    ));
-  it('Brace Superscript Error', () =>
+         <merror data-mjx-error="Double subscripts: use braces to clarify" title="Double subscripts: use braces to clarify">
+           <mtext>\\sum_2_3</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Brace Superscript Error', () => {
     toXmlMatch(
       tex2mml("x'^'"),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x\'^\'" display="block">
-  <merror data-mjx-error="Missing open brace for superscript" title="Missing open brace for superscript">
-    <mtext>x\'^\'</mtext>
-  </merror>
-</math>`
-    ));
-  it('Double Prime Error', () =>
+         <merror data-mjx-error="Missing open brace for superscript" title="Missing open brace for superscript">
+           <mtext>x\'^\'</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Double Prime Error', () => {
     toXmlMatch(
       tex2mml("x^\\prime'"),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x^\\prime\'" display="block">
-  <merror data-mjx-error="Prime causes double exponent: use braces to clarify" title="Prime causes double exponent: use braces to clarify">
-    <mtext>x^\\prime\'</mtext>
-  </merror>
-</math>`
-    ));
-  it('Hash Error', () =>
+         <merror data-mjx-error="Prime causes double exponent: use braces to clarify" title="Prime causes double exponent: use braces to clarify">
+           <mtext>x^\\prime\'</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Hash Error', () => {
     toXmlMatch(
       tex2mml('#'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="#" display="block">
-  <merror data-mjx-error="You can\'t use \'macro parameter character #\' in math mode" title="You can\'t use \'macro parameter character #\' in math mode">
-    <mtext>#</mtext>
-  </merror>
-</math>`
-    ));
-  it('Missing Right', () =>
+         <merror data-mjx-error="You can\'t use \'macro parameter character #\' in math mode" title="You can\'t use \'macro parameter character #\' in math mode">
+           <mtext>#</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Missing Right', () => {
     toXmlMatch(
       tex2mml('\\left(\\middle|'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left(\\middle|" display="block">
-  <merror data-mjx-error="Extra \\left or missing \\right" title="Extra \\left or missing \\right">
-    <mtext>\\left(\\middle|</mtext>
-  </merror>
-</math>`
-    ));
-  it('Orphan Middle', () =>
+         <merror data-mjx-error="Extra \\left or missing \\right" title="Extra \\left or missing \\right">
+           <mtext>\\left(\\middle|</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Orphan Middle', () => {
     toXmlMatch(
       tex2mml('\\middle|'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\middle|" display="block">
-  <merror data-mjx-error="Extra \\middle" title="Extra \\middle">
-    <mtext>\\middle|</mtext>
-  </merror>
-</math>`
-    ));
-  it('Middle with Right', () =>
+         <merror data-mjx-error="Extra \\middle" title="Extra \\middle">
+           <mtext>\\middle|</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Middle with Right', () => {
     toXmlMatch(
       tex2mml('\\middle|\\right)'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\middle|\\right)" display="block">
-  <merror data-mjx-error="Extra \\middle" title="Extra \\middle">
-    <mtext>\\middle|\\right)</mtext>
-  </merror>
-</math>`
-    ));
-  it('Misplaced Move Root', () =>
+         <merror data-mjx-error="Extra \\middle" title="Extra \\middle">
+           <mtext>\\middle|\\right)</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Misplaced Move Root', () => {
     toXmlMatch(
       tex2mml('\\uproot{2}\\sqrt[3]{a}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uproot{2}\\sqrt[3]{a}" display="block">
-  <merror data-mjx-error="\\uproot can appear only within a root" title="\\uproot can appear only within a root">
-    <mtext>\\uproot{2}\\sqrt[3]{a}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Multiple Move Root', () =>
+         <merror data-mjx-error="\\uproot can appear only within a root" title="\\uproot can appear only within a root">
+           <mtext>\\uproot{2}\\sqrt[3]{a}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Multiple Move Root', () => {
     toXmlMatch(
       tex2mml('\\sqrt[\\uproot{-2}\\uproot{2}\\beta]{k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt[\\uproot{-2}\\uproot{2}\\beta]{k}" display="block">
-  <merror data-mjx-error="Multiple use of \\uproot" title="Multiple use of \\uproot">
-    <mtext>\\sqrt[\\uproot{-2}\\uproot{2}\\beta]{k}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Incorrect Move Root', () =>
+         <merror data-mjx-error="Multiple use of \\uproot" title="Multiple use of \\uproot">
+           <mtext>\\sqrt[\\uproot{-2}\\uproot{2}\\beta]{k}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Incorrect Move Root', () => {
     toXmlMatch(
       tex2mml('\\sqrt[\\uproot-2.5\\beta]{k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt[\\uproot-2.5\\beta]{k}" display="block">
-  <merror data-mjx-error="The argument to \\uproot must be an integer" title="The argument to \\uproot must be an integer">
-    <mtext>\\sqrt[\\uproot-2.5\\beta]{k}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Double Over', () =>
+         <merror data-mjx-error="The argument to \\uproot must be an integer" title="The argument to \\uproot must be an integer">
+           <mtext>\\sqrt[\\uproot-2.5\\beta]{k}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Double Over', () => {
     toXmlMatch(
       tex2mml('1 \\over 2 \\over 3'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="1 \\over 2 \\over 3" display="block">
-  <merror data-mjx-error="Ambiguous use of \\over" title="Ambiguous use of \\over">
-    <mtext>1 \\over 2 \\over 3</mtext>
-  </merror>
-</math>`
-    ));
-  it('Token Illegal Type', () =>
+         <merror data-mjx-error="Ambiguous use of \\over" title="Ambiguous use of \\over">
+           <mtext>1 \\over 2 \\over 3</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Token Illegal Type', () => {
     toXmlMatch(
       tex2mml('\\mmlToken{mk}[]{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mk}[]{}" display="block">
-  <merror data-mjx-error="mk is not a token element" title="mk is not a token element">
-    <mtext>\\mmlToken{mk}[]{}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Token Wrong Type', () =>
+         <merror data-mjx-error="mk is not a token element" title="mk is not a token element">
+           <mtext>\\mmlToken{mk}[]{}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Token Wrong Type', () => {
     toXmlMatch(
       tex2mml('\\mmlToken{mrow}[]{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mrow}[]{}" display="block">
-  <merror data-mjx-error="mrow is not a token element" title="mrow is not a token element">
-    <mtext>\\mmlToken{mrow}[]{}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Token Invalid Attribute', () =>
+         <merror data-mjx-error="mrow is not a token element" title="mrow is not a token element">
+           <mtext>\\mmlToken{mrow}[]{}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Token Invalid Attribute', () => {
     toXmlMatch(
       tex2mml('\\mmlToken{mi}[m1=true]{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mi}[m1=true]{}" display="block">
-  <merror data-mjx-error="Invalid MathML attribute: m1=true" title="Invalid MathML attribute: m1=true">
-    <mtext>\\mmlToken{mi}[m1=true]{}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Token Unknown Attribute', () =>
+         <merror data-mjx-error="Invalid MathML attribute: m1=true" title="Invalid MathML attribute: m1=true">
+           <mtext>\\mmlToken{mi}[m1=true]{}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Token Unknown Attribute', () => {
     toXmlMatch(
       tex2mml('\\mmlToken{mo}[nothing="something"]{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mo}[nothing=&quot;something&quot;]{}" display="block">
-  <merror data-mjx-error="nothing is not a recognized attribute for mo" title="nothing is not a recognized attribute for mo">
-    <mtext>\\mmlToken{mo}[nothing=&quot;something&quot;]{}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Token Wrong Attribute', () =>
+         <merror data-mjx-error="nothing is not a recognized attribute for mo" title="nothing is not a recognized attribute for mo">
+           <mtext>\\mmlToken{mo}[nothing=&quot;something&quot;]{}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Token Wrong Attribute', () => {
     toXmlMatch(
       tex2mml('\\mmlToken{mi}[movablelimit=true]{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mmlToken{mi}[movablelimit=true]{}" display="block">
-  <merror data-mjx-error="movablelimit is not a recognized attribute for mi" title="movablelimit is not a recognized attribute for mi">
-    <mtext>\\mmlToken{mi}[movablelimit=true]{}</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingBeginExtraEnd', () =>
+         <merror data-mjx-error="movablelimit is not a recognized attribute for mi" title="movablelimit is not a recognized attribute for mi">
+           <mtext>\\mmlToken{mi}[movablelimit=true]{}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingBeginExtraEnd', () => {
     toXmlMatch(
       tex2mml('\\end{array}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\end{array}" display="block">
-  <merror data-mjx-error="Missing \\begin{array} or extra \\end{array}" title="Missing \\begin{array} or extra \\end{array}">
-    <mtext>\\end{array}</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraCloseMissingOpen', () =>
+         <merror data-mjx-error="Missing \\begin{array} or extra \\end{array}" title="Missing \\begin{array} or extra \\end{array}">
+           <mtext>\\end{array}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraCloseMissingOpen', () => {
     toXmlMatch(
       tex2mml('x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x}" display="block">
-  <merror data-mjx-error="Extra close brace or missing open brace" title="Extra close brace or missing open brace">
-    <mtext>x}</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingLeftExtraRight', () =>
+         <merror data-mjx-error="Extra close brace or missing open brace" title="Extra close brace or missing open brace">
+           <mtext>x}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingLeftExtraRight', () => {
     toXmlMatch(
       tex2mml('x\\right\\}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x\\right\\}" display="block">
-  <merror data-mjx-error="Missing \\left or extra \\right" title="Missing \\left or extra \\right">
-    <mtext>x\\right\\}</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraOpenMissingClose', () =>
+         <merror data-mjx-error="Missing \\left or extra \\right" title="Missing \\left or extra \\right">
+           <mtext>x\\right\\}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraOpenMissingClose', () => {
     toXmlMatch(
       tex2mml('{x'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{x" display="block">
-  <merror data-mjx-error="Extra open brace or missing close brace" title="Extra open brace or missing close brace">
-    <mtext>{x</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingScript Sub', () =>
+         <merror data-mjx-error="Extra open brace or missing close brace" title="Extra open brace or missing close brace">
+           <mtext>{x</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingScript Sub', () => {
     toXmlMatch(
       tex2mml('x_'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x_" display="block">
-  <merror data-mjx-error="Missing superscript or subscript argument" title="Missing superscript or subscript argument">
-    <mtext>x_</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingScript Sup', () =>
+         <merror data-mjx-error="Missing superscript or subscript argument" title="Missing superscript or subscript argument">
+           <mtext>x_</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingScript Sup', () => {
     toXmlMatch(
       tex2mml('x^'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x^" display="block">
-  <merror data-mjx-error="Missing superscript or subscript argument" title="Missing superscript or subscript argument">
-    <mtext>x^</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingOpenForSup', () =>
+         <merror data-mjx-error="Missing superscript or subscript argument" title="Missing superscript or subscript argument">
+           <mtext>x^</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingOpenForSup', () => {
     toXmlMatch(
       tex2mml('x^^'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x^^" display="block">
-  <merror data-mjx-error="Missing open brace for superscript" title="Missing open brace for superscript">
-    <mtext>x^^</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingOpenForSub', () =>
+         <merror data-mjx-error="Missing open brace for superscript" title="Missing open brace for superscript">
+           <mtext>x^^</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingOpenForSub', () => {
     toXmlMatch(
       tex2mml('x__'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x__" display="block">
-  <merror data-mjx-error="Missing open brace for subscript" title="Missing open brace for subscript">
-    <mtext>x__</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraLeftMissingRight', () =>
+         <merror data-mjx-error="Missing open brace for subscript" title="Missing open brace for subscript">
+           <mtext>x__</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraLeftMissingRight', () => {
     toXmlMatch(
       tex2mml('\\left\\{x'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\{x" display="block">
-  <merror data-mjx-error="Extra \\left or missing \\right" title="Extra \\left or missing \\right">
-    <mtext>\\left\\{x</mtext>
-  </merror>
-</math>`
-    ));
-  it('Misplaced Cr', () =>
+         <merror data-mjx-error="Extra \\left or missing \\right" title="Extra \\left or missing \\right">
+           <mtext>\\left\\{x</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Misplaced Cr', () => {
     toXmlMatch(
       tex2mml('a\\cr b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\cr b" display="block">
-  <merror data-mjx-error="Misplaced \\cr" title="Misplaced \\cr">
-    <mtext>a\\cr b</mtext>
-  </merror>
-</math>`
-    ));
-  it('Dimension Error', () =>
+         <merror data-mjx-error="Misplaced \\cr" title="Misplaced \\cr">
+           <mtext>a\\cr b</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Dimension Error', () => {
     toXmlMatch(
       tex2mml('a\\\\[abc] b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\\\[abc] b" display="block">
-  <merror data-mjx-error="Bracket argument to \\\\ must be a dimension" title="Bracket argument to \\\\ must be a dimension">
-    <mtext>a\\\\[abc] b</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingArgFor', () =>
+         <merror data-mjx-error="Bracket argument to \\\\ must be a dimension" title="Bracket argument to \\\\ must be a dimension">
+           <mtext>a\\\\[abc] b</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingArgFor', () => {
     toXmlMatch(
       tex2mml('\\sqrt'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt" display="block">
-  <merror data-mjx-error="Missing argument for \\sqrt" title="Missing argument for \\sqrt">
-    <mtext>\\sqrt</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraCloseMissingOpen 2', () =>
+         <merror data-mjx-error="Missing argument for \\sqrt" title="Missing argument for \\sqrt">
+           <mtext>\\sqrt</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraCloseMissingOpen 2', () => {
     toXmlMatch(
       tex2mml('\\sqrt}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt}" display="block">
-  <merror data-mjx-error="Extra close brace or missing open brace" title="Extra close brace or missing open brace">
-    <mtext>\\sqrt}</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingCloseBrace', () =>
+         <merror data-mjx-error="Extra close brace or missing open brace" title="Extra close brace or missing open brace">
+           <mtext>\\sqrt}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingCloseBrace', () => {
     toXmlMatch(
       tex2mml('\\sqrt{'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt{" display="block">
-  <merror data-mjx-error="Missing close brace" title="Missing close brace">
-    <mtext>\\sqrt{</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraCloseLooking1', () =>
+         <merror data-mjx-error="Missing close brace" title="Missing close brace">
+           <mtext>\\sqrt{</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraCloseLooking1', () => {
     toXmlMatch(
       tex2mml('\\sqrt[3}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt[3}" display="block">
-  <merror data-mjx-error="Extra close brace while looking for \']\'" title="Extra close brace while looking for \']\'">
-    <mtext>\\sqrt[3}</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingCloseBracket', () =>
+         <merror data-mjx-error="Extra close brace while looking for \']\'" title="Extra close brace while looking for \']\'">
+           <mtext>\\sqrt[3}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingCloseBracket', () => {
     toXmlMatch(
       tex2mml('\\sqrt[3{x}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\sqrt[3{x}" display="block">
-  <merror data-mjx-error="Could not find closing \']\' for argument to \\sqrt" title="Could not find closing \']\' for argument to \\sqrt">
-    <mtext>\\sqrt[3{x}</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingOrUnrecognizedDelim1', () =>
+         <merror data-mjx-error="Could not find closing \']\' for argument to \\sqrt" title="Could not find closing \']\' for argument to \\sqrt">
+           <mtext>\\sqrt[3{x}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingOrUnrecognizedDelim1', () => {
     toXmlMatch(
       tex2mml('\\left\\alpha b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left\\alpha b" display="block">
-  <merror data-mjx-error="Missing or unrecognized delimiter for \\left" title="Missing or unrecognized delimiter for \\left">
-    <mtext>\\left\\alpha b</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingOrUnrecognizedDelim2', () =>
+         <merror data-mjx-error="Missing or unrecognized delimiter for \\left" title="Missing or unrecognized delimiter for \\left">
+           <mtext>\\left\\alpha b</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingOrUnrecognizedDelim2', () => {
     toXmlMatch(
       tex2mml('\\left( b\\right'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\left( b\\right" display="block">
-  <merror data-mjx-error="Missing or unrecognized delimiter for \\right" title="Missing or unrecognized delimiter for \\right">
-    <mtext>\\left( b\\right</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingDimOrUnits', () =>
+         <merror data-mjx-error="Missing or unrecognized delimiter for \\right" title="Missing or unrecognized delimiter for \\right">
+           <mtext>\\left( b\\right</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingDimOrUnits', () => {
     toXmlMatch(
       tex2mml('\\rule{}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\rule{}" display="block">
-  <merror data-mjx-error="Missing dimension or its units for \\rule" title="Missing dimension or its units for \\rule">
-    <mtext>\\rule{}</mtext>
-  </merror>
-</math>`
-    ));
-  it('TokenNotFoundForCommand', () =>
+         <merror data-mjx-error="Missing dimension or its units for \\rule" title="Missing dimension or its units for \\rule">
+           <mtext>\\rule{}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('TokenNotFoundForCommand', () => {
     toXmlMatch(
       tex2mml('\\root {3] \\of 5'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\root {3] \\of 5" display="block">
-  <merror data-mjx-error="Could not find \\of for \\root" title="Could not find \\of for \\root">
-    <mtext>\\root {3] \\of 5</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraCloseLooking2', () =>
+         <merror data-mjx-error="Could not find \\of for \\root" title="Could not find \\of for \\root">
+           <mtext>\\root {3] \\of 5</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraCloseLooking2', () => {
     toXmlMatch(
       tex2mml('\\root [3} \\of 5 '),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\root [3} \\of 5 " display="block">
-  <merror data-mjx-error="Extra close brace while looking for \\of" title="Extra close brace while looking for \\of">
-    <mtext>\\root [3} \\of 5 </mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingOrUnrecognizedDelim', () =>
+         <merror data-mjx-error="Extra close brace while looking for \\of" title="Extra close brace while looking for \\of">
+           <mtext>\\root [3} \\of 5 </mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingOrUnrecognizedDelim', () => {
     toXmlMatch(
       tex2mml('\\genfrac{(}{a}{}{2}{1}{2}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\genfrac{(}{a}{}{2}{1}{2}" display="block">
-  <merror data-mjx-error="Undefined control sequence \\genfrac" title="Undefined control sequence \\genfrac">
-    <mtext>\\genfrac{(}{a}{}{2}{1}{2}</mtext>
-  </merror>
-</math>`
-    ));
-  it('ErroneousNestingEq', () =>
+         <merror data-mjx-error="Undefined control sequence \\genfrac" title="Undefined control sequence \\genfrac">
+           <mtext>\\genfrac{(}{a}{}{2}{1}{2}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ErroneousNestingEq', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{equation}\\begin{eqnarray}\\end{eqnarray}\\end{equation}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation}\\begin{eqnarray}\\end{eqnarray}\\end{equation}" display="block">
-  <merror data-mjx-error="Erroneous nesting of equation structures" title="Erroneous nesting of equation structures">
-    <mtext>\\begin{equation}\\begin{eqnarray}\\end{eqnarray}\\end{equation}</mtext>
-  </merror>
-</math>`
-    ));
-  it('ExtraAlignTab', () =>
+         <merror data-mjx-error="Erroneous nesting of equation structures" title="Erroneous nesting of equation structures">
+           <mtext>\\begin{equation}\\begin{eqnarray}\\end{eqnarray}\\end{equation}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('ExtraAlignTab', () => {
     toXmlMatch(
       tex2mml('\\cases{b & l & k}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\cases{b &amp; l &amp; k}" display="block">
-  <merror data-mjx-error="Extra alignment tab in \\cases text" title="Extra alignment tab in \\cases text">
-    <mtext>\\cases{b &amp; l &amp; k}</mtext>
-  </merror>
-</math>`
-    ));
-  it('Misplaced hline', () =>
+         <merror data-mjx-error="Extra alignment tab in \\cases text" title="Extra alignment tab in \\cases text">
+           <mtext>\\cases{b &amp; l &amp; k}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Misplaced hline', () => {
     toXmlMatch(
       tex2mml('\\hline'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\hline" display="block">
-  <merror data-mjx-error="Misplaced \\hline" title="Misplaced \\hline">
-    <mtext>\\hline</mtext>
-  </merror>
-</math>`
-    ));
-  it('UnsupportedHFill', () =>
+         <merror data-mjx-error="Misplaced \\hline" title="Misplaced \\hline">
+           <mtext>\\hline</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('UnsupportedHFill', () => {
     toXmlMatch(
       tex2mml('a\\hfill b'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\hfill b" display="block">
-  <merror data-mjx-error="Unsupported use of \\hfill" title="Unsupported use of \\hfill">
-    <mtext>a\\hfill b</mtext>
-  </merror>
-</math>`
-    ));
-  it('InvalidEnv', () =>
+         <merror data-mjx-error="Unsupported use of \\hfill" title="Unsupported use of \\hfill">
+           <mtext>a\\hfill b</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('InvalidEnv', () => {
     toXmlMatch(
       tex2mml('\\begin{\\ff}kk\\end{\\ff}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{\\ff}kk\\end{\\ff}" display="block">
-  <merror data-mjx-error="Invalid environment name \'\\ff\'" title="Invalid environment name \'\\ff\'">
-    <mtext>\\begin{\\ff}kk\\end{\\ff}</mtext>
-  </merror>
-</math>`
-    ));
-  it('EnvBadEnd', () =>
+         <merror data-mjx-error="Invalid environment name \'\\ff\'" title="Invalid environment name \'\\ff\'">
+           <mtext>\\begin{\\ff}kk\\end{\\ff}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('EnvBadEnd', () => {
     toXmlMatch(
       tex2mml('\\begin{equation}a\\end{array}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation}a\\end{array}" display="block">
-  <merror data-mjx-error="\\begin{equation} ended with \\end{array}" title="\\begin{equation} ended with \\end{array}">
-    <mtext>\\begin{equation}a\\end{array}</mtext>
-  </merror>
-</math>`
-    ));
-  it('EnvMissingEnd Array', () =>
+         <merror data-mjx-error="\\begin{equation} ended with \\end{array}" title="\\begin{equation} ended with \\end{array}">
+           <mtext>\\begin{equation}a\\end{array}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('EnvMissingEnd Array', () => {
     toXmlMatch(
       tex2mml('\\begin{array}a'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}a" display="block">
-  <merror data-mjx-error="Illegal pream-token (a)" title="Illegal pream-token (a)">
-    <mtext>\\begin{array}a</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingBoxFor', () =>
+         <merror data-mjx-error="Illegal pream-token (a)" title="Illegal pream-token (a)">
+           <mtext>\\begin{array}a</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingBoxFor', () => {
     toXmlMatch(
       tex2mml('\\raise{2pt}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\raise{2pt}" display="block">
-  <merror data-mjx-error="Missing box for \\raise" title="Missing box for \\raise">
-    <mtext>\\raise{2pt}</mtext>
-  </merror>
-</math>`
-    ));
-  it('MissingCloseBrace2', () =>
+         <merror data-mjx-error="Missing box for \\raise" title="Missing box for \\raise">
+           <mtext>\\raise{2pt}</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('MissingCloseBrace2', () => {
     toXmlMatch(
       tex2mml('\\begin{array}{c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c" display="block">
-  <merror data-mjx-error="Missing close brace" title="Missing close brace">
-    <mtext>\\begin{array}{c</mtext>
-  </merror>
-</math>`
-    ));
-  it('EnvMissingEnd Equation', () =>
+         <merror data-mjx-error="Missing close brace" title="Missing close brace">
+           <mtext>\\begin{array}{c</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('EnvMissingEnd Equation', () => {
     toXmlMatch(
       tex2mml('\\begin{equation}a'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation}a" display="block">
-  <merror data-mjx-error="Missing \\end{equation}" title="Missing \\end{equation}">
-    <mtext>\\begin{equation}a</mtext>
-  </merror>
-</math>`
-    ));
+         <merror data-mjx-error="Missing \\end{equation}" title="Missing \\end{equation}">
+           <mtext>\\begin{equation}a</mtext>
+         </merror>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/testsuite/tests/input/tex/Verb.test.ts
+++ b/testsuite/tests/input/tex/Verb.test.ts
@@ -1,64 +1,87 @@
 import { afterAll, beforeEach, describe, it } from '@jest/globals';
-import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
 import '#js/input/tex/verb/VerbConfiguration';
 
 beforeEach(() => setupTex(['base', 'verb']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Verb', () => {
-  it('Verb Plus ', () =>
+
+  /********************************************************************************/
+
+  it('Verb Plus ', () => {
     toXmlMatch(
       tex2mml('\\verb+{a}+'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb+{a}+" display="block">
-  <mtext mathvariant="monospace" data-latex="\\verb+{a}+">{a}</mtext>
-</math>`
-    ));
-  it('Verb Plus Empty', () =>
+         <mtext mathvariant="monospace" data-latex="\\verb+{a}+">{a}</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Verb Plus Empty', () => {
     toXmlMatch(
       tex2mml('\\verb ++'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb ++" display="block">
-  <mtext mathvariant="monospace" data-latex="\\verb ++"></mtext>
-</math>`
-    ));
-  it('Verb Plus Space', () =>
+         <mtext mathvariant="monospace" data-latex="\\verb ++"></mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Verb Plus Space', () => {
     toXmlMatch(
       tex2mml('\\verb + +'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb + +" display="block">
-  <mtext mathvariant="monospace" data-latex="\\verb + +">&#xA0;</mtext>
-</math>`
-    ));
-  it('Verb Minus', () =>
+         <mtext mathvariant="monospace" data-latex="\\verb + +">&#xA0;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Verb Minus', () => {
     toXmlMatch(
       tex2mml('\\verb -{a}-'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb -{a}-" display="block">
-  <mtext mathvariant="monospace" data-latex="\\verb -{a}-">{a}</mtext>
-</math>`
-    ));
-  it('Verb Minus Double', () =>
+         <mtext mathvariant="monospace" data-latex="\\verb -{a}-">{a}</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Verb Minus Double', () => {
     toXmlMatch(
       tex2mml('\\verb -{a--'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb -{a--" display="block">
-  <mtext mathvariant="monospace" data-latex="\\verb -{a-">{a</mtext>
-  <mo data-latex="-">&#x2212;</mo>
-</math>`
-    ));
-  it('Verb Error', () =>
-    toXmlMatch(
-      tex2mml('\\verb{a}'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb{a}" display="block">
-  <merror data-mjx-error="Can\'t find closing delimiter for \\verb">
-    <mtext>Can\'t find closing delimiter for \\verb</mtext>
-  </merror>
-</math>`
-    ));
-  it('Verb Missing Arg', () =>
-    toXmlMatch(
-      tex2mml('\\verb'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\verb" display="block">
-  <merror data-mjx-error="Missing argument for \\verb">
-    <mtext>Missing argument for \\verb</mtext>
-  </merror>
-</math>`
-    ));
+         <mtext mathvariant="monospace" data-latex="\\verb -{a-">{a</mtext>
+         <mo data-latex="-">&#x2212;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Verb Error', () => {
+    expectTexError('\\verb{a}').toBe('Can\'t find closing delimiter for \\verb');
+  });
+
+  /********************************************************************************/
+
+  it('Verb Missing Arg', () => {
+    expectTexError('\\verb').toBe('Missing argument for \\verb');
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('verb'));


### PR DESCRIPTION
I have found it difficult to read the test files, as it is hard to see where one starts and other stops, and the indenting of the XML is not consistent and gets in the way.  Consequently, I have reformatted all the tests to add separators between the tests and the `describe()` calls, and have normalized the indentation of the XML data.  This makes it easier for me to read the files, and I hope it helps you as well.

In addition, I changed the tests that look for errors to using the new `expectTexError()` calls.

This PR just does that reformatting to the test files that I didn't otherwise modify, except that one test was added to the `Colorv2.test.ts` file.

This PR is probably best viewed with spacing changes ignored, since most of the changes are indentation ones.