### PR TITLE
Fix Lookbehind assertions was not widely supported in browser

### DIFF
--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -1223,9 +1223,12 @@ export class FontData<
     const prefix = !dynamic.extension
       ? this.options.dynamicPrefix
       : this.CLASS.dynamicExtensions.get(dynamic.extension).prefix;
-    return dynamic.file.match(/^(?:[/[]|[a-z]+:\/\/|[a-z]:)/i)
-      ? dynamic.file
-      : prefix + '/' + dynamic.file.replace(/(?<!\.js)$/, '.js');
+    if (dynamic.file.match(/^(?:[/[]|[a-z]+:\/\/|[a-z]:)/i)) {
+      return dynamic.file;
+    } else {
+      const file = dynamic.file.endsWith('.js') ? dynamic.file : dynamic.file + '.js';
+      return prefix + '/' + file;
+    }
   }
 
   /**


### PR DESCRIPTION
The "Lookbehind in JS regular expressions" feature is not widely supported in browsers, and this lack of support is causing issues when using MathJax in certain scenarios.

Resolve issue https://github.com/mathjax/MathJax/issues/3352