### PR TITLE
Add tests for the colortbl package, and update its code

### DIFF
--- a/testsuite/tests/input/tex/Colortbl.test.ts
+++ b/testsuite/tests/input/tex/Colortbl.test.ts
@@ -1,0 +1,436 @@
+import { afterAll, beforeEach, describe, test } from '@jest/globals';
+import { getTokens, toXmlMatch, setupTex, tex2mml, expectTexError } from '#helpers';
+import { ColorArrayItem } from '#js/input/tex/colortbl/ColortblConfiguration.js';
+import '#js/input/tex/color/ColorConfiguration.js';
+
+import { Configuration } from '#js/input/tex/Configuration.js';
+import { ConfigurationType } from '#js/input/tex/HandlerTypes.js';
+
+beforeEach(() => setupTex(['base', 'colortbl']));
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Colortbl', () => {
+
+  /********************************************************************************/
+
+  test('cellcolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & \\cellcolor{red} b \\\\ \\cellcolor{yellow} c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; \\cellcolor{red} b \\\\ \\cellcolor{yellow} c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; \\cellcolor{red} b \\\\ \\cellcolor{yellow} c &amp; d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd mathbackground="yellow">
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd>
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor late', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & b \\cellcolor{red} \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; b \\cellcolor{red} \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; b \\cellcolor{red} \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="\\cellcolor{red}">b</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('rowcolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & b \\\\ \\rowcolor{yellow} c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; b \\\\ \\rowcolor{yellow} c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; b \\\\ \\rowcolor{yellow} c &amp; d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd>
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd mathbackground="yellow">
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('rowcolor late', () => {
+    expectTexError('\\begin{array}{cc} a & b \\\\ c & \\rowcolor{yellow} d \\end{array}')
+      .toBe('\\rowcolor must be at the beginning of a row');
+  });
+
+  /********************************************************************************/
+
+  test('columncolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & \\columncolor{yellow} b \\\\ c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; \\columncolor{yellow} b \\\\ c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; \\columncolor{yellow} b \\\\ c &amp; d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('columncolor late', () => {
+    expectTexError('\\begin{array}{cc} a & b \\\\ c & \\columncolor{yellow} d \\end{array}')
+      .toBe('\\columncolor must be in the top row or preamble');
+  });
+
+  /********************************************************************************/
+
+  test('columncolor in preamble', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{c>{\\columncolor{yellow}}c} a & b \\\\ c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c&gt;{\\columncolor{yellow}}c} a &amp; b \\\\ c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\columncolor{yellow}d\\end{array}">
+           <mtr data-latex-item="{c&gt;{\\columncolor{yellow}}c}" data-latex="{c&gt;{\\columncolor{yellow}}c}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{c&gt;{\\columncolor{yellow}}c}" data-latex="{c&gt;{\\columncolor{yellow}}c}">
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor in preamble', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{c>{\\cellcolor{yellow}}c} a & b \\\\ c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{c&gt;{\\cellcolor{yellow}}c} a &amp; b \\\\ c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\cellcolor{yellow}d\\end{array}">
+           <mtr data-latex-item="{c&gt;{\\cellcolor{yellow}}c}" data-latex="{c&gt;{\\cellcolor{yellow}}c}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{c&gt;{\\cellcolor{yellow}}c}" data-latex="{c&gt;{\\cellcolor{yellow}}c}">
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor with rowcolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & b \\\\ \\rowcolor{red} c & \\cellcolor{yellow} d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; b \\\\ \\rowcolor{red} c &amp; \\cellcolor{yellow} d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; b \\\\ \\rowcolor{red} c &amp; \\cellcolor{yellow} d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd>
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd mathbackground="red">
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor with columncolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & \\columncolor{red} b \\\\ c & \\cellcolor{yellow} d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red} b \\\\ c &amp; \\cellcolor{yellow} d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red} b \\\\ c &amp; \\cellcolor{yellow} d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('columncolor and rowcolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & \\columncolor{red} b \\\\ \\rowcolor{yellow} c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red} b \\\\ \\rowcolor{yellow} c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red} b \\\\ \\rowcolor{yellow} c &amp; d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd mathbackground="yellow">
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="yellow">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor with columncolor and rowcolor', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & \\columncolor{red} b \\\\ \\rowcolor{yellow} c & \\cellcolor{green} d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red} b \\\\ \\rowcolor{yellow} c &amp; \\cellcolor{green} d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red} b \\\\ \\rowcolor{yellow} c &amp; \\cellcolor{green} d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd mathbackground="yellow">
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="green">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('columncolor ignore overlap', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{cc} a & \\columncolor{red}[ignore][ignore] b \\\\ c & d \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red}[ignore][ignore] b \\\\ c &amp; d \\end{array}" display="block">
+         <mtable columnspacing="1em" rowspacing="4pt" columnalign="center center" data-frame-styles="" framespacing=".5em .125em" data-latex-item="{array}" data-latex="\\begin{array}{cc} a &amp; \\columncolor{red}[ignore][ignore] b \\\\ c &amp; d \\end{array}">
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="a">a</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="b">b</mi>
+             </mtd>
+           </mtr>
+           <mtr data-latex-item="{cc}" data-latex="{cc}">
+             <mtd>
+               <mi data-latex="c">c</mi>
+             </mtd>
+             <mtd mathbackground="red">
+               <mi data-latex="d">d</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor outside of table', () => {
+    expectTexError('\\cellcolor{red}')
+      .toBe('Unsupported use of \\cellcolor');
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor nested', () => {
+    expectTexError('\\begin{array}{c} \\frac{\\cellcolor{red} a}{b} \\end{array}')
+      .toBe('Unsupported use of \\cellcolor');
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor with frame', () => {
+    toXmlMatch(
+      tex2mml('\\begin{array}{|c|} \\cellcolor{red} a \\end{array}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{array}{|c|} \\cellcolor{red} a \\end{array}" display="block">
+         <menclose notation="left right" data-padding="0" data-latex-item="{array}" data-latex="\\begin{array}{|c|} \\cellcolor{red} a \\end{array}">
+           <mtable columnspacing="1em" rowspacing="4pt" data-frame-styles="" framespacing=".5em .125em">
+             <mtr data-latex-item="{|c|}" data-latex="{|c|}">
+               <mtd mathbackground="red">
+                 <mi data-latex="a">a</mi>
+               </mtd>
+             </mtr>
+           </mtable>
+         </menclose>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor in pmatrix', () => {
+    toXmlMatch(
+      tex2mml('\\pmatrix{ \\cellcolor{red} a }'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\pmatrix{ \\cellcolor{red} a }" display="block">
+         <mrow data-mjx-texclass="INNER" data-latex="\\pmatrix{ \\cellcolor{red} a }">
+           <mo data-mjx-texclass="OPEN">(</mo>
+           <mtable rowspacing="4pt" columnspacing="1em" data-frame-styles="" framespacing=".2em .125em">
+             <mtr data-latex-item="{" data-latex="{">
+               <mtd mathbackground="red">
+                 <mi data-latex="a">a</mi>
+               </mtd>
+             </mtr>
+           </mtable>
+           <mo data-mjx-texclass="CLOSE">)</mo>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('cellcolor with color model', () => {
+    toXmlMatch(
+      tex2mml('\\matrix{ \\cellcolor[rgb]{1,0,0} a }'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\matrix{ \\cellcolor[rgb]{1,0,0} a }" display="block">
+         <mtable rowspacing="4pt" columnspacing="1em" data-frame-styles="" framespacing=".2em .125em" data-latex="\\matrix{ \\cellcolor[rgb]{1,0,0} a }">
+           <mtr data-latex-item="{" data-latex="{">
+             <mtd mathbackground="#ff0000">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    )
+  });
+
+  /********************************************************************************/
+
+  test('color with no frame', () => {
+    class myArrayItem extends ColorArrayItem {
+      createMml() {
+        this.setProperty('arrayPadding', null);
+        return super.createMml();
+      }
+    }
+    Configuration.create('nopadding', {
+      [ConfigurationType.ITEMS]: {array: myArrayItem},
+      [ConfigurationType.PRIORITY]: 20
+    });
+    setupTex(['base', 'colortbl', 'nopadding']);
+    toXmlMatch(
+      tex2mml('\\matrix{ \\cellcolor[rgb]{1,0,0} a }'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\matrix{ \\cellcolor[rgb]{1,0,0} a }" display="block">
+         <mtable rowspacing="4pt" columnspacing="1em" data-frame-styles="" data-latex="\\matrix{ \\cellcolor[rgb]{1,0,0} a }">
+           <mtr data-latex-item="{" data-latex="{">
+             <mtd mathbackground="#ff0000">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+afterAll(() => getTokens('colortbl'));

--- a/ts/input/tex/colortbl/ColortblConfiguration.ts
+++ b/ts/input/tex/colortbl/ColortblConfiguration.ts
@@ -95,6 +95,9 @@ export class ColorArrayItem extends ArrayItem {
     //
     const mml = super.createMml();
     let table = mml.isKind('mrow') ? mml.childNodes[1] : mml;
+    if (table.isKind('mstyle')) {
+      table = table.childNodes[0].childNodes[0];
+    }
     if (table.isKind('menclose')) {
       table = table.childNodes[0].childNodes[0];
     }
@@ -180,7 +183,7 @@ new CommandMap('colortbl', {
  */
 const config = function (config: ParserConfiguration, jax: TeX<any, any, any>) {
   //
-  //  Make sure color is configured.  (It doesn't have to be included in tex.packages.)
+  //  Make sure color is configured.  (It doesn't have to be included in tex.packages)
   //
   if (!jax.parseOptions.packageData.has('color')) {
     ConfigurationHandler.get('color').config(config, jax);
@@ -190,10 +193,12 @@ const config = function (config: ParserConfiguration, jax: TeX<any, any, any>) {
 //
 //  Create the color-table configuration.
 //
-/* prettier-ignore */
+// Use priority 10 to make sure we are processed after the base package
+// (to override its array and config)
+//
 export const ColortblConfiguration = Configuration.create('colortbl', {
-  [ConfigurationType.HANDLER]: {[HandlerType.MACRO]: ['colortbl']},
-  [ConfigurationType.ITEMS]: {'array': ColorArrayItem},  // overrides original array class
-  [ConfigurationType.PRIORITY]: 10,                      // make sure we are processed after the base package (to override its array)
-  [ConfigurationType.CONFIG]: [config, 10]               // make sure we configure after the color package, if it is used.
+  [ConfigurationType.HANDLER]: { [HandlerType.MACRO]: ['colortbl'] },
+  [ConfigurationType.ITEMS]: { array: ColorArrayItem }, // overrides original array class
+  [ConfigurationType.PRIORITY]: 10,
+  [ConfigurationType.CONFIG]: [config, 10],
 });


### PR DESCRIPTION
This PR adds tests for the `colortbl` package.  The `ColortblConfiguration.ts` file adds lines 98-100 to skip over an `mstyle` that may have been added to set the `scriptlevel` for the table.  The comments from the configuration object itself are moved to before it so that prettier can be run on the configuration.