### PR TITLE
Add tests for the centernot, gensymb, tagformat, textcomp, and upgreek packages

### DIFF
--- a/testsuite/tests/input/tex/Centernot.test.ts
+++ b/testsuite/tests/input/tex/Centernot.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/centernot/CenternotConfiguration';
+
+beforeEach(() => setupTex(['base', 'centernot']));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Centernot', () => {
+
+  /********************************************************************************/
+
+  test('Centernot', () => {
+    toXmlMatch(
+      tex2mml('\\centernot{\\longrightarrow}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\centernot{\\longrightarrow}" display="block">
+         <mrow data-mjx-texclass="REL" data-latex="\\centerOver{\\longrightarrow}{{&#x29F8;}}">
+           <mrow data-mjx-texclass="ORD" data-latex="{\\longrightarrow}">
+             <mo stretchy="false" data-latex="\\longrightarrow">&#x27F6;</mo>
+           </mrow>
+           <mpadded width="0" lspace="-.5width">
+             <mpadded width="0" lspace="-.5width">
+               <mrow data-mjx-texclass="ORD" data-latex="{&#x29F8;}">
+                 <mo data-latex="&#x29F8;">&#x29F8;</mo>
+               </mrow>
+             </mpadded>
+             <mphantom>
+               <mrow data-mjx-texclass="ORD" data-latex="{\\longrightarrow}">
+                 <mo stretchy="false" data-latex="\\longrightarrow">&#x27F6;</mo>
+               </mrow>
+             </mphantom>
+           </mpadded>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Centerover', () => {
+    toXmlMatch(
+      tex2mml('\\centerOver{\\bigcirc}{1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\centerOver{\\bigcirc}{1}" display="block">
+         <mrow data-mjx-texclass="BIN" data-latex="\\centerOver{\\bigcirc}{1}">
+           <mrow data-mjx-texclass="ORD" data-latex="{\\bigcirc}">
+             <mo data-latex="\\bigcirc">&#x25EF;</mo>
+           </mrow>
+           <mpadded width="0" lspace="-.5width">
+             <mpadded width="0" lspace="-.5width">
+               <mn data-latex="1">1</mn>
+             </mpadded>
+             <mphantom>
+               <mrow data-mjx-texclass="ORD" data-latex="{\\bigcirc}">
+                 <mo data-latex="\\bigcirc">&#x25EF;</mo>
+               </mrow>
+             </mphantom>
+           </mpadded>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('centernot'));

--- a/testsuite/tests/input/tex/Color.test.ts
+++ b/testsuite/tests/input/tex/Color.test.ts
@@ -1,0 +1,545 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
+import '#js/input/tex/color/ColorConfiguration';
+
+beforeEach(() => setupTex(['base', 'color']));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Color named', () => {
+
+  /********************************************************************************/
+
+  test('Color extent', () => {
+    toXmlMatch(
+      tex2mml('\\color{red} x+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color{red} x+y" display="block">
+         <mstyle mathcolor="red" data-latex="\\color{red} x+y">
+           <mi data-latex="x">x</mi>
+           <mo data-latex="+">+</mo>
+           <mi data-latex="y">y</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Color limited', () => {
+    toXmlMatch(
+      tex2mml('{\\color{red} x}+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\color{red} x}+y" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{}">
+           <mstyle mathcolor="red">
+             <mi data-latex="x">x</mi>
+           </mstyle>
+         </mrow>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="y">y</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Color known', () => {
+    toXmlMatch(
+      tex2mml('{\\color{Peach} x}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\color{Peach} x}" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{\\color{Peach} x}">
+           <mstyle mathcolor="#F7965A">
+             <mi data-latex="x">x</mi>
+           </mstyle>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor{red}{a b} + c'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor{red}{a b} + c" display="block">
+         <mstyle mathcolor="red" data-latex="\\textcolor{red}{a b}">
+           <mi data-latex="a">a</mi>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="c">c</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor nested', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor{red}{\\textcolor{blue}{a} b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor{red}{\\textcolor{blue}{a} b}" display="block">
+         <mstyle mathcolor="red" data-latex="\\textcolor{red}{\\textcolor{blue}{a} b}">
+           <mstyle mathcolor="blue" data-latex="\\textcolor{blue}{a}">
+             <mi data-latex="a">a</mi>
+           </mstyle>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Colorbox', () => {
+    toXmlMatch(
+      tex2mml('\\colorbox{red}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\colorbox{red}{a b}" display="block">
+         <mpadded mathbackground="red" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\colorbox{red}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Fcolorbox', () => {
+    toXmlMatch(
+      tex2mml('\\fcolorbox{red}{yellow}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\fcolorbox{red}{yellow}{a b}" display="block">
+         <mpadded mathbackground="yellow" style="border: 2px solid red" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\fcolorbox{red}{yellow}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Definecolor', () => {
+    toXmlMatch(
+      tex2mml('\\definecolor{test}{named}{#48C}\\color{test} a'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\definecolor{test}{named}{#48C}\\color{test} a" display="block">
+         <mstyle mathcolor="#48C" data-latex="\\definecolor{test}{named}{#48C}\\color{test} a">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Color rgb', () => {
+
+  /********************************************************************************/
+
+  test('Color extent', () => {
+    toXmlMatch(
+      tex2mml('\\color[rgb]{1,0,0} x+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color[rgb]{1,0,0} x+y" display="block">
+         <mstyle mathcolor="#ff0000" data-latex="\\color[rgb]{1,0,0} x+y">
+           <mi data-latex="x">x</mi>
+           <mo data-latex="+">+</mo>
+           <mi data-latex="y">y</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Color limited', () => {
+    toXmlMatch(
+      tex2mml('{\\color[rgb]{1,0,0} x}+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\color[rgb]{1,0,0} x}+y" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{}">
+           <mstyle mathcolor="#ff0000">
+             <mi data-latex="x">x</mi>
+           </mstyle>
+         </mrow>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="y">y</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor[rgb]{1,0,0}{a b} + c'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor[rgb]{1,0,0}{a b} + c" display="block">
+         <mstyle mathcolor="#ff0000" data-latex="\\textcolor[rgb]{1,0,0}{a b}">
+           <mi data-latex="a">a</mi>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="c">c</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor nested', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor[rgb]{1,0,0}{\\textcolor[rgb]{0,0,1}{a} b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor[rgb]{1,0,0}{\\textcolor[rgb]{0,0,1}{a} b}" display="block">
+         <mstyle mathcolor="#ff0000" data-latex="\\textcolor[rgb]{1,0,0}{\\textcolor[rgb]{0,0,1}{a} b}">
+           <mstyle mathcolor="#0000ff" data-latex="\\textcolor[rgb]{0,0,1}{a}">
+             <mi data-latex="a">a</mi>
+           </mstyle>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Colorbox', () => {
+    toXmlMatch(
+      tex2mml('\\colorbox[rgb]{1,0,0}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\colorbox[rgb]{1,0,0}{a b}" display="block">
+         <mpadded mathbackground="#ff0000" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\colorbox[rgb]{1,0,0}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Fcolorbox', () => {
+    toXmlMatch(
+      tex2mml('\\fcolorbox[rgb]{1,0,0}[rgb]{1,1,0}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\fcolorbox[rgb]{1,0,0}[rgb]{1,1,0}{a b}" display="block">
+         <mpadded mathbackground="#ffff00" style="border: 2px solid #ff0000" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\fcolorbox[rgb]{1,0,0}[rgb]{1,1,0}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Definecolor', () => {
+    toXmlMatch(
+      tex2mml('\\definecolor{test}{rgb}{.25,.5,.75}\\color{test} a'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\definecolor{test}{rgb}{.25,.5,.75}\\color{test} a" display="block">
+         <mstyle mathcolor="#3f7fbf" data-latex="\\definecolor{test}{rgb}{.25,.5,.75}\\color{test} a">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Color RGB', () => {
+
+  /********************************************************************************/
+
+  test('Color extent', () => {
+    toXmlMatch(
+      tex2mml('\\color[RGB]{255,0,0} x+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color[RGB]{255,0,0} x+y" display="block">
+         <mstyle mathcolor="#ff0000" data-latex="\\color[RGB]{255,0,0} x+y">
+           <mi data-latex="x">x</mi>
+           <mo data-latex="+">+</mo>
+           <mi data-latex="y">y</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Color limited', () => {
+    toXmlMatch(
+      tex2mml('{\\color[RGB]{255,0,0} x}+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\color[RGB]{255,0,0} x}+y" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{}">
+           <mstyle mathcolor="#ff0000">
+             <mi data-latex="x">x</mi>
+           </mstyle>
+         </mrow>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="y">y</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor[RGB]{255,0,0}{a b} + c'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor[RGB]{255,0,0}{a b} + c" display="block">
+         <mstyle mathcolor="#ff0000" data-latex="\\textcolor[RGB]{255,0,0}{a b}">
+           <mi data-latex="a">a</mi>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="c">c</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor nested', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor[RGB]{255,0,0}{\\textcolor[RGB]{0,0,255}{a} b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor[RGB]{255,0,0}{\\textcolor[RGB]{0,0,255}{a} b}" display="block">
+         <mstyle mathcolor="#ff0000" data-latex="\\textcolor[RGB]{255,0,0}{\\textcolor[RGB]{0,0,255}{a} b}">
+           <mstyle mathcolor="#0000ff" data-latex="\\textcolor[RGB]{0,0,255}{a}">
+             <mi data-latex="a">a</mi>
+           </mstyle>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Colorbox', () => {
+    toXmlMatch(
+      tex2mml('\\colorbox[RGB]{255,0,0}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\colorbox[RGB]{255,0,0}{a b}" display="block">
+         <mpadded mathbackground="#ff0000" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\colorbox[RGB]{255,0,0}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Fcolorbox', () => {
+    toXmlMatch(
+      tex2mml('\\fcolorbox[RGB]{255,0,0}[RGB]{255,255,0}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\fcolorbox[RGB]{255,0,0}[RGB]{255,255,0}{a b}" display="block">
+         <mpadded mathbackground="#ffff00" style="border: 2px solid #ff0000" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\fcolorbox[RGB]{255,0,0}[RGB]{255,255,0}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Definecolor', () => {
+    toXmlMatch(
+      tex2mml('\\definecolor{test}{RGB}{8,128,200}\\color{test} a'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\definecolor{test}{RGB}{8,128,200}\\color{test} a" display="block">
+         <mstyle mathcolor="#0880c8" data-latex="\\definecolor{test}{RGB}{8,128,200}\\color{test} a">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Color gray', () => {
+
+  /********************************************************************************/
+
+  test('Color extent', () => {
+    toXmlMatch(
+      tex2mml('\\color[gray]{.5} x+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\color[gray]{.5} x+y" display="block">
+         <mstyle mathcolor="#7f7f7f" data-latex="\\color[gray]{.5} x+y">
+           <mi data-latex="x">x</mi>
+           <mo data-latex="+">+</mo>
+           <mi data-latex="y">y</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Color limited', () => {
+    toXmlMatch(
+      tex2mml('{\\color[gray]{.5} x}+y'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\color[gray]{.5} x}+y" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{}">
+           <mstyle mathcolor="#7f7f7f">
+             <mi data-latex="x">x</mi>
+           </mstyle>
+         </mrow>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="y">y</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor[gray]{.5}{a b} + c'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor[gray]{.5}{a b} + c" display="block">
+         <mstyle mathcolor="#7f7f7f" data-latex="\\textcolor[gray]{.5}{a b}">
+           <mi data-latex="a">a</mi>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+         <mo data-latex="+">+</mo>
+         <mi data-latex="c">c</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Textcolor nested', () => {
+    toXmlMatch(
+      tex2mml('\\textcolor[gray]{.5}{\\textcolor[gray]{.75}{a} b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolor[gray]{.5}{\\textcolor[gray]{.75}{a} b}" display="block">
+         <mstyle mathcolor="#7f7f7f" data-latex="\\textcolor[gray]{.5}{\\textcolor[gray]{.75}{a} b}">
+           <mstyle mathcolor="#bfbfbf" data-latex="\\textcolor[gray]{.75}{a}">
+             <mi data-latex="a">a</mi>
+           </mstyle>
+           <mi data-latex="b">b</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Colorbox', () => {
+    toXmlMatch(
+      tex2mml('\\colorbox[gray]{.5}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\colorbox[gray]{.5}{a b}" display="block">
+         <mpadded mathbackground="#7f7f7f" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\colorbox[gray]{.5}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Fcolorbox', () => {
+    toXmlMatch(
+      tex2mml('\\fcolorbox[gray]{.5}[gray]{.25}{a b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\fcolorbox[gray]{.5}[gray]{.25}{a b}" display="block">
+         <mpadded mathbackground="#3f3f3f" style="border: 2px solid #7f7f7f" width="+10px" height="+5px" depth="+5px" lspace="5px" data-latex="\\fcolorbox[gray]{.5}[gray]{.25}{a b}">
+           <mtext>a b</mtext>
+         </mpadded>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Definecolor', () => {
+    toXmlMatch(
+      tex2mml('\\definecolor{test}{gray}{.02}\\color{test} a'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\definecolor{test}{gray}{.02}\\color{test} a" display="block">
+         <mstyle mathcolor="#050505" data-latex="\\definecolor{test}{gray}{.02}\\color{test} a">
+           <mi data-latex="a">a</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Color errors', () => {
+
+  /********************************************************************************/
+
+  test('UndefinedColormodel', () => {
+    expectTexError('\\color[error]{error} x')
+      .toBe("Color model 'error' not defined");
+  });
+
+  /********************************************************************************/
+
+  test('ModelArg1 rgb', () => {
+    expectTexError('\\definecolor{test}{rgb}{1}')
+      .toBe('Color values for the rgb model require 3 numbers');
+  });
+
+  /********************************************************************************/
+
+  test('InvalidDecimalNumber rgb', () => {
+    expectTexError('\\definecolor{test}{rgb}{x,x,x}')
+      .toBe('Invalid decimal number');
+  });
+
+  /********************************************************************************/
+
+  test('ModelArg2 rgb', () => {
+    expectTexError('\\definecolor{test}{rgb}{10,10,10}')
+      .toBe('Color values for the rgb model must be between 0 and 1');
+  });
+
+  /********************************************************************************/
+
+  test('ModelArg1 RGB', () => {
+    expectTexError('\\definecolor{test}{RGB}{1}')
+      .toBe('Color values for the RGB model require 3 numbers');
+  });
+
+  /********************************************************************************/
+
+  test('InvalidDecimalNumber RGB', () => {
+    expectTexError('\\definecolor{test}{RGB}{x,x,x}')
+      .toBe('Invalid number');
+  });
+
+  /********************************************************************************/
+
+  test('ModelArg2 RGB', () => {
+    expectTexError('\\definecolor{test}{RGB}{1000,1000,1000}')
+      .toBe('Color values for the RGB model must be between 0 and 255');
+  });
+
+  /********************************************************************************/
+
+  test('InvalidDecimalNumber gray', () => {
+    expectTexError('\\definecolor{test}{gray}{x}')
+      .toBe('Invalid decimal number');
+  });
+
+  /********************************************************************************/
+
+  test('ModelArg2 gray', () => {
+    expectTexError('\\definecolor{test}{gray}{10}')
+      .toBe('Color values for the gray model must be between 0 and 1');
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('color'));

--- a/testsuite/tests/input/tex/Gensymb.test.ts
+++ b/testsuite/tests/input/tex/Gensymb.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/gensymb/GensymbConfiguration';
+
+beforeEach(() => setupTex(['base', 'gensymb']));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Gensymb', () => {
+
+  /********************************************************************************/
+
+  test('ohm', () => {
+    toXmlMatch(
+      tex2mml('\\ohm'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ohm" display="block">
+         <mi mathvariant="normal" class="MathML-Unit" data-latex="\\ohm">&#x2126;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('degree', () => {
+    toXmlMatch(
+      tex2mml('\\degree'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\degree" display="block">
+         <mi mathvariant="normal" class="MathML-Unit" data-latex="\\degree">&#xB0;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('celcius', () => {
+    toXmlMatch(
+      tex2mml('\\celsius'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\celsius" display="block">
+         <mi mathvariant="normal" class="MathML-Unit" data-latex="\\celsius">&#x2103;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('perthousand', () => {
+    toXmlMatch(
+      tex2mml('\\perthousand'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\perthousand" display="block">
+         <mi mathvariant="normal" class="MathML-Unit" data-latex="\\perthousand">&#x2030;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('micro', () => {
+    toXmlMatch(
+      tex2mml('\\micro'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\micro" display="block">
+         <mi mathvariant="normal" class="MathML-Unit" data-latex="\\micro">&#xB5;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('gensymb'));

--- a/testsuite/tests/input/tex/Tagformat.test.ts
+++ b/testsuite/tests/input/tex/Tagformat.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, test } from '@jest/globals';
+import { toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/tagformat/TagformatConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
+
+beforeEach(() => setupTex(['base', 'ams', 'tagformat'], {
+  tagformat: {
+    number: (n: number) => `A${n}`,
+    tag: (tag: string) => `[${tag}]`,
+    id: (id: string) => 'my-tag:' + id.replace(/\s/g, '_'),
+    url: (id: string, base: string) => `[[${base}#${encodeURIComponent(id)}]]`
+  },
+  tags: 'ams'
+}));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Tagformat', () => {
+
+  /********************************************************************************/
+
+  test('Basic tag', () => {
+    toXmlMatch(
+      tex2mml('x \\tag{1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x \\tag{1}" display="block">
+         <mtable displaystyle="true" data-latex="x \\tag{1}">
+           <mlabeledtr>
+             <mtd id="my-tag:1">
+               <mtext data-latex="\\text{[1]}">[1]</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{1}">x</mi>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Text tag', () => {
+    toXmlMatch(
+      tex2mml('x \\tag{x}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="x \\tag{x}" display="block">
+         <mtable displaystyle="true" data-latex="x \\tag{x}">
+           <mlabeledtr>
+             <mtd id="my-tag:x">
+               <mtext data-latex="\\text{[x]}">[x]</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{x}">x</mi>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Ref', () => {
+    toXmlMatch(
+      tex2mml('\\begin{align}x \\label{test}\\tag{x}\\\\ \\ref{test} \\end{align}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}x \\label{test}\\tag{x}\\\\ \\ref{test} \\end{align}" display="block">
+         <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}x \\label{test}\\tag{x}\\\\ \\ref{test} \\end{align}">
+           <mlabeledtr>
+             <mtd id="my-tag:test">
+               <mtext data-latex="\\text{[x]}">[x]</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{x}">x</mi>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr>
+             <mtd id="my-tag:A1">
+               <mtext data-latex="\\text{[A1]}">[A1]</mtext>
+             </mtd>
+             <mtd>
+               <mrow href="[[#my-tag%3Atest]]" class="MathJax_ref" data-latex="\\ref{test}">
+                 <mtext>x</mtext>
+               </mrow>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Eqref', () => {
+    toXmlMatch(
+      tex2mml('\\begin{align}x \\label{test}\\tag{x}\\\\ \\eqref{test} \\end{align}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}x \\label{test}\\tag{x}\\\\ \\eqref{test} \\end{align}" display="block">
+         <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}x \\label{test}\\tag{x}\\\\ \\eqref{test} \\end{align}">
+           <mlabeledtr>
+             <mtd id="my-tag:test">
+               <mtext data-latex="\\text{[x]}">[x]</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{x}">x</mi>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr>
+             <mtd id="my-tag:A1">
+               <mtext data-latex="\\text{[A1]}">[A1]</mtext>
+             </mtd>
+             <mtd>
+               <mrow href="[[#my-tag%3Atest]]" class="MathJax_ref" data-latex="\\eqref{test}">
+                 <mtext>[x]</mtext>
+               </mrow>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Custom ref', () => {
+    setupTex(['base', 'ams', 'tagformat'], {
+      tagformat: {
+        ref: (tag: string) => `**${tag}**`
+      },
+      tags: 'ams'
+    });
+    toXmlMatch(
+      tex2mml('\\begin{align}x \\label{test}\\tag{x}\\\\ \\eqref{test} \\end{align}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{align}x \\label{test}\\tag{x}\\\\ \\eqref{test} \\end{align}" display="block">
+         <mtable displaystyle="true" columnalign="right" columnspacing="" rowspacing="3pt" data-break-align="bottom" data-latex-item="{align}" data-latex="\\begin{align}x \\label{test}\\tag{x}\\\\ \\eqref{test} \\end{align}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:test">
+               <mtext data-latex="\\text{(x)}">(x)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{x}">x</mi>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mrow href="#mjx-eqn%3Atest" class="MathJax_ref" data-latex="\\eqref{test}">
+                 <mtext>**x**</mtext>
+               </mrow>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/testsuite/tests/input/tex/Textcomp.test.ts
+++ b/testsuite/tests/input/tex/Textcomp.test.ts
@@ -1,0 +1,1328 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/textcomp/TextcompConfiguration';
+import '#js/input/tex/textmacros/TextMacrosConfiguration';
+
+beforeEach(() => setupTex(['base', 'textcomp']));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Textcomp', () => {
+
+  /********************************************************************************/
+
+  test('textasciicircum', () => {
+    toXmlMatch(
+      tex2mml('\\textasciicircum'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciicircum" display="block">
+         <mtext data-latex="\\textasciicircum">^</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasciitilde', () => {
+    toXmlMatch(
+      tex2mml('\\textasciitilde'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciitilde" display="block">
+         <mtext data-latex="\\textasciitilde">~</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasteriskcentered', () => {
+    toXmlMatch(
+      tex2mml('\\textasteriskcentered'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasteriskcentered" display="block">
+         <mtext data-latex="\\textasteriskcentered">*</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbackslash', () => {
+    toXmlMatch(
+      tex2mml('\\textbackslash'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbackslash" display="block">
+         <mtext data-latex="\\textbackslash">\\</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbar', () => {
+    toXmlMatch(
+      tex2mml('\\textbar'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbar" display="block">
+         <mtext data-latex="\\textbar">|</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbraceleft', () => {
+    toXmlMatch(
+      tex2mml('\\textbraceleft'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbraceleft" display="block">
+         <mtext data-latex="\\textbraceleft">{</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbraceright', () => {
+    toXmlMatch(
+      tex2mml('\\textbraceright'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbraceright" display="block">
+         <mtext data-latex="\\textbraceright">}</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbullet', () => {
+    toXmlMatch(
+      tex2mml('\\textbullet'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbullet" display="block">
+         <mtext data-latex="\\textbullet">&#x2022;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdagger', () => {
+    toXmlMatch(
+      tex2mml('\\textdagger'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdagger" display="block">
+         <mtext data-latex="\\textdagger">&#x2020;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdaggerdbl', () => {
+    toXmlMatch(
+      tex2mml('\\textdaggerdbl'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdaggerdbl" display="block">
+         <mtext data-latex="\\textdaggerdbl">&#x2021;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textellipsis', () => {
+    toXmlMatch(
+      tex2mml('\\textellipsis'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textellipsis" display="block">
+         <mtext data-latex="\\textellipsis">&#x2026;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textemdash', () => {
+    toXmlMatch(
+      tex2mml('\\textemdash'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textemdash" display="block">
+         <mtext data-latex="\\textemdash">&#x2014;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textendash', () => {
+    toXmlMatch(
+      tex2mml('\\textendash'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textendash" display="block">
+         <mtext data-latex="\\textendash">&#x2013;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textexclamdown', () => {
+    toXmlMatch(
+      tex2mml('\\textexclamdown'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textexclamdown" display="block">
+         <mtext data-latex="\\textexclamdown">&#x00A1;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textgreater', () => {
+    toXmlMatch(
+      tex2mml('\\textgreater'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textgreater" display="block">
+         <mtext data-latex="\\textgreater">&#x003E;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textless', () => {
+    toXmlMatch(
+      tex2mml('\\textless'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textless" display="block">
+         <mtext data-latex="\\textless">&#x003C;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textordfeminine', () => {
+    toXmlMatch(
+      tex2mml('\\textordfeminine'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textordfeminine" display="block">
+         <mtext data-latex="\\textordfeminine">&#x00AA;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textordmasculine', () => {
+    toXmlMatch(
+      tex2mml('\\textordmasculine'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textordmasculine" display="block">
+         <mtext data-latex="\\textordmasculine">&#x00BA;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textparagraph', () => {
+    toXmlMatch(
+      tex2mml('\\textparagraph'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textparagraph" display="block">
+         <mtext data-latex="\\textparagraph">&#x00B6;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textperiodcentered', () => {
+    toXmlMatch(
+      tex2mml('\\textperiodcentered'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textperiodcentered" display="block">
+         <mtext data-latex="\\textperiodcentered">&#x00B7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textquestiondown', () => {
+    toXmlMatch(
+      tex2mml('\\textquestiondown'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textquestiondown" display="block">
+         <mtext data-latex="\\textquestiondown">&#x00BF;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textquotedblleft', () => {
+    toXmlMatch(
+      tex2mml('\\textquotedblleft'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textquotedblleft" display="block">
+         <mtext data-latex="\\textquotedblleft">&#x201C;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textquotedblright', () => {
+    toXmlMatch(
+      tex2mml('\\textquotedblright'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textquotedblright" display="block">
+         <mtext data-latex="\\textquotedblright">&#x201D;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textquoteleft', () => {
+    toXmlMatch(
+      tex2mml('\\textquoteleft'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textquoteleft" display="block">
+         <mtext data-latex="\\textquoteleft">&#x2018;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textquoteright', () => {
+    toXmlMatch(
+      tex2mml('\\textquoteright'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textquoteright" display="block">
+         <mtext data-latex="\\textquoteright">&#x2019;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textsection', () => {
+    toXmlMatch(
+      tex2mml('\\textsection'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textsection" display="block">
+         <mtext data-latex="\\textsection">&#x00A7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textunderscore', () => {
+    toXmlMatch(
+      tex2mml('\\textunderscore'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textunderscore" display="block">
+         <mtext data-latex="\\textunderscore">&#x005F;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textvisiblespace', () => {
+    toXmlMatch(
+      tex2mml('\\textvisiblespace'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textvisiblespace" display="block">
+         <mtext data-latex="\\textvisiblespace">&#x2423;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textacutedbl', () => {
+    toXmlMatch(
+      tex2mml('\\textacutedbl'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textacutedbl" display="block">
+         <mtext data-latex="\\textacutedbl">&#x02DD;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasciiacute', () => {
+    toXmlMatch(
+      tex2mml('\\textasciiacute'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciiacute" display="block">
+         <mtext data-latex="\\textasciiacute">&#x00B4;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasciibreve', () => {
+    toXmlMatch(
+      tex2mml('\\textasciibreve'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciibreve" display="block">
+         <mtext data-latex="\\textasciibreve">&#x02D8;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasciicaron', () => {
+    toXmlMatch(
+      tex2mml('\\textasciicaron'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciicaron" display="block">
+         <mtext data-latex="\\textasciicaron">&#x02C7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasciidieresis', () => {
+    toXmlMatch(
+      tex2mml('\\textasciidieresis'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciidieresis" display="block">
+         <mtext data-latex="\\textasciidieresis">&#x00A8;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textasciimacron', () => {
+    toXmlMatch(
+      tex2mml('\\textasciimacron'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textasciimacron" display="block">
+         <mtext data-latex="\\textasciimacron">&#x00AF;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textgravedbl', () => {
+    toXmlMatch(
+      tex2mml('\\textgravedbl'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textgravedbl" display="block">
+         <mtext data-latex="\\textgravedbl">&#x02F5;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texttildelow', () => {
+    toXmlMatch(
+      tex2mml('\\texttildelow'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texttildelow" display="block">
+         <mtext data-latex="\\texttildelow">&#x02F7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbaht', () => {
+    toXmlMatch(
+      tex2mml('\\textbaht'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbaht" display="block">
+         <mtext data-latex="\\textbaht">&#x0E3F;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcent', () => {
+    toXmlMatch(
+      tex2mml('\\textcent'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcent" display="block">
+         <mtext data-latex="\\textcent">&#x00A2;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcolonmonetary', () => {
+    toXmlMatch(
+      tex2mml('\\textcolonmonetary'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcolonmonetary" display="block">
+         <mtext data-latex="\\textcolonmonetary">&#x20A1;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcurrency', () => {
+    toXmlMatch(
+      tex2mml('\\textcurrency'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcurrency" display="block">
+         <mtext data-latex="\\textcurrency">&#x00A4;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdollar', () => {
+    toXmlMatch(
+      tex2mml('\\textdollar'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdollar" display="block">
+         <mtext data-latex="\\textdollar">&#x0024;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdong', () => {
+    toXmlMatch(
+      tex2mml('\\textdong'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdong" display="block">
+         <mtext data-latex="\\textdong">&#x20AB;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texteuro', () => {
+    toXmlMatch(
+      tex2mml('\\texteuro'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texteuro" display="block">
+         <mtext data-latex="\\texteuro">&#x20AC;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textflorin', () => {
+    toXmlMatch(
+      tex2mml('\\textflorin'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textflorin" display="block">
+         <mtext data-latex="\\textflorin">&#x0192;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textguarani', () => {
+    toXmlMatch(
+      tex2mml('\\textguarani'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textguarani" display="block">
+         <mtext data-latex="\\textguarani">&#x20B2;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textlira', () => {
+    toXmlMatch(
+      tex2mml('\\textlira'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textlira" display="block">
+         <mtext data-latex="\\textlira">&#x20A4;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textnaira', () => {
+    toXmlMatch(
+      tex2mml('\\textnaira'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textnaira" display="block">
+         <mtext data-latex="\\textnaira">&#x20A6;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textpeso', () => {
+    toXmlMatch(
+      tex2mml('\\textpeso'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textpeso" display="block">
+         <mtext data-latex="\\textpeso">&#x20B1;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textsterling', () => {
+    toXmlMatch(
+      tex2mml('\\textsterling'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textsterling" display="block">
+         <mtext data-latex="\\textsterling">&#x00A3;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textwon', () => {
+    toXmlMatch(
+      tex2mml('\\textwon'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textwon" display="block">
+         <mtext data-latex="\\textwon">&#x20A9;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textyen', () => {
+    toXmlMatch(
+      tex2mml('\\textyen'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textyen" display="block">
+         <mtext data-latex="\\textyen">&#x00A5;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcircledP', () => {
+    toXmlMatch(
+      tex2mml('\\textcircledP'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcircledP" display="block">
+         <mtext data-latex="\\textcircledP">&#x2117;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcompwordmark', () => {
+    toXmlMatch(
+      tex2mml('\\textcompwordmark'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcompwordmark" display="block">
+         <mtext data-latex="\\textcompwordmark">&#x200C;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcopyleft', () => {
+    toXmlMatch(
+      tex2mml('\\textcopyleft'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcopyleft" display="block">
+         <mtext data-latex="\\textcopyleft">&#x1F12F;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcopyright', () => {
+    toXmlMatch(
+      tex2mml('\\textcopyright'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcopyright" display="block">
+         <mtext data-latex="\\textcopyright">&#x00A9;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textregistered', () => {
+    toXmlMatch(
+      tex2mml('\\textregistered'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textregistered" display="block">
+         <mtext data-latex="\\textregistered">&#x00AE;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textservicemark', () => {
+    toXmlMatch(
+      tex2mml('\\textservicemark'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textservicemark" display="block">
+         <mtext data-latex="\\textservicemark">&#x2120;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texttrademark', () => {
+    toXmlMatch(
+      tex2mml('\\texttrademark'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texttrademark" display="block">
+         <mtext data-latex="\\texttrademark">&#x2122;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbardbl', () => {
+    toXmlMatch(
+      tex2mml('\\textbardbl'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbardbl" display="block">
+         <mtext data-latex="\\textbardbl">&#x2016;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbigcircle', () => {
+    toXmlMatch(
+      tex2mml('\\textbigcircle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbigcircle" display="block">
+         <mtext data-latex="\\textbigcircle">&#x25EF;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textblank', () => {
+    toXmlMatch(
+      tex2mml('\\textblank'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textblank" display="block">
+         <mtext data-latex="\\textblank">&#x2422;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textbrokenbar', () => {
+    toXmlMatch(
+      tex2mml('\\textbrokenbar'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textbrokenbar" display="block">
+         <mtext data-latex="\\textbrokenbar">&#x00A6;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdiscount', () => {
+    toXmlMatch(
+      tex2mml('\\textdiscount'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdiscount" display="block">
+         <mtext data-latex="\\textdiscount">&#x2052;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textestimated', () => {
+    toXmlMatch(
+      tex2mml('\\textestimated'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textestimated" display="block">
+         <mtext data-latex="\\textestimated">&#x212E;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textinterrobang', () => {
+    toXmlMatch(
+      tex2mml('\\textinterrobang'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textinterrobang" display="block">
+         <mtext data-latex="\\textinterrobang">&#x203D;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textinterrobangdown', () => {
+    toXmlMatch(
+      tex2mml('\\textinterrobangdown'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textinterrobangdown" display="block">
+         <mtext data-latex="\\textinterrobangdown">&#x2E18;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textmusicalnote', () => {
+    toXmlMatch(
+      tex2mml('\\textmusicalnote'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textmusicalnote" display="block">
+         <mtext data-latex="\\textmusicalnote">&#x266A;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textnumero', () => {
+    toXmlMatch(
+      tex2mml('\\textnumero'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textnumero" display="block">
+         <mtext data-latex="\\textnumero">&#x2116;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textopenbullet', () => {
+    toXmlMatch(
+      tex2mml('\\textopenbullet'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textopenbullet" display="block">
+         <mtext data-latex="\\textopenbullet">&#x25E6;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textpertenthousand', () => {
+    toXmlMatch(
+      tex2mml('\\textpertenthousand'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textpertenthousand" display="block">
+         <mtext data-latex="\\textpertenthousand">&#x2031;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textperthousand', () => {
+    toXmlMatch(
+      tex2mml('\\textperthousand'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textperthousand" display="block">
+         <mtext data-latex="\\textperthousand">&#x2030;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textrecipe', () => {
+    toXmlMatch(
+      tex2mml('\\textrecipe'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textrecipe" display="block">
+         <mtext data-latex="\\textrecipe">&#x211E;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textreferencemark', () => {
+    toXmlMatch(
+      tex2mml('\\textreferencemark'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textreferencemark" display="block">
+         <mtext data-latex="\\textreferencemark">&#x203B;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textlangle', () => {
+    toXmlMatch(
+      tex2mml('\\textlangle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textlangle" display="block">
+         <mtext data-latex="\\textlangle">&#x2329;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textrangle', () => {
+    toXmlMatch(
+      tex2mml('\\textrangle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textrangle" display="block">
+         <mtext data-latex="\\textrangle">&#x232A;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textlbrackdbl', () => {
+    toXmlMatch(
+      tex2mml('\\textlbrackdbl'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textlbrackdbl" display="block">
+         <mtext data-latex="\\textlbrackdbl">&#x27E6;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textrbrackdbl', () => {
+    toXmlMatch(
+      tex2mml('\\textrbrackdbl'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textrbrackdbl" display="block">
+         <mtext data-latex="\\textrbrackdbl">&#x27E7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textlquill', () => {
+    toXmlMatch(
+      tex2mml('\\textlquill'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textlquill" display="block">
+         <mtext data-latex="\\textlquill">&#x2045;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textrquill', () => {
+    toXmlMatch(
+      tex2mml('\\textrquill'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textrquill" display="block">
+         <mtext data-latex="\\textrquill">&#x2046;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcelsius', () => {
+    toXmlMatch(
+      tex2mml('\\textcelsius'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textcelsius" display="block">
+         <mtext data-latex="\\textcelsius">&#x2103;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdegree', () => {
+    toXmlMatch(
+      tex2mml('\\textdegree'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdegree" display="block">
+         <mtext data-latex="\\textdegree">&#x00B0;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdiv', () => {
+    toXmlMatch(
+      tex2mml('\\textdiv'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdiv" display="block">
+         <mtext data-latex="\\textdiv">&#x00F7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdownarrow', () => {
+    toXmlMatch(
+      tex2mml('\\textdownarrow'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdownarrow" display="block">
+         <mtext data-latex="\\textdownarrow">&#x2193;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textfractionsolidus', () => {
+    toXmlMatch(
+      tex2mml('\\textfractionsolidus'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textfractionsolidus" display="block">
+         <mtext data-latex="\\textfractionsolidus">&#x2044;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textleftarrow', () => {
+    toXmlMatch(
+      tex2mml('\\textleftarrow'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textleftarrow" display="block">
+         <mtext data-latex="\\textleftarrow">&#x2190;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textlnot', () => {
+    toXmlMatch(
+      tex2mml('\\textlnot'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textlnot" display="block">
+         <mtext data-latex="\\textlnot">&#x00AC;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textmho', () => {
+    toXmlMatch(
+      tex2mml('\\textmho'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textmho" display="block">
+         <mtext data-latex="\\textmho">&#x2127;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textminus', () => {
+    toXmlMatch(
+      tex2mml('\\textminus'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textminus" display="block">
+         <mtext data-latex="\\textminus">&#x2212;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textmu', () => {
+    toXmlMatch(
+      tex2mml('\\textmu'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textmu" display="block">
+         <mtext data-latex="\\textmu">&#x00B5;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textohm', () => {
+    toXmlMatch(
+      tex2mml('\\textohm'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textohm" display="block">
+         <mtext data-latex="\\textohm">&#x2126;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textonehalf', () => {
+    toXmlMatch(
+      tex2mml('\\textonehalf'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textonehalf" display="block">
+         <mtext data-latex="\\textonehalf">&#x00BD;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textonequarter', () => {
+    toXmlMatch(
+      tex2mml('\\textonequarter'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textonequarter" display="block">
+         <mtext data-latex="\\textonequarter">&#x00BC;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textonesuperior', () => {
+    toXmlMatch(
+      tex2mml('\\textonesuperior'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textonesuperior" display="block">
+         <mtext data-latex="\\textonesuperior">&#x00B9;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textpm', () => {
+    toXmlMatch(
+      tex2mml('\\textpm'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textpm" display="block">
+         <mtext data-latex="\\textpm">&#x00B1;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textrightarrow', () => {
+    toXmlMatch(
+      tex2mml('\\textrightarrow'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textrightarrow" display="block">
+         <mtext data-latex="\\textrightarrow">&#x2192;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textsurd', () => {
+    toXmlMatch(
+      tex2mml('\\textsurd'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textsurd" display="block">
+         <mtext data-latex="\\textsurd">&#x221A;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textthreequarters', () => {
+    toXmlMatch(
+      tex2mml('\\textthreequarters'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textthreequarters" display="block">
+         <mtext data-latex="\\textthreequarters">&#x00BE;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textthreesuperior', () => {
+    toXmlMatch(
+      tex2mml('\\textthreesuperior'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textthreesuperior" display="block">
+         <mtext data-latex="\\textthreesuperior">&#x00B3;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texttimes', () => {
+    toXmlMatch(
+      tex2mml('\\texttimes'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texttimes" display="block">
+         <mtext data-latex="\\texttimes">&#x00D7;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texttwosuperior', () => {
+    toXmlMatch(
+      tex2mml('\\texttwosuperior'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\texttwosuperior" display="block">
+         <mtext data-latex="\\texttwosuperior">&#x00B2;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textuparrow', () => {
+    toXmlMatch(
+      tex2mml('\\textuparrow'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textuparrow" display="block">
+         <mtext data-latex="\\textuparrow">&#x2191;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textborn', () => {
+    toXmlMatch(
+      tex2mml('\\textborn'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textborn" display="block">
+         <mtext data-latex="\\textborn">&#x002A;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdied', () => {
+    toXmlMatch(
+      tex2mml('\\textdied'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdied" display="block">
+         <mtext data-latex="\\textdied">&#x2020;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdivorced', () => {
+    toXmlMatch(
+      tex2mml('\\textdivorced'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textdivorced" display="block">
+         <mtext data-latex="\\textdivorced">&#x26AE;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textmarried', () => {
+    toXmlMatch(
+      tex2mml('\\textmarried'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\textmarried" display="block">
+         <mtext data-latex="\\textmarried">&#x26AD;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Textcompwith Textmacros', () => {
+  beforeEach(() => setupTex(['base', 'textmacros', 'textcomp']));
+
+  /********************************************************************************/
+
+  test('textasciicircum', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textasciicircum}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textasciicircum}" display="block">
+         <mtext data-latex="\\text{\\textasciicircum}">^</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textcentoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textcentoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textcentoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textcentoldstyle}">&#xA2;</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textdollaroldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textdollaroldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textdollaroldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textdollaroldstyle}">$</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textzerooldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textzerooldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textzerooldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textzerooldstyle}">0</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textoneoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textoneoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textoneoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textoneoldstyle}">1</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texttwooldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\texttwooldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\texttwooldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\texttwooldstyle}">2</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textthreeoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textthreeoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textthreeoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textthreeoldstyle}">3</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textfouroldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textfouroldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textfouroldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textfouroldstyle}">4</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textfiveoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textfiveoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textfiveoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textfiveoldstyle}">5</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textsixoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textsixoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textsixoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textsixoldstyle}">6</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textsevenoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textsevenoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textsevenoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textsevenoldstyle}">7</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('texteightoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\texteightoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\texteightoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\texteightoldstyle}">8</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('textnineoldstyle', () => {
+    toXmlMatch(
+      tex2mml('\\text{\\textnineoldstyle}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\text{\\textnineoldstyle}" display="block">
+         <mtext data-mjx-variant="-tex-oldstyle" mathvariant="normal" data-latex="\\text{\\textnineoldstyle}">9</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('textcomp'));

--- a/testsuite/tests/input/tex/Upgreek.test.ts
+++ b/testsuite/tests/input/tex/Upgreek.test.ts
@@ -1,0 +1,470 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml } from '#helpers';
+import '#js/input/tex/upgreek/UpgreekConfiguration';
+
+beforeEach(() => setupTex(['base', 'upgreek']));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Upgreek', () => {
+
+  /********************************************************************************/
+
+  test('upalpha', () => {
+    toXmlMatch(
+      tex2mml('\\upalpha'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upalpha" display="block">
+         <mi mathvariant="normal" data-latex="\\upalpha">&#x3B1;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upbeta', () => {
+    toXmlMatch(
+      tex2mml('\\upbeta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upbeta" display="block">
+         <mi mathvariant="normal" data-latex="\\upbeta">&#x03B2;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upgamma', () => {
+    toXmlMatch(
+      tex2mml('\\upgamma'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upgamma" display="block">
+         <mi mathvariant="normal" data-latex="\\upgamma">&#x03B3;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('updelta', () => {
+    toXmlMatch(
+      tex2mml('\\updelta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\updelta" display="block">
+         <mi mathvariant="normal" data-latex="\\updelta">&#x03B4;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upepsilon', () => {
+    toXmlMatch(
+      tex2mml('\\upepsilon'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upepsilon" display="block">
+         <mi mathvariant="normal" data-latex="\\upepsilon">&#x03F5;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upzeta', () => {
+    toXmlMatch(
+      tex2mml('\\upzeta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upzeta" display="block">
+         <mi mathvariant="normal" data-latex="\\upzeta">&#x03B6;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upeta', () => {
+    toXmlMatch(
+      tex2mml('\\upeta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upeta" display="block">
+         <mi mathvariant="normal" data-latex="\\upeta">&#x03B7;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('uptheta', () => {
+    toXmlMatch(
+      tex2mml('\\uptheta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uptheta" display="block">
+         <mi mathvariant="normal" data-latex="\\uptheta">&#x03B8;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upiota', () => {
+    toXmlMatch(
+      tex2mml('\\upiota'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upiota" display="block">
+         <mi mathvariant="normal" data-latex="\\upiota">&#x03B9;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upkappa', () => {
+    toXmlMatch(
+      tex2mml('\\upkappa'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upkappa" display="block">
+         <mi mathvariant="normal" data-latex="\\upkappa">&#x03BA;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('uplambda', () => {
+    toXmlMatch(
+      tex2mml('\\uplambda'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uplambda" display="block">
+         <mi mathvariant="normal" data-latex="\\uplambda">&#x03BB;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upmu', () => {
+    toXmlMatch(
+      tex2mml('\\upmu'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upmu" display="block">
+         <mi mathvariant="normal" data-latex="\\upmu">&#x03BC;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upnu', () => {
+    toXmlMatch(
+      tex2mml('\\upnu'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upnu" display="block">
+         <mi mathvariant="normal" data-latex="\\upnu">&#x03BD;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upxi', () => {
+    toXmlMatch(
+      tex2mml('\\upxi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upxi" display="block">
+         <mi mathvariant="normal" data-latex="\\upxi">&#x03BE;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upomicron', () => {
+    toXmlMatch(
+      tex2mml('\\upomicron'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upomicron" display="block">
+         <mi mathvariant="normal" data-latex="\\upomicron">&#x03BF;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('uppi', () => {
+    toXmlMatch(
+      tex2mml('\\uppi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uppi" display="block">
+         <mi mathvariant="normal" data-latex="\\uppi">&#x03C0;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('uprho', () => {
+    toXmlMatch(
+      tex2mml('\\uprho'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uprho" display="block">
+         <mi mathvariant="normal" data-latex="\\uprho">&#x03C1;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upsigma', () => {
+    toXmlMatch(
+      tex2mml('\\upsigma'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upsigma" display="block">
+         <mi mathvariant="normal" data-latex="\\upsigma">&#x03C3;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('uptau', () => {
+    toXmlMatch(
+      tex2mml('\\uptau'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uptau" display="block">
+         <mi mathvariant="normal" data-latex="\\uptau">&#x03C4;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upupsilon', () => {
+    toXmlMatch(
+      tex2mml('\\upupsilon'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upupsilon" display="block">
+         <mi mathvariant="normal" data-latex="\\upupsilon">&#x03C5;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upphi', () => {
+    toXmlMatch(
+      tex2mml('\\upphi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upphi" display="block">
+         <mi mathvariant="normal" data-latex="\\upphi">&#x03D5;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upchi', () => {
+    toXmlMatch(
+      tex2mml('\\upchi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upchi" display="block">
+         <mi mathvariant="normal" data-latex="\\upchi">&#x03C7;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('uppsi', () => {
+    toXmlMatch(
+      tex2mml('\\uppsi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\uppsi" display="block">
+         <mi mathvariant="normal" data-latex="\\uppsi">&#x03C8;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upomega', () => {
+    toXmlMatch(
+      tex2mml('\\upomega'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upomega" display="block">
+         <mi mathvariant="normal" data-latex="\\upomega">&#x03C9;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upvarepsilon', () => {
+    toXmlMatch(
+      tex2mml('\\upvarepsilon'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upvarepsilon" display="block">
+         <mi mathvariant="normal" data-latex="\\upvarepsilon">&#x03B5;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upvartheta', () => {
+    toXmlMatch(
+      tex2mml('\\upvartheta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upvartheta" display="block">
+         <mi mathvariant="normal" data-latex="\\upvartheta">&#x03D1;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upvarpi', () => {
+    toXmlMatch(
+      tex2mml('\\upvarpi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upvarpi" display="block">
+         <mi mathvariant="normal" data-latex="\\upvarpi">&#x03D6;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upvarrho', () => {
+    toXmlMatch(
+      tex2mml('\\upvarrho'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upvarrho" display="block">
+         <mi mathvariant="normal" data-latex="\\upvarrho">&#x03F1;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upvarsigma', () => {
+    toXmlMatch(
+      tex2mml('\\upvarsigma'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upvarsigma" display="block">
+         <mi mathvariant="normal" data-latex="\\upvarsigma">&#x03C2;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('upvarphi', () => {
+    toXmlMatch(
+      tex2mml('\\upvarphi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\upvarphi" display="block">
+         <mi mathvariant="normal" data-latex="\\upvarphi">&#x03C6;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Upgamma', () => {
+    toXmlMatch(
+      tex2mml('\\Upgamma'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Upgamma" display="block">
+         <mi mathvariant="normal" data-latex="\\Upgamma">&#x0393;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Updelta', () => {
+    toXmlMatch(
+      tex2mml('\\Updelta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Updelta" display="block">
+         <mi mathvariant="normal" data-latex="\\Updelta">&#x0394;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Uptheta', () => {
+    toXmlMatch(
+      tex2mml('\\Uptheta'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Uptheta" display="block">
+         <mi mathvariant="normal" data-latex="\\Uptheta">&#x0398;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Uplambda', () => {
+    toXmlMatch(
+      tex2mml('\\Uplambda'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Uplambda" display="block">
+         <mi mathvariant="normal" data-latex="\\Uplambda">&#x039B;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Upxi', () => {
+    toXmlMatch(
+      tex2mml('\\Upxi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Upxi" display="block">
+         <mi mathvariant="normal" data-latex="\\Upxi">&#x039E;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Uppi', () => {
+    toXmlMatch(
+      tex2mml('\\Uppi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Uppi" display="block">
+         <mi mathvariant="normal" data-latex="\\Uppi">&#x03A0;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Upsigma', () => {
+    toXmlMatch(
+      tex2mml('\\Upsigma'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Upsigma" display="block">
+         <mi mathvariant="normal" data-latex="\\Upsigma">&#x03A3;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Upupsilon', () => {
+    toXmlMatch(
+      tex2mml('\\Upupsilon'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Upupsilon" display="block">
+         <mi mathvariant="normal" data-latex="\\Upupsilon">&#x03A5;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Upphi', () => {
+    toXmlMatch(
+      tex2mml('\\Upphi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Upphi" display="block">
+         <mi mathvariant="normal" data-latex="\\Upphi">&#x03A6;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Uppsi', () => {
+    toXmlMatch(
+      tex2mml('\\Uppsi'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Uppsi" display="block">
+         <mi mathvariant="normal" data-latex="\\Uppsi">&#x03A8;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Upomega', () => {
+    toXmlMatch(
+      tex2mml('\\Upomega'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\Upomega" display="block">
+         <mi mathvariant="normal" data-latex="\\Upomega">&#x03A9;</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('upgreek'));


### PR DESCRIPTION
This PR adds new test files for the `centernot`, `gensymb`, `tagformat`, `textcomp`, and `upgreek` packages.  No code changes were needed in their corresponding `ts/input/tex package` files.

The remainder of the test PRs will include changes in the `ts/input/tex` files.