### PR TITLE
Refactor Tree Colorer

### DIFF
--- a/ts/a11y/explorer/TreeExplorer.ts
+++ b/ts/a11y/explorer/TreeExplorer.ts
@@ -25,7 +25,6 @@
 import { A11yDocument, Region } from './Region.js';
 import { AbstractExplorer } from './Explorer.js';
 import { ExplorerPool } from './ExplorerPool.js';
-import * as Sre from '../sre.js';
 
 export class AbstractTreeExplorer extends AbstractExplorer<void> {
   /**
@@ -86,18 +85,25 @@ export class FlameColorer extends AbstractTreeExplorer {
 
 export class TreeColorer extends AbstractTreeExplorer {
   /**
+   * Contrast value.
+   */
+  public contrast: ContrastPicker = new ContrastPicker();
+
+  private leaves: HTMLElement[] = [];
+  private modality: string = 'data-semantic-foreground';
+
+  /**
    * @override
    */
   public Start() {
     if (this.active) return;
     this.active = true;
-    const generator = Sre.getSpeechGenerator('Color');
     if (!this.node.hasAttribute('hasforegroundcolor')) {
-      generator.generateSpeech(this.node, this.mml);
+      this.colorLeaves();
       this.node.setAttribute('hasforegroundcolor', 'true');
     }
     // TODO: Make this cleaner in Sre.
-    (this.highlighter as any).colorizeAll(this.node);
+    this.leaves.forEach((leaf) => this.colorize(leaf));
   }
 
   /**
@@ -105,8 +111,118 @@ export class TreeColorer extends AbstractTreeExplorer {
    */
   public Stop() {
     if (this.active) {
-      (this.highlighter as any).uncolorizeAll(this.node);
+      this.leaves.forEach((leaf) => this.uncolorize(leaf));
     }
     this.active = false;
+  }
+
+  /**
+   * Colors the leave nodes of the expression.
+   */
+  private colorLeaves() {
+    this.leaves = Array.from(
+      this.node.querySelectorAll(
+        '[data-semantic-id]:not([data-semantic-children])'
+      )
+    );
+    for (const leaf of this.leaves) {
+      leaf.setAttribute(this.modality, this.contrast.generate());
+      this.contrast.increment();
+    }
+  }
+
+  /**
+   * Tree colors a single node.
+   *
+   * @param {HTMLElement} node The node.
+   */
+  public colorize(node: HTMLElement) {
+    if (node.hasAttribute(this.modality)) {
+      node.setAttribute(this.modality + '-old', node.style.color);
+      node.style.color = node.getAttribute(this.modality);
+    }
+  }
+
+  /**
+   * Removes tree coloring from a single node.
+   *
+   * @param {HTMLElement} node The node.
+   */
+  public uncolorize(node: HTMLElement) {
+    const fore = this.modality + '-old';
+    if (node.hasAttribute(fore)) {
+      node.style.color = node.getAttribute(fore);
+    }
+  }
+}
+
+export class ContrastPicker {
+  /**
+   * Hue value.
+   */
+  public hue = 10;
+
+  /**
+   * Saturation value.
+   */
+  public sat = 100;
+
+  /**
+   * Light value.
+   */
+  public light = 50;
+
+  /**
+   * Increment step. Prime closest to 50.
+   */
+  public incr = 53;
+
+  /**
+   * Generates the current color as rgb color in hex code.
+   *
+   * @returns {string} The rgb color attribute.
+   */
+  public generate(): string {
+    return ContrastPicker.hsl2rgb(this.hue, this.sat, this.light);
+  }
+
+  /**
+   * Increments the hue value of the current color.
+   */
+  public increment() {
+    this.hue = (this.hue + this.incr) % 360;
+  }
+
+  /**
+   * Transforms a HSL triple into an rgb value triple.
+   *
+   * @param {number} h The hue.
+   * @param {number} s The saturation.
+   * @param {number} l The luminosity.
+   * @returns {string} The string with rgb value triple with values in [0, 255].
+   */
+  public static hsl2rgb(h: number, s: number, l: number): string {
+    s = s > 1 ? s / 100 : s;
+    l = l > 1 ? l / 100 : l;
+    const c = (1 - Math.abs(2 * l - 1)) * s;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = l - c / 2;
+    let r = 0,
+      g = 0,
+      b = 0;
+    if (0 <= h && h < 60) {
+      [r, g, b] = [c, x, 0];
+    } else if (60 <= h && h < 120) {
+      [r, g, b] = [x, c, 0];
+    } else if (120 <= h && h < 180) {
+      [r, g, b] = [0, c, x];
+    } else if (180 <= h && h < 240) {
+      [r, g, b] = [0, x, c];
+    } else if (240 <= h && h < 300) {
+      [r, g, b] = [x, 0, c];
+    } else if (300 <= h && h < 360) {
+      [r, g, b] = [c, 0, x];
+    }
+    return `rgb(${(r + m) * 255}, ${(g + m) * 255}, ${(b + m) * 255})`;
   }
 }

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -23,12 +23,10 @@
  */
 
 import * as Api from '#sre/common/system.js';
-import * as SpeechGeneratorFactory from '#sre/speech_generator/speech_generator_factory.js';
 import { Engine } from '#sre/common/engine.js';
 import { ClearspeakPreferences } from '#sre/speech_rules/clearspeak_preferences.js';
 import { Highlighter } from '#sre/highlighter/highlighter.js';
 import * as HighlighterFactory from '#sre/highlighter/highlighter_factory.js';
-import { SpeechGenerator } from '#sre/speech_generator/speech_generator.js';
 import { SemanticNode } from '#sre/semantic_tree/semantic_node.js';
 import { parseInput } from '#sre/common/dom_util.js';
 import { Variables } from '#sre/common/variables.js';
@@ -36,8 +34,6 @@ import { Variables } from '#sre/common/variables.js';
 export { semanticMathmlNode } from '#sre/enrich_mathml/enrich.js';
 
 export type highlighter = Highlighter;
-
-export type speechGenerator = SpeechGenerator;
 
 export type semanticNode = SemanticNode;
 
@@ -64,8 +60,6 @@ export const clearspeakPreferences = ClearspeakPreferences;
 export const getHighlighter = HighlighterFactory.highlighter;
 
 export const updateHighlighter = HighlighterFactory.update;
-
-export const getSpeechGenerator = SpeechGeneratorFactory.generator;
 
 export const parseDOM = parseInput;
 


### PR DESCRIPTION
Refactors code for tree coloring from SRE to the actual explorer. This reduces the footprint of code that is pulled in from SRE. I will remove more dependencies once PR #1241 is merged.

Note, that commit 04775ebbe35a00344dc28eab0d2220637554d450 only contains changes from automatic formatting and linting.