### PR TITLE
Update test format for the noundefined package and fix coverage

### DIFF
--- a/testsuite/tests/input/tex/Noundefined.test.ts
+++ b/testsuite/tests/input/tex/Noundefined.test.ts
@@ -4,21 +4,38 @@ import '#js/input/tex/noundefined/NoUndefinedConfiguration';
 
 beforeEach(() => setupTex(['base', 'noundefined']));
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('Noundefined', () => {
-  it('Noundefined Single', () =>
+
+  /********************************************************************************/
+
+  it('Noundefined Single', () => {
     toXmlMatch(
       tex2mml('\\a'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\a" display="block">
-  <mtext mathcolor="red" data-latex="\\a">\\a</mtext>
-</math>`
-    ));
-  it('Noundefined Context', () =>
+         <mtext mathcolor="red" data-latex="\\a">\\a</mtext>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Noundefined Context', () => {
     toXmlMatch(
       tex2mml('a\\b c'),
       `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="a\\b c" display="block">
-  <mi data-latex="a">a</mi>
-  <mtext mathcolor="red" data-latex="\\b">\\b</mtext>
-  <mi data-latex="c">c</mi>
-</math>`
-    ));
+         <mi data-latex="a">a</mi>
+         <mtext mathcolor="red" data-latex="\\b">\\b</mtext>
+         <mi data-latex="c">c</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/ts/input/tex/noundefined/NoUndefinedConfiguration.ts
+++ b/ts/input/tex/noundefined/NoUndefinedConfiguration.ts
@@ -34,7 +34,7 @@ import TexParser from '../TexParser.js';
  */
 function noUndefined(parser: TexParser, name: string) {
   const textNode = parser.create('text', '\\' + name);
-  const options = parser.options.noundefined || {};
+  const options = parser.options.noundefined;
   const def = {} as { [name: string]: string };
   for (const id of ['color', 'background', 'size']) {
     if (options[id]) {


### PR DESCRIPTION
This PR updates the tests for the `noundefined` package.  It also removes `|| {}` in its configuration, since the `parser.options.noundefined` will always be defined when the package is initialized.