### PR TITLE
Use actual space rather than \s to trim mtext content (to not match U+00A0). (mathjax/MathJax#3353)

### DIFF
--- a/ts/input/tex/ParseUtil.ts
+++ b/ts/input/tex/ParseUtil.ts
@@ -602,8 +602,8 @@ export const ParseUtil = {
     // @test Label, Fbox, Hbox
     text = text
       .replace(/\n+/g, ' ')
-      .replace(/^\s+/, entities.nbsp)
-      .replace(/\s+$/, entities.nbsp);
+      .replace(/^ +/, entities.nbsp)
+      .replace(/ +$/, entities.nbsp);
     const textNode = parser.create('text', text);
     return parser.create('node', 'mtext', [], def, textNode);
   },


### PR DESCRIPTION
This PR changes the regexp used to trim spaces from the content of `mtext` elements generated by the `internalText()` command.  The `\s` pattern used originally would match non-breaking spaces (U+00A0), which should not be collapsed into other spaces.  So this uses just the actual space character, not all other space-like characters matched by `\s`.

Resolves issue mathjax/MathJax#3353.