### PR TITLE
Fix miscellaneous issues with components

### DIFF
--- a/components/mjs/dependencies.js
+++ b/components/mjs/dependencies.js
@@ -60,7 +60,8 @@ export const dependencies = {
   '[tex]/unicode': ['input/tex-base'],
   '[tex]/units': ['input/tex-base'],
   '[tex]/upgreek': ['input/tex-base'],
-  '[tex]/verb': ['input/tex-base']
+  '[tex]/verb': ['input/tex-base'],
+  'ui/menu': ['a11y/sre'],
 };
 
 export const paths = {

--- a/components/mjs/output/chtml/config.json
+++ b/components/mjs/output/chtml/config.json
@@ -4,12 +4,16 @@
     "targets": [
       "output/chtml.ts",
       "output/chtml",
+      "output/common.ts",
       "output/common"
     ]
   },
   "webpack": {
     "name": "output/chtml",
-    "libs": ["components/src/core/lib"],
+    "libs": [
+      "components/src/core/lib",
+      "components/src/startup/lib"
+    ],
     "font": false
   }
 }

--- a/components/mjs/output/svg/config.json
+++ b/components/mjs/output/svg/config.json
@@ -4,12 +4,16 @@
     "targets": [
       "output/svg.ts",
       "output/svg",
+      "output/common.ts",
       "output/common"
     ]
   },
   "webpack": {
     "name": "output/svg",
-    "libs": ["components/src/core/lib"],
+    "libs": [
+      "components/src/core/lib",
+      "components/src/startup/lib"
+    ],
     "font": false
   }
 }

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -128,7 +128,7 @@ const RESOLVE = function (js, dir, target, libs) {
   //  Add directory names to libraries
   //
   const libREs = libs
-        .map(lib => lib.replace(/components\/src\//, 'components/' + target + '/'))
+        .map(lib => lib.replace(/components\/(?:src|js)\//, 'components/' + target + '/'))
         .map(lib => (lib.charAt(0) === '.' ?
                      [jsRE, path.join(dir, lib) + path.sep] :
                      [mjRE, path.join(root, lib) + path.sep]));

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "import": "./components/mjs/*",
       "require": "./components/cjs/*"
     },
+    "./components/js/*": {
+      "import": "./components/mjs/*",
+      "require": "./components/cjs/*"
+    },
     "./require.mjs": "./bundle/require.mjs",
     "./es5/*": "./bundle/*",
     "./*": "./*"

--- a/ts/components/global.ts
+++ b/ts/components/global.ts
@@ -137,9 +137,12 @@ export function combineWithMathJax(config: any): MathJaxObject {
 }
 
 /**
- * Create the MathJax global, if it doesn't exist
+ * Create the MathJax global, if it doesn't exist or is not an object literal
  */
-if (typeof GLOBAL.MathJax === 'undefined') {
+if (
+  typeof GLOBAL.MathJax === 'undefined' ||
+  GLOBAL.MathJax.constructor !== {}.constructor
+) {
   GLOBAL.MathJax = {} as MathJaxConfig;
 }
 

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -248,7 +248,6 @@ export const options = {
     //
     allow: expandable({
       base: false,
-      'all-packages': false,
       autoload: false,
       configmacros: false,
       tagformat: false,


### PR DESCRIPTION
This PR makes miscellaneous updates to various component configurations and related changes.

* A `ui/menu` dependency on `a11y/sre` is added (since `SpeechMenu.ts` uses it).
* The `output/chtml` and `output/svg` config files now target `common.ts`, so that that will be included in the `MathJax._` tree, and the `components/src/startup/lib` is added so that `ts/components/package.ts` will be shared properly.  (Otherwise this leads to two separate copies of the `Package` class that don't know about what the other one has loaded.)
* The `webpack.common.js` and `package.json` are modified to allow `compoments/js` to obtain `compoments/mjs` or `components/cjs` depending on whether it is used in an `import` or a `require()`.  (The older `components/src` is still there for backward compatibility with v3, before we had the mjs/cjs split).
* The `global.ts` file is modified to check that the `MathJax` variable is actually an object literal, rather than a string or array or some other thing.
* The `all-packages` component is remove from the `\require` list, since that component was removed in a previous PR.