### PR TITLE
Fix problems with flame/hover, re-attaching after < and >, and with the menu loading extensions at startup

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -52,16 +52,19 @@ export type HTMLDOCUMENT = SpeechMathDocument<HTMLElement, Text, Document> & {
   menu?: any;
 };
 export type HTMLMATHITEM = SpeechMathItem<HTMLElement, Text, Document> & {
-  addListeners?(doc: SpeechMathDocument<HTMLElement, Text, Document>): void;
+  addListeners?(
+    node: HTMLElement,
+    doc: SpeechMathDocument<HTMLElement, Text, Document>
+  ): void;
 };
 export type MATHML = MathML<HTMLElement, Text, Document>;
 
 /*==========================================================================*/
 
 /**
- * Add STATE value for having the Explorer added (after TYPESET and before INSERTED or CONTEXT_MENU)
+ * Add STATE value for having the Explorer added (after INSERTED and before CONTEXT_MENU)
  */
-newState('EXPLORER', 160);
+newState('EXPLORER', STATE.INSERTED + 30);
 
 /**
  * The properties added to MathItem for the Explorer
@@ -197,9 +200,9 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
     /**
      * @override
      */
-    public addListeners(document: ExplorerMathDocument) {
-      super.addListeners?.(document);
-      this.explorers?.speech?.addListeners();
+    public addListeners(node: HTMLElement, document: ExplorerMathDocument) {
+      super.addListeners?.(node, document);
+      this.explorers?.updateNode(node);
     }
 
     /**

--- a/ts/a11y/explorer/Explorer.ts
+++ b/ts/a11y/explorer/Explorer.ts
@@ -84,6 +84,14 @@ export interface Explorer {
   RemoveEvents(): void;
 
   /**
+   * Update the node and adds events again when explorer node is cloned.
+   *
+   * @param {HTMLElement} node   The cloned node
+   * @param {boolean} events     Whether to add events to the node
+   */
+  UpdateNode(node: HTMLElement, events: boolean): void;
+
+  /**
    * Update the explorer after state changes.
    *
    * @param {boolean=} force Forces the update in any case. (E.g., even if
@@ -260,6 +268,16 @@ export class AbstractExplorer<T> implements Explorer {
   public RemoveEvents() {
     for (const [eventkind, eventfunc] of this.events) {
       this.node.removeEventListener(eventkind, eventfunc);
+    }
+  }
+
+  /**
+   * @override
+   */
+  public UpdateNode(node: HTMLElement, events: boolean) {
+    this.node = node;
+    if (events) {
+      this.AddEvents();
     }
   }
 

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -354,6 +354,17 @@ export class ExplorerPool {
   }
 
   /**
+   * Update the root node and add listeners for all attached explorers.
+   *
+   * @param {HTMLElement} node   The new root node
+   */
+  public updateNode(node: HTMLElement) {
+    for (const [name, explorer] of Object.entries(this.explorers)) {
+      explorer.UpdateNode(node, this.attached.includes(name));
+    }
+  }
+
+  /**
    * A highlighter for the explorer.
    */
   protected setPrimaryHighlighter() {

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -945,18 +945,24 @@ export class SpeechExplorer
       container.classList.remove(store.attachedClass);
     }
     const item = this.item;
-    this.node = container.cloneNode(false) as HTMLElement;
+    const node = container.cloneNode(false) as HTMLElement;
     if (item.end.node === item.typesetRoot) {
-      item.start.node = item.end.node = this.node;
+      item.start.node = item.end.node = node;
     }
-    item.typesetRoot = this.node;
+    this.refocus = this.current;
+    this.Stop();
+    item.typesetRoot = node;
     for (const child of Array.from(container.childNodes)) {
-      this.node.append(child);
+      if (child !== this.speech) {
+        node.append(child);
+      }
     }
-    item.addListeners(this.document);
-    container.parentNode.insertBefore(this.node, container);
-    container.remove();
-    store?.insert(this.node);
+    item.addListeners?.(node, this.document);
+    container.replaceWith(node);
+    store?.insert(node);
+    if (this.refocus) {
+      this.Start();
+    }
   }
 
   /**
@@ -1110,11 +1116,7 @@ export class SpeechExplorer
     this.img.remove();
     this.img = null;
     await promise;
-    this.pool.unhighlight();
     this.attachSpeech();
-    const current = this.current;
-    this.current = null;
-    this.setCurrent(current);
   }
 
   /********************************************************************/
