### PR TITLE
Update default spacing for mo elements that aren't in the operator dictionary (mathjax/MathJax#3288)

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -142,7 +142,7 @@ export class MmlMo extends AbstractMmlTokenNode {
    */
   /* prettier-ignore */
   /* eslint-disable no-misleading-character-class */
-  protected static mathaccents = new RegExp([
+  public static mathaccents = new RegExp([
     '^[',
     '\u00B4\u0301\u02CA',  // acute
     '\u0060\u0300\u02CB',  // grave
@@ -439,6 +439,7 @@ export class MmlMo extends AbstractMmlTokenNode {
     if (def) {
       return def;
     }
+    this.setProperty('noDictDef', true);
     const limits = this.attributes.get('movablelimits');
     const isOP = !!mo.match(CLASS.opPattern);
     if ((isOP || limits) && this.getProperty('texClass') === undefined) {

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -66,16 +66,17 @@ export type StringMap = { [key: string]: string };
 /**
  * MathML spacing rules
  */
-/* prettier-ignore */
-const SMALLSIZE = 2/18;
+const SMALLSIZE = 2 / 18;
+const MOSPACE = 5 / 18;
 
 /**
  * @param {boolean} script   The scriptlevel
+ * @param {boolean} nodict   True if the mo text is not in the operator dictionary
  * @param {number} size      The space size
- * @returns {number}          The size clamped to SMALLSIZE when scriptlevel > 0
+ * @returns {number}         The size clamped to SMALLSIZE when scriptlevel > 0
  */
-function MathMLSpace(script: boolean, size: number): number {
-  return script ? (size < SMALLSIZE ? 0 : SMALLSIZE) : size;
+function MathMLSpace(script: boolean, nodict: boolean, size: number): number {
+  return nodict ? MOSPACE : script ? (size < SMALLSIZE ? 0 : SMALLSIZE) : size;
 }
 
 /**
@@ -1053,14 +1054,15 @@ export class CommonWrapper<
     //
     // Get the lspace and rspace
     //
+    const noDictDef = node.getProperty('noDictDef');
     const attributes = node.attributes;
     const isScript = (attributes.get('scriptlevel') as number) > 0;
     this.bbox.L = attributes.isSet('lspace')
       ? Math.max(0, this.length2em(attributes.get('lspace')))
-      : MathMLSpace(isScript, node.lspace);
+      : MathMLSpace(isScript, noDictDef as boolean, node.lspace);
     this.bbox.R = attributes.isSet('rspace')
       ? Math.max(0, this.length2em(attributes.get('rspace')))
-      : MathMLSpace(isScript, node.rspace);
+      : MathMLSpace(isScript, noDictDef as boolean, node.rspace);
     //
     // If there are two adjacent <mo>, use enough left space to make it
     //   the maximum of the rspace of the first and lspace of the second


### PR DESCRIPTION
This PR fixes an issue with operator spacing when MathML spacing is being used and the operator isn't found in the operator dictionary.  The work done to find the TeX class for such operators interfered with the spacing in MathML spacing mode.  Here, we mark such nodes with a property that can be used to help determine the MathML spacing.

Resolve issue mathjax/MathJax#3288.