### PR TITLE
Don't allow inline breaks at negative spaces

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/ts/core/MmlTree/MmlNodes/mspace.ts
@@ -116,7 +116,9 @@ export class MmlMspace extends AbstractMmlTokenNode {
    *                     and width non-negative.
    */
   public get canBreak(): boolean {
-    return !this.attributes.hasOneOf(MmlMspace.NONSPACELIKE) &&
-      String(this.attributes.get('width')).trim().charAt(0) !== '-';
+    return (
+      !this.attributes.hasOneOf(MmlMspace.NONSPACELIKE) &&
+      String(this.attributes.get('width')).trim().charAt(0) !== '-'
+    );
   }
 }

--- a/ts/core/MmlTree/MmlNodes/mspace.ts
+++ b/ts/core/MmlTree/MmlNodes/mspace.ts
@@ -111,10 +111,12 @@ export class MmlMspace extends AbstractMmlTokenNode {
   }
 
   /**
-   * @returns {boolean}   True if mspace is allowed to break, i.e.,
-   *                     no height/depth, no styles, and no background color.
+   * @returns {boolean}  True if mspace is allowed to break, i.e.,
+   *                     no height/depth, no styles, no background color,
+   *                     and width non-negative.
    */
   public get canBreak(): boolean {
-    return !this.attributes.hasOneOf(MmlMspace.NONSPACELIKE);
+    return !this.attributes.hasOneOf(MmlMspace.NONSPACELIKE) &&
+      String(this.attributes.get('width')).trim().charAt(0) !== '-';
   }
 }

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -25,6 +25,7 @@ import { AbstractOutputJax } from '../core/OutputJax.js';
 import { MathDocument } from '../core/MathDocument.js';
 import { MathItem, Metrics, STATE } from '../core/MathItem.js';
 import { MmlNode, TEXCLASS } from '../core/MmlTree/MmlNode.js';
+import { MmlMspace } from '../core/MmlTree/MmlNodes/mspace.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
 import {
   FontData,
@@ -529,7 +530,7 @@ export abstract class CommonOutputJax<
         postbreak = linebreak === 'newline' && linebreakstyle === 'after';
       } else if (child.isKind('mspace')) {
         const linebreak = child.attributes.get('linebreak') as string;
-        if (linebreak !== 'nobreak') {
+        if (linebreak !== 'nobreak' && (child as MmlMspace).canBreak) {
           marked = this.markInlineBreak(
             marked,
             forcebreak,


### PR DESCRIPTION
This PR prevents negative spaces from being considered as valid breakpoints.  This is particularly important for in-line breaks, but affects both in-line and display breaking.