### PR TITLE
Fix position adjustment for scaled svg items with ids

### DIFF
--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -551,7 +551,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       return y;
     }
     const adaptor = this.adaptor;
-    const h = this.getBBox().h;
+    const {h, rscale} = this.getBBox();
     //
     //  Remove the element's children and put them into a <g> with transform
     //
@@ -570,7 +570,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       this.svg('text', { 'data-id-align': true }, [this.text('')])
     );
     adaptor.append(this.dom[0], g);
-    return y + h;
+    return y + h * rscale;
   }
 
   /**

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -551,7 +551,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       return y;
     }
     const adaptor = this.adaptor;
-    const {h, rscale} = this.getBBox();
+    const { h, rscale } = this.getBBox();
     //
     //  Remove the element's children and put them into a <g> with transform
     //


### PR DESCRIPTION
This PR fixes an issue where superscripts (or other scaled items) that have IDs are not positioned properly in SVG output.  For example, `10^4` has the 4 too high.  This is due to the correction being done to try to allow elements with IDs to be targets of a link and have the browser scroll to them properly.  Unfortunately, the position adjustement wasn't being properly scaled.