### PR TITLE
Add core promise-based typeset and convert functions, and simplify those in Startup.

### DIFF
--- a/testsuite/tests/util/Retries.test.ts
+++ b/testsuite/tests/util/Retries.test.ts
@@ -13,88 +13,136 @@ type MathJaxGlobal = MathJaxObject & {
 };
 const MathJax: MathJaxGlobal = Object.assign(MJX, {
   Callback: {
-    After(code: Function) {
-      setTimeout(code, 10);
+    After(code: () => void) {
+      setTimeout(code, 1);
     },
     mock() {return Object.assign(() => {}, {isCallback: true})}
   }
 });
 
+/**********************************************************************************/
+/**********************************************************************************/
+
 describe('handleRetriesFor() and retryAfter()', () => {
+
+  /********************************************************************************/
 
   test('handleRetriesFor() then/catch getting called', () => {
     expect(handleRetriesFor(() => 'success')).resolves.toBe('success');
     expect(handleRetriesFor(() => {throw Error('failed')})).rejects.toThrow('failed');
   });
 
+  /********************************************************************************/
+
   test('handleRetriesFor().then called after 3 retries', () => {
     let n = 0;
-    expect(
-      handleRetriesFor(() => {
-        if (++n < 3) {
-          let p = new Promise<void>((ok, _fail) => {
-            setTimeout(() => ok(), 10);
-          });
-          retryAfter(p);
-        }
-        return 'success';
-      }).then((result: string) => {
-        expect(result).toBe('success');
-        expect(n).toBe(3);
-      })
-    )
+    handleRetriesFor(() => {
+      if (++n < 3) {
+        let p = new Promise<void>((ok, _fail) => {
+          setTimeout(() => ok(), 1);
+        });
+        retryAfter(p);
+      }
+      return 'success';
+    }).then((result: string) => {
+      expect(result).toBe('success');
+      expect(n).toBe(3);
+    });
   });
+
+  /********************************************************************************/
 
   test('handleRetriesFor().catch called for fail on 3rd retry', () => {
     let n = 0;
-    expect(
-      handleRetriesFor(() => {
-        if (++n < 3) {
-          let p = new Promise<void>((ok, fail) => {
-            setTimeout(() => n < 2 ? ok() : fail('fail'), 10);
-          });
-          retryAfter(p);
-        }
-        return 'success';
-      }).catch((result: string) => {
-        expect(result).toBe('fail');
-        expect(n).toBe(2);
-      })
-    )
+    handleRetriesFor(() => {
+      if (++n < 3) {
+        let p = new Promise<void>((ok, fail) => {
+          setTimeout(() => n < 2 ? ok() : fail('fail'), 1);
+        });
+        retryAfter(p);
+      }
+      return 'success';
+    }).catch((result: string) => {
+      expect(result).toBe('fail');
+      expect(n).toBe(2);
+    });
   });
+
+  /********************************************************************************/
 
   test('handleRetriesFor().catch called for error on 3rd retry', () => {
     let n = 0;
-    expect(
-      handleRetriesFor(() => {
-        if (++n < 3) {
-          let p = new Promise<void>((ok, _fail) => {
-            setTimeout(() => ok(), 10);
-          });
-          retryAfter(p);
-        }
-        throw Error('fail');
-      }).catch((err: Error) => {
-        expect(err.message).toBe('fail');
-        expect(n).toBe(3);
-      })
-    )
+    handleRetriesFor(() => {
+      if (++n < 3) {
+        let p = new Promise<void>((ok, _fail) => {
+          setTimeout(() => ok(), 1);
+        });
+        retryAfter(p);
+      }
+      throw Error('fail');
+    }).catch((err: Error) => {
+      expect(err.message).toBe('fail');
+      expect(n).toBe(3);
+    });
   });
+
+  /********************************************************************************/
 
   test('v2 retry', () => {
     let n = 0;
-    expect(handleRetriesFor(() => {
-        if (++n < 3) {
-          throw Object.assign(new Error('restart'), {
-            restart: MathJax.Callback.mock()  // mark this error as a v2 restart
-          });
-        }
-        return 'success';
-      }).then((result: string) => {
-        expect(result).toBe('success');
-        expect(n).toBe(3);
-      })
-    )
+    handleRetriesFor(() => {
+      if (++n < 3) {
+        throw Object.assign(new Error('restart'), {
+          restart: MathJax.Callback.mock()  // mark this error as a v2 restart
+        });
+      }
+      return 'success';
+    }).then((result: string) => {
+      expect(result).toBe('success');
+      expect(n).toBe(3);
+    });
   });
 
+  /********************************************************************************/
+
+  test('handleRetriedFor() async success', () => {
+    expect(handleRetriesFor(async () => {
+      const wait = new Promise((ok, _fail) => setTimeout(() => ok('success'), 1));
+      return (await wait);
+    })).resolves.toBe('success');
+  });
+
+  /********************************************************************************/
+
+  test('handleRetriedFor() async fails', () => {
+    expect(handleRetriesFor(async () => {
+      const wait = new Promise((_ok, fail) => setTimeout(() => fail('fail'), 1));
+      return (await wait);
+    })).rejects.toBe('fail');
+  });
+
+  /********************************************************************************/
+
+  test('handleRetriedFor() async with retry', () => {
+    let n = 0;
+    handleRetriesFor(async () => {
+      if (++n < 3) {
+        await new Promise<void>((ok, _fail) => setTimeout(ok, 1));
+        let p = new Promise<void>((ok, _fail) => {
+          setTimeout(() => ok(), 1);
+        });
+        retryAfter(p);
+      }
+      return 'success';
+    }).then((result: string) => {
+      expect(result).toBe('success');
+      expect(n).toBe(3);
+    });
+  });
+
+  /********************************************************************************/
+
 });
+
+/**********************************************************************************/
+/**********************************************************************************/

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -122,7 +122,7 @@ export function SpeechMathItemMixin<
       const promise = this.generatorPool
         .Speech(this)
         .catch((err) => document.options.speechError(document, this, err));
-      document.renderPromises.push(promise);
+      document.savePromise(promise);
     }
 
     /**

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -36,6 +36,7 @@ import { MmlFactory } from '../core/MmlTree/MmlFactory.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
 import { BitField, BitFieldClass } from '../util/BitField.js';
 import { PrioritizedList } from '../util/PrioritizedList.js';
+import { handleRetriesFor } from '../util/Retries.js';
 
 /*****************************************************************/
 
