### PR TITLE
Implement new explorer paradigm

### DIFF
--- a/components/mjs/a11y/semantic-enrich/semantic-enrich.js
+++ b/components/mjs/a11y/semantic-enrich/semantic-enrich.js
@@ -3,20 +3,6 @@ import './lib/semantic-enrich.js';
 import {combineDefaults} from '#js/components/global.js';
 import {EnrichHandler} from '#js/a11y/semantic-enrich.js';
 import {MathML} from '#js/input/mathml.js';
-import {Package} from '#js/components/package.js';
-import {hasWindow} from '#js/util/context.js';
-
-if (MathJax.loader) {
-  let path = Package.resolvePath('[sre]', false);
-  if (!hasWindow) {
-    // In Node get the absolute path to the pool file.
-    try {
-      const require = MathJax.config.loader.require;
-      path = require.resolve(path, MathJax.config.options.worker.pool).replace(/\/.*?$/, '');
-    } catch(_err) { }
-  }
-  combineDefaults(MathJax.config, 'options', { worker: { path } });
-}
 
 if (MathJax.startup) {
   MathJax.startup.extendHandler(

--- a/components/mjs/a11y/speech/speech.js
+++ b/components/mjs/a11y/speech/speech.js
@@ -1,6 +1,26 @@
 import './lib/speech.js';
 
+import {combineDefaults} from '#js/components/global.js';
+import {Package} from '#js/components/package.js';
+import {hasWindow} from '#js/util/context.js';
 import {SpeechHandler} from '#js/a11y/speech.js';
+
+if (MathJax.loader) {
+  let path = Package.resolvePath('[sre]', false);
+  if (!hasWindow) {
+    if (MathJax.config.loader.require?.resolve) {
+      const require = MathJax.config.loader.require;
+      const pool = MathJax.config.options?.worker?.pool || 'speech-workerpool.js';
+      path = path.replace(/\/bundle\/sre$/, '/cjs/a11y/sre');
+      path = require.resolve(`${path}/${pool}`).replace(/\/[^\/]*$/, '');
+    } else {
+      path = '';
+    }
+  }
+  if (path) {
+    combineDefaults(MathJax.config, 'options', { worker: { path } });
+  }
+}
 
 if (MathJax.startup) {
   MathJax.startup.extendHandler(handler => SpeechHandler(handler));

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "clean:mod": "clean() { pnpm -s log:comp \"Cleaning $1 module\"; pnpm -s clean:dir $1 && pnpm -s clean:lib $1; }; clean",
     "=============================================================================== copy": "",
     "copy:assets": "pnpm -s log:comp 'Copying assets'; copy() { pnpm -s copy:mj2 $1 && pnpm -s copy:mml3 $1 && pnpm -s copy:html $1; }; copy",
-    "copy:html": "copy() { pnpm -s log:single 'Copying worker html file'; pnpm copyfiles -u 1 'ts/a11y/sre/*.html' 'ts/a11y/sre/require.*' $1; }; copy",
+    "copy:html": "copy() { pnpm -s log:single 'Copying sre auxiliary files'; pnpm copyfiles -u 1 'ts/a11y/sre/*.html' 'ts/a11y/sre/require.*' $1; }; copy",
     "copy:mj2": "copy() { pnpm -s log:single 'Copying legacy code AsciiMath'; pnpm copyfiles -u 1 'ts/input/asciimath/legacy/**/*' $1; }; copy",
     "copy:mml3": "copy() { pnpm -s log:single 'Copying legacy code MathML3'; pnpm copyfiles -u 1 ts/input/mathml/mml3/mml3.sef.json $1; }; copy",
     "copy:pkg": "copy() { pnpm -s log:single \"Copying package.json to $1\"; pnpm copyfiles -u 2 components/bin/package.json $1; }; copy",

--- a/testsuite/tests/util/Context-android.test.ts
+++ b/testsuite/tests/util/Context-android.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 
-const window = {document: {}, navigator: {appVersion: 'Linux'}};
+const window = {document: {}, navigator: {userAgent: 'Android', appVersion: ''}};
 (global as any).window = window;
 
 describe('context object', () => {

--- a/testsuite/tests/util/Context-node.test.ts
+++ b/testsuite/tests/util/Context-node.test.ts
@@ -4,7 +4,7 @@ import { context, hasWindow } from '#js/util/context.js';
 describe('context object', () => {
 
   test('context', () => {
-    expect(context).toEqual({window: null, document: null});
+    expect(context).toEqual({window: null, document: null, os: 'unknown'});
     expect(hasWindow).toBe(false);
   });
 

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -223,7 +223,6 @@ export class ExplorerPool {
   protected mml: string;
 
   /**
-   
    * The primary highlighter shared by all explorers.
    */
   private _highlighter: Sre.highlighter;
@@ -296,7 +295,6 @@ export class ExplorerPool {
     const a11y = this.document.options.a11y;
     for (const [key, explorer] of Object.entries(this.explorers)) {
       if (explorer instanceof SpeechExplorer) {
-        explorer.AddEvents();
         explorer.stoppable = false;
         keyExplorers.unshift(explorer);
         if (

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -21,19 +21,15 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import {
-  A11yDocument,
-  HoverRegion,
-  SpeechRegion,
-  LiveRegion,
-} from './Region.js';
+import { HoverRegion, SpeechRegion, LiveRegion } from './Region.js';
 import { STATE } from '../../core/MathItem.js';
-import type { ExplorerMathItem } from '../explorer.js';
+import type { ExplorerMathItem, ExplorerMathDocument } from '../explorer.js';
 import { Explorer, AbstractExplorer } from './Explorer.js';
 import { ExplorerPool } from './ExplorerPool.js';
 import { MmlNode } from '../../core/MmlTree/MmlNode.js';
-import { honk, InPlace } from '../speech/SpeechUtil.js';
+import { honk, SemAttr } from '../speech/SpeechUtil.js';
 import { GeneratorPool } from '../speech/GeneratorPool.js';
+import { context } from '../../util/context.js';
 
 /**
  * Interface for keyboard explorers. Adds the necessary keyboard events.
@@ -64,24 +60,25 @@ export interface KeyExplorer extends Explorer {
   FocusOut(event: FocusEvent): void;
 
   /**
-   * Move made on keypress.
-   *
-   * @param event The keyboard event when a key is pressed.
-   */
-  Move(event: KeyboardEvent): void;
-
-  /**
    * A method that is executed if no move is executed.
    */
   NoMove(): void;
 }
 
+/**********************************************************************/
+
+/**
+ * Type of function that implements a key press action
+ */
+type keyMapping = (
+  explorer: SpeechExplorer,
+  event: KeyboardEvent
+) => boolean | void;
+
 /**
  * Selectors for walking.
  */
-const roles = ['tree', 'group', 'treeitem'];
-const nav = roles.map((x) => `[role="${x}"]`).join(',');
-const prevNav = roles.map((x) => `[tabindex="0"][role="${x}"]`).join(',');
+const nav = '[data-speech-node]';
 
 /**
  * Predicate to check if element is a MJX container.
@@ -89,9 +86,142 @@ const prevNav = roles.map((x) => `[tabindex="0"][role="${x}"]`).join(',');
  * @param {HTMLElement} el The HTML element.
  * @returns {boolean} True if the element is an mjx-container.
  */
-function isContainer(el: HTMLElement): boolean {
+export function isContainer(el: HTMLElement): boolean {
   return el.matches('mjx-container');
 }
+
+/**
+ * Test if an event has any modifier keys
+ *
+ * @param {MouseEvent|KeyboardEvent} event   The event to check
+ * @param {boolean} shift                    True if shift is to be included in check
+ * @returns {boolean}                        True if shift, ctrl, alt, or meta key is pressed
+ */
+export function hasModifiers(
+  event: MouseEvent | KeyboardEvent,
+  shift: boolean = true
+): boolean {
+  return (
+    (event.shiftKey && shift) || event.metaKey || event.altKey || event.ctrlKey
+  );
+}
+
+/**********************************************************************/
+
+/**
+ * Creates a customized help dialog
+ *
+ * @param {string} title   The title to use for the message
+ * @param {string} select  Additional ways to select the typeset math
+ * @returns {string}       The customized message
+ */
+function helpMessage(title: string, select: string): string {
+  return `
+<H2>Exploring expressions ${title}</h2>
+
+<p>The mathematics on this page is being rendered by <a
+href="https://www.mathjax.org/" target="_blank">MathJax</a>, which
+generates both the text spoken by screen readers, as well as the
+visual layout for sighted users.</p>
+
+<p>Expressions typeset by MathJax can be explored interactively, and
+are focusable.  You can use the TAB key to move to a typeset
+expression${select}.  Initially, the expression will be read in full,
+but you can use the following keys to explore the expression
+further:<p>
+
+<ul>
+
+<li><b>Down Arrow</b> moves one level deeper into the expression to
+allow you to explore the current subexpression term by term.</li>
+
+<li><b>Up Arrow</b> moves back up a level within the expression.</li>
+
+<li><b>Right Arrow</b> moves to the next term in the current
+subexpression.</li>
+
+<li><b>Left Arrow</b> moves to the next term in the current
+subexpression.</li>
+
+<li><b>Enter</b> or <b>Return</b> clicks a link or activates an active
+subexpression.</li>
+
+<li><b>Space</b> opens the MathJax contextual menu where you can view
+or copy the source format of the expression, or modify MathJax's
+settings.</li>
+
+<li><b>Escape</b> exits the expression explorer.</li>
+
+<li><b>x</b> gives a summary of the current subexpression.</li>
+
+<li><b>d</b> gives the current depth within the expression.</li>
+
+<li><b>&gt;</b> cycles through the available speech rule sets
+(MathSpeak, ClearSpeak, ChromeVox).</li>
+
+<li><b>&lt;</b> cycles through the verbosity levels for the current
+rule set.</li>
+
+<li><b>h</b> produces this help listing.</li>
+</ul>
+
+<p>The MathJax contextual menu allows you to enable or disable speech
+or Braille generation for mathematical expressions, the language to
+use for the spoken mathematics, and other features of MathJax.  In
+particular, the Explorer submenu allows you to specify how the
+mathematics should be identified in the page (e.g., by saying "math"
+when the expression is spoken), and whether or not to include a
+message about the letter "h" bringing up this dialog box.</p>
+
+<p>The contextual menu also provides options for viewing or copying a
+MathML version of the expression or its original source format,
+creating an SVG version of the expression, and viewing various other
+information.</p>
+
+<p>For more help, see the <a
+href="https://docs.mathjax.org/en/latest/basic/accessibility.html"
+targe="_blank">MathJax accessibility documentation.</a></p>
+`;
+}
+
+/**
+ * Help for the different OS versions
+ */
+const helpData: Map<string, [string, string]> = new Map([
+  [
+    'MacOS',
+    [
+      'on Mac OS and iOS using VoiceOver',
+      ', or the VoiceOver arrow keys to select an expression',
+    ],
+  ],
+  [
+    'Windows',
+    [
+      'in Windows using NVDA or JAWS',
+      `. The screen reader should enter focus or forms mode automatically
+when the expression gets the browser focus, but if not, you can toggle
+focus mode using NVDA+space in NVDA; for JAWS, Enter should start
+forms mode while Numpad Plus leaves it.  Also note that you can use
+the NVDA or JAWS key plus the arrow keys to explore the expression
+even in browse mode, and you can use NVDA+shift+arrow keys to
+navigate out of an expression that has the focus in NVDA`,
+    ],
+  ],
+  [
+    'Unix',
+    [
+      'in Unix using Orca',
+      `, and Orca should enter focus mode automatically.  If not, use the
+Orca+a key to toggle focus mode on or off.  Also note that you can use
+Orca+arrow keys to explore expressions even in browse mode`,
+    ],
+  ],
+  ['unknown', ['with a Screen Reader.', '']],
+]);
+
+/**********************************************************************/
+/**********************************************************************/
 
 /**
  * @class
@@ -103,20 +233,36 @@ export class SpeechExplorer
   extends AbstractExplorer<string>
   implements KeyExplorer
 {
-  /**
-   * Flag indicating if the explorer is attached to an object.
+  /*
+   * The explorer key mapping
    */
-  public attached: boolean = false;
+  protected static keyMap: Map<string, keyMapping> = new Map([
+    ['Tab', () => true],
+    ['Control', (explorer) => explorer.controlKey()],
+    ['Escape', (explorer) => explorer.escapeKey()],
+    ['Enter', (explorer, event) => explorer.enterKey(event)],
+    ['ArrowDown', (explorer) => (explorer.active ? explorer.moveDown() : true)],
+    ['ArrowUp', (explorer) => (explorer.active ? explorer.moveUp() : true)],
+    ['ArrowLeft', (explorer) => (explorer.active ? explorer.moveLeft() : true)],
+    [
+      'ArrowRight',
+      (explorer) => (explorer.active ? explorer.moveRight() : true),
+    ],
+    [' ', (explorer) => explorer.spaceKey()],
+    ['h', (explorer) => explorer.hKey()],
+    ['H', (explorer) => explorer.hKey()],
+    ['>', (explorer) => (explorer.active ? explorer.nextRules() : false)],
+    ['<', (explorer) => (explorer.active ? explorer.nextStyle() : false)],
+    ['x', (explorer) => (explorer.active ? explorer.summary() : false)],
+    ['X', (explorer) => (explorer.active ? explorer.summary() : false)],
+    ['d', (explorer) => (explorer.active ? explorer.depth() : false)],
+    ['D', (explorer) => (explorer.active ? explorer.depth() : false)],
+  ] as [string, keyMapping][]);
 
   /**
    * Switches on or off the use of sound on this explorer.
    */
   public sound: boolean = false;
-
-  /**
-   * Id of the element focused before the restart.
-   */
-  public restarted: string = null;
 
   /**
    * Convenience getter for generator pool of the item.
@@ -128,167 +274,639 @@ export class SpeechExplorer
   }
 
   /**
-   * The original tabindex value before explorer was attached.
+   * Shorthand for the item's ARIA role
+   *
+   * @returns {string}  The role
    */
-  private oldIndex: number = null;
+  protected get role(): string {
+    return this.item.ariaRole;
+  }
 
   /**
-   * The currently focused elements.
+   * Shorthand for the item's ARIA role description
+   *
+   * @returns {string}  The role description
+   */
+  protected get description(): string {
+    return this.item.roleDescription;
+  }
+
+  /**
+   * Shorthand for the item's "none" indicator
+   *
+   * @returns {string}  The string to use for no description
+   */
+  protected get none(): string {
+    return this.item.none;
+  }
+
+  /**
+   * The currently focused element.
    */
   protected current: HTMLElement = null;
 
   /**
-   * Flag registering if events of the explorer are attached.
+   * The clicked node from a mousedown event
+   */
+  protected clicked: HTMLElement = null;
+
+  /**
+   * Node to focus on when restarted
+   */
+  public refocus: HTMLElement = null;
+
+  /**
+   * True when we are refocusing on the speech node
+   */
+  protected focusSpeech: boolean = false;
+
+  /**
+   * Selector string for re-focusing after re-rendering
+   */
+  public restarted: string = null;
+
+  /**
+   * The transient speech node
+   */
+  protected speech: HTMLElement = null;
+
+  /**
+   * The speech node when the top-level node has no role
+   */
+  protected img: HTMLElement = null;
+
+  /**
+   * True when top-level role is none
+   */
+  protected descend: boolean = false;
+
+  /**
+   * True when explorer is attached to a node
+   */
+  public attached: boolean = false;
+
+  /**
+   * Treu if events of the explorer are attached.
    */
   private eventsAttached: boolean = false;
 
-  /**
-   * Flag to register if the last event was an explorer move. This is important
-   * so the explorer does not stop (by FocusOut) during a focus shift.
+  /********************************************************************/
+  /*
+   * The event handlers
    */
-  private move = false;
-
-  /**
-   * Register the mousedown event. Prevent FocusIn executing twice from click
-   * and mousedown.
-   */
-  private mousedown = false;
 
   /**
    * @override
    */
   protected events: [string, (x: Event) => void][] = super.Events().concat([
+    ['focusin', this.FocusIn.bind(this)],
+    ['focusout', this.FocusOut.bind(this)],
     ['keydown', this.KeyDown.bind(this)],
     ['mousedown', this.MouseDown.bind(this)],
     ['click', this.Click.bind(this)],
-    ['focusin', this.FocusIn.bind(this)],
-    ['focusout', this.FocusOut.bind(this)],
   ]);
 
-  /**
-   * Test of an event has any modifier keys
-   *
-   * @param {MouseEvent} event   The event to check
-   * @returns {boolean}          True if shift, ctrl, alt, or meta key is pressed
-   */
-  protected hasModifiers(event: MouseEvent): boolean {
-    return event.shiftKey || event.metaKey || event.altKey || event.ctrlKey;
-  }
-
-  /**
-   * Records a mouse down event on the element. This ensures that focus events
-   * only fire if they were not triggered by a mouse click.
-   *
-   * @param {MouseEvent} e The mouse event.
-   */
-  private MouseDown(e: MouseEvent) {
-    this.FocusOut(null);
-    this.mousedown = true;
-    if (this.hasModifiers(e)) return;
-    document.getSelection()?.removeAllRanges();
-  }
-
-  /**
-   * Moves on mouse click to the closest clicked element.
-   *
-   * @param {MouseEvent} event The mouse click event.
-   */
-  public Click(event: MouseEvent) {
-    const clicked = (event.target as HTMLElement).closest(nav) as HTMLElement;
-    if (this.hasModifiers(event) || document.getSelection().type === 'Range') {
-      this.FocusOut(null);
-      return;
-    }
-    if (this.node.getAttribute('tabIndex') === '-1') return;
-    if (!this.node.contains(clicked)) {
-      // In case the mjx-container is in a div, we get the click, although it is outside.
-      this.mousedown = false;
-    }
-    if (this.node.contains(clicked)) {
-      const prev = this.node.querySelector(prevNav);
-      if (prev) {
-        prev.removeAttribute('tabindex');
-        this.FocusOut(null);
-      }
-      this.current = clicked;
-      if (!this.triggerLinkMouse()) {
-        this.Start();
-      }
-      event.preventDefault();
-    }
-  }
-
-  // Avoids double focus in event and thus double Start.
-  private focusin = false;
 
   /**
    * @override
    */
-  public FocusIn(event: FocusEvent) {
+  public FocusIn(_event: FocusEvent) {
     if (this.item.outputData.nofocus) {
-      return;
+      return; // we are refocusing after the menu has closed
     }
-    if (this.mousedown) {
-      this.mousedown = false;
-      return;
+    if (!this.clicked) {
+      this.Start();
     }
-    if (this.focusin) {
-      return;
-    }
-    this.focusin = !this.focusin;
-    this.current = this.current || this.node.querySelector('[role="treeitem"]');
-    this.Start();
-    event.preventDefault();
+    this.clicked = null;
   }
 
   /**
    * @override
    */
   public FocusOut(_event: FocusEvent) {
-    (document.activeElement as HTMLElement)?.blur();
-    // This guard is to FF and Safari, where focus in fired only once on
-    // keyboard.
-    if (!this.active) return;
-    this.generators.CleanUp(this.current);
-    this.generators.lastMove = InPlace.NONE;
-    if (!this.move) {
+    if (this.current && !this.focusSpeech) {
+      this.setCurrent(null);
       this.Stop();
-    }
-    this.current?.removeAttribute('tabindex');
-    this.node.setAttribute('tabindex', '0');
-  }
-
-  /**
-   * @override
-   */
-  public Attach() {
-    super.Attach();
-    this.attached = true;
-    this.oldIndex = this.node.tabIndex;
-    this.node.tabIndex = 0;
-  }
-
-  /**
-   * @override
-   */
-  public AddEvents() {
-    if (!this.eventsAttached) {
-      super.AddEvents();
-      this.eventsAttached = true;
+      if (!document.hasFocus()) {
+        this.focusTop();
+      }
     }
   }
 
   /**
    * @override
    */
-  public Detach() {
+  public KeyDown(event: KeyboardEvent) {
+    if (hasModifiers(event, false)) return;
+    //
+    // Get the key action, if there is one and perform it
+    //
+    const CLASS = this.constructor as typeof SpeechExplorer;
+    const action = CLASS.keyMap.get(event.key);
+    const result = action ? action(this, event) : this.undefinedKey(event);
+    //
+    // If result is true, propagate event,
+    // Otherwise stop the event, and if false, play the honk sound
+    //
+    if (result) return;
+    this.stopEvent(event);
+    if (result === false && this.sound) {
+      this.NoMove();
+    }
+  }
+
+  /**
+   * Handle clicks that perform selections, and keep track of clicked node
+   * so that the focusin event will know something was clicked.
+   *
+   * @param {MouseEvent} event   The mouse down event
+   */
+  private MouseDown(event: MouseEvent) {
+    if (hasModifiers(event) || event.buttons !== 0) return;
+    //
+    // Get the speech element that was clicked
+    //
+    const clicked = this.findClicked(
+      event.target as HTMLElement,
+      event.x,
+      event.y
+    );
+    //
+    // If it is the info icon, top the event and let the click handler process it
+    //
+    if (clicked === this.document.infoIcon) {
+      this.stopEvent(event);
+      return;
+    }
+    //
+    // Remove any selection ranges and
+    // if the clicked element is not the top-level node,
+    //   if the target is the highlight rectangle, refocus on the clicked element
+    //   otherwise record the click for the focusin handler
+    //
+    document.getSelection()?.removeAllRanges();
+    if (document.activeElement !== this.node) {
+      if ((event.target as HTMLElement).getAttribute('sre-highlighter-added')) {
+        this.refocus = clicked;
+      } else {
+        this.clicked = clicked;
+      }
+    }
+  }
+
+  /**
+   * Handle a click event
+   *
+   * @param {MouseEvent} event   The mouse click event
+   */
+  public Click(event: MouseEvent) {
+    //
+    // If we are extending a click region, focus out
+    //
+    if (hasModifiers(event) || event.buttons !== 0 || document.getSelection().type === 'Range') {
+      this.FocusOut(null);
+      return;
+    }
+    //
+    // Get the speech element that was clicked
+    //
+    const clicked = this.findClicked(
+      event.target as HTMLElement,
+      event.x,
+      event.y
+    );
+    //
+    // If it was the info icon, open the help dialog
+    //
+    if (clicked === this.document.infoIcon) {
+      this.stopEvent(event);
+      this.help();
+      return;
+    }
+    //
+    // If the node contains the clickd element,
+    //   don't propagate the event
+    //   focus on the clicked element when focusin occurs
+    //   start the explorer if this isn't a link
+    //
+    if (!clicked || this.node.contains(clicked)) {
+      this.stopEvent(event);
+      this.refocus = clicked;
+      if (!this.triggerLinkMouse()) {
+        this.Start();
+      }
+    }
+  }
+
+  /********************************************************************/
+  /*
+   * The Key action functions
+   */
+
+  /**
+   * The space key opens the menu, so it propagates, but we retain the
+   * current focus to refocus it when the menu closes.
+   *
+   * @returns {boolean}  Don't cancel the event
+   */
+  protected spaceKey(): boolean {
+    this.refocus = this.current;
+    return true;
+  }
+
+  /**
+   * Stop speeking.
+   *
+   * @returns {boolean}  Don't cancel the event
+   */
+  protected controlKey(): boolean {
+    speechSynthesis.cancel();
+    return true;
+  }
+
+  /**
+   * Open the help dialog, and refocus when it closes.
+   */
+  protected hKey() {
+    this.refocus = this.current;
+    this.help();
+  }
+
+  /**
+   * Stop exploring and focus the top element
+   *
+   * @returns {boolean}  Don't cancel the event
+   */
+  protected escapeKey(): boolean {
+    this.Stop();
+    this.focusTop();
+    return true;
+  }
+
+  /**
+   * Process Enter key events
+   *
+   * @returns {void | boolean}  False means play the honk sound
+   */
+  protected enterKey(event: KeyboardEvent): void | boolean {
     if (this.active) {
-      this.node.tabIndex = this.oldIndex;
-      this.oldIndex = null;
-      this.node.removeAttribute('role');
+      if (this.triggerLinkKeyboard(event)) {
+        this.Stop();
+      } else {
+        const expandable = this.actionable(this.current);
+        if (!expandable) {
+          return false;
+        }
+        this.refocus = expandable;
+        expandable.dispatchEvent(new Event('click'));
+      }
+    } else {
+      this.Start();
     }
-    this.attached = false;
   }
+
+  /**
+   * Move to deeper level in the expression
+   *
+   * @returns {boolean | void}  False if no node, void otherwise
+   */
+  protected moveDown(): boolean | void {
+    return this.moveTo(this.current.querySelector(nav));
+  }
+
+  /**
+   * Move to higher level in expression
+   *
+   * @returns {boolean | void}  False if no node, void otherwise
+   */
+  protected moveUp(): boolean | void {
+    return this.moveTo(this.current.parentElement.closest(nav));
+  }
+
+  /**
+   * Move to next term in the expression
+   *
+   * @returns {boolean | void}  False if no node, void otherwise
+   */
+  protected moveRight(): boolean | void {
+    return this.moveTo(this.nextSibling(this.current));
+  }
+
+  /**
+   * Move to previous term in the expression
+   *
+   * @returns {boolean | void}  False if no node, void otherwise
+   */
+  protected moveLeft(): boolean | void {
+    return this.moveTo(this.prevSibling(this.current));
+  }
+
+  /**
+   * Move to a specified node, unless it is null
+   *
+   * @param {HTMLElement} node   The node to move it
+   * @returns {boolean | void}   False if no node, void otherwise
+   */
+  protected moveTo(node: HTMLElement): void | boolean {
+    if (!node) return false;
+    this.setCurrent(node);
+  }
+
+  /**
+   * Determine if an event that is not otherwise mapped should be
+   * allowed to propagate.
+   *
+   * @param {KeyboardEvent} event   The event to check
+   * @returns {boolean}             True if not active or the event has a modifier
+   */
+  protected undefinedKey(event: KeyboardEvent): boolean {
+    return !this.active || hasModifiers(event);
+  }
+
+  /**
+   * Computes the nesting depth announcement for the currently focused sub
+   * expression.
+   */
+  public depth() {
+    const parts = [
+      [
+        this.node.getAttribute('data-semantic-level') ?? 'Level',
+        this.current.getAttribute('aria-level') ?? '0',
+      ]
+        .join(' ')
+        .trim(),
+    ];
+    if (this.actionable(this.current)) {
+      parts.unshift(
+        this.node.getAttribute(
+          this.current.childNodes.length === 0
+            ? 'data-semantic-expandable'
+            : 'data-semantic-collapsible'
+        ) ?? ''
+      );
+    }
+    this.speak(parts.join(' '), this.current.getAttribute(SemAttr.BRAILLE));
+  }
+
+  /**
+   * Computes the summary for this expression.
+   */
+  public summary() {
+    const summary = this.current.getAttribute(SemAttr.SUMMARY);
+    this.speak(
+      summary,
+      this.current.getAttribute(SemAttr.BRAILLE),
+      this.SsmlAttributes(this.current)
+    );
+  }
+
+  /**
+   * Cycles to next speech rule set if possible and recomputes the speech for
+   * the expression.
+   */
+  public nextRules() {
+    this.node.removeAttribute('data-speech-attached');
+    this.restartAfter(this.generators.nextRules(this.item));
+  }
+
+  /**
+   * Cycles to next speech style or preference if possible and recomputes the
+   * speech for the expression.
+   */
+  public nextStyle() {
+    this.node.removeAttribute('data-speech-attached');
+    this.restartAfter(this.generators.nextStyle(this.current, this.item));
+  }
+
+  /**
+   * Displays the help dialog.
+   */
+  protected help() {
+    const adaptor = this.document.adaptor;
+    const helpSizer = adaptor.node('mjx-help-sizer', {}, [
+      adaptor.node(
+        'mjx-help-dialog',
+        { tabindex: 0, role: 'dialog', 'aria-labeledby': 'mjx-help-label' },
+        [
+          adaptor.node('h1', { id: 'mjx-help-label' }, [
+            adaptor.text('MathJax Expression Explorer Help'),
+          ]),
+          adaptor.node('div'),
+          adaptor.node('input', { type: 'button', value: 'Close' }),
+        ]
+      ),
+    ]);
+    document.body.append(helpSizer);
+    const help = helpSizer.firstChild as HTMLElement;
+    help.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (event.code === 'Escape') {
+        help.remove();
+        this.node.focus();
+        this.stopEvent(event);
+      }
+    });
+    help.addEventListener('focusout', () => {
+      setTimeout(() => {
+        if (!help.contains(document.activeElement)) {
+          help.remove();
+        }
+      }, 10);
+    });
+    help.lastChild.addEventListener('click', () => {
+      help.remove();
+      this.node.focus();
+    });
+    const [title, select] = helpData.get(context.os);
+    (help.childNodes[1] as HTMLElement).innerHTML = helpMessage(title, select);
+    help.focus();
+  }
+
+  /********************************************************************/
+  /*
+   * Methods to handle the currently selected node and its speech
+   */
+
+  /**
+   * Set the currently selected node and speak its label, if requested.
+   *
+   * @param {HTMLElement} node         The node that should become current
+   * @param {boolean} addSpeech        True if speech is to be added for that node
+   * @param {boolean} addDescription   True if the speech node should get a description
+   */
+  protected setCurrent(
+    node: HTMLElement,
+    addSpeech: boolean = true,
+    addDescription: boolean = false
+  ) {
+    if (!document.hasFocus()) {
+      this.refocus = this.current;
+    }
+    //
+    // Let AT know we are making changes
+    //
+    this.node.setAttribute('aria-busy', 'true');
+    //
+    // If there is a current selection
+    //   clear it and remove the associated speech
+    //   if we aren't setting a new selection
+    //   (i.e., we are focusing out)
+    //
+    if (this.current) {
+      this.current.classList.remove('mjx-selected');
+      this.pool.unhighlight();
+      this.current = null;
+      if (!node) {
+        this.removeSpeech();
+      }
+    }
+    //
+    // If there is a current node
+    //   Select it and add its speech, if requested
+    //
+    this.current = node;
+    if (this.current) {
+      this.current.classList.add('mjx-selected');
+      this.pool.highlight([this.current]);
+      if (addSpeech) {
+        this.addSpeech(node, addDescription);
+      }
+    }
+    //
+    // Done making changes
+    //
+    this.node.removeAttribute('aria-busy');
+  }
+
+  /**
+   * Remove the top-level speech node and create
+   *   a temporary one for the given node.
+   *
+   * @param {HTMLElement} node   The node to be spoken
+   * @param {boolean} describe   True if the description should be added
+   */
+  protected addSpeech(node: HTMLElement, describe: boolean) {
+    this.img?.remove();
+    let speech = [
+      node.getAttribute(SemAttr.PREFIX),
+      node.getAttribute(SemAttr.SPEECH),
+      node.getAttribute(SemAttr.POSTFIX),
+    ]
+      .join(' ')
+      .trim();
+    if (describe) {
+      let description =
+        this.description === this.none ? '' : ', ' + this.description;
+      if (this.descend && this.document.options.a11y.help) {
+        description += ', press h for help';
+      }
+      speech += description;
+    }
+    this.speak(speech, node.getAttribute(SemAttr.BRAILLE));
+    this.node.setAttribute('tabindex', '-1');
+  }
+
+  /**
+   * If there is a speech node, remove it
+   *   and put back the top-level node, if needed.
+   */
+  protected removeSpeech() {
+    if (this.speech) {
+      this.speech.remove();
+      this.speech = null;
+      this.node.append(this.img);
+      this.node.setAttribute('tabindex', '0');
+    }
+  }
+
+  /**
+   * Create a new speech node and sets its needed attributes,
+   *   then add it to the container and focus it.  If there is
+   *   and old speech node, remove it after a delay (the delay
+   *   is needed for Orca on Linux).
+   *
+   * @param {string} speech        The string to speak
+   * @param {string} braille       The braille string
+   * @param {string[]} ssml        The SSML attributes to add
+   * @param {string} description   The description to add to the speech
+   */
+  public speak(
+    speech: string,
+    braille: string = '',
+    ssml: string[] = null,
+    description: string = this.none
+  ) {
+    const oldspeech = this.speech;
+    this.speech = document.createElement('mjx-speech');
+    this.speech.setAttribute('role', 'math');
+    if (speech) {
+      this.speech.setAttribute('aria-label', speech);
+      this.speech.setAttribute(SemAttr.SPEECH, speech);
+      if (ssml) {
+        this.speech.setAttribute(SemAttr.PREFIX_SSML, ssml[0] || '');
+        this.speech.setAttribute(SemAttr.SPEECH_SSML, ssml[1] || '');
+        this.speech.setAttribute(SemAttr.POSTFIX_SSML, ssml[2] || '');
+      }
+    }
+    if (braille) {
+      this.speech.setAttribute('aria-braillelabel', braille);
+    }
+    this.speech.setAttribute('aria-roledescription', description);
+    this.speech.setAttribute('tabindex', '0');
+    this.node.append(this.speech);
+    this.focusSpeech = true;
+    this.speech.focus();
+    this.focusSpeech = false;
+    this.Update();
+    if (oldspeech) {
+      setTimeout(() => oldspeech.remove(), 0);
+    }
+  }
+
+  /**
+   * Set up the MathItem output to handle the speech exploration
+   */
+  public attachSpeech() {
+    const item = this.item;
+    const container = this.node;
+    const speech = container.getAttribute(SemAttr.SPEECH);
+    for (const child of Array.from(container.childNodes) as HTMLElement[]) {
+      child.setAttribute('aria-hidden', 'true'); // hide the content
+    }
+    container.setAttribute('has-speech', 'true');
+    const description = item.roleDescription;
+    if (!this.descend) {
+      container.setAttribute('aria-label', speech);
+      container.setAttribute('role', item.ariaRole);
+      container.setAttribute('aria-roledescription', description);
+    }
+    this.img?.remove();
+    this.img = this.document.adaptor.node('mjx-speech', {
+      'aria-label': speech + (description ? ', ' + description : ''),
+      role: 'img',
+      'aria-roledescription': item.none,
+    });
+    container.appendChild(this.img);
+  }
+
+  /**
+   * Undo any changes from attachSpeech()
+   */
+  public detachSpeech() {
+    const container = this.node;
+    this.img?.remove();
+    container.removeAttribute('aria-label');
+    container.removeAttribute('role');
+    container.removeAttribute('aria-roledescription');
+    container.removeAttribute('has-speech');
+    for (const child of Array.from(container.childNodes) as HTMLElement[]) {
+      child.removeAttribute('aria-hidden');
+    }
+  }
+
+  /********************************************************************/
+  /*
+   * Utility functions
+   */
 
   /**
    * Navigate one step to the right on the same level.
@@ -338,18 +956,283 @@ export class SpeechExplorer
     return null;
   }
 
-  protected moves: Map<string, (node: HTMLElement) => HTMLElement | null> =
-    new Map([
-      ['ArrowDown', (node: HTMLElement) => node.querySelector(nav)],
-      ['ArrowUp', (node: HTMLElement) => node.parentElement.closest(nav)],
-      ['ArrowLeft', this.prevSibling.bind(this)],
-      ['ArrowRight', this.nextSibling.bind(this)],
-      ['>', this.nextRules.bind(this)],
-      ['<', this.nextStyle.bind(this)],
-      ['x', this.summary.bind(this)],
-      ['Enter', this.expand.bind(this)],
-      ['d', this.depth.bind(this)],
-    ]);
+  /**
+   * Find the speech node that was clicked, if any
+   *
+   * @param {HTMLElement} node   The target node that was clicked
+   * @param {number} x           The x-coordinate of the click
+   * @param {number} y           The y-coordinate of the click
+   * @returns {HTMLElement}      The clicked node or null
+   */
+  protected findClicked(node: HTMLElement, x: number, y: number): HTMLElement {
+    //
+    // Check if the click is on the info icon and return that if it is.
+    //
+    const icon = this.document.infoIcon;
+    if (icon === node || icon.contains(node)) {
+      return icon;
+    }
+    //
+    // For CHTML, get the closest navigable parent element.
+    //
+    if (this.node.getAttribute('jax') !== 'SVG') {
+      return node.closest(nav) as HTMLElement;
+    }
+    //
+    // For SVG, look through the tree to find the element whose bounding box
+    // contains the click (x,y) position.
+    //
+    let found = null;
+    let clicked = this.node;
+    while (clicked) {
+      if (clicked.matches(nav)) {
+        found = clicked; // could be this node, but check if a child is clicked
+      }
+      const nodes = Array.from(clicked.childNodes) as HTMLElement[];
+      clicked = null;
+      for (const child of nodes) {
+        if (
+          child !== this.speech &&
+          child !== this.img &&
+          child.tagName.toLowerCase() !== 'rect'
+        ) {
+          const { left, right, top, bottom } = child.getBoundingClientRect();
+          if (left <= x && x <= right && top <= y && y <= bottom) {
+            clicked = child;
+            break;
+          }
+        }
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Focus the container node without activating it (e.g., when Escape is pressed)
+   */
+  protected focusTop() {
+    this.focusSpeech = true;
+    this.node.focus();
+    this.focusSpeech = false;
+  }
+
+  /**
+   * Get the SSML attribute array
+   *
+   * @param {HTMLElement} node  The node whose SSML attributes are to be obtained
+   * @returns {string[]}        The prefix/summary/postfix array
+   */
+  protected SsmlAttributes(node: HTMLElement): string[] {
+    return [
+      node.getAttribute(SemAttr.PREFIX_SSML),
+      node.getAttribute(SemAttr.SUMMARY_SSML),
+      node.getAttribute(SemAttr.POSTFIX_SSML),
+    ];
+  }
+
+  /**
+   * Restarts the explorer after a promise resolves (e.g., for an maction rerender)
+   *
+   * @param {Promise<void>} promise  The promise to restart after
+   */
+  protected async restartAfter(promise: Promise<void>) {
+    this.img.remove();
+    this.img = null;
+    await promise;
+    this.attachSpeech();
+    const current = this.current;
+    this.current = null;
+    this.setCurrent(current);
+  }
+
+  /********************************************************************/
+  /*
+   * Base class overrides
+   */
+
+  /**
+   * @param {ExplorerMathDocument} document The accessible math document.
+   * @param {ExplorerPool} pool The explorer pool.
+   * @param {SpeechRegion} region The speech region for the explorer.
+   * @param {HTMLElement} node The node the explorer is assigned to.
+   * @param {LiveRegion} brailleRegion The braille region.
+   * @param {HoverRegion} magnifyRegion The magnification region.
+   * @param {MmlNode} _mml The internal math node.
+   * @param {ExplorerMathItem} item The math item.
+   * @class
+   * @augments {AbstractExplorer}
+   */
+  constructor(
+    public document: ExplorerMathDocument,
+    public pool: ExplorerPool,
+    public region: SpeechRegion,
+    protected node: HTMLElement,
+    public brailleRegion: LiveRegion,
+    public magnifyRegion: HoverRegion,
+    _mml: MmlNode,
+    public item: ExplorerMathItem
+  ) {
+    super(document, pool, null, node);
+  }
+
+  /**
+   * Determine the node that should be made active when we start
+   * (the refocus, current, or restarted node, if any otherwise null)
+   *
+   * @returns {HTMLElement}   The node to be made the current node
+   */
+  protected findStartNode(): HTMLElement {
+    let node = this.refocus || this.current;
+    if (!node && this.restarted) {
+      node = this.node.querySelector(this.restarted);
+    }
+    this.refocus = this.restarted = null;
+    return node;
+  }
+
+  /**
+   * @override
+   */
+  public async Start() {
+    //
+    // If we aren't attached or already active, return
+    //
+    if (!this.attached || this.active) return;
+    //
+    // If there is no speech, request the speech and wait for it
+    //
+    if (this.item.state() < STATE.ATTACHSPEECH) {
+      this.item.attachSpeech(this.document);
+      await this.generators.promise;
+    }
+    //
+    // If we are respnding to a focusin on the speech node, we are done
+    //
+    if (this.focusSpeech) return;
+    //
+    // Mark the node as active (for CSS that turns on the info icon)
+    // and add the info icon.
+    //
+    this.node.classList.add('mjx-explorer-active');
+    this.node.append(this.document.infoIcon);
+    //
+    // Get the node to make current, and determine if we need to add a
+    // speech node (or just use the top-level node), then set the
+    // current node (which creates the speech) and start the explorer.
+    //
+    const node = this.findStartNode();
+    const add = this.descend || !!node;
+    this.setCurrent(node || this.node.querySelector(nav), add, !node);
+    super.Start();
+    //
+    // Add the help message if we are focusing the top-level node
+    //
+    if (!node && !this.descend && this.document.options.a11y.help) {
+      const description = this.description;
+      this.node.setAttribute(
+        'aria-roledescription',
+        (description === this.none ? '' : description + ' ') +
+          'press h for help' +
+          (context.os === 'unix' ? ' when focused' : '')
+      );
+    }
+    //
+    // Show any needed regions
+    //
+    const options = this.document.options;
+    const a11y = options.a11y;
+    if (a11y.subtitles && a11y.speech && options.enableSpeech) {
+      this.region.Show(this.node, this.highlighter);
+    }
+    if (a11y.viewBraille && a11y.braille && options.enableBraille) {
+      this.brailleRegion.Show(this.node, this.highlighter);
+    }
+    if (a11y.keyMagnifier) {
+      this.magnifyRegion.Show(this.current, this.highlighter);
+    }
+    this.Update();
+  }
+
+  /**
+   * @override
+   */
+  public Stop() {
+    if (this.active) {
+      const description = this.description;
+      if (this.node.getAttribute('aria-roledescription') !== description) {
+        this.node.setAttribute('aria-roledescription', description);
+      }
+      this.node.classList.remove('mjx-explorer-active');
+      this.document.infoIcon.remove();
+      this.pool.unhighlight();
+      this.magnifyRegion.Hide();
+      this.region.Hide();
+      this.brailleRegion.Hide();
+    }
+    super.Stop();
+  }
+
+  /**
+   * @override
+   */
+  public Update() {
+    if (!this.active) return;
+    this.region.node = this.node;
+    this.generators.updateRegions(
+      this.speech || this.node,
+      this.region,
+      this.brailleRegion
+    );
+    this.magnifyRegion.Update(this.current);
+  }
+
+  /**
+   * @override
+   */
+  public Attach() {
+    if (this.attached) return;
+    super.Attach();
+    this.node.setAttribute('tabindex', '0');
+    this.descend = this.role === 'none';
+    this.attached = true;
+  }
+
+  /**
+   * @override
+   */
+  public Detach() {
+    super.RemoveEvents();
+    this.node.removeAttribute('role');
+    this.node.removeAttribute('aria-roledescription');
+    this.node.removeAttribute('aria-label');
+    this.img?.remove();
+    if (this.active) {
+      this.node.setAttribute('tabindex', '0');
+    }
+    this.attached = false;
+  }
+
+  /**
+   * @override
+   */
+  public NoMove() {
+    honk();
+  }
+
+  /**
+   * @override
+   */
+  public AddEvents() {
+    if (!this.eventsAttached) {
+      super.AddEvents();
+      this.eventsAttached = true;
+    }
+  }
+
+  /********************************************************************/
+  /*
+   * Actions and links
+   */
 
   /**
    * Checks if a node is actionable, i.e., corresponds to an maction.
@@ -363,310 +1246,12 @@ export class SpeechExplorer
   }
 
   /**
-   * Computes the nesting depth announcement for the currently focused sub
-   * expression.
-   *
-   * @param {HTMLElement} node The current node.
-   * @returns {HTMLElement} The refocused node.
-   */
-  public depth(node: HTMLElement): HTMLElement {
-    this.generators.depth(node, this.node, !!this.actionable(node));
-    this.refocus();
-    this.generators.lastMove = InPlace.DEPTH;
-    return node;
-  }
-
-  /**
-   * Expands or collapses the currently focused node.
-   *
-   * @param {HTMLElement} node The focused node.
-   * @returns {HTMLElement} The node if action was successful. O/w null.
-   */
-  public expand(node: HTMLElement): HTMLElement {
-    const expandable = this.actionable(node);
-    if (!expandable) {
-      return null;
-    }
-    expandable.dispatchEvent(new Event('click'));
-    return node;
-  }
-
-  /**
-   * Computes the summary for this expression. This is temporary and will be
-   * replaced by the full speech on focus out.
-   *
-   * @param {HTMLElement} node The targeted node.
-   * @returns {HTMLElement} The refocused targeted node.
-   */
-  public summary(node: HTMLElement): HTMLElement {
-    this.generators.summary(node);
-    this.refocus();
-    this.generators.lastMove = InPlace.SUMMARY;
-    return node;
-  }
-
-  /**
-   * Cycles to next speech rule set if possible and recomputes the speech for
-   * the expression.
-   *
-   * @param {HTMLElement} node The targeted node.
-   * @returns {HTMLElement} The refocused targeted node.
-   */
-  public nextRules(node: HTMLElement): HTMLElement {
-    this.node.removeAttribute('data-speech-attached');
-    this.generators.nextRules(this.item);
-    this.refocus();
-    return node;
-  }
-
-  /**
-   * Cycles to next speech style or preference if possible and recomputes the
-   * speech for the expression.
-   *
-   * @param {HTMLElement} node The targeted node.
-   * @returns {HTMLElement} The refocused targeted node.
-   */
-  public nextStyle(node: HTMLElement): HTMLElement {
-    this.node.removeAttribute('data-speech-attached');
-    this.generators.nextStyle(node, this.item);
-    this.refocus();
-    return node;
-  }
-
-  /**
-   * Refocuses the active elements, after recomputed speech and to alert
-   * screenreaders of changes.
-   */
-  private refocus() {
-    this.Stop();
-    this.Restart((_err) => {
-      this.node.setAttribute('data-speech-attached', 'true');
-      this.Start();
-    });
-  }
-
-  /**
-   * @override
-   */
-  public Move(e: KeyboardEvent) {
-    this.move = true;
-    const target = e.target as HTMLElement;
-    const move = this.moves.get(e.key);
-    let next = null;
-    if (move) {
-      e.preventDefault();
-      next = move(target);
-    }
-    if (next) {
-      target.removeAttribute('tabindex');
-      next.setAttribute('tabindex', '0');
-      next.focus();
-      this.current = next;
-      this.move = false;
-      return true;
-    }
-    this.move = false;
-    return false;
-  }
-
-  /**
-   * @override
-   */
-  public NoMove() {
-    honk();
-  }
-
-  /**
-   * @param {A11yDocument} document The accessible math document.
-   * @param {ExplorerPool} pool The explorer pool.
-   * @param {SpeechRegion} region The speech region for the explorer.
-   * @param {HTMLElement} node The node the explorer is assigned to.
-   * @param {LiveRegion} brailleRegion The braille region.
-   * @param {HoverRegion} magnifyRegion The magnification region.
-   * @param {MmlNode} _mml The internal math node.
-   * @param {ExplorerMathItem} item The math item.
-   * @class
-   * @augments {AbstractExplorer}
-   */
-  constructor(
-    public document: A11yDocument,
-    public pool: ExplorerPool,
-    public region: SpeechRegion,
-    protected node: HTMLElement,
-    public brailleRegion: LiveRegion,
-    public magnifyRegion: HoverRegion,
-    _mml: MmlNode,
-    public item: ExplorerMathItem
-  ) {
-    super(document, pool, null, node);
-  }
-
-  /**
-   * Wait for speech to be reattached.
-   *
-   * @param {(err: string) => void} handler The error handling function should
-   *      restart fail.
-   */
-  private async Restart(handler: (err: string) => void = (_err: string) => {}) {
-    this.generators.promise
-      .then(() => this.Start())
-      .catch((err) => {
-        console.info(`Restart error for ${err}`);
-        handler(err);
-      });
-  }
-
-  /**
-   * @override
-   */
-  public Start() {
-    // In case the speech is not attached yet, we generate it
-    if (this.item.state() < STATE.ATTACHSPEECH) {
-      this.item.attachSpeech(this.document);
-    }
-    if (!this.attached) return;
-    if (!this.node.hasAttribute('data-speech-attached')) {
-      this.Restart();
-      return;
-    }
-    if (this.node.hasAttribute('tabindex')) {
-      this.node.removeAttribute('tabindex');
-    }
-    if (this.active) return;
-    if (this.restarted !== null) {
-      // Here we refocus after a restart: We either find the previously focused
-      // node or we assume that it is inside the collapsed expression tree and
-      // focus on the collapsed element.
-      this.current = this.node.querySelector(
-        `[data-semantic-id="${this.restarted}"]`
-      );
-      if (!this.current) {
-        const dummies = Array.from(
-          this.node.querySelectorAll('[data-semantic-type="dummy"]')
-        ).map((x) => x.getAttribute('data-semantic-id'));
-        let internal = this.generators.element.querySelector(
-          `[data-semantic-id="${this.restarted}"]`
-        );
-        while (internal && internal !== this.generators.element) {
-          const sid = internal.getAttribute('data-semantic-id');
-          if (dummies.includes(sid)) {
-            this.current = this.node.querySelector(
-              `[data-semantic-id="${sid}"]`
-            );
-            break;
-          }
-          internal = internal.parentNode as Element;
-        }
-      }
-      this.restarted = null;
-    }
-    if (!this.current) {
-      // In case something went wrong when focusing or restarting, we start on
-      // the root node by default.
-      this.current = this.node.childNodes[0] as HTMLElement;
-    }
-    const options = this.document.options;
-    this.current.setAttribute('tabindex', '0');
-    this.current.focus();
-    super.Start();
-    if (options.a11y.subtitles && options.a11y.speech && options.enableSpeech) {
-      this.region.Show(this.node, this.highlighter);
-    }
-    if (
-      options.a11y.viewBraille &&
-      options.a11y.braille &&
-      options.enableBraille
-    ) {
-      this.brailleRegion.Show(this.node, this.highlighter);
-    }
-    if (options.a11y.keyMagnifier) {
-      this.magnifyRegion.Show(this.current, this.highlighter);
-    }
-    this.Update();
-  }
-
-  /**
-   * @override
-   */
-  public Update() {
-    // TODO (v4): This avoids double voicing on initial startup!
-    if (!this.active) return;
-    this.pool.unhighlight();
-    this.pool.highlight([this.current]);
-    this.region.node = this.node;
-    this.generators.updateRegions(
-      this.current,
-      this.region,
-      this.brailleRegion
-    );
-    this.magnifyRegion.Update(this.current);
-  }
-
-  /**
-   * @override
-   */
-  public KeyDown(event: KeyboardEvent) {
-    const code = event.key;
-    if (code === 'Tab') {
-      return;
-    }
-    if (code === ' ') {
-      return;
-    }
-    if (code === 'Control') {
-      speechSynthesis.cancel();
-      return;
-    }
-    if (code === 'Escape') {
-      this.Stop();
-      this.stopEvent(event);
-      return;
-    }
-    if (code === 'Enter') {
-      if (!this.active && event.target instanceof HTMLAnchorElement) {
-        event.target.dispatchEvent(new MouseEvent('click'));
-        this.stopEvent(event);
-        return;
-      }
-      if (this.active && this.triggerLinkKeyboard(event)) {
-        this.Stop();
-        this.stopEvent(event);
-        return;
-      }
-      if (!this.active) {
-        if (!this.current) {
-          this.current = this.node.querySelector('[role="treeitem"]');
-        }
-        this.Start();
-        this.stopEvent(event);
-        return;
-      }
-    }
-    if (this.active) {
-      if (this.Move(event)) {
-        this.stopEvent(event);
-        this.Update();
-        return;
-      }
-      if (event.getModifierState(code)) {
-        return;
-      }
-      if (this.sound) {
-        this.NoMove();
-      }
-    }
-  }
-
-  /**
    * Programmatically triggers a link if the focused node contains one.
    *
    * @param {KeyboardEvent} event The keyboard event for the last keydown event.
    * @returns {boolean} True if link was successfully triggered.
    */
   protected triggerLinkKeyboard(event: KeyboardEvent): boolean {
-    if (event.code !== 'Enter') {
-      return false;
-    }
     if (!this.current) {
       if (event.target instanceof HTMLAnchorElement) {
         event.target.dispatchEvent(new MouseEvent('click'));
@@ -683,12 +1268,13 @@ export class SpeechExplorer
    * @param {HTMLElement} node The node with the link.
    * @returns {boolean} True if link was successfully triggered.
    */
-  protected triggerLink(node: HTMLElement) {
+  protected triggerLink(node: HTMLElement): boolean {
     const focus = node
       ?.getAttribute('data-semantic-postfix')
       ?.match(/(^| )link($| )/);
     if (focus) {
       node.parentNode.dispatchEvent(new MouseEvent('click'));
+      setTimeout(() => this.FocusOut(null), 50);
       return true;
     }
     return false;
@@ -700,7 +1286,7 @@ export class SpeechExplorer
    * @returns {boolean} True if link was successfully triggered.
    */
   protected triggerLinkMouse(): boolean {
-    let node = this.current;
+    let node = this.refocus;
     while (node && node !== this.node) {
       if (this.triggerLink(node)) {
         return true;
@@ -711,24 +1297,19 @@ export class SpeechExplorer
   }
 
   /**
-   * @override
-   */
-  public Stop() {
-    if (this.active) {
-      this.focusin = false;
-      this.pool.unhighlight();
-      this.magnifyRegion.Hide();
-      this.region.Hide();
-      this.brailleRegion.Hide();
-    }
-    super.Stop();
-  }
-
-  /**
    * @returns {string} The semantic id of the node that is currently focused.
    */
   public semanticFocus(): string {
-    const node = this.current || this.node;
-    return node.getAttribute('data-semantic-id');
+    const focus = [];
+    let name = 'data-semantic-id';
+    let node = this.current || this.node;
+    const action = this.actionable(node);
+    if (action) {
+      name = 'data-maction-id';
+      node = action;
+      focus.push(nav);
+    }
+    focus.unshift(`[${name}="${node.getAttribute(name)}"]`);
+    return focus.join(' ');
   }
 }

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -287,7 +287,7 @@ export class StringRegion extends AbstractRegion<string> {
     }
     if (this.inner) {
       this.inner.textContent = '';
-      this.inner.textContent = speech;
+      this.inner.textContent = speech || '\u00a0';
     }
   }
 

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -196,6 +196,9 @@ export function EnrichedMathItemMixin<
           }
           const enriched = Sre.toEnriched(mml);
           this.inputData.enrichedMml = math.math = this.serializeMml(enriched);
+          math.math = math.math
+            .replace(/ role="treeitem"/g, ' data-speech-node="true"')
+            .replace(/ aria-(?:posinset|owns|setsize)=".*?"/g, '');
           math.display = this.display;
           math.compile(document);
           this.root = math.root;

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -72,7 +72,14 @@ export class GeneratorPool<N, T, D> {
    * @param {OptionList} options The option list.
    */
   public set options(options: OptionList) {
-    this._options = Object.assign({}, options?.sre || {});
+    this._options = Object.assign(
+      {},
+      options?.sre || {},
+      {
+        enableSpeech: options.enableSpeech,
+        enableBraille: options.enableBraille
+      }
+    );
     delete this._options.custom;
   }
 

--- a/ts/a11y/speech/SpeechUtil.ts
+++ b/ts/a11y/speech/SpeechUtil.ts
@@ -256,4 +256,5 @@ export enum SemAttr {
   PREFIX_SSML = 'data-semantic-prefix',
   POSTFIX = 'data-semantic-postfix-none',
   POSTFIX_SSML = 'data-semantic-postfix',
+  BRAILLE = 'data-semantic-braille',
 }

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -29,8 +29,9 @@ import {
   Structure,
   StructureData,
 } from './MessageTypes.js';
-import { MathItem } from '../../core/MathItem.js';
+import { SpeechMathItem } from '../speech.js';
 import { hasWindow } from '../../util/context.js';
+import { SemAttr } from './SpeechUtil.js';
 
 /**
  * Class for relevant task information.
@@ -38,7 +39,7 @@ import { hasWindow } from '../../util/context.js';
 class Task<N, T, D> {
   constructor(
     public cmd: PoolCommand,
-    public item: MathItem<N, T, D>,
+    public item: SpeechMathItem<N, T, D>,
     public resolve: (value: any) => void,
     public reject: (cmd: string) => void
   ) {}
@@ -192,11 +193,11 @@ export class WorkerHandler<N, T, D> {
    * Send messages to the worker.
    *
    * @param {PoolCommand} msg The command message.
-   * @param {MathItem} item Optional MathItem that is being processed
+   * @param {SpeechMathItem} item Optional SpeechMathItem that is being processed
    *     command name as input.
    * @returns {Promise<any>} A promise that resolves when the command completes
    */
-  public Post(msg: PoolCommand, item?: MathItem<N, T, D>): Promise<any> {
+  public Post(msg: PoolCommand, item?: SpeechMathItem<N, T, D>): Promise<any> {
     const promise = new Promise((resolve, reject) => {
       this.tasks.push(new Task(msg, item, resolve, reject));
     });
@@ -218,9 +219,9 @@ export class WorkerHandler<N, T, D> {
   /**
    * Remove a task from the task list.
    *
-   * @param {MathItem} item   The item whose task is to be canceled.
+   * @param {SpeechMathItem} item   The item whose task is to be canceled.
    */
-  public Cancel(item: MathItem<N, T, D>) {
+  public Cancel(item: SpeechMathItem<N, T, D>) {
     const i = this.tasks.findIndex((task) => task.item === item);
     if (i > 0) {
       this.tasks[i].reject(`Task ${this.tasks[i].cmd.cmd} cancelled`);
@@ -255,13 +256,13 @@ export class WorkerHandler<N, T, D> {
    *
    * @param {string} math The mml string.
    * @param {OptionList} options The options list.
-   * @param {MathItem} item The mathitem for reattaching the speech.
+   * @param {SpeechMathItem} item The mathitem for reattaching the speech.
    * @returns {Promise<void>} A promise that resolves when the command completes
    */
   public async Speech(
     math: string,
     options: OptionList,
-    item: MathItem<N, T, D>
+    item: SpeechMathItem<N, T, D>
   ): Promise<void> {
     this.Attach(
       item,
@@ -287,13 +288,13 @@ export class WorkerHandler<N, T, D> {
    *
    * @param {string} math The mml string.
    * @param {OptionList} options The options list.
-   * @param {MathItem} item The mathitem for reattaching the speech.
+   * @param {SpeechMathItem} item The mathitem for reattaching the speech.
    * @returns {Promise<void>} A promise that resolves when the command completes
    */
   public async nextRules(
     math: string,
     options: OptionList,
-    item: MathItem<N, T, D>
+    item: SpeechMathItem<N, T, D>
   ): Promise<void> {
     this.Attach(
       item,
@@ -326,14 +327,14 @@ export class WorkerHandler<N, T, D> {
    * @param {string} math The linearized mml expression.
    * @param {OptionList} options The options list.
    * @param {string} nodeId The semantic Id of the currenctly focused node.
-   * @param {MathItem} item The mathitem for reattaching the speech.
+   * @param {SpeechMathItem} item The mathitem for reattaching the speech.
    * @returns {Promise<void>} A promise that resolves when the command completes
    */
   public async nextStyle(
     math: string,
     options: OptionList,
     nodeId: string,
-    item: MathItem<N, T, D>
+    item: SpeechMathItem<N, T, D>
   ): Promise<void> {
     this.Attach(
       item,
@@ -360,13 +361,13 @@ export class WorkerHandler<N, T, D> {
   /**
    * Attach the speech structure to an item's DOM
    *
-   * @param {MathItem} item             The MathItem to attach to
+   * @param {SpeechMathItem} item       The SpeechMathItem to attach to
    * @param {boolean} speech            True when speech should be added
    * @param {boolean} braille           True when Braille should be added
    * @param {StructureData} structure   The speech structure to attach
    */
   public Attach(
-    item: MathItem<N, T, D>,
+    item: SpeechMathItem<N, T, D>,
     speech: boolean,
     braille: boolean,
     structure: StructureData
@@ -393,16 +394,24 @@ export class WorkerHandler<N, T, D> {
       adaptor.setAttribute(node, 'data-semantic-type', 'dummy');
       this.setSpecialAttributes(node, sid, '');
     }
-    this.setSpeechAttributes(adaptor.childNodes(container)[0], '', data, speech, braille);
+    this.setSpeechAttributes(
+      adaptor.childNodes(container)[0],
+      '',
+      data,
+      speech,
+      braille
+    );
     if (speech) {
       if (data.label) {
-        adaptor.setAttribute(container, 'aria-label', data.label);
+        adaptor.setAttribute(container, SemAttr.SPEECH, data.label);
+        item.outputData.speech = data.label;
       }
       adaptor.setAttribute(container, 'data-speech-attached', 'true');
     }
     if (braille) {
       if (data.braillelabel) {
-        adaptor.setAttribute(container, 'aria-braillelabel', data.braillelabel);
+        adaptor.setAttribute(container, SemAttr.BRAILLE, data.braillelabel);
+        item.outputData.braille = data.braillelabel;
       }
       if (data.braille) {
         adaptor.setAttribute(container, 'data-braille-attached', 'true');
@@ -436,8 +445,7 @@ export class WorkerHandler<N, T, D> {
     }
     if (braille && data.braille?.[id]) {
       const value = data.braille[id]['braille-none'] || '';
-      adaptor.setAttribute(node, 'data-semantic-braille', value);
-      adaptor.setAttribute(node, 'aria-braillelabel', value);
+      adaptor.setAttribute(node, SemAttr.BRAILLE, value);
     }
   }
 
@@ -500,6 +508,44 @@ export class WorkerHandler<N, T, D> {
       if (value) {
         this.adaptor.setAttribute(node, `${prefix}${key.toLowerCase()}`, value);
       }
+    }
+  }
+
+  /**
+   * Remove speech attributes from a MathItem
+   *
+   * @param {SpeechMathItem} item   The MathItem whose speech attributes should be removed.
+   */
+  public Detach(item: SpeechMathItem<N, T, D>) {
+    const container = item.typesetRoot;
+    this.adaptor.removeAttribute(container, 'data-speech-attached');
+    this.adaptor.removeAttribute(container, 'data-braille-attached');
+    this.detachSpeech(container);
+  }
+
+  /**
+   * Recursively remove speech attributes from a DOM tree
+   *
+   * @param {N} node  The root node of the tree to modify
+   */
+  public detachSpeech(node: N) {
+    const adaptor = this.adaptor;
+    const children = adaptor.childNodes(node);
+    if (!children) return;
+    if (adaptor.kind(node) !== '#text') {
+      for (const key of [
+        'none',
+        'summary-none',
+        'speech',
+        'speech-none',
+        'summary',
+        'braille',
+      ]) {
+        adaptor.removeAttribute(node, `data-semantic-${key}`);
+      }
+    }
+    for (const child of children) {
+      this.detachSpeech(child as N);
     }
   }
 

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -488,7 +488,7 @@ export abstract class Startup {
     ) => {
       options.end = STATE.CONVERT;
       options.format = input.name;
-      const node = await Startup.document.convertPromise(math, options)
+      const node = await Startup.document.convertPromise(math, options);
       return Startup.toMML(node);
     };
   }

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -115,7 +115,6 @@ export class CHTML<N, T, D> extends CommonOutputJax<
         'padding-box xywh(-1em -2px calc(100% + 2em) calc(100% + 4px))',
     },
 
-    'mjx-container[jax="CHTML"] :focus': { outline: 'solid 2px' },
     'mjx-container [space="1"]': { 'margin-left': '.111em' },
     'mjx-container [space="2"]': { 'margin-left': '.167em' },
     'mjx-container [space="3"]': { 'margin-left': '.222em' },

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -101,6 +101,7 @@ export class MJContextMenu extends ContextMenu {
   public unpost() {
     super.unpost();
     this.mathItem.outputData.nofocus = false;
+    this.mathItem = null;
   }
 
   /*======================================================================*/

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -86,6 +86,11 @@ export interface MenuMathItem
   addMenu(document: MenuMathDocument, force?: boolean): void;
 
   /**
+   * @param {MenuMathDocument} document   The document where the menu is being added
+   */
+  getMenus(document: MenuMathDocument): void;
+
+  /**
    * @param {MenuMathDocument} document   The document to check for if anything is being loaded
    */
   checkLoading(document: MenuMathDocument): void;
@@ -113,6 +118,13 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
         document.menu.addMenu(this);
       }
       this.state(STATE.CONTEXT_MENU);
+    }
+
+    /**
+     * @param {MenuMathDocument} document   The document where the menu is being added
+     */
+    public getMenus(document: MenuMathDocument) {
+      (document.menu.menu.store as any).sort();
     }
 
     /**
@@ -191,6 +203,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       renderActions: expandable({
         ...BaseDocument.OPTIONS.renderActions,
         addMenu: [STATE.CONTEXT_MENU],
+        getMenus: [STATE.INSERTED + 5, false],
         checkLoading: [STATE.UNPROCESSED + 1],
       }),
     };
@@ -243,6 +256,13 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
     }
 
     /**
+     * @override
+     */
+    public getMenus() {
+      (this.menu.menu.store as any).sort();
+    }
+
+    /**
      * Checks if there are files being loaded by the menu, and restarts the typesetting if so
      *
      * @returns {MenuMathDocument}   The MathDocument (so calls can be chained)
@@ -270,15 +290,6 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       if (state < STATE.CONTEXT_MENU) {
         this.processed.clear('context-menu');
       }
-      return this;
-    }
-
-    /**
-     * @override
-     */
-    public updateDocument() {
-      super.updateDocument();
-      (this.menu.menu.store as any).sort();
       return this;
     }
   };

--- a/ts/ui/menu/MenuUtil.ts
+++ b/ts/ui/menu/MenuUtil.ts
@@ -26,8 +26,7 @@ import { context } from '../../util/context.js';
 /**
  * True when platform is a Mac (so we can enable CMD menu item for zoom trigger)
  */
-export const isMac =
-  context.window?.navigator?.platform?.substring(0, 3) === 'Mac';
+export const isMac = context.os === 'MacOS';
 
 /**
  * @param {string} text   The text to be copied to the clipboard

--- a/ts/util/context.ts
+++ b/ts/util/context.ts
@@ -32,4 +32,24 @@ export const hasWindow = typeof window !== 'undefined';
 export const context = {
   window: hasWindow ? window : null,
   document: hasWindow ? window.document : null,
+  os: (() => {
+    if (hasWindow && window.navigator) {
+      const app = window.navigator.appVersion;
+      const osNames = [
+        ['Win', 'Windows'],
+        ['Mac', 'MacOS'],
+        ['X11', 'Unix'],
+        ['Linux', 'Unix'],
+      ];
+      for (const [key, os] of osNames) {
+        if (app.includes(key)) {
+          return os;
+        }
+      }
+      if (window.navigator.userAgent.includes('Android')) {
+        return 'Unix';
+      }
+    }
+    return 'unknown';
+  })(),
 };


### PR DESCRIPTION
This PR implements a new paradigm for the expression explorer.  The main goals are:

* Work across the major browser/OS/screen-reader combinations.
* Properly read the full expression when reading the whole page or stepping through the page sentence-by-sentence (or by other units).
* Automatically enter "focus mode" when the expression is focused via tabbing or clicking
* Allow control over the description of the math (e.g., "clickable math") used during reading and focusing.
* A "press H for help" message should be spoken when the math is first focused (but can be turned off by a menu preference).

I tested with 11 combinations (Chrome, Firefox, and Safari on MacOS with VoiceOver; Chrome, Firefox, and Edge on Windows with NVDA and JAWS; and Chrome and Firefox on Linux with Orca) and I believe the all these goals are met.  I spent several weeks experimenting with these 11 configurations to find out what worked the same among them and what worked differently in order to try to find a common approach that worked for all the combinations.  Unfortunately, there didn't seem to be a single setup that worked consistently across all 11, but fortunately, within an OS, there was a setup that worked for all the browser/screen-reader combinations, so it is possible to make it work without users having to change settings by hand.

The prior approach (in the current beta.7 version) is to add aria-labels and `role="treeitem"` to the sub-nodes of the DOM tree and move the focus among these as the expression is explored.  This had several problems.  First, `treeitem` nodes must be in a container with `role="tree"`, which was not the case for us.  Second, it did not enter "focus mode" automatically.  Third, it did not read the full expression when reading the full page in some of the combinations.  Fourth, it basically did not work at all in VoiceOver.

In the new approach, rather than focusing the various node in the math display tree, when you walk to a new node that should be spoken, the explorer inserts a new temporary node that has the needed aria-label and focuses that while visually highlighting the proper display node.  The temporary node is removed when you navigate to the next node and a new one is added for the new speech.  The whole display tree has `aria-hidden="true"` and only the new speech node is visible to the AT.  This part works consistently across all the browser/OS/screen-reader combinations tested.  The only point of contention is how the top-level container element is handled.

In MacOS, there is no "focus mode" versus "browse mode" dichotomy, but in Windows and Unix, we need trigger the screen reader to enter "focus mode" when the expression is focused.  That requires the top-level `mjx-container` to have a role that does that, such as `application` or `tree`.  While `tree` could be used to enter focus mode, this role is designed as a means of making selections, and screen readers speak extra information about where you are in the tree and whether the current item is selected or not, which interferes with the reading of the math itself.  (E.g., NDVA would say things like "item 1 of 8, not selected" when moving within the expression.)  So it turned out to be impractical to use the `tree` role.  The `application` role was the only one that worked consistently across browsers and screen readers in Windows.  Fortunately, that role also works with Orca in Unix.  This role also has the advantage that its `aria-label` is spoken when reading through the page, whereas other roles would end up not speaking anything, so the math was skipped when reading through the page.

For MacOS, the handling of the various top-level roles varied widely across browsers, and there was not a role that would be read properly in all browsers when the page is being read as a whole.  The solution used here is to insert an extra node in the container that holds the speech for the entire equation and give it `role="img"`, since that seems to be one of the few roles whose `aria-label` will be spoken when the page is being read (this is also needed for JAWS to read the expression while reading the full page, if I recall correctly).  The top-level container gets no `role` or `aria-label` in this case, and when the expression is focused, the explorer descends to the `math` node and produces its speech (for Windows and Linux, the focus must remain on the container in order for the screen reader to enter focus mode).

In order to handle the "press H for help" message, MacOS includes it in the speech string when the expression is first focused (it is on the temporary node created for the speech).  Because the other OSs must keep the top-level expression focused in order to enter focus mode, the help message is added to the `aria-roledescription` on the fly (technically not legal, but works; this is the only illegal thing being done in this new explorer, though the use of `img` role is not ideal).

The timing of when the temporary images are created and removed, and when the `tabindex` is changed is important, and has been carefully managed, here.

I will add more comments about the details of the changes below soon, but wanted to get the PR out so that you can be trying it out in the meantime.