### PR TITLE
Add tests for util/context.ts and fix coverage for asyncLoad

### DIFF
--- a/testsuite/tests/util/Context-browser.test.ts
+++ b/testsuite/tests/util/Context-browser.test.ts
@@ -1,0 +1,14 @@
+import { describe, test, expect } from '@jest/globals';
+
+const window = {document: {}};
+(global as any).window = window;
+
+describe('context object', () => {
+
+  test('context', async () => {
+    let {context, hasWindow} = await import("#js/util/context.js");
+    expect(context).toEqual({window: window, document: window.document});
+    expect(hasWindow).toBe(true);
+  });
+
+});

--- a/testsuite/tests/util/Context-node.test.ts
+++ b/testsuite/tests/util/Context-node.test.ts
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+import { context, hasWindow } from '#js/util/context.js';
+
+describe('context object', () => {
+
+  test('context', () => {
+    expect(context).toEqual({window: null, document: null});
+    expect(hasWindow).toBe(false);
+  });
+
+});

--- a/ts/util/asyncLoad/esm.ts
+++ b/ts/util/asyncLoad/esm.ts
@@ -31,9 +31,7 @@ let root = new URL(import.meta.url).href.replace(
 if (!mathjax.asyncLoad) {
   mathjax.asyncLoad = async (name: string) => {
     const file = name.charAt(0) === '.' ? new URL(name, root).pathname : name;
-    return import(file).then((result) =>
-      result.default === undefined ? result : result.default
-    );
+    return import(file).then((result) => result.default ?? result);
   };
 }
 

--- a/ts/util/asyncLoad/esm.ts
+++ b/ts/util/asyncLoad/esm.ts
@@ -31,7 +31,9 @@ let root = new URL(import.meta.url).href.replace(
 if (!mathjax.asyncLoad) {
   mathjax.asyncLoad = async (name: string) => {
     const file = name.charAt(0) === '.' ? new URL(name, root).pathname : name;
-    return import(file).then((result) => result?.default || result);
+    return import(file).then((result) =>
+      result.default === undefined ? result : result.default
+    );
   };
 }
 

--- a/ts/util/asyncLoad/system.ts
+++ b/ts/util/asyncLoad/system.ts
@@ -33,9 +33,7 @@ if (!mathjax.asyncLoad && typeof System !== 'undefined' && System.import) {
     const file = (
       name.charAt(0) === '.' ? new URL(name, root) : new URL(name, 'file://')
     ).href;
-    return System.import(file).then((result: any) =>
-      result.default === undefined ? result : result.default
-    );
+    return System.import(file).then((result: any) => result.default ?? result);
   };
 }
 

--- a/ts/util/asyncLoad/system.ts
+++ b/ts/util/asyncLoad/system.ts
@@ -33,7 +33,9 @@ if (!mathjax.asyncLoad && typeof System !== 'undefined' && System.import) {
     const file = (
       name.charAt(0) === '.' ? new URL(name, root) : new URL(name, 'file://')
     ).href;
-    return System.import(file).then((result: any) => result?.default || result);
+    return System.import(file).then((result: any) =>
+      result.default === undefined ? result : result.default
+    );
   };
 }
 


### PR DESCRIPTION
This PR adds a `Context-browser.test.ts` file that tests the `ts/util/context.ts` file in a browser by including a fake `window` object, and a `Context-node.test.ts` to test `ts/util/context.ts` when used in node.

Also, two `asyncLoad` files are adjusted so that the coverage is properly computed.