### PR TITLE
Add more log print when pack failed

### DIFF
--- a/components/bin/pack
+++ b/components/bin/pack
@@ -79,14 +79,18 @@ async function readJSON(dir) {
       '-c', path.relative('.', path.join(compPath, 'webpack.config.' + target))
     ]);
     child.stdout.on('data', (data) => buffer.push(String(data)));
-    child.stdout.on('close', (code) => {
+    child.stderr.on('data', (data) => console.error(String(data)));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        fail('Webpack failed with code ' + code);
+        return;
+      }
       const json = JSON.parse(buffer.join(''));
       if (json.errors && json.errors.length) {
         fail(json.errors[0].message);
       }
       ok(json);
     });
-    child.stderr.on('data', (data) => console.error(String(data)));
   });
 }
 

--- a/components/bin/pack
+++ b/components/bin/pack
@@ -86,6 +86,7 @@ async function readJSON(dir) {
       }
       ok(json);
     });
+    child.stderr.on('data', (data) => console.error(String(data)));
   });
 }
 


### PR DESCRIPTION
The error messages emitted by spawned webpack were not printed, which caused difficulties in adapting the script. 

Simply print stderr.

Before
![image](https://github.com/user-attachments/assets/e4406c3f-bd83-42c4-99d0-20a5e9d7c37a)

After
![image](https://github.com/user-attachments/assets/841617a2-e92c-49d1-bdc3-66d0f05a69fc)
