### PR TITLE
Add tests for the setoptions package and fix code

### DIFF
--- a/testsuite/tests/input/tex/Setoptions.test.ts
+++ b/testsuite/tests/input/tex/Setoptions.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, test } from '@jest/globals';
+import {
+  toXmlMatch,
+  setupTex,
+  setupTexTypeset,
+  tex2mml,
+  typeset2mml,
+  setupComponents,
+  expectTexError
+} from '#helpers';
+import '#js/input/tex/setoptions/SetoptionsConfiguration';
+import '#js/input/tex/ams/AmsConfiguration';
+import '#js/input/tex/units/UnitsConfiguration';
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Setoptions', () => {
+
+  beforeEach(() => setupTex(['base', 'ams', 'units', 'setoptions']));
+
+  /********************************************************************************/
+
+  test('Set TeX option', () => {
+    toXmlMatch(
+      tex2mml('\\setOptions{tagSide=left} a=b\\tag{1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions{tagSide=left} a=b\\tag{1}" display="block">
+         <mtable side="left" displaystyle="true" data-latex="\\setOptions{tagSide=left} a=b\\tag{1}">
+           <mlabeledtr>
+             <mtd id="mjx-eqn:1">
+               <mtext data-latex="\\text{(1)}">(1)</mtext>
+             </mtd>
+             <mtd>
+               <mi data-latex="a">a</mi>
+               <mo data-latex="=">=</mo>
+               <mi data-latex="\\tag{1}">b</mi>
+             </mtd>
+           </mlabeledtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Set invalid option', () => {
+    expectTexError('\\setOptions{x=y}')
+      .toBe('Invalid TeX option "x"');
+  });
+
+  /********************************************************************************/
+
+  test('Set prohibited option', () => {
+    expectTexError('\\setOptions{tags=all}')
+      .toBe('Option "tags" is not allowed to be set');
+  });
+
+  /********************************************************************************/
+
+  test('Set invalid package', () => {
+    expectTexError('\\setOptions[abc]{x=y}')
+      .toBe('Not a defined package: abc');
+  });
+
+  /********************************************************************************/
+
+  test('Set prohibited package', () => {
+    expectTexError('\\setOptions[setoptions]{setoptions=true}')
+      .toBe(`Options can't be set for package "setoptions"`);
+  });
+
+  /********************************************************************************/
+
+  test('Set package string option', () => {
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="50%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}">
+           <mtr>
+             <mtd columnalign="left">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Set package boolean option', () => {
+    toXmlMatch(
+      tex2mml('\\setOptions[units]{loose=true} \\units[1]{kg}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[units]{loose=true} \\units[1]{kg}" display="block">
+         <mn data-latex="1">1</mn>
+         <mtext data-latex="~">&#xA0;</mtext>
+         <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{kg}">
+           <mi data-mjx-auto-op="false" data-latex="kg">kg</mi>
+         </mrow>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Set pacjage regexp option', () => {
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{operatornamePattern=/^[a-z0-9]+/} \\operatorname{ab1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{operatornamePattern=/^[a-z0-9]+/} \\operatorname{ab1}" display="block">
+         <mi data-latex="\\setOptions[ams]{operatornamePattern=/^[a-z0-9]+/} \\operatorname{ab1}">ab1</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Set regexp option with flags', () => {
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{operatornamePattern=/^[a-z0-9]+/i} \\operatorname{ab1}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{operatornamePattern=/^[a-z0-9]+/i} \\operatorname{ab1}" display="block">
+         <mi data-latex="\\setOptions[ams]{operatornamePattern=/^[a-z0-9]+/i} \\operatorname{ab1}">ab1</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Set invalid package option', () => {
+    expectTexError('\\setOptions[ams]{x=y}')
+      .toBe('Invalid option "x" for package "ams"');
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Setoptions options', () => {
+
+  /********************************************************************************/
+
+  test('allowPackageDefault false',() => {
+    setupTex(['base', 'ams', 'setoptions'], {setoptions: {allowPackageDefault: false}});
+    expectTexError('\\setOptions[ams]{multlineWidth=50%}')
+      .toBe(`Options can't be set for package "ams"`);
+  });
+
+  /********************************************************************************/
+
+  test('allowPackageDefault false ams true',() => {
+    setupTex(['base', 'ams', 'setoptions'], {
+      setoptions: {
+        allowPackageDefault: false,
+        allowOptions: {ams: true}
+      }
+    });
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="50%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}">
+           <mtr>
+             <mtd columnalign="left">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('allowOptionsDefault false',() => {
+    setupTex(['base', 'ams', 'setoptions'], {setoptions: {allowOptionsDefault: false}});
+    expectTexError('\\setOptions[ams]{multlineWidth=50%}')
+      .toBe('Option "multlineWidth" is not allowed to be set for package ams');
+  });
+
+  /********************************************************************************/
+
+  test('allowOptionsDefault false ams true',() => {
+    setupTex(['base', 'ams', 'setoptions'], {
+      setoptions: {
+        allowOptionsDefault: false,
+        allowOptions: {ams: true}
+      }
+    });
+    expectTexError('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}')
+      .toBe('Option "multlineWidth" is not allowed to be set for package ams');
+  });
+
+  /********************************************************************************/
+
+  test('allowOptionsDefault false ams multlineWidth true',() => {
+    setupTex(['base', 'ams', 'setoptions'], {
+      setoptions: {
+        allowOptionsDefault: false,
+        allowOptions: {
+          ams: {multlineWidth: true}
+        }
+      }
+    });
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="50%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}">
+           <mtr>
+             <mtd columnalign="left">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+    expectTexError('\\setOptions[ams]{multlineIndent=50%} \\begin{multline} a \\end{multline}')
+      .toBe('Option "multlineIndent" is not allowed to be set for package ams');
+  });
+
+  /********************************************************************************/
+
+  test('filterPackage',() => {
+    setupTex(['base', 'ams', 'setoptions'], {
+      setoptions: {
+        filterPackage: (_parser: any, _extension: string) => false
+      }
+    });
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}">
+           <mtr>
+             <mtd columnalign="left">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('filterOption',() => {
+    setupTex(['base', 'ams', 'setoptions'], {
+      setoptions: {
+        filterOption: (_parser: any, _extension: string, _key: string) => false
+      }
+    });
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="100%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}">
+           <mtr>
+             <mtd columnalign="left">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('filterValue',() => {
+    setupTex(['base', 'ams', 'setoptions'], {
+      setoptions: {
+        filterValue: (_parser: any, _extension: string, _option: string, _value: string) => '25%'
+      }
+    });
+    toXmlMatch(
+      tex2mml('\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}" display="block">
+         <mtable displaystyle="true" rowspacing=".5em" columnspacing="100%" width="25%" data-array-padding="1em 1em" data-width-includes-label="true" data-latex-item="{multline}" data-latex="\\setOptions[ams]{multlineWidth=50%} \\begin{multline} a \\end{multline}">
+           <mtr>
+             <mtd columnalign="left">
+               <mi data-latex="a">a</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/
+
+describe('Setoptions Require', () => {
+
+  setupComponents({
+    loader: {load: ['input/tex-base', '[tex]/require']}
+  });
+
+  beforeEach(() => setupTexTypeset(['base', 'require', 'setoptions']));
+
+  /********************************************************************************/
+
+  test('Require', async () => {
+    toXmlMatch(
+      await typeset2mml('\\require{bbox} \\bbox[red]{x}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\require{bbox} \\bbox[red]{x}" display="block">
+         <mstyle mathbackground="red" data-latex="\\Require{bbox}\\setOptions[bbox]{} \\bbox[red]{x}">
+           <mi data-latex="x">x</mi>
+         </mstyle>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  test('Require with option', async () => {
+    toXmlMatch(
+      await typeset2mml('\\require[ugly=true]{units} \\nicefrac{a}{b}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\require[ugly=true]{units} \\nicefrac{a}{b}" display="block">
+         <mfrac data-latex="\\Require{units}\\setOptions[units]{ugly=true} \\nicefrac{a}{b}">
+           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{a}">
+             <mi mathvariant="normal" data-latex="a">a</mi>
+           </mrow>
+           <mrow data-mjx-texclass="ORD" data-latex="\\mathrm{b}">
+             <mi mathvariant="normal" data-latex="b">b</mi>
+           </mrow>
+         </mfrac>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+});
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/ts/input/tex/setoptions/SetOptionsConfiguration.ts
+++ b/ts/input/tex/setoptions/SetOptionsConfiguration.ts
@@ -35,6 +35,7 @@ import { ParseUtil } from '../ParseUtil.js';
 import { Macro } from '../Token.js';
 import BaseMethods from '../base/BaseMethods.js';
 import { expandable, isObject } from '../../../util/Options.js';
+import { PrioritizedList } from '../../../util/PrioritizedList.js';
 
 export const SetOptionsUtil = {
   /**
@@ -42,7 +43,7 @@ export const SetOptionsUtil = {
    *
    * @param {TexParser} parser   The active tex parser.
    * @param {string} extension   The name of the package whose option is being set.
-   * @returns {boolean}           True when options can be set for this package.
+   * @returns {boolean}          True when options can be set for this package.
    */
   filterPackage(parser: TexParser, extension: string): boolean {
     if (extension !== 'tex' && !ConfigurationHandler.get(extension)) {
@@ -69,23 +70,32 @@ export const SetOptionsUtil = {
    * @param {TexParser} parser   The active tex parser.
    * @param {string} extension   The name of the package whose option is being set.
    * @param {string} option      The name of the option being set.
-   * @returns {boolean}           True when the option can be set.
+   * @returns {boolean}          True when the option can be set.
    */
   filterOption(parser: TexParser, extension: string, option: string): boolean {
     const config = parser.options.setoptions;
     const options = config.allowOptions[extension] || {};
+    const isTex = extension === 'tex';
     const allow =
       Object.hasOwn(options, option) && !isObject(options[option])
         ? options[option]
         : null;
     if (allow === false || (allow === null && !config.allowOptionsDefault)) {
-      throw new TexError(
-        'OptionNotSettable',
-        'Option "%1" is not allowed to be set',
-        option
-      );
+      if (isTex) {
+        throw new TexError(
+          'TeXOptionNotSettable',
+          'Option "%1" is not allowed to be set',
+          option
+        );
+      } else {
+        throw new TexError(
+          'OptionNotSettable',
+          'Option "%1" is not allowed to be set for package %2',
+          option,
+          extension
+        );
+      }
     }
-    const isTex = extension === 'tex';
     const extOptions = isTex ? parser.options : parser.options[extension];
     if (!extOptions || !Object.hasOwn(extOptions, option)) {
       if (isTex) {
@@ -109,19 +119,23 @@ export const SetOptionsUtil = {
   /**
    * Verify an option's value before setting it.
    *
-   * @param {TexParser} _parser   The active tex parser.
-   * @param {string} _extension   The name of the package whose option this is.
-   * @param {string} _option      The name of the option being set.
-   * @param {string} value       The value to give to the option.
-   * @returns {string}            The (possibly modified) value for the option
+   * @param {TexParser} _parser            The active tex parser.
+   * @param {string} _extension            The name of the package whose option this is.
+   * @param {string} _option               The name of the option being set.
+   * @param {string} value                 The value to give to the option.
+   * @returns {string | boolean | RegExp}  The (possibly modified) value for the option
    */
   filterValue(
     _parser: TexParser,
     _extension: string,
     _option: string,
     value: string
-  ): string {
-    return value;
+  ): string | boolean | RegExp {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const match = value.match(/^\/(.*)\/([dgimsuvy]*)$/);
+    return match ? new RegExp(match[1], match[2]) : value;
   },
 };
 
@@ -145,10 +159,6 @@ function SetOptions(parser: TexParser, name: string) {
   parser.Push(parser.itemFactory.create('null'));
 }
 
-const setOptionsMap = new CommandMap('setoptions', {
-  setOptions: SetOptions,
-});
-
 /**
  * If the require package is available, save the original require,
  *   and define a macro that loads the extension and sets
@@ -161,9 +171,12 @@ function setoptionsConfig(
   _config: ParserConfiguration,
   jax: TeX<any, any, any>
 ) {
-  const require = jax.parseOptions.handlers
-    .get(HandlerType.MACRO)
-    .lookup('require') as any;
+  const setOptionsMap = new CommandMap('setoptions', {
+    setOptions: SetOptions,
+  });
+  const macros = jax.parseOptions.handlers.get(HandlerType.MACRO);
+  macros.add(['setoptions'], null, PrioritizedList.DEFAULTPRIORITY - 1); // put it in front of the standard maps
+  const require = macros.lookup('require') as any;
   if (require) {
     setOptionsMap.add('Require', new Macro('Require', require._func));
     setOptionsMap.add(
@@ -178,7 +191,6 @@ function setoptionsConfig(
 }
 
 export const SetOptionsConfiguration = Configuration.create('setoptions', {
-  [ConfigurationType.HANDLER]: { macro: ['setoptions'] },
   [ConfigurationType.CONFIG]: setoptionsConfig,
   [ConfigurationType.PRIORITY]: 3, // must be less than the priority of the require package (which is 5).
   /* prettier-ignore */


### PR DESCRIPTION
This PR adds tests for the `setoptions` package, and updates its configuration file.

The changes to the configuration include:
* Breaking the error message at 82-86 into two messages, one for the TeX options, and one for package options, mirroring the messages in (original) lines 91-103.
* To do that, the `isTex`variable is moved earlier to line 78.
* The `filterValue()` function is extended to handle RegExp values (like the one for the ams parameter `operatornamePattern`).
* The `setoptions` command map is now created within the `setoptionsConfig()` function.  This means that the map will be recreated for each instance of the `setoptions` package, so if there are two TeX input jax created, one with `[tex]/require` includes and one without it, the first will get the updated `\require` macro that allows options, while the second will have the original `\require`.  The original version would have shared the `setoptions` map between the two, so both would get the updated `\require`.