### PR TITLE
Change order of root and radicand. (mathjax/MathJax#3335)

### DIFF
--- a/ts/output/svg/Wrappers/msqrt.ts
+++ b/ts/output/svg/Wrappers/msqrt.ts
@@ -180,14 +180,14 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
       //  Create the SVG structure for the root
       //
       const SVG = this.standardSvgNodes(parents);
+      surd.toSVG(SVG);
+      const dx = this.addRoot(SVG, root, sbox, H);
       const BASE = this.adaptor.append(SVG[0], this.svg('g')) as N;
+      base.toSVG([BASE]);
       //
       //  Place the children
       //
-      const dx = this.addRoot(SVG, root, sbox, H);
-      surd.toSVG(SVG);
       surd.place(dx, H - sbox.h);
-      base.toSVG([BASE]);
       base.place(dx + sbox.w, 0);
       this.adaptor.append(
         SVG[SVG.length - 1],


### PR DESCRIPTION
This PR changes the order of the root and the radicand in the SVG output for `mroot` elements, as requested by the AMS in mathjax/MathJax#3335.