### PR TITLE
Fix incorrect character for \char`\x (was incorrectly set to \char'\x)

### DIFF
--- a/testsuite/tests/input/tex/Unicode.test.ts
+++ b/testsuite/tests/input/tex/Unicode.test.ts
@@ -231,22 +231,22 @@ describe('Unicode others', () => {
 
   it('Char alpha', () => {
     toXmlMatch(
-      tex2mml('\\char\'A'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\char'A" display="block">
-         <mi data-latex="\\char'A">A</mi>
-       </math>`
-    );
+      tex2mml('\\char`A'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\char\`A" display="block">
+        <mi data-latex="\\char\`A">A</mi>
+      </math>`
+    )
   });
 
   /********************************************************************************/
 
   it('Char command number', () => {
     toXmlMatch(
-      tex2mml('\\char\'\\3'),
-      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\char'\\3" display="block">
-         <mn data-latex="\\char'\\3">3</mn>
+      tex2mml('\\char`\\3'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\char\`\\3" display="block">
+        <mn data-latex="\\char\`\\3">3</mn>
        </math>`
-    );
+    )
   });
 
   /********************************************************************************/
@@ -306,7 +306,7 @@ describe('Unicode Errors', () => {
   /********************************************************************************/
 
   it('Unicode InvalidAlphanumeric', () => {
-    expectTexError('\\char\'\\nix')
+    expectTexError('\\char`\\nix')
       .toBe('Invalid alphanumeric constant for \\char');
   });
 

--- a/ts/input/tex/unicode/UnicodeConfiguration.ts
+++ b/ts/input/tex/unicode/UnicodeConfiguration.ts
@@ -134,12 +134,20 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
     let c = '';
     const text = parser.string.substring(parser.i);
     if (next === "'") {
-      match = text.match(/^'(?:([0-7]{1,7}) ?|(\\\S)|(.))/u);
+      match = text.match(/^'([0-7]{1,7}) ?/u);
       if (match) {
-        if (match[1]) {
-          c = String.fromCodePoint(parseInt(match[1], 8));
-        } else if (match[3]) {
-          c = match[3];
+        c = String.fromCodePoint(parseInt(match[1], 8));
+      }
+    } else if (next === '"') {
+      match = text.match(/^"([0-9A-F]{1,6}) ?/);
+      if (match) {
+        c = String.fromCodePoint(parseInt(match[1], 16));
+      }
+    } else if (next === '`') {
+      match = text.match(/^`(?:(\\\S)|(.))/u);
+      if (match) {
+        if (match[2]) {
+          c = match[2];
         } else {
           parser.i += 2;
           const cs = [...parser.GetCS()];
@@ -153,11 +161,6 @@ const UnicodeMethods: { [key: string]: ParseMethod } = {
           c = cs[0];
           match = [''];
         }
-      }
-    } else if (next === '"') {
-      match = text.match(/^"([0-9A-F]{1,6}) ?/);
-      if (match) {
-        c = String.fromCodePoint(parseInt(match[1], 16));
       }
     } else {
       match = text.match(/^([0-9]{1,7}) ?/);


### PR DESCRIPTION
This PR fixes an error in the `\char` command where it was using `\char'\x` where it should have been using ``\char`\x``.  It also updates the tests accordingly.