### PR TITLE
Some fixes for the separation of speech from enrichment

### DIFF
--- a/components/mjs/a11y/speech/config.json
+++ b/components/mjs/a11y/speech/config.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "component": "a11y/speech",
-    "targets": ["a11y/speech.ts", "a11y/speech"]
+    "targets": ["a11y/speech.ts", "a11y/speech"],
+    "exclude": ["a11y/speech/SpeechMenu.ts"]
   },
   "webpack": {
     "name": "a11y/speech",

--- a/components/mjs/a11y/speech/speech.js
+++ b/components/mjs/a11y/speech/speech.js
@@ -1,8 +1,7 @@
 import './lib/speech.js';
 
 import {SpeechHandler} from '#js/a11y/speech.js';
-import {hasWindow} from '#js/util/context.js';
 
-if (MathJax.startup && hasWindow) {
+if (MathJax.startup) {
   MathJax.startup.extendHandler(handler => SpeechHandler(handler));
 }

--- a/components/mjs/dependencies.js
+++ b/components/mjs/dependencies.js
@@ -17,8 +17,9 @@
 
 export const dependencies = {
   'a11y/semantic-enrich': ['input/mml', 'a11y/sre'],
+  'a11y/speech': ['a11y/semantic-enrich'],
   'a11y/complexity': ['a11y/semantic-enrich'],
-  'a11y/explorer': ['a11y/semantic-enrich'],
+  'a11y/explorer': ['a11y/speech'],
   '[mml]/mml3': ['input/mml'],
   '[tex]/action': ['input/tex-base', '[tex]/newcommand'],
   '[tex]/ams': ['input/tex-base'],

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -39,7 +39,6 @@ import { MathML } from '../input/mathml.js';
 import { SerializedMmlVisitor } from '../core/MmlTree/SerializedMmlVisitor.js';
 import { OptionList, expandable } from '../util/Options.js';
 import * as Sre from './sre.js';
-import { GeneratorPool } from './speech/GeneratorPool.js';
 
 /*==========================================================================*/
 
@@ -109,9 +108,9 @@ export class enrichVisitor<N, T, D> extends SerializedMmlVisitor {
  */
 export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
   /**
-   * The speech generators for this math item.
+   * The serialization visitor
    */
-  generatorPool: GeneratorPool<N, T, D>;
+  toMathML: (node: MmlNode, math: MathItem<N, T, D>) => string;
 
   /**
    * @param {MathDocument} document  The document where enrichment is occurring
@@ -149,10 +148,6 @@ export function EnrichedMathItemMixin<
   toMathML: (node: MmlNode, math: MathItem<N, T, D>) => string
 ): Constructor<EnrichedMathItem<N, T, D>> & B {
   return class extends BaseMathItem {
-    /**
-     * @override
-     */
-    public generatorPool = new GeneratorPool<N, T, D>();
 
     /**
      *  The MathML serializer
@@ -196,7 +191,7 @@ export function EnrichedMathItemMixin<
         try {
           let mml;
           if (!this.inputData.originalMml) {
-            mml = this.inputData.originalMml = toMathML(this.root, this);
+            mml = this.inputData.originalMml = this.toMathML(this.root, this);
           } else {
             mml = this.adjustSelections();
           }
@@ -326,11 +321,6 @@ export function EnrichedMathDocumentMixin<
         braille: 'nemeth',                 // TODO: Dummy switch for braille
         structure: true,                   // Generates full aria structure
         aria: true,
-      }),
-      /* prettier-ignore */
-      a11y: expandable({
-        speech: true,                      // switch on speech output
-        braille: true,                     // switch on Braille output
       }),
     };
 


### PR DESCRIPTION
Here are some changes that I would make to your separation of enhancement from speech.

* I've removed the `SpeechMenu.js` file from the speech component, as that would cause the menu code to be included in the speech component, and you could get two conflicting copies of it if both the speech and menu components are loaded (though a combined component should be OK).

* I removed the check for `hasWindow` from the speech component, as that would prevent it from working in node applications.  (Of course, you will need my node updates in order for that to work.)

* I added the semantic-enrich dependency for the speech component, and made the explorer dependent on the speech extension.  These might have been the source of the problem you were having, but I'm not sure.

* I removed the generator pool from the semantic-enrich code, since it is not used there, and I think it would have caused unneeded duplicate creations of the pools.

* I moved the `a11y` options to the speech code, as that is where they are used.

* I removed the duplicate `sre` options from the speech code, as they are already in the `EnhanceDocument` on which the `SpeechDocument` is based, so don't need to be set again.  These are used in the enhancement process, so need to remain in the enhanced document, but if there are any that aren't used there, they could be moved to the speech document.  But since you can specify deep speech during enhancement, I think they are all needed there, right?

* I removed the visitor and `toMathML` code from the speech file, and use the `toMathML` that is already in the enhanced MathItem.

* Finally, I did remove the asynchronous speech code.

After these changes, it all seems to work for me, both in the lab, and in stand-alone pages with lots of math using laxy loading.  See if that works better for you.