### PR TITLE
Miscellaneous tests for core tex files, and update code

### DIFF
--- a/testsuite/tests/input/tex/Tex.test.ts
+++ b/testsuite/tests/input/tex/Tex.test.ts
@@ -1,0 +1,626 @@
+import { beforeEach, describe, test, expect } from '@jest/globals';
+import {
+  toXmlMatch,
+  toXmlArrayMatch,
+  toMathML,
+  tex2mml,
+  page2mml,
+  setupTex,
+  setupTexPage,
+  setupComponents,
+  trapOutput,
+  trapErrors,
+  expectTexError
+} from '#helpers';
+import '#js/input/tex/ams/AmsConfiguration';
+import '#js/input/tex/newcommand/NewcommandConfiguration';
+
+import { TeX } from '#js/input/tex.js';
+import { MmlFactory } from '#js/core/MmlTree/MmlFactory.js';
+
+import { Configuration, ConfigurationHandler } from '#js/input/tex/Configuration.js';
+import { HandlerType, ConfigurationType } from '#js/input/tex/HandlerTypes.js';
+import { CommandMap } from '#js/input/tex/TokenMap.js';
+import { Token } from '#js/input/tex/Token.js';
+import { TagsFactory } from '#js/input/tex/Tags.js';
+import TexError from '#js/input/tex/TexError.js';
+import { ParseUtil, KeyValueTypes, KeyValueDef } from '#js/input/tex/ParseUtil.js';
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+const tex = new TeX();
+tex.setMmlFactory(new MmlFactory());
+
+describe('TeX', () => {
+  test('Reset', () => expect(tex.reset()).toBe(undefined));
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('NodeFactory', () => {
+
+  test('createText null text', () => {
+    expect(tex.parseOptions.nodeFactory.create('text', null)).toBe(null)
+  });
+
+  test('create null kind', () => {
+    toXmlMatch(
+      toMathML(tex.parseOptions.nodeFactory.create('undefined', 'mi')),
+      `<mi></mi>`
+    );
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('NodeUtil', () => {
+
+  test('inferred propery', () => {
+    const mrow = tex.parseOptions.nodeFactory.create('node', 'mrow', [], {inferred: true});
+    expect(mrow.getProperty('inferred')).toBe(undefined);
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Stack', () => {
+
+  new CommandMap('stackMacros', {
+    showStack: (parser) => {parser.stack.toString()},
+    getTop: 'getTop'  // coverage for macro defined by name of method in methods object
+  }, {
+    getTop: (parser) => {
+      const top = parser.stack.Top(5);
+      const mtext = parser.create('token', 'mtext', {}, top === null ? 'yes' : 'no');
+      parser.Push(mtext);
+    },
+  });
+
+  Configuration.create('stackMacros', {
+    [ConfigurationType.HANDLER]: {
+      [HandlerType.MACRO]: ['stackMacros']
+    }
+  });
+
+  beforeEach(() => setupTex(['base', 'stackMacros']));
+
+  /********************************************************************************/
+
+  test('toString', () => {
+    toXmlMatch(
+      tex2mml('\\showStack'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\showStack" display="block"></math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('getTop', () => {
+    setupTex(['base', 'stackMacros']);
+    toXmlMatch(
+      tex2mml('\\getTop'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\getTop" display="block">
+         <mtext data-latex="\\getTop">yes</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Token', () => {
+
+  test('token', () => {
+    const token = new Token('x', 'y', {});
+    expect(token.token).toBe('x');
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Tags', () => {
+
+  test('noTag', () => {
+    expect((tex.parseOptions.tags as any).noTag).toBe(false);
+  });
+
+  test('Unknown default', () => {
+    TagsFactory.setDefault('unknown');
+    const message = trapErrors(() => {TagsFactory.create('error')});
+    TagsFactory.setDefault('none');
+    expect(message).toBe('Unknown tags class');
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('TexError', () => {
+
+  test('Number argument', () => {
+    const err = new TexError('test', 'Number: %1', 1 as any);
+    expect(err.message).toBe('Number: 1');
+  });
+
+  test('Braced insertion', () => {
+    const err = new TexError('test', 'Msg: %{1}, Number: %{2}', 'OK', 2 as any);
+    expect(err.message).toBe('Msg: OK, Number: 2');
+  });
+
+  test('Plural', () => {
+    const err = new TexError('test', '%{plural:%1|abc}', 'apple');
+    expect(err.message).toBe('%{plural:%1|abc}');
+  });
+
+  test('Percent', () => {
+    const err = new TexError('test', '10%%');
+    expect(err.message).toBe('10%');
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+setupComponents({
+  loader: {load: ['input/tex-base']}
+});
+
+describe('FindTeX', () => {
+
+  setupTexPage(['base']);
+
+  /********************************************************************************/
+
+  test('display math', async () => {
+    toXmlArrayMatch(
+      await page2mml('abc $$ x + 1 $$ def'),
+      [
+        `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex=" x + 1 " display="block">
+           <mi data-latex="x">x</mi>
+           <mo data-latex="+">+</mo>
+           <mn data-latex="1">1</mn>
+         </math>`
+      ]
+    );
+  });
+
+  /********************************************************************************/
+
+  test('environment', async () => {
+    toXmlArrayMatch(
+      await page2mml('abc \\begin{equation} x=y \\end{equation} def'),
+      [
+        `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{equation} x=y \\end{equation}" display="block">
+           <mi data-latex="x">x</mi>
+           <mo data-latex="=">=</mo>
+           <mi data-latex="y">y</mi>
+         </math>`
+      ]
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Nested braces', async () => {
+    toXmlArrayMatch(
+      await page2mml('abc $$a + {\\bf b} + c$$ def'),
+      [
+        `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a + {\\bf b} + c" display="block">
+           <mi data-latex="a">a</mi>
+           <mo data-latex="+">+</mo>
+           <mrow data-mjx-texclass="ORD" data-latex="{b}">
+             <mi mathvariant="bold" data-latex="b">b</mi>
+           </mrow>
+           <mo data-latex="+">+</mo>
+           <mi data-latex="c">c</mi>
+         </math>`
+      ]
+    );
+  });
+
+  /********************************************************************************/
+
+  test('processEscapes', async () => {
+    toXmlArrayMatch(
+      await page2mml('abc \\$ def'),
+      [
+        `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="$">
+           <mrow data-mjx-texclass="ORD">
+             <mo data-latex="$">$</mo>
+           </mrow>
+         </math>`
+      ]
+    );
+  });
+
+  /********************************************************************************/
+
+  test('ref undefined', async () => {
+    toXmlArrayMatch(
+      await page2mml('abc \\ref{x} def'),
+      [
+        `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\ref{x}">
+           <mrow href="#" class="MathJax_ref" data-latex="\\ref{x}">
+             <mtext>???</mtext>
+           </mrow>
+         </math>`
+      ]
+    );
+  });
+
+  /********************************************************************************/
+
+  test('No close delim', () => {
+    expect(page2mml('abc $$ x + 1')).resolves.toEqual([]);
+  });
+
+  /********************************************************************************/
+
+  test('No close delim', () => {
+    expect(page2mml('abc \\begin{align} x + 1')).resolves.toEqual([]);
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Configuration', () => {
+
+  /********************************************************************************/
+
+  test('keys', () => {
+    expect(Array.from(ConfigurationHandler.keys()).length > 0).toBe(true);
+  });
+
+  /********************************************************************************/
+
+  test('init', () => {
+    const init = () => {};
+    const config = Configuration.create('init', {
+      [ConfigurationType.INIT]: init
+    });
+    expect(config.init).toBe(init);
+  });
+
+  /********************************************************************************/
+
+  test('init null', () => {
+    expect(ConfigurationHandler.get('base').init).toBe(null);
+  });
+
+  /********************************************************************************/
+
+  test('Package priority', () => {
+    const order: number[] = [];
+    Configuration.create('priority 1', {
+      [ConfigurationType.INIT]: () => {order.push(1)}
+    });
+    Configuration.create('priority 2', {
+      [ConfigurationType.INIT]: () => {order.push(2)}
+    });
+    setupTex([['priority 1', 1], ['priority 2', 2]]);
+    expect(order).toEqual([1, 2]);
+    setupTex([['priority 1', 2], ['priority 2', 1]]);
+    expect(order).toEqual([1, 2, 2, 1]);
+  });
+
+  /********************************************************************************/
+
+  test('Parser error', () => {
+    Configuration.create('error', {
+      [ConfigurationType.PARSER]: 'error'
+    });
+    const message = trapErrors(() => {new TeX({packages: ['base', 'error']})});
+    expect(message).toBe("Package 'error' doesn't target the proper parser");
+  });
+
+  /********************************************************************************/
+
+  test('Package error', () => {
+    const message = trapOutput('warn', () => new TeX({packages: ['base', 'undefined']}));
+    expect(message).toBe("MathJax Warning: Package 'undefined' not found.  Omitted.");
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('MapHandler', () => {
+
+  /********************************************************************************/
+
+  test('Undefined', () => {
+    Configuration.create('BadHandler', {
+      [ConfigurationType.HANDLER]: {
+        [HandlerType.MACRO]: ['undefindHandler']
+      }
+    });
+    const message = trapOutput('log', () => new TeX({packages: ['base', 'BadHandler']}));
+    expect(message).toBe("TexParser Warning: Configuration 'undefindHandler' not found! Omitted.");
+  });
+
+  /********************************************************************************/
+
+  test('remove', () => {
+    const fallback = () => {};
+    Configuration.create('fallback', {
+      [ConfigurationType.FALLBACK]: {
+        [HandlerType.MACRO]: fallback
+      }
+    });
+    const tex = new TeX({packages: ['fallback']});
+    const map = (tex as any).configuration.handlers.get(HandlerType.MACRO);
+    expect(Array.from((map as any)._fallback).length).toBe(1);
+    map.remove([], fallback);
+    expect(Array.from((map as any)._fallback).length).toBe(0);
+  });
+
+  /********************************************************************************/
+
+  test('toString', () => {
+    const map = (tex as any).configuration.handlers.get(HandlerType.MACRO);
+    expect(map.toString())
+      .toBe('mathchar7, mathchar0mo, mathchar0mi, ucGreek, lcGreek, macros, delimiter');
+  });
+
+  /********************************************************************************/
+
+  test('retrieve', () => {
+    const handlers = (tex as any).configuration.handlers;
+    expect(handlers.retrieve('undefined')).toBe(null);
+  });
+
+  /********************************************************************************/
+
+  test('keys', () => {
+    const handlers = (tex as any).configuration.handlers;
+    expect(Array.from(handlers.keys()).sort()).toEqual(Object.values(HandlerType).sort());
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('TexParser', () => {
+
+  /********************************************************************************/
+
+  test('toString', () => {
+    let output = '';
+    new CommandMap('showParser', {
+      showparser(parser: any) {
+        output = parser.toString();
+      }
+    });
+    Configuration.create('showParser', {
+      [ConfigurationType.HANDLER]: {
+        [HandlerType.MACRO]: ['showParser']
+      }
+    });
+    setupTex(['base', 'showParser']);
+    tex2mml('\\showparser');
+    expect(output).toBe(
+      [
+        'character: digit, letter, special, command',
+        'delimiter: delimiter',
+        'macro: showParser, mathchar7, mathchar0mo, mathchar0mi, ucGreek, lcGreek, macros, delimiter',
+        'environment: environment',
+        ''
+      ].join('\n')
+    );
+  });
+
+  test('GetBrackets nested [', () => {
+    setupTex(['base', 'ams']);
+    toXmlMatch(
+      tex2mml('\\xrightarrow[{[x]}]{a}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\xrightarrow[{[x]}]{a}" display="block">
+         <munderover data-latex="\\xrightarrow[{[x]}]{a}">
+           <mo data-mjx-texclass="REL">&#x2192;</mo>
+           <mpadded width="+0.833em" lspace="0.278em" voffset=".15em" depth="-.15em">
+             <mrow data-mjx-texclass="ORD" data-latex="{[x]}">
+               <mo data-latex="[" stretchy="false">[</mo>
+               <mi data-latex="x">x</mi>
+               <mo data-latex="]" stretchy="false">]</mo>
+             </mrow>
+             <mspace height=".75em"></mspace>
+           </mpadded>
+           <mpadded width="+0.833em" lspace="0.278em" voffset="-.2em" height="-.2em">
+             <mi data-latex="a">a</mi>
+             <mspace depth=".2em"></mspace>
+           </mpadded>
+         </munderover>
+       </math>`
+    );
+  });
+
+  test('GetBrackets matchBrakets', () => {
+    new CommandMap('matchBrackets', {
+      matchbrackets(parser: any, name: string) {
+        const arg = parser.GetBrackets(name, '', true);
+        parser.Push(parser.create('token', 'mtext', {}, arg));
+      }
+    });
+    Configuration.create('matchBrackets', {
+      [ConfigurationType.HANDLER]: {
+        [HandlerType.MACRO]: ['matchBrackets']
+      }
+    });
+    setupTex(['base', 'matchBrackets']);
+    toXmlMatch(
+      tex2mml('\\matchbrackets[[x]]'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\matchbrackets[[x]]" display="block">
+         <mtext data-latex="\\matchbrackets[[x]]">[x]</mtext>
+       </math>`
+    );
+  });
+
+  test('mml', () => {
+    new CommandMap('mml', {
+      mml(parser: any) {
+        parser.mml();
+      }
+    });
+    Configuration.create('mml', {
+      [ConfigurationType.HANDLER]: {
+        [HandlerType.MACRO]: ['mml']
+      }
+    });
+    setupTex(['base', 'mml']);
+    toXmlMatch(
+      tex2mml('{\\mml}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="{\\mml}" display="block">
+         <mrow data-mjx-texclass="ORD" data-latex="{\\mml}"></mrow>
+       </math>`
+    );
+  });
+
+  test('Removed delimiter', () => {
+    setupTex(['base', 'ams', 'newcommand']);
+    toXmlMatch(
+      tex2mml('\\let\\vert=x \\begin{vmatrix} a \\end{vmatrix}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\let\\vert=x \\begin{vmatrix} a \\end{vmatrix}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" data-latex-item="{vmatrix}" data-latex="\\let\\vert=x \\begin{vmatrix} a \\end{vmatrix}">
+           <mtr>
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('ParseUtil', () => {
+
+  /********************************************************************************/
+
+  test('keyValue', () => {
+    expect(ParseUtil.keyvalOptions('ab')).toEqual({ab: true});
+    expect(ParseUtil.keyvalOptions('ab=true')).toEqual({ab: true});
+    expect(ParseUtil.keyvalOptions('ab=false')).toEqual({ab: false});
+    expect(ParseUtil.keyvalOptions('ab=xyz')).toEqual({ab: 'xyz'});
+    expect(ParseUtil.keyvalOptions('ab=')).toEqual({ab: ''});
+    expect(ParseUtil.keyvalOptions('{ab=}')).toEqual({ab: ''});
+    expect(ParseUtil.keyvalOptions('{{ab=}}')).toEqual({'ab=': true});
+    expect(ParseUtil.keyvalOptions('ab=1,cd')).toEqual({'ab': "1", cd: true});
+    expect(ParseUtil.keyvalOptions('ab cd=x')).toEqual({'ab cd': 'x'});
+    expect(ParseUtil.keyvalOptions('{ab,c=d}=x')).toEqual({'ab,c=d': 'x'});
+    expect(ParseUtil.keyvalOptions('ab=\\x')).toEqual({ab: '\\x'});
+    expect(ParseUtil.keyvalOptions('ab=\\{')).toEqual({ab: '\\{'});
+    expect(ParseUtil.keyvalOptions('ab={a\\{b}')).toEqual({ab: 'a\\{b'});
+    expect(ParseUtil.keyvalOptions('ab=\\')).toEqual({ab: '\\'});
+    expect(ParseUtil.keyvalOptions('a\\b=c')).toEqual({'a\\b': 'c'});
+  });
+
+  test('keyValue braces', () => {
+    expect(ParseUtil.keyvalOptions('ab={{{cd} ef}}')).toEqual({ab: '{cd} ef'});
+    expect(ParseUtil.keyvalOptions('ab={{{cd} ef}}', null, false, true)).toEqual({ab: '{{cd} ef}'});
+    expect(ParseUtil.keyvalOptions('ab={x,y=z}')).toEqual({ab: 'x,y=z'});
+  });
+
+  test('keyValue extra open brace', () => {
+    const message = trapErrors(() => ParseUtil.keyvalOptions('ab={c{d}'));
+    expect(message).toBe('Extra open brace or missing close brace');
+  });
+
+  test('keyValue extra close brace', () => {
+    const message = trapErrors(() => ParseUtil.keyvalOptions('ab=c{d}}'));
+    expect(message).toBe('Extra close brace or missing open brace');
+  });
+
+  test('keyValue allowed values', () => {
+    expect(ParseUtil.keyvalOptions('ab', {ab: 1})).toEqual({ab: true});
+    expect(ParseUtil.keyvalOptions('ab', {abc: 1})).toEqual({});
+    expect(ParseUtil.keyvalOptions('ab', {ab: KeyValueTypes.boolean})).toEqual({ab: true});
+    expect(ParseUtil.keyvalOptions('ab=true', {ab: KeyValueTypes.boolean})).toEqual({ab: true});
+    expect(ParseUtil.keyvalOptions('ab=1.2', {ab: KeyValueTypes.number})).toEqual({ab: 1.2});
+    expect(ParseUtil.keyvalOptions('ab=12', {ab: KeyValueTypes.integer})).toEqual({ab: 12});
+    expect(ParseUtil.keyvalOptions('ab=xy', {ab: KeyValueTypes.string})).toEqual({ab: 'xy'});
+    expect(ParseUtil.keyvalOptions('ab=x', {ab: KeyValueDef.oneof('x','y')})).toEqual({ab: 'x'});
+    expect(ParseUtil.keyvalOptions('ab=y', {ab: KeyValueDef.oneof('x','y')})).toEqual({ab: 'y'});
+    expect(ParseUtil.keyvalOptions('ab=2em', {ab: KeyValueTypes.dimen})).toEqual({ab: '2em'});
+  });
+
+  test('keyValue allowed with errors', () => {
+    function trap(test: string, allow: any) {
+      return expect(trapErrors(() => ParseUtil.keyvalOptions(test, allow, true)));
+    }
+    const error = "Value for key 'ab' is not of the expected type";
+    trap('ab', {abc: 1}).toBe('Invalid option: ab');
+    trap('ab=x', {ab: KeyValueTypes.boolean}).toBe(error);
+    trap('ab=x', {ab: KeyValueTypes.number}).toBe(error);
+    trap('ab=1.2', {ab: KeyValueTypes.integer}).toBe(error);
+    trap('ab=', {ab: KeyValueTypes.string}).toBe('(no error)');
+    trap('ab=z', {ab: KeyValueDef.oneof('x','y')}).toBe(error);
+    trap('ab=2xy', {ab: KeyValueTypes.dimen}).toBe(error);
+    trap('ab=2', {ab: KeyValueTypes.dimen}).toBe(error);
+  });
+
+  test('fixedFence', () => {
+    function create(kind: string, options?: any, children?: any[]) {
+      return tex.mmlFactory.create(kind, options, children);
+    }
+    const mrow = create('mrow', {}, [create('mi')]);
+    const mml = ParseUtil.fixedFence(tex.parseOptions, '(', mrow, ')');
+    const kinds = mml.childNodes.map((node) => node.kind);
+    expect(kinds).toEqual(['MathChoice', 'mi', 'MathChoice']);
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('ColumnParser', () => {
+
+  /********************************************************************************/
+
+  test('Error', () => {
+    new CommandMap('cError', {
+      cError(parser: any) {
+        const array = parser.itemFactory.create('array');
+        parser.configuration.columnParser.process(parser, '@{x', array);
+      }
+    });
+    Configuration.create('cError', {
+      [ConfigurationType.HANDLER]: {
+        [HandlerType.MACRO]: ['cError']
+      }
+    });
+    setupTex(['base', 'cError']);
+    expectTexError('\\cError').toBe('Missing close brace');
+  });
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -577,7 +577,7 @@ export abstract class AbstractMmlNode
   }
 
   /**
-   * If there is an inferred row, the the children of that instead
+   * If there is an inferred row, set the children of that instead
    *
    * @override
    */

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -203,7 +203,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     this.latex = math.math;
     let node: MmlNode;
     this.parseOptions.tags.startEquation(math);
-    let globalEnv;
     let parser;
     try {
       parser = new TexParser(
@@ -212,7 +211,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
         this.parseOptions
       );
       node = parser.mml();
-      globalEnv = parser.stack.global;
     } catch (err) {
       if (!(err instanceof TexError)) {
         throw err;
@@ -222,9 +220,6 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     }
     node = this.parseOptions.nodeFactory.create('node', 'math', [node]);
     node.attributes.set(TexConstant.Attr.LATEX, this.latex);
-    if (globalEnv?.indentalign) {
-      NodeUtil.setAttribute(node, 'indentalign', globalEnv.indentalign);
-    }
     if (math.display) {
       NodeUtil.setAttribute(node, 'display', 'block');
     }

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -139,8 +139,7 @@ export class ColumnParser {
         );
       }
       const code = state.template.codePointAt(state.i);
-      const c = (state.c =
-        code === undefined ? '' : String.fromCodePoint(code));
+      const c = (state.c = String.fromCodePoint(code));
       state.i += c.length;
       if (!Object.hasOwn(this.columnHandler, c)) {
         throw new TexError('BadPreamToken', 'Illegal pream-token (%1)', c);
@@ -263,7 +262,7 @@ export class ColumnParser {
    * @returns {string} The dimension string
    */
   public getDimen(state: ColumnState): string {
-    const dim = this.getBraces(state) || '';
+    const dim = this.getBraces(state);
     if (!UnitUtil.matchDimen(dim)[0]) {
       throw new TexError(
         'MissingColumnDimOrUnits',
@@ -299,7 +298,7 @@ export class ColumnParser {
    */
   public getBraces(state: ColumnState): string {
     while (state.template[state.i] === ' ') state.i++;
-    if (state.i > state.template.length) {
+    if (state.i >= state.template.length) {
       throw new TexError(
         'MissingArgForColumn',
         'Missing argument for %1 column declaration',

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -437,7 +437,10 @@ export class ParserConfiguration {
   protected getPackage(name: string): Configuration {
     const config = ConfigurationHandler.get(name);
     if (config && !this.parsers.includes(config.parser)) {
-      throw Error(`Package ${name} doesn't target the proper parser`);
+      throw Error(`Package '${name}' doesn't target the proper parser`);
+    }
+    if (!config) {
+      this.warn(`Package '${name}' not found.  Omitted.`);
     }
     return config;
   }
@@ -476,5 +479,14 @@ export class ParserConfiguration {
     for (const [post, priority] of config.postprocessors) {
       jax.postFilters.add(post, priority);
     }
+  }
+
+  /**
+   * Prints a warning message.
+   *
+   * @param {string} message The warning.
+   */
+  private warn(message: string) {
+    console.warn('MathJax Warning: ' + message);
   }
 }

--- a/ts/input/tex/MapHandler.ts
+++ b/ts/input/tex/MapHandler.ts
@@ -79,7 +79,7 @@ export class SubHandler {
     for (const name of maps.slice().reverse()) {
       const map = MapHandler.getMap(name);
       if (!map) {
-        this.warn('Configuration ' + name + ' not found! Omitted.');
+        this.warn(`Configuration '${name}' not found! Omitted.`);
         return;
       }
       this._configuration.add(map, priority);

--- a/ts/input/tex/NodeUtil.ts
+++ b/ts/input/tex/NodeUtil.ts
@@ -327,6 +327,26 @@ const NodeUtil = {
   getOp(mo: MmlMo, form: string = 'infix'): OperatorDef {
     return MmlMo.OPTABLE[form][mo.getText()] || null;
   },
+
+  /**
+   * Gets an explicit or inherited attribute of an mo, or its default from the
+   * operator dictionary, or the default value
+   *
+   * @param {MmlMo} mo       The mo node.
+   * @param {string} attr    The attribute to return.
+   * @returns {Property}     The attributes property.
+   */
+  getMoAttribute(mo: MmlNode, attr: string): Property {
+    if (!mo.attributes.isSet(attr)) {
+      for (const form of ['infix', 'postfix', 'prefix']) {
+        const value = this.getOp(mo, form)?.[3]?.[attr];
+        if (value !== undefined) {
+          return value;
+        }
+      }
+    }
+    return mo.attributes.get(attr);
+  },
 };
 
 export default NodeUtil;

--- a/ts/input/tex/ParseMethods.ts
+++ b/ts/input/tex/ParseMethods.ts
@@ -121,7 +121,7 @@ const ParseMethods = {
   },
 
   /**
-   * Handle mathcharupper-case Greek in current family.
+   * Handle upper-case Greek in current family.
    *
    * @param {TexParser} parser The current tex parser.
    * @param {Token} mchar The parsed token.

--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -60,7 +60,7 @@ export type KeyValueType = KeyValueDef<any>;
  *  const allowed = {
  *    compact: KeyValueTypes.boolean,
  *    direction: KeyValueDef.oneof('up', 'down'),
- *    'open-brace': KeyValueType.string
+ *    'open-brace': KeyValueTypes.string
  *  };
  *
  *  ParseUtil.keyvalOptions(options, allowed, true);

--- a/ts/input/tex/StackItem.ts
+++ b/ts/input/tex/StackItem.ts
@@ -552,7 +552,7 @@ export abstract class BaseItem extends MmlStack implements StackItem {
   }
 
   /**
-   * Get error messages for a particular types of stack items. This reads error
+   * Get error messages for a particular types of stack item. This reads error
    * messages from the static errors object, which can be extended in
    * subclasses.
    *
@@ -561,6 +561,6 @@ export abstract class BaseItem extends MmlStack implements StackItem {
    */
   public getErrors(kind: string): string[] {
     const CLASS = this.constructor as typeof BaseItem;
-    return (CLASS.errors || {})[kind] || BaseItem.errors[kind];
+    return CLASS.errors[kind] || BaseItem.errors[kind];
   }
 }

--- a/ts/input/tex/TexError.ts
+++ b/ts/input/tex/TexError.ts
@@ -75,9 +75,6 @@ export default class TexError {
           }
         }
       }
-      if (parts[i] == null) {
-        parts[i] = '???';
-      }
     }
     return parts.join('');
   }

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -263,7 +263,7 @@ export default class TexParser {
    */
   public convertDelimiter(c: string): string {
     const token = this.lookup(HandlerType.DELIMITER, c) as Token;
-    return token && token.char ? token.char : null;
+    return token?.char ?? null;
   }
 
   /**

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -263,7 +263,7 @@ export default class TexParser {
    */
   public convertDelimiter(c: string): string {
     const token = this.lookup(HandlerType.DELIMITER, c) as Token;
-    return token ? token.char : null;
+    return token && token.char ? token.char : null;
   }
 
   /**
@@ -315,7 +315,7 @@ export default class TexParser {
    * @param {boolean} noneOK True if no argument is OK.
    * @returns {string} The next argument.
    */
-  public GetArgument(_name: string, noneOK?: boolean): string {
+  public GetArgument(_name: string, noneOK: boolean = false): string {
     switch (this.GetNext()) {
       case '':
         if (!noneOK) {
@@ -383,18 +383,18 @@ export default class TexParser {
       return def;
     }
     const j = ++this.i;
-    let parens = 0;
+    let braces = 0;
     let brackets = 0;
     while (this.i < this.string.length) {
       switch (this.string.charAt(this.i++)) {
         case '{':
-          parens++;
+          braces++;
           break;
         case '\\':
           this.i++;
           break;
         case '}':
-          if (parens-- <= 0) {
+          if (braces-- <= 0) {
             // @test ExtraCloseLooking1
             throw new TexError(
               'ExtraCloseLooking',
@@ -404,10 +404,10 @@ export default class TexParser {
           }
           break;
         case '[':
-          if (parens === 0) brackets++;
+          if (braces === 0) brackets++;
           break;
         case ']':
-          if (parens === 0) {
+          if (braces === 0) {
             if (!matchBrackets || brackets === 0) {
               return this.string.slice(j, this.i - 1);
             }
@@ -431,7 +431,7 @@ export default class TexParser {
    * @param {boolean=} braceOK Are braces around the delimiter OK.
    * @returns {string} The delimiter name.
    */
-  public GetDelimiter(name: string, braceOK?: boolean): string {
+  public GetDelimiter(name: string, braceOK: boolean = false): string {
     let c = this.GetNext();
     this.i += c.length;
     if (this.i <= this.string.length) {
@@ -496,7 +496,7 @@ export default class TexParser {
       this.i++;
     }
     const j = this.i;
-    let parens = 0;
+    let braces = 0;
     while (this.i < this.string.length) {
       const k = this.i;
       let c = this.GetNext();
@@ -506,10 +506,10 @@ export default class TexParser {
           c += this.GetCS();
           break;
         case '{':
-          parens++;
+          braces++;
           break;
         case '}':
-          if (parens === 0) {
+          if (braces === 0) {
             // @test ExtraCloseLooking2
             throw new TexError(
               'ExtraCloseLooking',
@@ -517,10 +517,10 @@ export default class TexParser {
               token
             );
           }
-          parens--;
+          braces--;
           break;
       }
-      if (parens === 0 && c === token) {
+      if (braces === 0 && c === token) {
         return this.string.slice(j, k);
       }
     }
@@ -706,7 +706,7 @@ export default class TexParser {
   ) {
     if (!node.childNodes[pos1] || !node.childNodes[pos2]) return;
     const expr =
-      node.childNodes[pos1].attributes.get(TexConstant.Attr.LATEX) +
+      (node.childNodes[pos1].attributes.get(TexConstant.Attr.LATEX) || '') +
       comp +
       node.childNodes[pos2].attributes.get(TexConstant.Attr.LATEX);
     node.attributes.set(TexConstant.Attr.LATEX, expr);
@@ -718,7 +718,6 @@ export default class TexParser {
    * @param {MmlNode} atom The current Mml node.
    */
   private composeBraces(atom: MmlNode) {
-    if (!atom) return;
     const str = this.composeBracedContent(atom);
     atom.attributes.set(TexConstant.Attr.LATEX, `{${str}}`);
   }


### PR DESCRIPTION
This PR adds a `Tex.test.ts` file that is intended to complete the coverage of the TeX input jax main files for lines that aren't run by other package-based tests.  Therefore, it is a bit of a hodge-podge of miscellaneous tests.

It also includes modifications to a number of the core TeX files in order to either correct bugs, or remove unreachable code, as described below:

* In `tex.ts`, the `globalEnv` is no longer used.  It was part of handling the `multline` environment, but that was changed some time ago in the `ams` package, while this code was never removed.
* in `ColumnParser.js`: 
   - the `codePointAt()` function never returns undefined. (line 142)
   - the `getBraces()` function always returns a string, so no need for `|| ''`. (line 265)
   - we want to stop at the end of the string, not one past it (bug). (line 301)
* In `Configuration.ts`,
  - an error message is improved (line 440)
  - and a new warning added (line 443) for when a package is used that isn't defined,
  - using a new `warn()` method like the one in `MapHandler.ts`. (lines 483-491)
* In `FilterUtil.ts`
  - the `data-latex` and `data-latex-item` attributes were interfering with the combining or relations, so the code has been updated to take those into account. (lines 65-70 and 248-254)
  - because `getList()` checks that the items it returns are children of the `MathItem.root` node, their `parent` is always defined, except for the top-level `math` element; since these are `msubsup` elements, they always have a `parent`, so the checks for that are not needed. (lines 107-111 and 140-144)
  - because `walkTree()` doesn't descend into token nodes, the only nodes that it receives will always have an `attributes` property (lines 192-194)
  - an `mstyle` node always has an inferred row as its 0th child, and that always has a `childNode` array (line 329)
* A new `getMoAttribute()` function is added to `NodeUtil.ts` in order to look up an `mo` element's attribute, using the operator dictionary if it is not explicitly given (note that this is used during the construction of the internal MathML tree, before inheritance is put in place, so surrounding `mstyle` changes aren't taken into account); if no operator-dictionary entry exists, the default value is used.
* In `ParseUtil.ts`,
  - using the `KeyValueTypes` caused type errors in `.ts` files, so I have reorganized that a bit to make it work without having to cast anything.  I had to move the `oneof()` method to the `KeyValueDef` class (renamed from `KeyValueType`, which is now a `type`).  So a type definition object would look like:
    
    ``` js
    const allowed = {
      compact: KeyValueTypes.boolean,
      direction: KeyValueDef.oneof('up', 'down'),
      'open-brace': KeyValueTypes.string
    };
    ```
    
    with `KeyValueDef.oneof` rather than `KeyValueTypes.oneof`.  Not as nice, but I wasn't able to get Typescript to accept it any other way.
  - the checking for erroneous nesting of environments was updated some time ago, and that broke the `empheq` package, which nests AMS environments inside an `empheq` environment.  This needed a new `nestStart` property to resolve the issue. (line 818)
* In `StackItem.ts`, all stak items inherit the `error` property of the base item, so it is never undefined. (line 564)
* In `TexError.ts`, the `parts` are never `null`, as the separators always have to match at least one character or they wouldn't be matched.
* In `TexParser.ts`,
  - we add a check for the the character being undefined in order to get the `null` branch coverage. (line 266)
  - The changes in 318 to 523 are just cosmetic: assign `false` as default rather than leaving it undefined, and change `parens` to `braces`, since that is what is really being counted.
  - line 709 prevents `undefined` from being used in things like `^a` that have no base.
  - the node passed to `composeBraces()` is never emtpy.
  - the `!node.childNodes[pos1]` in line 707 is really not needed, either, since the base node is always defined (it is an empty `mi` in `^a` for example), but I've left this in just in case, as I don't really know how this function is used.