### PR TITLE
Add ability to cancel tasks, and update to allow components to work in node

### DIFF
--- a/components/mjs/a11y/sre/workerpool/speech-workerpool.js
+++ b/components/mjs/a11y/sre/workerpool/speech-workerpool.js
@@ -1,1 +1,6 @@
+import {VERSION} from '#js/components/version.js';
 export * from '#js/a11y/sre/speech-workerpool.js';
+
+if (typeof MathJax !== 'undefined' && MathJax.loader) {
+  MathJax.loader.checkVersion('sre/speech-workerpool', VERSION, 'sre/speech-workerpool');
+}

--- a/components/mjs/a11y/util.js
+++ b/components/mjs/a11y/util.js
@@ -2,11 +2,13 @@ import {Loader} from '#js/components/loader.js';
 import '../input/mml/init.js';
 import {Sre} from './sre/sre.js';
 import './semantic-enrich/semantic-enrich.js';
+import './speech/speech.js';
 import './explorer/explorer.js';
 
 Loader.preLoaded(
   'a11y/sre',
   'a11y/semantic-enrich',
+  'a11y/speech',
   'a11y/explorer'
 );
 

--- a/components/mjs/core/core.js
+++ b/components/mjs/core/core.js
@@ -10,5 +10,10 @@ if (MathJax.startup) {
   MathJax.startup.useAdaptor('browserAdaptor');
 }
 if (MathJax.loader) {
-  MathJax._.mathjax.mathjax.asyncLoad = (name => MathJax.loader.load(name));
+  const config = MathJax.config.loader;
+  MathJax._.mathjax.mathjax.asyncLoad = (
+    (name) => name.substring(0, 5) === 'node:'
+      ? config.require(name)
+      : MathJax.loader.load(name).then(result => result[0])
+  );
 }

--- a/lab/build/init.js
+++ b/lab/build/init.js
@@ -1,0 +1,3 @@
+global.SREfeature = {
+  json: '../../../bundle/sre/mathmaps'
+};

--- a/lab/build/sre.js
+++ b/lab/build/sre.js
@@ -1,1 +1,2 @@
+import './init.js';
 export * from '#js/a11y/sre/sre.js';

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -300,8 +300,6 @@ export function EnrichedMathDocumentMixin<
     public static OPTIONS: OptionList = {
       ...BaseDocument.OPTIONS,
       enableEnrichment: true,
-      enableSpeech: true,
-      enableBraille: true,
       enrichError: (
         doc: EnrichedMathDocument<N, T, D>,
         math: EnrichedMathItem<N, T, D>,

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -109,20 +109,20 @@ export function SpeechMathItemMixin<
       if (
         this.isEscaped ||
         !(document.options.enableSpeech || document.options.enableBraille)
-      )
+      ) {
         return;
+      }
       document.getWebworker();
       this.generatorPool.init(
         document.options,
         document.adaptor,
         document.webworker
       );
-      try {
-        this.outputData.mml = this.toMathML(this.root, this);
-        this.generatorPool.Speech(this);
-      } catch (err) {
-        document.options.speechError(document, this, err);
-      }
+      this.outputData.mml = this.toMathML(this.root, this);
+      const promise = this.generatorPool
+        .Speech(this)
+        .catch((err) => document.options.speechError(document, this, err));
+      document.renderPromises.push(promise);
     }
 
     /**
@@ -136,6 +136,13 @@ export function SpeechMathItemMixin<
     //   //   typeset math here.  trhis should undo whatever was done
     //   //   by the attachSpeech() method.
     // }
+
+    /**
+     * @override
+     */
+    clear() {
+      this.generatorPool.cancel(this);
+    }
   };
 }
 
@@ -325,6 +332,14 @@ export function SpeechMathDocumentMixin<
         // should call detachSpeech() on all MathItems if state >= STATE.TYPESET
       }
       return this;
