### PR TITLE
Fix Lookbehind assertions was not widely supported in browser

### DIFF
--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -1225,7 +1225,7 @@ export class FontData<
       : this.CLASS.dynamicExtensions.get(dynamic.extension).prefix;
     return dynamic.file.match(/^(?:[/[]|[a-z]+:\/\/|[a-z]:)/i)
       ? dynamic.file
-      : prefix + '/' + dynamic.file.replace(/(?<!\.js)$/, '.js');
+      : prefix + '/' + dynamic.file.replace(/(\.js)?$/, '.js');
   }
 
   /**


### PR DESCRIPTION
The "Lookbehind in JS regular expressions" feature is not widely supported in browsers, and this lack of support is causing issues when using MathJax in certain scenarios.

Resolve issue https://github.com/mathjax/MathJax/issues/3352