### PR TITLE
Add tests for the cases and empheq packages and update code

### DIFF
--- a/testsuite/tests/input/tex/Cases.test.ts
+++ b/testsuite/tests/input/tex/Cases.test.ts
@@ -1,0 +1,510 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
+import '#js/input/tex/cases/CasesConfiguration';
+import '#js/input/tex/empheq/EmpheqConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
+
+beforeEach(() => setupTex(['base', 'ams', 'cases'], {tags: 'cases'}));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Cases', () => {
+
+  /********************************************************************************/
+
+  test('Numcases', () => {
+    toXmlMatch(
+      tex2mml('\\begin{numcases}{f(x)=} 1 & if $x > 0$ \\\\ 0 & otherwise \\end{numcases}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{numcases}{f(x)=} 1 &amp; if $x &gt; 0$ \\\\ 0 &amp; otherwise \\end{numcases}" display="block">
+         <mtable columnalign="right left left left" columnspacing="0em 1em" rowspacing=".2em" data-break-align="top top top" data-latex="\\begin{numcases}{f(x)=} 1 &amp; if $x &gt; 0$ \\\\ 0 &amp; otherwise \\end{numcases}">
+           <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="f">f</mi>
+                   <mo data-latex="(" stretchy="false">(</mo>
+                   <mi data-latex="x">x</mi>
+                   <mo data-latex=")" stretchy="false">)</mo>
+                   <mo data-latex="=">=</mo>
+                   <mo data-latex="\\mmlToken{mo}{\\U{7B}}">{</mo>
+                   <mspace width="0.167em" data-latex="\\,"></mspace>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top">
+                         <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+                           <mtd>
+                             <mtext data-latex="\\text{(1)}">(1)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mn data-latex="1">1</mn>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mstyle>
+                                 <mtext>if&#xA0;</mtext>
+                                 <mrow data-mjx-texclass="ORD">
+                                   <mi data-latex="x">x</mi>
+                                   <mo data-latex="&gt;">&gt;</mo>
+                                   <mn data-latex="0">0</mn>
+                                 </mrow>
+                                 <mtext>&#xA0;</mtext>
+                               </mstyle>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                         <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+                           <mtd>
+                             <mtext data-latex="\\text{(2)}">(2)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mn data-latex="0">0</mn>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mtext>otherwise&#xA0;</mtext>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top" align="baseline 1">
+                       <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+                         <mtd>
+                           <mtext data-latex="\\text{(1)}">(1)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mn data-latex="1">1</mn>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mstyle>
+                               <mtext>if&#xA0;</mtext>
+                               <mrow data-mjx-texclass="ORD">
+                                 <mi data-latex="x">x</mi>
+                                 <mo data-latex="&gt;">&gt;</mo>
+                                 <mn data-latex="0">0</mn>
+                               </mrow>
+                               <mtext>&#xA0;</mtext>
+                             </mstyle>
+                           </mstyle>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em"></mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mn data-latex="1">1</mn>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mstyle>
+                   <mtext>if&#xA0;</mtext>
+                   <mrow data-mjx-texclass="ORD">
+                     <mi data-latex="x">x</mi>
+                     <mo data-latex="&gt;">&gt;</mo>
+                     <mn data-latex="0">0</mn>
+                   </mrow>
+                   <mtext>&#xA0;</mtext>
+                 </mstyle>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+             <mtd id="mjx-eqn:2">
+               <mtext data-latex="\\text{(2)}">(2)</mtext>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mn data-latex="0">0</mn>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mtext>otherwise&#xA0;</mtext>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('subnumcases', () => {
+    toXmlMatch(
+      tex2mml('\\begin{subnumcases}{f(x)=} 1 & if $x > 0$ \\\\ 0 & otherwise \\end{subnumcases}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{subnumcases}{f(x)=} 1 &amp; if $x &gt; 0$ \\\\ 0 &amp; otherwise \\end{subnumcases}" display="block">
+         <mtable columnalign="right left left left" columnspacing="0em 1em" rowspacing=".2em" data-break-align="top top top" data-latex="\\begin{subnumcases}{f(x)=} 1 &amp; if $x &gt; 0$ \\\\ 0 &amp; otherwise \\end{subnumcases}">
+           <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+             <mtd id="mjx-eqn:1a">
+               <mtext data-latex="\\text{(1a)}">(1a)</mtext>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="f">f</mi>
+                   <mo data-latex="(" stretchy="false">(</mo>
+                   <mi data-latex="x">x</mi>
+                   <mo data-latex=")" stretchy="false">)</mo>
+                   <mo data-latex="=">=</mo>
+                   <mo data-latex="\\mmlToken{mo}{\\U{7B}}">{</mo>
+                   <mspace width="0.167em" data-latex="\\,"></mspace>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top">
+                         <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+                           <mtd>
+                             <mtext data-latex="\\text{(1a)}">(1a)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mn data-latex="1">1</mn>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mstyle>
+                                 <mtext>if&#xA0;</mtext>
+                                 <mrow data-mjx-texclass="ORD">
+                                   <mi data-latex="x">x</mi>
+                                   <mo data-latex="&gt;">&gt;</mo>
+                                   <mn data-latex="0">0</mn>
+                                 </mrow>
+                                 <mtext>&#xA0;</mtext>
+                               </mstyle>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                         <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+                           <mtd>
+                             <mtext data-latex="\\text{(1b)}">(1b)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mn data-latex="0">0</mn>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mtext>otherwise&#xA0;</mtext>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top" align="baseline 1">
+                       <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+                         <mtd>
+                           <mtext data-latex="\\text{(1a)}">(1a)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mn data-latex="1">1</mn>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mstyle>
+                               <mtext>if&#xA0;</mtext>
+                               <mrow data-mjx-texclass="ORD">
+                                 <mi data-latex="x">x</mi>
+                                 <mo data-latex="&gt;">&gt;</mo>
+                                 <mn data-latex="0">0</mn>
+                               </mrow>
+                               <mtext>&#xA0;</mtext>
+                             </mstyle>
+                           </mstyle>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em"></mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mn data-latex="1">1</mn>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mstyle>
+                   <mtext>if&#xA0;</mtext>
+                   <mrow data-mjx-texclass="ORD">
+                     <mi data-latex="x">x</mi>
+                     <mo data-latex="&gt;">&gt;</mo>
+                     <mn data-latex="0">0</mn>
+                   </mrow>
+                   <mtext>&#xA0;</mtext>
+                 </mstyle>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr data-latex-item="{f(x)=}" data-latex="{f(x)=}">
+             <mtd id="mjx-eqn:1b">
+               <mtext data-latex="\\text{(1b)}">(1b)</mtext>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mn data-latex="0">0</mn>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mtext>otherwise&#xA0;</mtext>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases with macro', () => {
+    toXmlMatch(
+      tex2mml('\\begin{numcases}{A=} 1 & if {x\\\\y}\\$ \\end{numcases}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{numcases}{A=} 1 &amp; if {x\\\\y}\\$ \\end{numcases}" display="block">
+         <mtable columnalign="right left left left" columnspacing="0em 1em" rowspacing=".2em" data-break-align="top top top" data-latex="\\begin{numcases}{A=} 1 &amp; if {x\\\\y}\\$ \\end{numcases}">
+           <mlabeledtr data-latex-item="{A=}" data-latex="{A=}">
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="A">A</mi>
+                   <mo data-latex="=">=</mo>
+                   <mo data-latex="\\mmlToken{mo}{\\U{7B}}">{</mo>
+                   <mspace width="0.167em" data-latex="\\,"></mspace>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top">
+                         <mlabeledtr data-latex-item="{A=}" data-latex="{A=}">
+                           <mtd>
+                             <mtext data-latex="\\text{(1)}">(1)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mn data-latex="1">1</mn>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mtext>if {x\\y}$&#xA0;</mtext>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top" align="baseline 1">
+                       <mlabeledtr data-latex-item="{A=}" data-latex="{A=}">
+                         <mtd>
+                           <mtext data-latex="\\text{(1)}">(1)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mn data-latex="1">1</mn>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mtext>if {x\\y}$&#xA0;</mtext>
+                           </mstyle>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em"></mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mn data-latex="1">1</mn>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mtext>if {x\\y}$&#xA0;</mtext>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('numcases extra brace', () => {
+    expectTexError('\\begin{numcases}{A=} x & } \\end{numcases}')
+      .toBe('Extra close brace or missing open brace');
+  });
+
+  /********************************************************************************/
+
+  test('numcases extra column', () => {
+    expectTexError('\\begin{numcases}{A=} x & y & z \\end{numcases}')
+      .toBe('Extra alignment tab in text for numcase environment');
+  });
+
+  /********************************************************************************/
+
+  test('entry not in numcases', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} x & y \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} x &amp; y \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} x &amp; y \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="x">x</mi>
+             </mtd>
+             <mtd>
+               <mi data-latex="y">y</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('numcases with explicit tag', () => {
+    toXmlMatch(
+      tex2mml('\\begin{numcases}{A=} x\\tag{A} & y \\end{numcases}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{numcases}{A=} x\\tag{A} &amp; y \\end{numcases}" display="block">
+         <mtable columnalign="right left left left" columnspacing="0em 1em" rowspacing=".2em" data-break-align="top top top" data-latex="\\begin{numcases}{A=} x\\tag{A} &amp; y \\end{numcases}">
+           <mlabeledtr data-latex-item="{A=}" data-latex="{A=}">
+             <mtd id="mjx-eqn:A">
+               <mtext data-latex="\\text{(A)}">(A)</mtext>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="A">A</mi>
+                   <mo data-latex="=">=</mo>
+                   <mo data-latex="\\mmlToken{mo}{\\U{7B}}">{</mo>
+                   <mspace width="0.167em" data-latex="\\,"></mspace>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top">
+                         <mlabeledtr data-latex-item="{A=}" data-latex="{A=}">
+                           <mtd>
+                             <mtext data-latex="\\text{(A)}">(A)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="\\tag{A}">x</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mtext>y&#xA0;</mtext>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top" align="baseline 1">
+                       <mlabeledtr data-latex-item="{A=}" data-latex="{A=}">
+                         <mtd>
+                           <mtext data-latex="\\text{(A)}">(A)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mi data-latex="\\tag{A}">x</mi>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mtext>y&#xA0;</mtext>
+                           </mstyle>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em"></mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mi data-latex="\\tag{A}">x</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mtext>y&#xA0;</mtext>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('numcases not complete', () => {
+    expectTexError('\\begin{numcases}{A=} x & y\\')
+      .toBe('Missing \\end{numcases}');
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('cases'));

--- a/testsuite/tests/input/tex/Empheq.test.ts
+++ b/testsuite/tests/input/tex/Empheq.test.ts
@@ -1,0 +1,922 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
+import '#js/input/tex/empheq/EmpheqConfiguration';
+import '#js/input/tex/cases/CasesConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
+
+beforeEach(() => setupTex(['base', 'ams', 'empheq', 'cases'], {tags: 'ams'}));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Empheq', () => {
+
+  /********************************************************************************/
+
+  test('Empheq Left', () => {
+    toXmlMatch(
+      tex2mml('\\begin{empheq}[left=L\\Rightarrow]{align} a&=b\\\\ c&=d \\end{empheq}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{empheq}[left=L\\Rightarrow]{align} a&amp;=b\\\\ c&amp;=d \\end{empheq}" display="block">
+         <mtable displaystyle="true" columnalign="right right left" columnspacing="0em 0em" rowspacing="3pt" data-break-align="bottom top" data-latex="\\begin{align} a&amp;=b\\\\ c&amp;=d \\end{empheq}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="L">L</mi>
+                   <mo stretchy="false" data-latex="\\Rightarrow">&#x21D2;</mo>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top">
+                         <mlabeledtr>
+                           <mtd>
+                             <mtext data-latex="\\text{(1)}">(1)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="a">a</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mi></mi>
+                               <mo data-latex="=">=</mo>
+                               <mi data-latex="b">b</mi>
+                             </mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                         <mlabeledtr>
+                           <mtd>
+                             <mtext data-latex="\\text{(2)}">(2)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="c">c</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mi></mi>
+                               <mo data-latex="=">=</mo>
+                               <mi data-latex="d">d</mi>
+                             </mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" align="baseline 1">
+                       <mlabeledtr>
+                         <mtd>
+                           <mtext data-latex="\\text{(1)}">(1)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mi data-latex="a">a</mi>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mi></mi>
+                             <mo data-latex="=">=</mo>
+                             <mi data-latex="b">b</mi>
+                           </mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi></mi>
+                 <mo data-latex="=">=</mo>
+                 <mi data-latex="b">b</mi>
+               </mstyle>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr>
+             <mtd id="mjx-eqn:2">
+               <mtext data-latex="\\text{(2)}">(2)</mtext>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi></mi>
+                 <mo data-latex="=">=</mo>
+                 <mi data-latex="d">d</mi>
+               </mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Empheq Right', () => {
+    toXmlMatch(
+      tex2mml('\\begin{empheq}[right=\\Leftarrow R]{align} a&=b\\\\ c&=d \\end{empheq}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{empheq}[right=\\Leftarrow R]{align} a&amp;=b\\\\ c&amp;=d \\end{empheq}" display="block">
+         <mtable displaystyle="true" columnalign="right left left" columnspacing="0em 0em" rowspacing="3pt" data-break-align="bottom top" data-latex="\\begin{align} a&amp;=b\\\\ c&amp;=d \\end{empheq}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi></mi>
+                 <mo data-latex="=">=</mo>
+                 <mi data-latex="b">b</mi>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mo stretchy="false" data-latex="\\Leftarrow">&#x21D0;</mo>
+                   <mi data-latex="R">R</mi>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top">
+                         <mlabeledtr>
+                           <mtd>
+                             <mtext data-latex="\\text{(1)}">(1)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="a">a</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mi></mi>
+                               <mo data-latex="=">=</mo>
+                               <mi data-latex="b">b</mi>
+                             </mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                         <mlabeledtr>
+                           <mtd>
+                             <mtext data-latex="\\text{(2)}">(2)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="c">c</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mi></mi>
+                               <mo data-latex="=">=</mo>
+                               <mi data-latex="d">d</mi>
+                             </mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" align="baseline 1">
+                       <mlabeledtr>
+                         <mtd>
+                           <mtext data-latex="\\text{(1)}">(1)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mi data-latex="a">a</mi>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mi></mi>
+                             <mo data-latex="=">=</mo>
+                             <mi data-latex="b">b</mi>
+                           </mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr>
+             <mtd id="mjx-eqn:2">
+               <mtext data-latex="\\text{(2)}">(2)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi></mi>
+                 <mo data-latex="=">=</mo>
+                 <mi data-latex="d">d</mi>
+               </mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases with label', () => {
+    toXmlMatch(
+      tex2mml('\\begin{numcases}{A=\\label{test}} a&=b \\end{numcases}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{numcases}{A=\\label{test}} a&amp;=b \\end{numcases}" display="block">
+         <mtable columnalign="right left left left" columnspacing="0em 1em" rowspacing=".2em" data-break-align="top top top" data-latex="\\begin{numcases}{A=\\label{test}} a&amp;=b \\end{numcases}">
+           <mlabeledtr data-latex-item="{A=\\label{test}}" data-latex="{A=\\label{test}}">
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="A">A</mi>
+                   <mo data-latex="\\label{test}">=</mo>
+                   <mo data-latex="\\mmlToken{mo}{\\U{7B}}">{</mo>
+                   <mspace width="0.167em" data-latex="\\,"></mspace>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top">
+                         <mlabeledtr data-latex-item="{A=\\label{test}}" data-latex="{A=\\label{test}}">
+                           <mtd>
+                             <mtext data-latex="\\text{(1)}">(1)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="a">a</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mtext>=b&#xA0;</mtext>
+                             </mstyle>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em"></mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable columnalign="left left left" columnspacing="1em" rowspacing=".2em" data-break-align="top top top" align="baseline 1">
+                       <mlabeledtr data-latex-item="{A=\\label{test}}" data-latex="{A=\\label{test}}">
+                         <mtd>
+                           <mtext data-latex="\\text{(1)}">(1)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mi data-latex="a">a</mi>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em">
+                             <mtext>=b&#xA0;</mtext>
+                           </mstyle>
+                         </mtd>
+                         <mtd>
+                           <mstyle indentshift="2em"></mstyle>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mtext>=b&#xA0;</mtext>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em"></mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases empty right', () => {
+    toXmlMatch(
+      tex2mml('\\begin{empheq}[right=x]{align}  \\end{empheq}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{empheq}[right=x]{align}  \\end{empheq}" display="block">
+         <mtable displaystyle="true" columnalign=" left" columnspacing=" 0em" rowspacing="3pt" data-break-align="" data-latex="\\begin{align}  \\end{empheq}">
+           <mtr>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="x">x</mi>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable displaystyle="true" columnalign="" columnspacing="0em" rowspacing="3pt" data-break-align=""></mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable displaystyle="true" columnalign="" columnspacing="0em" rowspacing="3pt" data-break-align="" align="baseline 1"></mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases empty left', () => {
+    toXmlMatch(
+      tex2mml('\\begin{empheq}[left=x]{multline}  \\end{empheq}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{empheq}[left=x]{multline}  \\end{empheq}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="0em 100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" columnalign="right center" data-latex="\\begin{multline}  \\end{empheq}">
+           <mtr>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="x">x</mi>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true"></mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" align="baseline 1"></mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases ', () => {
+    toXmlMatch(
+      tex2mml('\\begin{empheq}[right=x]{align} a \\\\ b&=c \\end{empheq}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{empheq}[right=x]{align} a \\\\ b&amp;=c \\end{empheq}" display="block">
+         <mtable displaystyle="true" columnalign="right left left" columnspacing="0em 0em" rowspacing="3pt" data-break-align="bottom top" data-latex="\\begin{align} a \\\\ b&amp;=c \\end{empheq}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd></mtd>
+             <mtd>
+               <mpadded height="0" depth="0" voffset="height">
+                 <mpadded height="0" depth="0" voffset="-1height">
+                   <mi data-latex="x">x</mi>
+                   <mphantom>
+                     <mpadded width="0">
+                       <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top">
+                         <mlabeledtr>
+                           <mtd>
+                             <mtext data-latex="\\text{(1)}">(1)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="a">a</mi>
+                           </mtd>
+                         </mlabeledtr>
+                         <mlabeledtr>
+                           <mtd>
+                             <mtext data-latex="\\text{(2)}">(2)</mtext>
+                           </mtd>
+                           <mtd>
+                             <mi data-latex="b">b</mi>
+                           </mtd>
+                           <mtd>
+                             <mstyle indentshift="2em">
+                               <mi></mi>
+                               <mo data-latex="=">=</mo>
+                               <mi data-latex="c">c</mi>
+                             </mstyle>
+                           </mtd>
+                         </mlabeledtr>
+                       </mtable>
+                     </mpadded>
+                   </mphantom>
+                 </mpadded>
+                 <mphantom>
+                   <mpadded width="0">
+                     <mtable displaystyle="true" columnalign="right left" columnspacing="0em" rowspacing="3pt" data-break-align="bottom top" align="baseline 1">
+                       <mlabeledtr>
+                         <mtd>
+                           <mtext data-latex="\\text{(1)}">(1)</mtext>
+                         </mtd>
+                         <mtd>
+                           <mi data-latex="a">a</mi>
+                         </mtd>
+                       </mlabeledtr>
+                     </mtable>
+                   </mpadded>
+                 </mphantom>
+               </mpadded>
+             </mtd>
+           </mlabeledtr>
+           <mlabeledtr>
+             <mtd id="mjx-eqn:2">
+               <mtext data-latex="\\text{(2)}">(2)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="b">b</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi></mi>
+                 <mo data-latex="=">=</mo>
+                 <mi data-latex="c">c</mi>
+               </mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases alignedat', () => {
+    toXmlMatch(
+      tex2mml('\\begin{empheq}{alignat=2} a & b & c & d \\end{empheq}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{empheq}{alignat=2} a &amp; b &amp; c &amp; d \\end{empheq}" display="block">
+         <mtable displaystyle="true" columnalign="right left right left" columnspacing="0em 0em 0em" rowspacing="3pt" data-break-align="bottom top bottom top" data-latex="\\begin{alignat}{2} a &amp; b &amp; c &amp; d \\end{empheq}">
+           <mlabeledtr data-latex-item="{2}" data-latex="{2}">
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi data-latex="b">b</mi>
+               </mstyle>
+             </mtd>
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd>
+               <mstyle indentshift="2em">
+                 <mi data-latex="d">d</mi>
+               </mstyle>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Numcases invalid env', () => {
+    expectTexError('\\begin{empheq}{split} \\end{empheq}')
+      .toBe('Invalid environment "split" for empheq');
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Empheq Characters', () => {
+
+  /********************************************************************************/
+
+  test('empheqlbrace', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlbrace'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlbrace" display="block">
+         <mo data-latex="\\empheqlbrace">{</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlbrace', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlbrace'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlbrace" display="block">
+         <mo data-latex="\\empheqlbrace">{</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrbrace', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrbrace'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrbrace" display="block">
+         <mo data-latex="\\empheqrbrace">}</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlbrack', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlbrack'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlbrack" display="block">
+         <mo data-latex="\\empheqlbrack">[</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrbrack', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrbrack'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrbrack" display="block">
+         <mo data-latex="\\empheqrbrack">]</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlangle', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlangle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlangle" display="block">
+         <mo data-latex="\\empheqlangle">&#x27E8;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrangle', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrangle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrangle" display="block">
+         <mo data-latex="\\empheqrangle">&#x27E9;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlparen', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlparen'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlparen" display="block">
+         <mo data-latex="\\empheqlparen">(</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrparen', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrparen'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrparen" display="block">
+         <mo data-latex="\\empheqrparen">)</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlvert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlvert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlvert" display="block">
+         <mo data-latex="\\empheqlvert">|</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrvert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrvert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrvert" display="block">
+         <mo data-latex="\\empheqrvert">|</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test(' empheqlVert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlVert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlVert" display="block">
+         <mo data-latex="\\empheqlVert">&#x2016;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrVert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrVert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrVert" display="block">
+         <mo data-latex="\\empheqrVert">&#x2016;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlfloor', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlfloor'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlfloor" display="block">
+         <mo data-latex="\\empheqlfloor">&#x230A;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrfloor', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrfloor'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrfloor" display="block">
+         <mo data-latex="\\empheqrfloor">&#x230B;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqlceil', () => {
+    toXmlMatch(
+      tex2mml('\\empheqlceil'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqlceil" display="block">
+         <mo data-latex="\\empheqlceil">&#x2308;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqrceil', () => {
+    toXmlMatch(
+      tex2mml('\\empheqrceil'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqrceil" display="block">
+         <mo data-latex="\\empheqrceil">&#x2309;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglbrace', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglbrace'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglbrace" display="block">
+         <mo data-latex="\\empheqbiglbrace">{</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrbrace', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrbrace'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrbrace" display="block">
+         <mo data-latex="\\empheqbigrbrace">}</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglbrack', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglbrack'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglbrack" display="block">
+         <mo data-latex="\\empheqbiglbrack">[</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrbrack', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrbrack'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrbrack" display="block">
+         <mo data-latex="\\empheqbigrbrack">]</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglangle', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglangle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglangle" display="block">
+         <mo data-latex="\\empheqbiglangle">&#x27E8;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrangle', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrangle'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrangle" display="block">
+         <mo data-latex="\\empheqbigrangle">&#x27E9;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglparen', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglparen'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglparen" display="block">
+         <mo data-latex="\\empheqbiglparen">(</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrparen', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrparen'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrparen" display="block">
+         <mo data-latex="\\empheqbigrparen">)</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglvert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglvert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglvert" display="block">
+         <mo data-latex="\\empheqbiglvert">|</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrvert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrvert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrvert" display="block">
+         <mo data-latex="\\empheqbigrvert">|</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglVert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglVert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglVert" display="block">
+         <mo data-latex="\\empheqbiglVert">&#x2016;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrVert', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrVert'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrVert" display="block">
+         <mo data-latex="\\empheqbigrVert">&#x2016;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglfloor', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglfloor'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglfloor" display="block">
+         <mo data-latex="\\empheqbiglfloor">&#x230A;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrfloor', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrfloor'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrfloor" display="block">
+         <mo data-latex="\\empheqbigrfloor">&#x230B;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbiglceil', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbiglceil'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbiglceil" display="block">
+         <mo data-latex="\\empheqbiglceil">&#x2308;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigrceil', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigrceil'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigrceil" display="block">
+         <mo data-latex="\\empheqbigrceil">&#x2309;</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheql', () => {
+    toXmlMatch(
+      tex2mml('\\empheql('),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheql(" display="block">
+         <mo data-latex="\\empheql(">(</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqr',() => {
+    toXmlMatch(
+      tex2mml('\\empheqr)'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqr)" display="block">
+         <mo data-latex="\\empheqr)">)</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigl', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigl('),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigl(" display="block">
+         <mo data-latex="\\empheqbigl(">(</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('empheqbigr', () => {
+    toXmlMatch(
+      tex2mml('\\empheqbigr)'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\empheqbigr)" display="block">
+         <mo data-latex="\\empheqbigr)">)</mo>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('empheq'));

--- a/ts/input/tex/cases/CasesConfiguration.ts
+++ b/ts/input/tex/cases/CasesConfiguration.ts
@@ -66,7 +66,7 @@ export class CasesTags extends AmsTags {
       this.subcounter++;
       this.tag(this.formatNumber(this.counter, this.subcounter), false);
     } else {
-      if (this.subcounter === 0 || this.currentTag.env !== 'numcases-left') {
+      if (this.currentTag.env !== 'numcases-left') {
         this.counter++;
       }
       this.tag(this.formatNumber(this.counter), false);
@@ -102,7 +102,7 @@ export const CasesMethods = {
       EmpheqUtil.left(
         table,
         original,
-        left + '\\empheqlbrace\\,',
+        left + '\\mmlToken{mo}{\\U{7B}}\\,',
         parser,
         'numcases-left'
       );
@@ -192,7 +192,13 @@ export const CasesMethods = {
         //   characters in the main loop)
         //
         const cs = (tex.slice(i + 1).match(/^[a-z]+|./i) || [])[0];
-        if (cs === '\\' || cs === 'cr' || cs === 'end' || cs === 'label') {
+        if (
+          cs === '\\' ||
+          cs === 'cr' ||
+          cs === 'end' ||
+          cs === 'label' ||
+          cs === undefined
+        ) {
           break;
         } else {
           i += cs.length;

--- a/ts/input/tex/empheq/EmpheqConfiguration.ts
+++ b/ts/input/tex/empheq/EmpheqConfiguration.ts
@@ -58,13 +58,18 @@ export const EmpheqMethods = {
     } else {
       ParseUtil.checkEqnEnv(parser);
       const opts = parser.GetBrackets('\\begin{' + begin.getName() + '}') || '';
-      const [env, n] = (
-        parser.GetArgument('\\begin{' + begin.getName() + '}') || ''
-      ).split(/=/);
+      const [env, n] = parser
+        .GetArgument('\\begin{' + begin.getName() + '}')
+        .split(/=/);
       if (!EmpheqUtil.checkEnv(env)) {
-        throw new TexError('UnknownEnv', 'Unknown environment "%1"', env);
+        throw new TexError(
+          'EmpheqInvalidEnv',
+          'Invalid environment "%1" for %2',
+          env,
+          begin.getName()
+        );
       }
-      begin.setProperty('nestable', true);
+      begin.setProperty('nestStart', true);
       if (opts) {
         begin.setProperties(
           EmpheqUtil.splitOptions(opts, { left: 1, right: 1 })

--- a/ts/input/tex/empheq/EmpheqUtil.ts
+++ b/ts/input/tex/empheq/EmpheqUtil.ts
@@ -164,12 +164,15 @@ export const EmpheqUtil = {
   ) {
     table.attributes.set(
       'columnalign',
-      'right ' + (table.attributes.get('columnalign') || '')
+      'right ' + table.attributes.get('columnalign')
     );
     table.attributes.set(
       'columnspacing',
-      '0em ' + (table.attributes.get('columnspacing') || '')
+      '0em ' + table.attributes.get('columnspacing')
     );
+    if (table.childNodes.length === 0) {
+      table.appendChild(parser.create('node', 'mtr'));
+    }
     let mtd;
     for (const row of table.childNodes.slice(0).reverse()) {
       mtd = parser.create('node', 'mtd');
@@ -202,10 +205,12 @@ export const EmpheqUtil = {
     if (table.childNodes.length === 0) {
       table.appendChild(parser.create('node', 'mtr'));
     }
-    const m = EmpheqUtil.columnCount(table);
     const row = table.childNodes[0];
-    while (row.childNodes.length < m)
+    const m =
+      EmpheqUtil.columnCount(table) + (row.isKind('mlabeledtr') ? 1 : 0);
+    while (row.childNodes.length < m) {
       row.appendChild(parser.create('node', 'mtd'));
+    }
     const mtd = row.appendChild(parser.create('node', 'mtd')) as MmlMtd;
     EmpheqUtil.rowspanCell(mtd, right, original, parser, env);
     table.attributes.set(
@@ -217,7 +222,7 @@ export const EmpheqUtil = {
     );
     table.attributes.set(
       'columnspacing',
-      ((table.attributes.get('columnspacing') as string) || '')
+      (table.attributes.get('columnspacing') as string)
         .split(/ /)
         .slice(0, m - 1)
         .join(' ') + ' 0em'


### PR DESCRIPTION
This PR adds tests for the `cases` and `empheq` packages, and updates their code.

In `CasesConfiguration.ts`,
* The `subnumber` is non-zero only in `subnumcases`, which is handled in the condition above, so technically, this `if` should always be true and could be removed, but we don't really want increment the tag counter during the processing of the left-hand material, so we leave it with that condition only.
* In order to use the `\empheqlbrace` at line 105, we would need to load the `empheq` extension and add it to the `package` list.  Rather than force the user to do that, we use `\mmlToken` to create a stretchy brace instead.
* In line 200, we check that the `cs` is defined, which it might not be if the `\\` is at the end of the line.

In `EmpheqConfiguration.ts`,
* Since `GetArgument()` always returns a string, there is no need for `|| ''`. (line 62)
* The error message at line 65 is adjusted.
* The property `nestStart` is used instead of `nestable` in order to avoid the erroneous nesting message.  This requires the changes to `ParseUtil.ts` that are in the `test-tex` branch.

In `EmpheqUtil.ts`,
* Since `attributes.get()` will return the default value (always a string), there is no need for the `|| ''` (lines 167, 171, and 225).
* We create an empty row if there are no rows at line 173-175.
* At line 210, we skip over the tag cell of an `mlabeledtr` row, and we add braces around the loop.