+    }
+
+    /**
+     * @override
+     */
+    public async done() {
+      await this.webworker.Stop();
+      return super.done();
     }
   };
 }

--- a/ts/a11y/speech/MessageTypes.ts
+++ b/ts/a11y/speech/MessageTypes.ts
@@ -21,11 +21,6 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-export interface PromiseFunctions {
-  resolve: () => void;
-  reject: (cmd: string) => void;
-}
-
 export type Message = { [key: string]: any };
 
 export type WorkerCommand = {
@@ -38,3 +33,7 @@ export type PoolCommand = {
   cmd: string;
   data: WorkerCommand | Message;
 };
+
+export type Structure = { [id: string]: any };
+export type StructureData = Structure | string;
+export type StructurePromise = Promise<StructureData>;

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -34,6 +34,10 @@
  */
 type OptionList = { [name: string]: any };
 type Message = { [key: string]: any };
+type WorkerResult = Promise<any>;
+type WorkerFunction = (data: Message) => WorkerResult;
+type Structure = { [id: string]: any };
+type StructureData = Structure | string;
 
 declare let global: any;
 declare const SRE: any;
@@ -49,7 +53,8 @@ declare const SRE: any;
 
     global.DedicatedWorkerGlobalScope = global.constructor; // so SRE knows we are a worker
 
-    global.copyStructure = (structure: any) => JSON.stringify(structure);
+    global.copyStructure = (structure: StructureData) =>
+      JSON.stringify(structure);
 
     //
     // Create addEventListener() and postMessage() function
@@ -85,8 +90,8 @@ declare const SRE: any;
     };
   } else {
     global = (self as any).global = self; // for web workers make global be the self object
-    global.copyStructure = (structure: any) => structure;
-    global.SREfeature = { json: './mathmaps/' };
+    global.copyStructure = (structure: StructureData) => structure;
+    global.SREfeature = { json: './mathmaps' };
   }
   global.exports = self; // lets SRE get defined as a global variable
 