@@ -373,11 +374,6 @@ export interface MathDocument<N, T, D> {
   renderActions: RenderList<N, T, D>;
 
   /**
-   * The promises that indicate when rendering is fully complete
-   */
-  renderPromises: Promise<void>[];
-
-  /**
    * This object tracks what operations have been performed, so that (when
    *  asynchronous operations are used), the ones that have already been
    *  completed won't be performed again.
@@ -417,8 +413,17 @@ export interface MathDocument<N, T, D> {
 
   /**
    * Perform the renderActions on the document
+   *
+   * @returns {MathDocument}    The math document instance
    */
   render(): MathDocument<N, T, D>;
+
+  /**
+   * Perform the renderActions on the document with retry handling
+   *
+   * @returns {Promise<MathDocument>}   A promise that resolves when the render is complete
+   */
+  renderPromise(): Promise<MathDocument<N, T, D>>;
 
   /**
    * Rerender the MathItems on the page
@@ -429,20 +434,58 @@ export interface MathDocument<N, T, D> {
   rerender(start?: number): MathDocument<N, T, D>;
 
   /**
+   * Rerender the MathItems on the page
+   *
+   * @param {number} start              The state to start rerendering at
+   * @returns {Promise<MathDocument>}   A promise that resolves when the rerender is complete
+   */
+  rerenderPromise(start?: number): Promise<MathDocument<N, T, D>>;
+
+  /**
    * Convert a math string to the document's output format
    *
    * @param {string} math           The math string to convert
-   * @param {OptionList} options   The options for the conversion (e.g., format, ex, em, etc.)
-   * @returns {MmlNode|N}            The MmlNode or N node for the converted content
+   * @param {OptionList} options    The options for the conversion (e.g., format, ex, em, etc.)
+   * @returns {MmlNode|N}           The MmlNode or N node for the converted content
    */
   convert(math: string, options?: OptionList): MmlNode | N;
+
+  /**
+   * Convert a math string to the document's output format
+   *
+   * @param {string} math           The math string to convert
+   * @param {OptionList} options    The options for the conversion (e.g., format, ex, em, etc.)
+   * @returns {Promise<MmlNode|N>}  A promise that resolves when the conversion is complete
+   */
+  convertPromise(math: string, options?: OptionList): Promise<MmlNode | N>;
+
+  /**
+   * Perform an action when previous actions are complete.
+   * (Used to chain promise-based typeset and conversion actions.)
+   */
+  whenReady(action: () => any): Promise<any>;
+
+  /**
+   * Return a promise that resolves when all of the  action promises have been resolved
+   */
+  actionPromises(): Promise<any[]>;
+
+  /**
+   * Clear the action promises
+   */
+  clearPromises(): void;
+
+  /**
+   * Save a promise in the action romises list
+   */
+  savePromise(promise: Promise<any>): void;
 
   /**
    * Locates the math in the document and constructs the MathList
    *  for the document.
    *
    * @param {OptionList} options  The options for locating the math
-   * @returns {MathDocument}       The math document instance
+   * @returns {MathDocument}      The math document instance
    */
   findMath(options?: OptionList): MathDocument<N, T, D>;
 
@@ -685,7 +728,14 @@ export abstract class AbstractMathDocument<N, T, D>
   /**
    * The render action promise list
    */
-  public renderPromises: Promise<void>[];
+  protected _actionPromises: Promise<void>[];
+
+  /**
+   * Promise for the current typeset or conversion action
+   * (used to chain the promise-based calls so they don't
+   * overlap).
+   */
+  protected _readyPromise: Promise<any>;
 
   /**
    * The bit-field used to tell what steps have been taken on the document (for retries)
@@ -726,7 +776,8 @@ export abstract class AbstractMathDocument<N, T, D>
     this.renderActions = RenderList.create<N, T, D>(
       this.options['renderActions']
     );
-    this.renderPromises = [];
+    this._actionPromises = [];
+    this._readyPromise = Promise.resolve();
     this.processed = new AbstractMathDocument.ProcessBits();
     this.outputJax =
       this.options['OutputJax'] || new DefaultOutputJax<N, T, D>();
@@ -785,9 +836,23 @@ export abstract class AbstractMathDocument<N, T, D>
    * @override
    */
   public render() {
-    this.renderPromises = [];
+    this.clearPromises();
     this.renderActions.renderDoc(this);
     return this;
+  }
+
+  /**
+   * @override
+   */
+  public renderPromise() {
+    return this.whenReady(() =>
+      handleRetriesFor(async () => {
+        this.render();
+        await this.actionPromises();
+        this.clearPromises();
+        return this;
+      })
+    );
   }
 
   /**
@@ -797,6 +862,20 @@ export abstract class AbstractMathDocument<N, T, D>
     this.state(start - 1);
     this.render();
     return this;
+  }
+
+  /**
+   * @override
+   */
+  public rerenderPromise(start: number = STATE.RERENDER) {
+    return this.whenReady(() =>
+      handleRetriesFor(async () => {
+        this.rerender(start);
+        await this.actionPromises();
+        this.clearPromises();
+        return this;
+      })
+    );
   }
 
   /**
@@ -833,8 +912,74 @@ export abstract class AbstractMathDocument<N, T, D>
     if (this.outputJax.options.merrorInheritFont) {
       mitem.outputData.merrorFamily = family;
     }
+    this.clearPromises();
     mitem.convert(this, end);
     return mitem.typesetRoot || mitem.root;
+  }
+
+  /**
+   * @override
+   */
+  public convertPromise(math: string, options: OptionList = {}) {
+    return this.whenReady(() =>
+      handleRetriesFor(async () => {
+        const node = this.convert(math, options);
+        await this.actionPromises();
+        this.clearPromises();
+        return node;
+      })
+    );
+  }
+
+  /**
+   * @override
+   */
+  public whenReady(action: () => any): Promise<any> {
+    return (this._readyPromise = this._readyPromise.then(() => {
+      //
+      // Cache old _readyPromise and replace it with a resolved
+      // promise in case action() calls whenReady(), so we don't get
+      // a circular dependency where the action is waiting on itself.
+      //
+      const ready = this._readyPromise;
+      this._readyPromise = Promise.resolve();
+      //
+      // Do the action and save its result.
+      //
+      const result = action();
+      //
+      // Put back the original promise.
+      //
+      this._readyPromise = ready;
+      //
+      // Return the result of the action, which may be a promise for
+      // when action is complete.  If it is, then the original
+      // _readyPromise will wait on it to complete before it resolves,
+      // since promises that return promises automatically chain.
+      //
+      return result;
+    }));
+  }
+
+  /**
+   * @override
+   */
+  public actionPromises() {
+    return Promise.all(this._actionPromises);
+  }
+
+  /**
+   * @override
+   */
+  public clearPromises() {
+    this._actionPromises = [];
+  }
+
+  /**
+   * @override
+   */
+  public savePromise(promise: Promise<any>) {
+    this._actionPromises.push(promise);
   }
 
   /**

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -948,16 +948,23 @@ export abstract class AbstractMathDocument<N, T, D>
       //
       const result = action();
       //
+      // Get a promise that returns the result after
+      // any new _readyPromise resolves (in case action
+      // called whenReady() or another function that does).
+      //
+      const promise = this._readyPromise.then(() => result);
+      //
       // Put back the original promise.
       //
       this._readyPromise = ready;
       //
-      // Return the result of the action, which may be a promise for
-      // when action is complete.  If it is, then the original
+      // Return promise that returns the result.  The original
       // _readyPromise will wait on it to complete before it resolves,
       // since promises that return promises automatically chain.
+      // This inserts any new _readyPromise promises into the
+      // original _readyPromise chain at this point.
       //
-      return result;
+      return promise;
     }));
   }
 

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -1589,16 +1589,15 @@ export class Menu {
   protected rerender(start: number = STATE.TYPESET) {
     this.rerenderStart = Math.min(start, this.rerenderStart);
     const startup = MathJax.startup;
-    if (!Menu.loading && startup.rerenderPromise) {
-      startup.rerenderPromise = startup.promise = startup.rerenderPromise.then(
-        () =>
-          mathjax.handleRetriesFor(() => {
-            if (this.rerenderStart <= STATE.COMPILED) {
-              this.document.reset({ inputJax: [] });
-            }
-            this.document.rerender(this.rerenderStart);
-            this.rerenderStart = STATE.LAST;
-          })
+    if (!Menu.loading && startup.hasTypeset) {
+      startup.document.whenReady(
+        () => {
+          if (this.rerenderStart <= STATE.COMPILED) {
+            this.document.reset({ inputJax: [] });
+          }
+          this.document.rerender(this.rerenderStart);
+          this.rerenderStart = STATE.LAST;
+        }
       );
     }
   }

--- a/ts/util/Retries.ts
+++ b/ts/util/Retries.ts
@@ -82,14 +82,14 @@ export function handleRetriesFor(code: () => any): Promise<any> {
       } else {
         fail(err);
       }
-    }
+    };
     //
     // Run the user code
     //   If it returns a promise, wait on it
     //     when done, resolve the original promise with its returned value,
     //     or if it errors, handle a retry or fail with the error.
     //   Otherwise resolve the original promise with the result.
-    // If there was an error, handle a retry otherwise faile with the error.
+    // If there was an error, handle a retry otherwise fail with the error.
     try {
       const result = code();
       if (result instanceof Promise) {


### PR DESCRIPTION
Now that both speech and output (when font data is loaded) use promises and retries, it seems appropriate to add promise-based calls to the core MathDocument for typesetting and conversion, like the ones in the Startup module.

This PR adds those functions.  In particular, new `renderPromise()`, `rerenderPromise()`, and `convertPromise()` methods are added to the `MathDocument` class, and the Startup module now takes advantage of these when creating `MathJax.typesetPromise()` and the various conversion functions like `MathJax.tex2chtmlPromise()`.

The old `MathJax.typesetPromise()` and conversion functions had been modified to use the `MathJax.startup.promise` to make sure that they operated serially.  The new MathDocument methods now do that using a new `_readyPromise`, and a new `whenReady()` method is added to the MathDocument to make that easier.  This function takes an action to be performed when the current `_readyPromise` has been resolved, and resets that promise to a new promise that resolves when the action is complete.  (This is effectively makes a queue of actions to be performed serially, with actions that return promises causing the following actions to wait until the earlier ones complete.)  Some care is taken to prevent a circular dependency where the action performed by `whenReady()` tries to wait on the promise that it is supposed to resolve.  (See the comments in that function.)  That way, even though `renderPromise()` uses `whenReady()` itself, you can still call `renderPromise()` from within an action that appears within another `whenReady()` call, as is done in some of the functions created by the Startup module.

The `handleRetriesFor()` function, which handles promises created by loading of extensions, is extended to handle async functions, since those are used in the new promise-based rendering and conversion functions.  New tests are added to cover this case in the `Retries.test.ts` file.

All of the promise-based functions wait not just for retry promises, but also for any promises created during processing of the document's renderActions (like those created for handling the speech creation).  The variable use to store these has been made private and renamed `_actionPromises`, and service routines `savePromise()`, `clearPromises()` and `actionPromises()` have been added in order to manipulate the list of saved promises, rather than dealing with the promise array directly.  So the speech component calls `document.savePromise()` rather than `document.renderPromises.push()` as it used to.

The Startup module has been updated to take advantage of the new promise-based code of the document.  In the past, it used its own `Startup.promise` to serialize the promise-based calls, but it now uses that only to indicate when the initial typesetting is complete, and falls back on the `whenReady()` function to handle the serialization.  It also used to have a `rerenderPromise` that was used for the menu code when a re-render action was necessary when a component was loaded (it is only needed of anything has been typset already, so no re-rendering needs to be done during startup when the menu may be loading user-selected components.)  This promise has been replaced by a boolean `hasTypeset` indicating that typesetting has occurred, and a rerender is needed.