@@ -1304,8 +1306,9 @@ export class SpeechExplorer
   /**
    * @override
    */
-  public addListeners() {
-    super.AddEvents();
+  public UpdateNode(node: HTMLElement, active: boolean) {
+    this.eventsAttached = false;
+    super.UpdateNode(node, active);
   }
 
   /********************************************************************/

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -607,7 +607,7 @@ export class WorkerHandler<N, T, D> {
      * Signals that the worker has finished its last task.
      *
      * @param {WorkerHandler} pool The active handler for the worker.
-     * @param {Message} data The data received from the worker. Ignored.
+     * @param {Message} data The data received from the worker.
      */
     Finished(pool: WorkerHandler<N, T, D>, data: Message) {
       const task = pool.tasks.shift();
@@ -617,6 +617,18 @@ export class WorkerHandler<N, T, D> {
         task.reject(data.error);
       }
       pool.postNext();
+    },
+
+    /**
+     * Logs a message from the worker
+     *
+     * @param {WorkerHandler} pool The active handler for the worker.
+     * @param {Message} data The data received from the worker.
+     */
+    Log(pool: WorkerHandler<N, T, D>, data: Message) {
+      if (pool.options.debug) {
+        console.log(data.msg);
+      }
     },
   };
 }

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -110,7 +110,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
       fill: 'blue',
       stroke: 'blue',
     },
-    'rect[sre-highlighter-added]': {
+    'rect[sre-highlighter-added]:has(+ .mjx-selected)': {
       stroke: 'black',
       'stroke-width': '80px',
     },


### PR DESCRIPTION
# Overview

This PR fixes several more problems with the explorer:

1. Fixes the flame and hover highlighting by making sure the event handlers are re-attached.
2. Makes sure that flame and hover can be turned on and off properly, and that they start up when sticky menu selections are on.
3. Fixes flame display in SVG output.
4. Removes the outline from flame and hover highlighting in SVG output.
5. Fixes problems with `<` and `>` in Chrome.
6. Adds a missing `Log()` command in the web-worker code.
7. Adjusts the menu code for loading extensions so that the complexity extension in particular will load properly on startup when its menu item is selected.

-----

# Details

## explorer.ts

The `EXPLORER` state is move to after the `INSERTED` state, so that the output is actually in the page when the flame highlighter tries to measure the size of SVG output nodes.

The `addListeners()` method now has the new container node as a parameter so that the explorers can update their `node` properties using a new `updateNode()` method of the explorer pool

## Explorer.ts

We add the `UpdateNode()` method to the base `Explorer` class.  It updates the saved `node` and adds any needed event handlers, when requested.

## ExplorerPool.ts

We add an `updateNode()` method that calls `UpdateNode()` on all the explorers, indicating whether event handlers should be added (by whether the explorer is attached or not).

## KeyExplorer.ts

The `updateAT()` method is updated to sop and restart the explorer if it has a current selection (as is the case when the style or ruleset is changed).  This resolves the problems with `<` and `>`.

The unhighlightin and setting of the `current` value are removed from the `restartAfter()` method, as the changes to `updateAT()` now cause the unhighlighting and restarting the speech to occur when that is called by the `attachSpeech()` method.

The `addListeners()` method has been replaces by the `UpdateNode()` method, and we override it here to unset `eventsAttached` so that the super-class `UpdateNode()` will re-add the events.

## WebWorker.ts

The `Log()` command is added, as it was missing and caused error messages during debugging.

## svg.ts

The CSS selector for adding a border to the highlighter rectangles has been made more specific so that flame and hover highlighting are not outlined.

## MenuHandler.ts

The `addListeners()` method now has the `node` argument.

The `checkLoading()` method has been modified to return a boolean that is used to stop the renderActions when loading is still occurring.  This is needed because in that case the `MathJax.startup.document` is replaced when the component loads (since there will be a new handler that needs to be included); in the past, the `restartAfter()` calls would cause the `renderActions` to be restarted on the **original** document, not the new one.  Now, the return value of `true` will cause the render actions to stop, but the callback from the `loadComponents()` call already includes a `rerender()` call, and so it will start the render actions will be run again on the new document automatically.  These changes were the key to getting the complexity extension to load properly on startup.

The `checkLoading` render action now calls `doc.checkLoading()` by hand, since that is the only way to return the `true` value that stops the render actions.

The old `checkLoading()` method is now `_checkLoading()`, and the new `checkLoading()` calls it and traps the retry errors to determine wherther to stop the render actions or not.
