### PR TITLE
Miscellaneous small updates

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -822,10 +822,10 @@ export abstract class AbstractMathDocument<N, T, D>
     const mitem = new this.options.MathItem(math, jax, display);
     mitem.start.node = this.adaptor.body(this.document);
     mitem.setMetrics(em, ex, containerWidth, scale);
-    if (this.outputJax.options.mtextInheritFont) {
+    if (family && this.outputJax.options.mtextInheritFont) {
       mitem.outputData.mtextFamily = family;
     }
-    if (this.outputJax.options.merrorInheritFont) {
+    if (family && this.outputJax.options.merrorInheritFont) {
       mitem.outputData.merrorFamily = family;
     }
     mitem.convert(this, end);

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -55,8 +55,7 @@ export class HTMLDomStrings<N, T, D> {
   /* prettier-ignore */
   public static OPTIONS: OptionList = {
     skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code',
-                   'annotation', 'annotation-xml', 'select', 'option',
-                   'mjx-container'],
+                   'math', 'select', 'option', 'mjx-container'],
                                         // The names of the tags whose contents will not be
                                         // scanned for math delimiters
 

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -230,6 +230,9 @@ export class MathMLCompile<N, T, D> {
           case 'vbox':
             mml.setProperty('vbox', value);
             break;
+          default:
+            mml.attributes.set(name, value);
+            break;
         }
       } else if (name !== 'class') {
         const val = value.toLowerCase();

--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -236,7 +236,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
         const end = start.index + start[this.sub].length;
         if (math.length === 2) {
           match = protoItem<N, T>(
-            '',
+            '\\',
             math.substring(1),
             '',
             n,

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -654,7 +654,7 @@ export abstract class CommonOutputJax<
     const getFamily =
       this.options.mtextInheritFont || this.options.merrorInheritFont;
     const test = this.getTestElement(node, display);
-    const metrics = this.measureMetrics(test, getFamily);
+    const metrics = { ...this.measureMetrics(test, getFamily), display };
     this.adaptor.remove(test);
     return metrics;
   }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1524,7 +1524,7 @@ export class Menu {
     if (!this.settings.texHints) {
       svg = svg
         .replace(
-          / data-mjx-(?:texclass|alternate|variant|smallmatrix|mathaccent|auto-op|script-align|vbox)=".*?"/g,
+          / data-mjx-(?:texclass|alternate|variant|pseudoscript|smallmatrix|mathaccent|auto-op|script-align|vbox)=".*?"/g,
           ''
         )
         .replace(/ data-mml-node="TeXAtom"/g, '');


### PR DESCRIPTION
This PR makes a few miscellaneous changes that I found while updating the documentation.

* In `MathDocument.ts`, you only need to set the `mtextFamily` and `merrorFamily` if we are inheriting the them.
* In `HTMLDomStrings.ts`, the `skipHtmlTags` array is simplified (`math` is added and annotation nodes are removed, since they shoudl be inside `math` nodes).
* In `MathMLCompile.ts`,  any `data-mjx-` attribute that isn't otherwise handled is added as an attribute (e.g., `data-mjx-hdw`, `data-mjx-error`, etc., for example).
* In `FindTeX.ts`, escaped MathItems now get a `\` as their opening delimiter, so that if the Math is inserted back into the page (e.g., when setting `state()` back to 0), the escaped character will be replaced properly.
* In `common.ts`, the `display` value is now included in the metrics from `getMetricsFor()`.
* `Menu.ts`, the `data-mjx-pseudoscript` attribute is now filtered along with the other TeX attributes.