### PR TITLE
Update tests for amscd

### DIFF
--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -4,743 +4,872 @@ import '#js/input/tex/amscd/AmsCdConfiguration';
 
 beforeEach(() => setupTex(['base', 'amscd']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('AmsCD', () => {
-  it('AmsCD-1', () =>
+
+  /********************************************************************************/
+
+  it('AmsCD-1', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="a">a</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
-              <mpadded width="0">
-                <mi data-latex="b">b</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mrow>
-          <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
-              <mpadded width="0">
-                <mi data-latex="c">c</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="C">C</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="d">d</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="D">D</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-2', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="a">a</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
+                     <mpadded width="0">
+                       <mi data-latex="b">b</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mrow>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
+                     <mpadded width="0">
+                       <mi data-latex="c">c</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="C">C</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="d">d</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-2', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @<<< B @>>> C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2190;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="C">C</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd></mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" stretchy="true" symmetric="true" lspace="0" rspace="0">&#x2225;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2191;</mo>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mi data-latex="D">D</mi>
-      </mtd>
-      <mtd>
-        <mo minsize="2.75em" stretchy="true">=</mo>
-      </mtd>
-      <mtd>
-        <mi data-latex="E">E</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-3', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&lt;&lt;&lt; B @&gt;&gt;&gt; C\\\\@. @| @AAA\\\\@. D @= E\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2190;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="C">C</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd></mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" stretchy="true" symmetric="true" lspace="0" rspace="0">&#x2225;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2191;</mo>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+             <mtd>
+               <mo minsize="2.75em" stretchy="true">=</mo>
+             </mtd>
+             <mtd>
+               <mi data-latex="E">E</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-3', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>b> B\\\\@VlVrV @AlArA\\\\C @<a<b< D\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <munderover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em">
-            <mi data-latex="b">b</mi>
-          </mpadded>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="a">a</mi>
-          </mpadded>
-        </munderover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\llap{l}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\llap{l}">
-              <mpadded width="0" lspace="-1width">
-                <mi data-latex="l">l</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-          <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{r}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{r}">
-              <mpadded width="0">
-                <mi data-latex="r">r</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mrow>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\llap{l}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\llap{l}">
-              <mpadded width="0" lspace="-1width">
-                <mi data-latex="l">l</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-          <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2191;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{r}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{r}">
-              <mpadded width="0">
-                <mi data-latex="r">r</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="C">C</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <munderover>
-          <mo minsize="2.75em">&#x2190;</mo>
-          <mpadded width="+.67em" lspace=".33em">
-            <mi data-latex="b">b</mi>
-          </mpadded>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="a">a</mi>
-          </mpadded>
-        </munderover>
-      </mtd>
-      <mtd>
-        <mi data-latex="D">D</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-4', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;b&gt; B\\\\@VlVrV @AlArA\\\\C @&lt;a&lt;b&lt; D\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <munderover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em">
+                   <mi data-latex="b">b</mi>
+                 </mpadded>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="a">a</mi>
+                 </mpadded>
+               </munderover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\llap{l}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\llap{l}">
+                     <mpadded width="0" lspace="-1width">
+                       <mi data-latex="l">l</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{r}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{r}">
+                     <mpadded width="0">
+                       <mi data-latex="r">r</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mrow>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\llap{l}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\llap{l}">
+                     <mpadded width="0" lspace="-1width">
+                       <mi data-latex="l">l</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2191;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{r}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{r}">
+                     <mpadded width="0">
+                       <mi data-latex="r">r</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="C">C</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <munderover>
+                 <mo minsize="2.75em">&#x2190;</mo>
+                 <mpadded width="+.67em" lspace=".33em">
+                   <mi data-latex="b">b</mi>
+                 </mpadded>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="a">a</mi>
+                 </mpadded>
+               </munderover>
+             </mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-4', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{CD}A @>>> B@>\\text{very long label}>>C\\\\@VVV @VVV @VVV\\\\D @>>> E@>>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mtext data-latex="\\text{very long label}">very long label</mtext>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="C">C</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="D">D</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="E">E</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="F">F</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-5', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B@&gt;\\text{very long label}&gt;&gt;C\\\\@VVV @VVV @VVV\\\\D @&gt;&gt;&gt; E@&gt;&gt;&gt; F\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mtext data-latex="\\text{very long label}">very long label</mtext>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="C">C</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="D">D</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="E">E</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="F">F</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-5', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{CD}A @>>> B @>{\\text{very long label}}>> C \\\\@VVV @VVV @VVV \\\\D @>>> E @>{\\phantom{\\text{very long label}}}>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mrow data-mjx-texclass="ORD" data-latex="{\\text{very long label}}">
-              <mtext data-latex="\\text{very long label}">very long label</mtext>
-            </mrow>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="C">C</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="D">D</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="E">E</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mrow data-mjx-texclass="ORD" data-latex="{\\phantom{\\text{very long label}}}">
-              <mrow data-mjx-texclass="ORD" data-latex="\\phantom{\\text{very long label}}">
-                <mphantom>
-                  <mtext data-latex="\\text{very long label}">very long label</mtext>
-                </mphantom>
-              </mrow>
-            </mrow>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="F">F</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-6', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mrow data-mjx-texclass="ORD" data-latex="{\\text{very long label}}">
+                     <mtext data-latex="\\text{very long label}">very long label</mtext>
+                   </mrow>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="C">C</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="D">D</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="E">E</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mrow data-mjx-texclass="ORD" data-latex="{\\phantom{\\text{very long label}}}">
+                     <mrow data-mjx-texclass="ORD" data-latex="\\phantom{\\text{very long label}}">
+                       <mphantom>
+                         <mtext data-latex="\\text{very long label}">very long label</mtext>
+                       </mphantom>
+                     </mrow>
+                   </mrow>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="F">F</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-6', () => {
     toXmlMatch(
       tex2mml(
         '\\begin{CD}A @>>> B @>{\\text{very long label}}>> C \\\\@VVV @VVV @VVV \\\\D @>>> E @>{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}>> F\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mrow data-mjx-texclass="ORD" data-latex="{\\text{very long label}}">
-              <mtext data-latex="\\text{very long label}">very long label</mtext>
-            </mrow>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="C">C</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="D">D</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="E">E</mi>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mrow data-mjx-texclass="ORD" data-latex="{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}">
-              <mrow data-mjx-texclass="ORD" data-latex="\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}">
-                <mpadded width="0">
-                  <mrow data-mjx-texclass="ORD" data-latex="\\scriptstyle{\\ \\ \\ \\text{shorter}}">
-                    <mtext>&#xA0;</mtext>
-                    <mtext>&#xA0;</mtext>
-                    <mtext>&#xA0;</mtext>
-                    <mtext data-latex="\\text{shorter}">shorter</mtext>
-                  </mrow>
-                </mpadded>
-              </mrow>
-              <mrow data-mjx-texclass="ORD" data-latex="\\phantom{\\text{very long label}}">
-                <mphantom>
-                  <mtext data-latex="\\text{very long label}">very long label</mtext>
-                </mphantom>
-              </mrow>
-            </mrow>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="F">F</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-width', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;&gt;&gt; B @&gt;{\\text{very long label}}&gt;&gt; C \\\\@VVV @VVV @VVV \\\\D @&gt;&gt;&gt; E @&gt;{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}&gt;&gt; F\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mrow data-mjx-texclass="ORD" data-latex="{\\text{very long label}}">
+                     <mtext data-latex="\\text{very long label}">very long label</mtext>
+                   </mrow>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="C">C</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="D">D</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mspace width="2.75em" linebreak="nobreak" data-latex="\\kern 2.75em"></mspace>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="E">E</mi>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mrow data-mjx-texclass="ORD" data-latex="{\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}\\phantom{\\text{very long label}}}">
+                     <mrow data-mjx-texclass="ORD" data-latex="\\rlap{\\scriptstyle{\\ \\ \\ \\text{shorter}}}">
+                       <mpadded width="0">
+                         <mrow data-mjx-texclass="ORD" data-latex="\\scriptstyle{\\ \\ \\ \\text{shorter}}">
+                           <mtext>&#xA0;</mtext>
+                           <mtext>&#xA0;</mtext>
+                           <mtext>&#xA0;</mtext>
+                           <mtext data-latex="\\text{shorter}">shorter</mtext>
+                         </mrow>
+                       </mpadded>
+                     </mrow>
+                     <mrow data-mjx-texclass="ORD" data-latex="\\phantom{\\text{very long label}}">
+                       <mphantom>
+                         <mtext data-latex="\\text{very long label}">very long label</mtext>
+                       </mphantom>
+                     </mrow>
+                   </mrow>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="F">F</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-width', () => {
     toXmlMatch(
       tex2mml(
         '\\minCDarrowwidth{5cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="5cm">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="a">a</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
-              <mpadded width="0">
-                <mi data-latex="b">b</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mrow>
-          <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
-              <mpadded width="0">
-                <mi data-latex="c">c</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="C">C</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="5cm">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="d">d</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="D">D</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-height', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="5cm">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="a">a</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
+                     <mpadded width="0">
+                       <mi data-latex="b">b</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mrow>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
+                     <mpadded width="0">
+                       <mi data-latex="c">c</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="C">C</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="5cm">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="d">d</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-height', () => {
     toXmlMatch(
       tex2mml(
         '\\minCDarrowheight{4cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="a">a</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
-              <mpadded width="0">
-                <mi data-latex="b">b</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mrow>
-          <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
-              <mpadded width="0">
-                <mi data-latex="c">c</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="C">C</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="2.75em">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="d">d</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="D">D</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('AmsCD-both', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="a">a</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
+                     <mpadded width="0">
+                       <mi data-latex="b">b</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mrow>
+                 <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
+                     <mpadded width="0">
+                       <mi data-latex="c">c</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="C">C</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="d">d</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('AmsCD-both', () => {
     toXmlMatch(
       tex2mml(
         '\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'
       ),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
-  <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
-    <mtr>
-      <mtd>
-        <mi data-latex="A">A</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="5cm">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="a">a</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="B">B</mi>
-      </mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mrow>
-          <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
-              <mpadded width="0">
-                <mi data-latex="b">b</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-      <mtd>
-        <mrow>
-          <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
-          <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
-            <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
-              <mpadded width="0">
-                <mi data-latex="c">c</mi>
-              </mpadded>
-            </mrow>
-          </mstyle>
-        </mrow>
-      </mtd>
-      <mtd></mtd>
-    </mtr>
-    <mtr>
-      <mtd>
-        <mi data-latex="C">C</mi>
-        <mpadded height="8.5pt" depth="2pt"></mpadded>
-      </mtd>
-      <mtd>
-        <mover>
-          <mo minsize="5cm">&#x2192;</mo>
-          <mpadded width="+.67em" lspace=".33em" voffset=".1em">
-            <mi data-latex="d">d</mi>
-          </mpadded>
-        </mover>
-      </mtd>
-      <mtd>
-        <mi data-latex="D">D</mi>
-      </mtd>
-    </mtr>
-  </mtable>
-</math>`
-    ));
-  it('Suspicious Return', () =>
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\minCDarrowheight{4cm}\\minCDarrowwidth{5cm}\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="5cm">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="a">a</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
+                     <mpadded width="0">
+                       <mi data-latex="b">b</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mrow>
+                 <mo minsize="4cm" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
+                     <mpadded width="0">
+                       <mi data-latex="c">c</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="C">C</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="5cm">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="d">d</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Suspicious Return', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @Ra>> BaD\\end{CD}'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}" display="block">
-      <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}">
-        <mtr>
-          <mtd>
-            <mi data-latex="A">A</mi>
-            <mrow data-mjx-texclass="ORD">
-              <mo data-latex="@">@</mo>
-            </mrow>
-            <mi data-latex="R">R</mi>
-            <mi data-latex="a">a</mi>
-            <mo data-latex="&gt;">&gt;&gt;</mo>
-            <mi data-latex="B">B</mi>
-            <mi data-latex="a">a</mi>
-            <mi data-latex="D">D</mi>
-          </mtd>
-        </mtr>
-      </mtable>
-    </math>`
-    ));
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @Ra&gt;&gt; BaD\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mrow data-mjx-texclass="ORD">
+                 <mo data-latex="@">@</mo>
+               </mrow>
+               <mi data-latex="R">R</mi>
+               <mi data-latex="a">a</mi>
+               <mo data-latex="&gt;&gt;">&gt;&gt;</mo>
+               <mi data-latex="B">B</mi>
+               <mi data-latex="a">a</mi>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
 
-describe.skip('AmsCD Options', () => {
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('AmsCD Options', () => {
+
   beforeEach(() => setupTex(['base', 'amscd'], { amscd: {hideHorizontalLabels: true } }));
-  it('Hide Horizontal Labels', () =>
+
+  /********************************************************************************/
+
+  it('Hide Horizontal Labels', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @>a>> B\\\\@VVbV @VVcV\\\\C @>d>> D\\end{CD}'),
-      ``
-    ));
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}" display="block">
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @&gt;a&gt;&gt; B\\\\@VVbV @VVcV\\\\C @&gt;d&gt;&gt; D\\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mpadded depth="0" height=".67em">
+                 <mover>
+                   <mo minsize="2.75em">&#x2192;</mo>
+                   <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                     <mi data-latex="a">a</mi>
+                   </mpadded>
+                 </mover>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mrow>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{b}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{b}">
+                     <mpadded width="0">
+                       <mi data-latex="b">b</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mrow>
+                 <mo minsize="1.75em" symmetric="true" lspace="0" rspace="0">&#x2193;</mo>
+                 <mstyle displaystyle="false" scriptlevel="1" data-latex="\\scriptstyle\\rlap{c}">
+                   <mrow data-mjx-texclass="ORD" data-latex="\\rlap{c}">
+                     <mpadded width="0">
+                       <mi data-latex="c">c</mi>
+                     </mpadded>
+                   </mrow>
+                 </mstyle>
+               </mrow>
+             </mtd>
+             <mtd></mtd>
+           </mtr>
+           <mtr>
+             <mtd>
+               <mi data-latex="C">C</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mpadded depth="0" height=".67em">
+                 <mover>
+                   <mo minsize="2.75em">&#x2192;</mo>
+                   <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                     <mi data-latex="d">d</mi>
+                   </mpadded>
+                 </mover>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mi data-latex="D">D</mi>
+             </mtd>
+           </mtr>
+        </mtable>
+      </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/
 
 afterAll(() => getTokens('amscd'));

--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -126,16 +126,14 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
         } // minsize needs work
         const pad: EnvList = { width: '+.67em', lspace: '.33em' };
         mml = parser.create('node', 'munderover', [mml]) as MmlMunderover;
-        if (a) {
-          const nodeA = new TexParser(
-            a,
-            parser.stack.env,
-            parser.configuration
-          ).mml();
-          const mpadded = parser.create('node', 'mpadded', [nodeA], pad);
-          NodeUtil.setAttribute(mpadded, 'voffset', '.1em');
-          NodeUtil.setChild(mml, mml.over, mpadded);
-        }
+        const nodeA = new TexParser(
+          a,
+          parser.stack.env,
+          parser.configuration
+        ).mml();
+        const mpadded = parser.create('node', 'mpadded', [nodeA], pad);
+        NodeUtil.setAttribute(mpadded, 'voffset', '.1em');
+        NodeUtil.setChild(mml, mml.over, mpadded);
         if (b) {
           const nodeB = new TexParser(
             b,

--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -124,37 +124,35 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
         if (!a) {
           a = '\\kern ' + top.getProperty('minw');
         } // minsize needs work
-        if (a || b) {
-          const pad: EnvList = { width: '+.67em', lspace: '.33em' };
-          mml = parser.create('node', 'munderover', [mml]) as MmlMunderover;
-          if (a) {
-            const nodeA = new TexParser(
-              a,
-              parser.stack.env,
-              parser.configuration
-            ).mml();
-            const mpadded = parser.create('node', 'mpadded', [nodeA], pad);
-            NodeUtil.setAttribute(mpadded, 'voffset', '.1em');
-            NodeUtil.setChild(mml, mml.over, mpadded);
-          }
-          if (b) {
-            const nodeB = new TexParser(
-              b,
-              parser.stack.env,
-              parser.configuration
-            ).mml();
-            NodeUtil.setChild(
-              mml,
-              mml.under,
-              parser.create('node', 'mpadded', [nodeB], pad)
-            );
-          }
-          if (parser.configuration.options.amscd.hideHorizontalLabels) {
-            mml = parser.create('node', 'mpadded', mml, {
-              depth: 0,
-              height: '.67em',
-            });
-          }
+        const pad: EnvList = { width: '+.67em', lspace: '.33em' };
+        mml = parser.create('node', 'munderover', [mml]) as MmlMunderover;
+        if (a) {
+          const nodeA = new TexParser(
+            a,
+            parser.stack.env,
+            parser.configuration
+          ).mml();
+          const mpadded = parser.create('node', 'mpadded', [nodeA], pad);
+          NodeUtil.setAttribute(mpadded, 'voffset', '.1em');
+          NodeUtil.setChild(mml, mml.over, mpadded);
+        }
+        if (b) {
+          const nodeB = new TexParser(
+            b,
+            parser.stack.env,
+            parser.configuration
+          ).mml();
+          NodeUtil.setChild(
+            mml,
+            mml.under,
+            parser.create('node', 'mpadded', [nodeB], pad)
+          );
+        }
+        if (parser.configuration.options.amscd.hideHorizontalLabels) {
+          mml = parser.create('node', 'mpadded', [mml], {
+            depth: 0,
+            height: '.67em',
+          });
         }
       } else {
         //
@@ -201,7 +199,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
    */
   cell(parser: TexParser, name: string) {
     const top = parser.stack.Top() as ArrayItem;
-    if ((top.table || []).length % 2 === 0 && (top.row || []).length === 0) {
+    if (top.table.length % 2 === 0 && top.row.length === 0) {
       //
       // Add a strut to the first cell in even rows to get
       // better spacing of arrow rows.


### PR DESCRIPTION
This PR updates the tests for the `amscd` package and its code.

Here, the `if (a || b)` on line 127 is always true due to lines 124 to 126 that set `a` when it is not set.  The `if` is removed, and the block indentation is adjusted.

The change at line 204 is because the table and row arrays are always defined.

Again, viewing without white-space changes is useful, here.