### PR TITLE
Misc fixes

### DIFF
--- a/components/bin/makeAll
+++ b/components/bin/makeAll
@@ -125,10 +125,9 @@ function fileRegExp(name) {
 }
 
 /**
- * Get and change the current working directory
+ * Get the current working directory
  */
 const root = process.cwd();
-process.chdir(path.dirname(path.dirname(__dirname)));
 
 /**
  * Regular expression for the components directory

--- a/components/bin/pack
+++ b/components/bin/pack
@@ -23,10 +23,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-
 const fs = require('fs');
 const path = require('path');
-const {spawn} = require('child_process');
+const {spawn, execSync} = require('child_process');
 
 /**
  * The module type to use ('cjs' or 'mjs')
@@ -40,11 +39,10 @@ const bundle = (process.argv[3] || 'bundle');
 
 /**
  * @param {string} name    The file name to turn into a Regular expression
- * @param {string} tail    Additional regexp to include after the file path
  * @return {RegExp}        The regular expression for the name,
  */
-function fileRegExp(name, tail = '') {
-  return new RegExp(name.replace(/([\\.{}[\]()?*^$])/g, '\\$1') + tail, 'g');
+function fileRegExp(name) {
+  return new RegExp(name.replace(/([\\.{}[\]()?*^$])/g, '\\$1'), 'g');
 }
 
 /**
@@ -59,13 +57,21 @@ function fileSize(file) {
  * Regular expressions for the components directory and the MathJax .js location
  */
 const compPath = path.dirname(__dirname);
-const nodePath = path.join(__dirname, '..', '..', 'node_modules');
 const mjPath = path.dirname(compPath);
 const jsPath = path.join(__dirname, '..', '..', target);
 const compRE = fileRegExp(compPath);
 const rootRE = fileRegExp(path.dirname(jsPath));
-const nodeRE = fileRegExp(nodePath, '(?:/\\.pnpm/.*?/node_modules)?');
+const nodeRE = /^.*\/node_modules/;
 const fontRE = new RegExp('^.*\\/(mathjax-[^\/-]*)(?:-font)?\/(build|[cm]js)');
+
+/**
+ * Find the directory where npx runs (so we know where "npx webpack" will run)
+ * (We use npx rather than pnpm here as it seems that pnpm doesn't
+ * find the executable from a node_modules directory higher than the
+ * first package.json, and extensions and fonts can have their own
+ * package.json.)
+ */
+const packDir = String(execSync('npx node -e "console.log(process.cwd())"'));
 
 /**
  * @param {string} dir   The directory to pack
@@ -74,9 +80,10 @@ const fontRE = new RegExp('^.*\\/(mathjax-[^\/-]*)(?:-font)?\/(build|[cm]js)');
 async function readJSON(dir) {
   return new Promise((ok, fail) => {
     const buffer = [];
-    const child = spawn('pnpm', [
-      'webpack', '--env', `dir=${dir}`, '--env', `bundle=${bundle}`, '--json',
-      '-c', path.relative('.', path.join(compPath, 'webpack.config.' + target))
+    const child = spawn('npx', [
+      'webpack', '--env', `dir=${path.relative(packDir, path.resolve(dir))}`,
+      '--env', `bundle=${bundle}`, '--json',
+      '-c', path.relative(packDir, path.join(compPath, 'webpack.config.' + target))
     ]);
     child.stdout.on('data', (data) => buffer.push(String(data)));
     child.stderr.on('data', (data) => console.error(String(data)));

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -223,6 +223,7 @@ export function AssistiveMmlMathDocumentMixin<
         display: 'block !important',
         width: 'auto !important',
         overflow: 'hidden !important',
+        'text-indent': '0px ! important',
         /*
          *  Don't allow the assistive MathML to become part of the selection
          */

--- a/ts/adaptors/lite/Element.ts
+++ b/ts/adaptors/lite/Element.ts
@@ -30,7 +30,6 @@ import { LiteWindow } from './Window.js';
 import { asyncLoad } from '../../util/AsyncLoad.js';
 import { mathjax } from '../../mathjax.js';
 
-
 declare const MathJax: any;
 
 /**

--- a/ts/adaptors/lite/Element.ts
+++ b/ts/adaptors/lite/Element.ts
@@ -28,6 +28,10 @@ import { LiteDocument } from './Document.js';
 import { LiteWindow } from './Window.js';
 
 import { asyncLoad } from '../../util/AsyncLoad.js';
+import { mathjax } from '../../mathjax.js';
+
+
+declare const MathJax: any;
 
 /**
  * A minimal webworker interface
@@ -168,9 +172,11 @@ export class LiteIFrame extends LiteElement {
       `${this.options.path}/${this.options.worker}`,
       this.options.debug,
     ];
-    const { WorkerPool, setContext } = await asyncLoad(
-      `${this.options.path}/speech-workerpool.js`
-    );
+    const pool = `${this.options.path}/speech-workerpool.js`;
+    if (MathJax?.loader) {
+      MathJax.loader.versions.set(pool, mathjax.version);
+    }
+    const { WorkerPool, setContext } = await asyncLoad(pool);
     setContext({
       Worker: LiteWorker,
       window: this.contentWindow,

--- a/ts/components/package.ts
+++ b/ts/components/package.ts
@@ -326,6 +326,7 @@ export class Package {
             this.failed('Can\'t load "' + url + '"\n' + err.message.trim())
           );
       } else {
+        this.result = result;
         this.checkLoad();
       }
     } catch (err) {

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -378,6 +378,7 @@ export abstract class Startup {
    *   If there is a registered output jax
    *     Make input2output() and input2outputPromise conversion methods and outputStylesheet() method
    * Create the MathJax.done() method.
+   * Create the MathJax.whenReady() method.
    */
   public static makeMethods() {
     if (Startup.input && Startup.output) {
@@ -393,6 +394,8 @@ export abstract class Startup {
       }
     }
     MathJax.done = () => Startup.document.done();
+    MathJax.whenReady = (action: () => any) =>
+      Startup.document.whenReady(action);
   }
 
   /**

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -178,7 +178,7 @@ export function RequireLoad(parser: TexParser, name: string) {
     mathjax.retryAfter(Loader.load(extension));
   }
   const require = LOADERCONFIG[extension]?.rendererExtensions;
-  const menu = (MathJax.startup.document as MenuMathDocument).menu;
+  const menu = (MathJax.startup.document as MenuMathDocument)?.menu;
   if (require && menu) {
     menu.addRequiredExtensions(require);
   }

--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -164,6 +164,13 @@ export const ChtmlMmultiscripts = (function <
       '[script-align="right"] > mjx-row > mjx-cell': {
         'text-align': 'right',
       },
+      //
+      // This declaration avoids a Safari positioning bug:
+      //
+      'mjx-none': {
+        display: 'inline-block',
+        height: '1px',
+      },
     };
 
     /*************************************************************/


### PR DESCRIPTION
This is a collection of miscellaneous fixes that I have accumulated while updating the documentation for v4.

The `makeAll` and `pack` changes are to handle building of fonts and third-party extensions better.

The `assistive-mml` change is to prevent the assistive MathML representation from being pushed outside the bounding box of the MathJax output.

The `lite/Element.ts` changes are to prevent the version mismatch error when a node application uses MathJax components rather than direct calls, and the loader uses the `MathJax.loader.load()` command.

The `components/package.ts` change is to get the proper result returned when `require()` is used in `MathJax.loader.load` (e.g., when `MathJax = {loader: {require: require}}` is used in CommonJS applications).

The `components/startup.ts` change is to add a `MathJax.whenReady()` command to access the document's `whenReady()` method.

The `RequireConfiguration.ts` change is to prevent an error when the menu code isn't loaded (e.g., when components are loaded by hand rather than through a combined component, and `ui/menu` isn't included).

The `mmultiscripts.ts` change is to avoid a bug in WebKit that causes incorrect placement of scripts when `<none>` is used as a superscript in `<mmultiscripts>`.