### PR TITLE
Remove checkSre() calls in combined configurations

### DIFF
--- a/components/mjs/a11y/semantic-enrich/config.json
+++ b/components/mjs/a11y/semantic-enrich/config.json
@@ -2,10 +2,7 @@
   "build": {
     "component": "a11y/semantic-enrich",
     "targets": [
-      "a11y/semantic-enrich.ts",
-      "a11y/speech/SpeechUtil.ts",
-      "a11y/speech/GeneratorPool.ts",
-      "a11y/speech/WebWorker.ts"
+      "a11y/semantic-enrich.ts"
     ]
   },
   "webpack": {

--- a/components/mjs/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/mjs/a11y/semantic-enrich/semantic-enrich.js
@@ -1,17 +1,12 @@
 import './lib/semantic-enrich.js';
 
 import {combineDefaults} from '#js/components/global.js';
-import * as Sre from '#js/a11y/sre.js';
 import {EnrichHandler} from '#js/a11y/semantic-enrich.js';
 import {MathML} from '#js/input/mathml.js';
 import {Package} from '#js/components/package.js';
 import {hasWindow} from '#js/util/context.js';
 
 if (MathJax.loader) {
-  combineDefaults(MathJax.config.loader, 'a11y/semantic-enrich', {
-    checkReady: () => Sre.sreReady(),
-  });
-
   let path = Package.resolvePath('[sre]', false);
   if (!hasWindow) {
     // In Node get the absolute path to the pool file.

--- a/components/mjs/a11y/sre/sre.js
+++ b/components/mjs/a11y/sre/sre.js
@@ -1,5 +1,6 @@
 import './lib/sre.js';
 import './sre_config.js';
+import {combineDefaults} from '#js/components/global.js';
 import {context} from '#js/util/context.js';
 import * as Sre from '#js/a11y/sre.js';
 
@@ -9,3 +10,8 @@ if (MathJax.startup) {
   (context.window || global).SREfeature.custom = (loc) => Sre.preloadLocales(loc);
 }
 
+if (MathJax.loader) {
+  combineDefaults(MathJax.config.loader, 'a11y/sre', {
+    checkReady: () => Sre.sreReady(),
+  });
+}

--- a/components/mjs/a11y/util.js
+++ b/components/mjs/a11y/util.js
@@ -1,6 +1,6 @@
 import {Loader} from '#js/components/loader.js';
 import '../input/mml/init.js';
-import {Sre} from './sre/sre.js';
+import './sre/sre.js';
 import './semantic-enrich/semantic-enrich.js';
 import './explorer/explorer.js';
 
@@ -9,7 +9,3 @@ Loader.preLoaded(
   'a11y/semantic-enrich',
   'a11y/explorer'
 );
-
-export function checkSre(startup) {
-  return () => startup(() => Sre.sreReady());
-}

--- a/components/mjs/mml-chtml-nofont/mml-chtml-nofont.js
+++ b/components/mjs/mml-chtml-nofont/mml-chtml-nofont.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -15,4 +15,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('mml-chtml-nofont');
 
-loadFont(checkSre(startup));
+loadFont(startup);

--- a/components/mjs/mml-chtml/mml-chtml.js
+++ b/components/mjs/mml-chtml/mml-chtml.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -15,4 +15,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('mml-chtml');
 
-loadFont(checkSre(startup), true);
+loadFont(startup, true);

--- a/components/mjs/mml-svg-nofont/mml-svg-nofont.js
+++ b/components/mjs/mml-svg-nofont/mml-svg-nofont.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -15,4 +15,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('mml-svg-nofont');
 
-loadFont(checkSre(startup));
+loadFont(startup);

--- a/components/mjs/mml-svg/mml-svg.js
+++ b/components/mjs/mml-svg/mml-svg.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -15,4 +15,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('mml-svg');
 
-loadFont(checkSre(startup), true);
+loadFont(startup, true);

--- a/components/mjs/tex-chtml-nofont/tex-chtml-nofont.js
+++ b/components/mjs/tex-chtml-nofont/tex-chtml-nofont.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/tex/tex.js';
 import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'core',
@@ -14,4 +14,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-chtml-nofont');
 
-loadFont(checkSre(startup));
+loadFont(startup);

--- a/components/mjs/tex-chtml/tex-chtml.js
+++ b/components/mjs/tex-chtml/tex-chtml.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/tex/tex.js';
 import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -15,4 +15,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-chtml');
 
-loadFont(checkSre(startup), true);
+loadFont(startup, true);

--- a/components/mjs/tex-mml-chtml-nofont/tex-mml-chtml-nofont.js
+++ b/components/mjs/tex-mml-chtml-nofont/tex-mml-chtml-nofont.js
@@ -5,7 +5,7 @@ import '../input/tex/tex.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -16,4 +16,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-mml-chtml-nofont');
 
-loadFont(checkSre(startup));
+loadFont(startup);

--- a/components/mjs/tex-mml-chtml/tex-mml-chtml.js
+++ b/components/mjs/tex-mml-chtml/tex-mml-chtml.js
@@ -5,7 +5,7 @@ import '../input/tex/tex.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/chtml/chtml.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -16,4 +16,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-mml-chtml');
 
-loadFont(checkSre(startup), true);
+loadFont(startup, true);

--- a/components/mjs/tex-mml-svg-nofont/tex-mml-svg-nofont.js
+++ b/components/mjs/tex-mml-svg-nofont/tex-mml-svg-nofont.js
@@ -5,7 +5,7 @@ import '../input/tex/tex.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -16,4 +16,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-mml-svg-nofont');
 
-loadFont(checkSre(startup));
+loadFont(startup);

--- a/components/mjs/tex-mml-svg/tex-mml-svg.js
+++ b/components/mjs/tex-mml-svg/tex-mml-svg.js
@@ -5,7 +5,7 @@ import '../input/tex/tex.js';
 import '../input/mml/mml.js';
 import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -16,4 +16,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-mml-svg');
 
-loadFont(checkSre(startup), true);
+loadFont(startup, true);

--- a/components/mjs/tex-svg-nofont/tex-svg-nofont.js
+++ b/components/mjs/tex-svg-nofont/tex-svg-nofont.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/tex/tex.js';
 import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'core',
@@ -14,4 +14,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-svg-nofont');
 
-loadFont(checkSre(startup));
+loadFont(startup);

--- a/components/mjs/tex-svg/tex-svg.js
+++ b/components/mjs/tex-svg/tex-svg.js
@@ -4,7 +4,7 @@ import '../core/core.js';
 import '../input/tex/tex.js';
 import {loadFont} from '../output/svg/svg.js';
 import '../ui/menu/menu.js';
-import {checkSre} from '../a11y/util.js';
+import '../a11y/util.js';
 
 Loader.preLoaded(
   'loader', 'startup',
@@ -15,4 +15,4 @@ Loader.preLoaded(
 );
 Loader.saveVersion('tex-svg');
 
-loadFont(checkSre(startup), true);
+loadFont(startup, true);


### PR DESCRIPTION
This is the PR that I promised that removes the `cherckSre()` function from the `a11y/util.js` file.  It removes its usage in all the combined components.

In addition, it remove the SpeechUtil, GeneratorPool, and WebWorker targets from the semantic-enrich build configuration, since they are not used there (they are loaded by the speech component), and removes the `sreReady()` call from there.  Instead, that is being made in the `sre` commponent itself (just to make sure that SRE is ready to go when the components are finished loading).

