### PR TITLE
Update refocus from menu actions, and adjust some options

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -287,6 +287,7 @@ export function ExplorerMathDocumentMixin<
         viewBraille: false,                // display Braille output as subtitles
         voicing: false,                    // switch on speech output
         help: true,                        // include "press h for help" messages on focus
+        roleDescription: 'math',           // the role description to use for math expressions
       }
     };
 
@@ -429,6 +430,7 @@ export function ExplorerMathDocumentMixin<
         options.a11y.speechRules = `${options.sre.domain}-${options.sre.style}`;
       }
       options.MathItem = ExplorerMathItemMixin(options.MathItem, toMathML);
+      options.MathItem.roleDescription = options.roleDescription;
       this.explorerRegions = new RegionPool(this);
       if ('addStyles' in this) {
         (this as any).addStyles(

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -371,7 +371,11 @@ export class SpeechExplorer
    */
   public FocusIn(_event: FocusEvent) {
     if (this.item.outputData.nofocus) {
-      return; // we are refocusing after the menu has closed
+      //
+      // we are refocusing after a menu or dialog box has closed
+      //
+      this.item.outputData.nofocus = false;
+      return;
     }
     if (!this.clicked) {
       this.Start();
@@ -421,7 +425,7 @@ export class SpeechExplorer
    * @param {MouseEvent} event   The mouse down event
    */
   private MouseDown(event: MouseEvent) {
-    if (hasModifiers(event) || event.buttons !== 0) return;
+    if (hasModifiers(event) || event.buttons === 2) return;
     //
     // Get the speech element that was clicked
     //
@@ -464,7 +468,7 @@ export class SpeechExplorer
     //
     if (
       hasModifiers(event) ||
-      event.buttons !== 0 ||
+      event.buttons === 2 ||
       document.getSelection().type === 'Range'
     ) {
       this.FocusOut(null);

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -92,9 +92,9 @@ export class GeneratorPool<N, T, D> {
     adaptor: DOMAdaptor<N, T, D>,
     webworker: WorkerHandler<N, T, D>
   ) {
+    this.options = options;
     if (this._init) return;
     this.adaptor = adaptor;
-    this.options = options;
     this.webworker = webworker;
     this._init = true;
   }

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -87,8 +87,6 @@ export class SVG<N, T, D> extends CommonOutputJax<
   public static OPTIONS: OptionList = {
     ...CommonOutputJax.OPTIONS,
     blacker: 3,                     // the stroke-width to use for SVG character paths
-    internalSpeechTitles: true,     // insert <title> tags with speech content
-    titleID: 0,                     // initial id number to use for aria-labeledby titles
     fontCache: 'local',             // or 'global' or 'none'
     localID: null,                  // ID to use for local font cache (for single equation processing)
     useXlink: true,                 // true to include xlink namespace for <use> hrefs, false to not

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -204,35 +204,6 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
       }
     }
 
-    /**
-     * Handle adding speech to the top-level node, if any.
-     */
-    protected handleSpeech() {
-      const adaptor = this.adaptor;
-      const attributes = this.node.attributes;
-      const speech = (attributes.get('aria-label') ||
-        attributes.get('data-semantic-speech')) as string;
-      if (speech) {
-        const id = this.getTitleID();
-        const label = this.svg('title', { id }, [this.text(speech)]);
-        adaptor.insert(label, adaptor.firstChild(this.dom[0]));
-        adaptor.setAttribute(this.dom[0], 'aria-labeledby', id);
-        adaptor.removeAttribute(this.dom[0], 'aria-label');
-        for (const child of this.childNodes[0].childNodes) {
-          child.dom.forEach((node) =>
-            adaptor.setAttribute(node, 'aria-hidden', 'true')
-          );
-        }
-      }
-    }
-
-    /**
-     * @returns {string}  A unique ID to use for aria-labeledby title elements
-     */
-    protected getTitleID(): string {
-      return 'mjx-svg-title-' + String(this.jax.options.titleID++);
-    }
-
     /************************************************************/
 
     /**
@@ -245,9 +216,6 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
       if (display) {
         adaptor.setAttribute(this.jax.container, 'display', 'true');
         this.handleDisplay();
-      }
-      if (this.jax.document.options.internalSpeechTitles) {
-        this.handleSpeech();
       }
     }
 

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -56,6 +56,11 @@ export class MJContextMenu extends ContextMenu {
   public mathItem: MathItem<HTMLElement, Text, Document> = null;
 
   /**
+   * Records the mathItem's nofocus value when a SelectInfo dialog is opened
+   */
+  public nofocus: boolean = false;
+
+  /**
    * The document options
    */
   public settings: OptionList;
@@ -100,8 +105,11 @@ export class MJContextMenu extends ContextMenu {
    */
   public unpost() {
     super.unpost();
-    this.mathItem.outputData.nofocus = false;
+    if (this.mathItem) {
+      this.mathItem.outputData.nofocus = this.nofocus;
+    }
     this.mathItem = null;
+    this.nofocus = false;
   }
 
   /*======================================================================*/

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -119,7 +119,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
     if (this.options.filterSRE) {
       const keys = Object.keys(list).filter((id) =>
         id.match(
-          /^(?:data-semantic-.*?|role|aria-(?:level|posinset|setsize|owns))$/
+          /^(?:data-semantic-.*?|data-speech-node|role|aria-(?:level|posinset|setsize|owns))$/
         )
       );
       for (const key of keys) {


### PR DESCRIPTION
This PR is an update to `update/explorer` that fixes some problems with refocusing the selected item when the menu is use from within the explorer, particularly when the menu selection opens a dialog.  It also moves the `roleDescription` option to the explorer's `a11y` options, so it can be configured even when the menu component is not loaded, and removes the `internalSpeechTitles` option, which is no longer supported since the speech is added to the DOM elements after the output is created.

The changes in `explorer.ts` make `roleDescription` an `a11y` option for the document.

In `KeyExplorer.ts`, we clear the `nofocus` setting after it is used, and change the button checking from `button !== 0` to `button === 2` when checking for right mouse buttons that will cause context-menu events.

In `GeneratorPool.ts` the setting of the options in the `init()` function is always done, so that if the menu changes `enableSpeech` or `enableBraille` and does a re-render of the output (which calls `init()` again), the options will be updated.

The changes to the SVG output jax are to remove the `internalSpeechTitles` option and the code that implements it.

The changes to the menu code is to better set the `MathItem.outputData.nofocus` and to set the speech explorer's `refocus` value to the node that was selected before the menu opened.  Because there are focus changes that clear the selection before the `contextmenu` event is triggered, we use a `mousedown`event to record the current selection before it is lost.

When a dialog is opened by a menu action, we need to keep the `nofocus` value, so introduce a new `postInfo()` method that records the `nofocus` value before posting an `Info` or `SelectableInfo` dialog box.  This is used for all the `.post()` commands in the menu.

The `roleDescription` setting now uses `a11yVar<string>()` so we don't need to call `setA11yVar()` by hand in `setRoleDescrition()`.

We add some checks to make sure `options.displayOverflow` and `options.linebreak` are available (since these are defined in `output/common.ts`, and may not be in all output jax).

We check for `MathJax._.a11y.explorer` rather than just `MathJax._.a11y.speech` or the other extensions, since we load `explorer`.  This makes sure the explorer is available, not just the lesser extension.

We add code to tell the explorer where to refocus when the scale dialog box is open (it uses `prompt()` rather than an `Info` instance, so `postInfo()` isn't being called for this).

Finally, we remove the `data-speech-node` attributes that where introduced by the explorer update.