### PR TITLE
Change to using @mathjax/src rather than mathjax-full

### DIFF
--- a/components/bin/link-full
+++ b/components/bin/link-full
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 const dir = path.join(__dirname, '..', '..');
+const src = path.join(dir, 'node_modules', '@mathjax', 'src');
 
-if (fs.existsSync(path.join(dir, 'node_modules')) &&
-   !fs.existsSync(path.join(dir, 'node_modules', 'mathjax-full'))) {
-  fs.symlinkSync(dir, path.join(dir, 'node_modules', 'mathjax-full'));
+if (fs.existsSync(path.join(dir, 'node_modules')) && !fs.existsSync(src)) {
+  fs.symlinkSync(dir, src);
 }

--- a/components/bin/package.json
+++ b/components/bin/package.json
@@ -1,9 +1,9 @@
 {
   "type": "commonjs",
   "imports": {
-    "#js/*": "mathjax-full/cjs/*",
-    "#source/*": "mathjax-full/components/cjs/*",
-    "#root/*": "mathjax-full/cjs/components/cjs/*",
+    "#js/*": "@mathjax/src/cjs/*",
+    "#source/*": "@mathjax/src/components/cjs/*",
+    "#root/*": "@mathjax/src/cjs/components/cjs/*",
     "#menu/*": "mj-context-menu/cjs/*",
     "#sre/*": "speech-rule-engine/cjs/*",
     "#mhchem/*": "mhchemparser/dist/*",

--- a/components/mjs/fullpath.cjs
+++ b/components/mjs/fullpath.cjs
@@ -19,7 +19,7 @@
  * Gets the fully resolved path from a webpack request object using the
  * correct package.json file to map pseudo-packages to the mjs/cjs directories.
  * When this file is in the components/cjs directory, it will use the
- * package.json in that directory, which maps them to the mathjax-full/cjs files.
+ * package.json in that directory, which maps them to the @mathjax/src/cjs files.
  * When in the components/mjs directory, the main package.json file will be used.
  */
 

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -55,6 +55,7 @@ const PLUGINS = function (js, dir, target, font, jax, name) {
   //
   // Replace components/mjs/root with the webpack version
   //   and map mathjax-full/js to mathjax-full/${target}
+  //   similarly for @mathjax/src/js.
   //
   const plugins = [
     new webpack.NormalModuleReplacementPlugin(
@@ -65,6 +66,12 @@ const PLUGINS = function (js, dir, target, font, jax, name) {
       /mathjax-full\/js\//,
       function (resource) {
         resource.request = resource.request.replace(/mathjax-full\/js\//, `mathjax-full/${target}/`);
+      }
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@mathjax\/src\/js\//,
+      function (resource) {
+        resource.request = resource.request.replace(/@mathjax\/src\/js\//, `@mathjax/src/${target}/`);
       }
     )
   ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mathjax-full",
-  "version": "4.0.0-beta.7",
+  "name": "@mathjax/src",
+  "version": "4.0.0-beta.8",
   "description": "Beautiful and accessible math in all browsers. MathJax is an open-source JavaScript display engine for LaTeX, MathML, and AsciiMath notation that works in all browsers and in server-side node applications. This package includes the source code as well as the packaged components.",
   "keywords": [
     "MathJax",
@@ -50,9 +50,9 @@
     "./*": "./*"
   },
   "imports": {
-    "#js/*": "mathjax-full/mjs/*",
-    "#source/*": "mathjax-full/components/mjs/*",
-    "#root/*": "mathjax-full/mjs/components/mjs/*",
+    "#js/*": "@mathjax/src/mjs/*",
+    "#source/*": "@mathjax/src/components/mjs/*",
+    "#root/*": "@mathjax/src/mjs/components/mjs/*",
     "#menu/*": "mj-context-menu/js/*",
     "#sre/*": "speech-rule-engine/js/*",
     "#mhchem/*": "mhchemparser/esm/*",
@@ -102,7 +102,7 @@
     "cjs:components:finalize": "pnpm -s log:comp 'Finalize cjs components'; pnpm -s cjs:components:copy && pnpm -s copy:pkg components/cjs && pnpm -s clean:lib cjs",
     "cjs:components:make": "make() { pnpm -s log:single 'Making cjs components'; components/bin/makeAll --cjs --terse --bundle-cjs $1 components/cjs; }; make",
     "cjs:components:src:build": "pnpm -s log:comp 'Building cjs components sources'; pnpm cjs:components:clean && pnpm cjs:components:compile && pnpm cjs:components:finalize",
-    "cjs:src:build": "pnpm -s log:comp 'Building cjs sources'; pnpm -s link:full && pnpm clean:dir cjs && pnpm -s cjs:compile && pnpm -s copy:assets cjs && pnpm -s copy:pkg cjs",
+    "cjs:src:build": "pnpm -s log:comp 'Building cjs sources'; pnpm -s link:src && pnpm clean:dir cjs && pnpm -s cjs:compile && pnpm -s copy:assets cjs && pnpm -s copy:pkg cjs",
     "cjs:copy:components": "pnpm -s log:single 'Moving cjs files from components' && pnpm copyfiles -u 2 'components/mjs/**/*.cjs' 'components/mjs/**/*.d.cts' components/cjs",
     "cjs:copy:ts": "pnpm -s log:single 'Moving cjs files from ts' && pnpm copyfiles -u 1 'ts/**/*.cjs' cjs",
     "=============================================================================== mjs": "",
@@ -111,7 +111,7 @@
     "mjs:compile": "pnpm -s log:single 'Compiling mjs typescript files'; pnpm tsc --project tsconfig/mjs.json && pnpm tsc --project tsconfig/worker.json",
     "mjs:components:build": "pnpm -s log:comp 'Compiling mjs component files'; pnpm clean:lib mjs && pnpm clean:dir bundle && pnpm mjs:components:make && pnpm mjs:bundle:finalize",
     "mjs:components:make": "pnpm -s log:single 'Making mjs components'; components/bin/makeAll --mjs --terse components/mjs",
-    "mjs:src:build": "pnpm -s log:comp 'Building mjs sources'; pnpm -s link:full && pnpm -s clean:dir mjs && pnpm -s mjs:compile && pnpm -s copy:assets mjs",
+    "mjs:src:build": "pnpm -s log:comp 'Building mjs sources'; pnpm -s link:src && pnpm -s clean:dir mjs && pnpm -s mjs:compile && pnpm -s copy:assets mjs",
     "=============================================================================== mml3": "",
     "mml3:make:xslt": "pnpm xslt3 -t -xsl:/tmp/mml3.xsl -export:ts/input/mathml/mml3/mml3.sef.json -nogo",
     "mml3:post:xslt": "pnpm rimraf /tmp/mml3.xsl",
@@ -119,7 +119,7 @@
     "mml3-xslt": "pnpm -s mml3:pre:xslt && pnpm -s mml3:make:xslt && pnpm -s mml3:post:xslt",
     "=============================================================================== misc": "",
     "lab:sre": "pnpm -s log:single 'Making lab/sre'; node components/bin/makeAll --terse lab/build",
-    "link:full": "pnpm -s log:single 'Setting symbolic link'; node components/bin/link-full",
+    "link:src": "pnpm -s log:single 'Setting symbolic link'; node components/bin/link-full",
     "use-cjs": "echo '{\n  \"extends\": \"./tsconfig/cjs.json\"\n}' > tsconfig.json",
     "use-mjs": "echo '{\n  \"extends\": \"./tsconfig/mjs.json\"\n}' > tsconfig.json",
     "=============================================================================== aliases": "",


### PR DESCRIPTION
This PR moves `mathjax-full` to a scoped package, `@mathjax/src`, as we have discussed.  The fonts are already scoped, and this completes the move to `@mathjax`.