@@ -111,24 +116,18 @@ declare const SRE: any;
    */
   self.addEventListener(
     'message',
-    async function (event: MessageEvent) {
+    function (event: MessageEvent) {
       if (event.data.debug) {
         console.log('Iframe  >>>  Worker:', event.data);
       }
       const { cmd, data } = event.data;
       if (Object.hasOwn(Commands, cmd)) {
         Pool('Log', `running ${cmd}`);
-        try {
-          await Commands[cmd](data);
-        } catch (err) {
-          Pool('Error', copyError(err));
-          Finished(cmd, false);
-          return;
-        }
-        Finished(cmd, true);
+        Commands[cmd](data)
+          .then((result) => Finished(cmd, { result }))
+          .catch((error) => Finished(cmd, { error: error.message }));
       } else {
-        Pool('Error', { message: `Invalid worker command: ${cmd}` });
-        Finished(cmd, false);
+        Finished(cmd, { error: `Invalid worker command: ${cmd}` });
       }
     },
     false
@@ -137,51 +136,38 @@ declare const SRE: any;
   /**
    * These are the commands that can be sent from the main window via the iframe.
    */
-  const Commands: {
-    [id: string]: (data: Message) => void | Promise<void>;
-  } = {
+  const Commands: { [id: string]: WorkerFunction } = {
     /**
      * This loads one or more libraries.
      *
      * @param {Message} data The data object
-     * @returns {Promise} A promise that completes when the imports are done
+     * @returns {WorkerResult} A promise the completes when the imports are done
      */
-    import(data: Message): Promise<void> {
+    import(data: Message): WorkerResult {
       return Array.isArray(data.imports)
         ? Promise.all(data.imports.map((file: string) => import(file)))
         : import(data.imports);
     },
 
     /**
-     * Sets the SRE feature vector in the worker. Useful for presetting mathmaps
-     * path or custom loader.
-     *
-     * @param {Message} data The data object
-     */
-    feature(data: Message) {
-      global.SREfeature = {
-        json: data.json,
-      };
-    },
-
-    /**
      * Setup the speech rule engine.
      *
      * @param {Message} data The feature vector for SRE.
+     * @returns {WorkerResult} A promise the completes when the imports are done
      */
-    setup(data: Message) {
-      if (data) {
-        SRE.setupEngine(data);
-      }
+    setup(data: Message): WorkerResult {
+      if (!data) return Promise.resolve();
+      SRE.setupEngine(data);
+      return SRE.engineReady();
     },
 
     /**
      * Compute speech
      *
      * @param {Message} data The data object
-     * @returns {Promise<void>} Promise fulfilled when computation is complete.
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
-    speech(data: Message): Promise<void> {
+    speech(data: Message): WorkerResult {
       return Speech(SRE.workerSpeech, data.mml, data.options);
     },
 
@@ -189,9 +175,9 @@ declare const SRE: any;
      * Compute speech for the next rule set
      *
      * @param {Message} data The data object
-     * @returns {Promise<void>} Promise fulfilled when computation is complete.
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
-    nextRules(data: Message): Promise<void> {
+    nextRules(data: Message): WorkerResult {
       return Speech(SRE.workerNextRules, data.mml, data.options);
     },
 
@@ -199,9 +185,9 @@ declare const SRE: any;
      * Compute speech for the next style or preference
      *
      * @param {Message} data The data object
-     * @returns {Promise<void>} Promise fulfilled when computation is complete.
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
-    nextStyle(data: Message): Promise<void> {
+    nextStyle(data: Message): WorkerResult {
       return Speech(SRE.workerNextStyle, data.mml, data.options, data.nodeId);
     },
   };
@@ -235,10 +221,10 @@ declare const SRE: any;
    * Post that the current command is finished to the client.
    *
    * @param {string} cmd The command that has finished.
-   * @param {boolean} success Flag indicating if success of the command.
+   * @param {Message} msg The data to send back (error or result)
    */
-  function Finished(cmd: string, success: boolean = true) {
-    Client('Finished', { cmd: cmd, success: success });
+  function Finished(cmd: string, msg: Message) {
+    Client('Finished', { ...msg, cmd: cmd, success: !msg.error });
   }
 
   /**
@@ -250,22 +236,17 @@ declare const SRE: any;
    * @param {string} mml The mml expression.
    * @param {OptionList} options Setup options for SRE.
    * @param {string[]} rest Remaining arguments.
+   * @returns {Promise<StructureData>} A promise returning the data to be attached to the DOM
    */
   async function Speech(
-    func: (
-      mml: string,
-      options: OptionList,
-      rest: string[]
-    ) => { [id: string]: string },
+    func: (mml: string, options: OptionList, rest: string[]) => StructureData,
     mml: string,
     options: OptionList,
     ...rest: string[]
-  ) {
-    if (mml) {
-      let structure = await func.call(null, mml, options, ...rest);
-      structure = structure ?? {};
-      Client('Attach', global.copyStructure(structure));
-    }
+  ): Promise<StructureData> {
+    if (!mml) return '';
+    const structure = (await func.call(null, mml, options, ...rest)) ?? {};
+    return global.copyStructure(structure);
   }
 
   /**

--- a/ts/a11y/sre/speech-workerpool.html
+++ b/ts/a11y/sre/speech-workerpool.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UTF-8"/>
+<meta charset="UTF-8" />
 <title>MathJax webworker pool</title>
   <!--
-   | The main purpose of this file is to allow a resources from the CDN
+   | The main purpose of this file is to allow resources from the CDN
    | to be loaded into the webworkers.  That is possible because this file
    | is loaded from the CDN into the iframe, and since this file is from 
    | the CDN and it is where the webworkers are started, the webworkers can

--- a/ts/adaptors/lite/Element.ts
+++ b/ts/adaptors/lite/Element.ts
@@ -144,7 +144,7 @@ export class LiteIFrame extends LiteElement {
     // Subclass the Worker from node:worder_threads to include
     //  addEventListener and postMessage methods
     //
-    const { Worker } = await asyncLoad('worker_threads');
+    const { Worker } = await asyncLoad('node:worker_threads');
     class LiteWorker {
       protected worker: WebWorker;
       constructor(url: string, options: OptionList = {}) {

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -193,9 +193,9 @@ export const Loader = {
    * @param {string[]} names  The packages to load
    * @returns {Promise}       A promise that resolves when all the named packages are ready
    */
-  load(...names: string[]): Promise<void | string[]> {
+  load(...names: string[]): Promise<any[]> {
     if (names.length === 0) {
-      return Promise.resolve();
+      return Promise.resolve([]);
     }
     const promises = [];
     for (const name of names) {
@@ -207,8 +207,8 @@ export const Loader = {
       extension.checkNoLoad();
       promises.push(
         extension.promise.then(() => {
-          if (!CONFIG.versionWarnings) return;
           if (
+            CONFIG.versionWarnings &&
             extension.isLoaded &&
             !Loader.versions.has(Package.resolvePath(name))
           ) {
@@ -216,7 +216,8 @@ export const Loader = {
               `No version information available for component ${name}`
             );
           }
-        }) as Promise<null>
+          return extension.result;
+        }) as Promise<any>
       );
     }
     Package.loadAll();

--- a/ts/components/package.ts
+++ b/ts/components/package.ts
@@ -89,6 +89,11 @@ export class Package {
   public promise: Promise<string>;
 
   /**
+   * The result of loading a module via the custom loader
+   */
+  public result: any = {};
+
+  /**
    * True when the package is being loaded but hasn't yet finished loading
    */
   protected isLoading: boolean = false;
@@ -315,6 +320,7 @@ export class Package {
       const result = CONFIG.require(url);
       if (result instanceof Promise) {
         result
+          .then((result) => (this.result = result))
           .then(() => this.checkLoad())
           .catch((err) =>
             this.failed('Can\'t load "' + url + '"\n' + err.message.trim())

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -230,7 +230,7 @@ export abstract class Startup {
    * @returns {string}        The serialized MathML from the tree
    */
   public static toMML(node: MmlNode): string {
-    return Startup.visitor.visitTree(node, document);
+    return Startup.visitor.visitTree(node, this.document);
   }
 
   /**
@@ -382,6 +382,7 @@ export abstract class Startup {
    *   Make input2mml() and input2mmlPromise() conversion methods and inputReset() method
    *   If there is a registered output jax
    *     Make input2output() and input2outputPromise conversion methods and outputStylesheet() method
+   * Create the MathJax.done() method.
    */
   public static makeMethods() {
     if (Startup.input && Startup.output) {
@@ -396,6 +397,7 @@ export abstract class Startup {
         Startup.makeOutputMethods(iname, oname, jax);
       }
     }
+    MathJax.done = () => Startup.document.done();
   }
 
   /**

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -511,6 +511,11 @@ export interface MathDocument<N, T, D> {
   clear(): MathDocument<N, T, D>;
 
   /**
+   * Indicate that the MathDocument is no longer needed.
+   */
+  done(): Promise<void>;
+
+  /**
    * Merges a MathList into the list for this document.
    *
    * @param {MathList} list   The MathList to be merged into this document's list
@@ -1059,6 +1064,13 @@ export abstract class AbstractMathDocument<N, T, D>
   /**
    * @override
    */
+  public done() {
+    return Promise.resolve();
+  }
+
+  /**
+   * @override
+   */
   public concat(list: MathList<N, T, D>) {
     this.math.merge(list);
     return this;
@@ -1069,6 +1081,9 @@ export abstract class AbstractMathDocument<N, T, D>
    */
   public clearMathItemsWithin(containers: ContainerList<N>) {
     const items = this.getMathItemsWithin(containers);
+    for (const item of items.slice(0).reverse()) {
+      item.clear();
+    }
     this.math.remove(...items);
     return items;
   }

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -200,6 +200,11 @@ export interface MathItem<N, T, D> {
    *                           to the document when rolling back a typeset version
    */
   reset(restore?: boolean): void;
+
+  /**
+   * Clear any data (the MathItem's container is being removed)
+   */
+  clear(): void;
 }
 
 /*****************************************************************/
@@ -247,7 +252,7 @@ export function protoItem<N, T>(
   start: number,
   end: number,
   display: boolean = null
-) {
+): ProtoItem<N, T> {
   const item: ProtoItem<N, T> = {
     open: open,
     math: math,
@@ -414,7 +419,9 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public removeFromDocument(_restore: boolean = false) {}
+  public removeFromDocument(_restore: boolean = false) {
+    this.clear();
+  }
 
   /**
    * @override
@@ -453,6 +460,11 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   public reset(restore: boolean = false) {
     this.state(STATE.UNPROCESSED, restore);
   }
+
+  /**
+   * @override
+   */
+  clear() {}
 }
 
 /*****************************************************************/

--- a/ts/handlers/html/HTMLMathItem.ts
+++ b/ts/handlers/html/HTMLMathItem.ts
@@ -124,6 +124,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
    * @override
    */
   public removeFromDocument(restore: boolean = false) {
+    super.removeFromDocument(restore);
     if (this.state() >= STATE.TYPESET) {
       const adaptor = this.adaptor;
       const node = this.start.node;


### PR DESCRIPTION
# Overview

The main purposes of this PR are to:

1.  Add the ability to cancel worker tasks (and to do so when MathItems are removed from the document math list)
2.  Support using the components in node applications.  (The current code only works for direct imports of the MathJax modules.  This extends support to using the MathJax components as well.)

It also changes how the worker handles promises.  Rather than having the GeneratorPool create promises, the WorkerHandler's `Post()` command now does that automatically, so every command send to the worker pool has a promise that resolves when that command is complete.

This change also includes the ability to pass data back from the worker to the client via that promise.  This allows the worker to send the speech structure data back via the promise rather than a client `Attach()` command.  The client now uses that data to do the attach action itself.  This allows the worker to start processing other commands while the client is attaching the speech from the previous one, since the worker will have finished its command when it passes back the speech structure, rather than having to wait fo the client to attach and then finish.

# The Details

In the worker pool configuration file, we add the verisons check (so we don't get an error message about missing version information when a node application's `LiteIFrame` loads the worker pool data via `asyncLoad()`).

We add the speech component to the `a11y/util.js`so that the combined components that include the assisitive tools will include the speech component.

We extend the `asyncLoad()` definition in the core component to potentially handle loading node packages (we do that in the `LiteIFrame` by loading the `node:module` node package).  In a node application that has set the `require` configuration option properly to either the node `require` or to `(file) => import(file)`, or an equivalent, this will allow loading of core node modules.

The version of SRE in the `lab` directory now sets up the mathmaps path to work in the lab.  (The typo that I had in the `SREfeature` that you corrected actually allowed it to work before, but now that that has been corrected, it no longer does, but this takes care of that.)

The speech and Braille controls are removed from the semantic-enrich component, since they are not used there, and are already in the speech component, where they are used.

In `speech.ts`, the GeneratorPool's `Speech()` function now returns a promise (see below), so we take advantage of that insteach of using a try/catch construction.  We also push the promise into the document's `renderPromises` array so that `MathJax.typesetPromise()` will wait for it before resolving.  That way, the speech will be on the DOM nodes when the typeset promise resolves (as it is in beta.7).

The MathItem's `clear()` method now cancels its speech task, if there is one.

The MathDocument now gets a `done()` method that terminates the worker pool.

In `GeneratorPool.ts`:

* Since the `Post()` command of the `WorkerHandler` now creates promises automatically (see below), we don't need to get our own promises.
* The promises can return values, so they are `Promise<any>` not `Promise<void>`.
* The `Speech()` command now saves that promise and returns it (as do `nextRules` and `nextStyle`).
* A new `cancel()` method cancels any task saved for this MathItem.

In `MessageTypes.ts`, the `PromiseFunctions` are no longer needed, and we add some types for the speech structure that will be passed back from the worker.

In `WebWorker.ts`:
* The `resolve()` function can now pass an argument.
* The `Post()` method now creates a promise for the task automatically.
* The `Speech()` method is moved down to be next to the `nextRules` and `nextStyle` methods.
* A new `Cancel()` method is added to allow a pending task to be canceled (removed from the task list) and its promise rejected.  We might want to make a convention for this so that warnings aren't produced when tasks are canceled explicitly.
* The methods that post messages to the worker now all return promises.
* The `Speech()` command is now an `async` function that waits for the worker to return the speech structure and then calls `Attach()` on using that.  (The worker no longer calls `Attach()` itself, but just returns the data, so it can go on to do other tasks while the speech is being attached.)
* Similarly for `nextRules` and `nextStyle`.
* The `Attach()` function has been moved out the worker commands and is now just a regular method.  It is also broken into three parts (rather than creating functions internally), and `setSpecialAttributes()` is moved here along with the other separated out `setSpeechAttribute()` and `setSpeechAttributes()`.
* The `Terminate()` method now rejects all the tasks in the list, and before terminating the worker pool.
* The `Stop()` method now waits for the termination to complete before removing the iframe.
* The `Finished()` method now returns either the result from the worker, or an error message from it.

In `speech-worker.ts`:
* We define the structure types (just to be more expressive), and use them in the `copyStructure()` commands.
* The event listener is restructured slightly.  All the commands now return promises (se below), so we take advantage of that to `then()` and `catch()` rather than a try/catch structure.  An error state is indicated by an `error` property of the `msg` passed to `Finished()` (see below).
* We use `WorkerFunction` and `WorkerResult` types for more specificity.
* The `feature()` command is removed, since SRE is already configured and loaded, so this would have no effect.
* The `setup()` command now waits for the setup to take effect (though the command is not used currently).
* The `Finished()` now takes a `msg` parameter that is sent back to the client.  The `success` property is set according to whether there is an error message or not.
* The `Speech()` action is simplified a bit, and now returns the speech structure data rather than asking the client to attach.  The client gets the structure data from the promise it got when posting the worker command, and does the attach operation itself.

The `LiteIFrame` element indicates that `asyncLoad` needs to load a node module so that the `asyncLoad` from the `core` component will not use the Package module's loader.

The `loader.ts` file now allows the `Load()` function to return the results of the load operations (i.e., the exported values of the packages that were loaded).  This allows the `LiteIFrame` to get the exported values from the `speech-workerpool` when components are being used in node.  The results are stored in new `results` properties of the `Package` data (see below).

In `package.ts`, we now retain the result of loading a package, i.e., its exported values, so that the component loader can return those.

In `startup.ts`, we fix a typo with the document used for the `toMML()` function (argh), and create a new `MathJax.done()` function that is used to terminate the worker pool, if it was started.

In `MathDocument.ts`:
* We add the `done()` method that can be used to clean up anything when the document is no longer needed.  (We use it to terminate the worker pool in the speech handler.)
* The `clearMathItemsWithin()` now calls each MathItem's `clear()` method (used to cancel its speech task, if any).

In `MathItem.ts`, we add the new `clear()` method, and call it from the `removeFromDocument()` method, so that if a MathItem is removed, its tasks are canceled.

Finally, in `HTMLMathItem.ts`, we make sure the super-class `removeFromDocument()` is called (so the `clear()` is performed).


