### PR TITLE
Add an `insertStyles()` method to update styles when an extension is loaded

### DIFF
--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -349,6 +349,9 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    */
   public addStyles(styles: StyleJson) {
     this.styles.push(styles);
+    if ('insertStyles' in this.outputJax) {
+      (this.outputJax as any).insertStyles(styles);
+    }
   }
 
   /**

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -282,6 +282,18 @@ export class CHTML<N, T, D> extends CommonOutputJax<
   }
 
   /**
+   * @override
+   */
+  public insertStyles(styles: StyleJson) {
+    if (this.chtmlStyles) {
+      this.adaptor.insertRules(
+        this.chtmlStyles,
+        new StyleJsonSheet(styles).getStyleRules()
+      );
+    }
+  }
+
+  /**
    * @param {ChtmlWrapper} wrapper   The MML node wrapper whose HTML is to be produced
    * @param {N} parent     The HTML node to contain the HTML
    */

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -92,19 +92,19 @@ export abstract class CommonOutputJax<
   D,
   /* prettier-ignore */
   WW extends CommonWrapper<
-    N, T, D, 
+    N, T, D,
     CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
     WW, WF, WC, CC, VV, DD, FD, FC
   >,
   /* prettier-ignore */
   WF extends CommonWrapperFactory<
-    N, T, D, 
+    N, T, D,
     CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
     WW, WF, WC, CC, VV, DD, FD, FC
   >,
   /* prettier-ignore */
   WC extends CommonWrapperClass<
-    N, T, D, 
+    N, T, D,
     CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
     WW, WF, WC, CC, VV, DD, FD, FC
   >,
@@ -871,6 +871,13 @@ export abstract class CommonOutputJax<
       this
     );
   }
+
+  /**
+   * Insert styles into an existing stylesheet
+   *
+   * @param {StyleJson} _styles  The styles to insert
+   */
+  public insertStyles(_styles: StyleJson) {}
 
   /*****************************************************************/
 

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -34,7 +34,7 @@ import {
   SvgFontData,
   SvgFontDataClass,
 } from './svg/FontData.js';
-import { StyleJson } from '../util/StyleJson.js';
+import { StyleJson, StyleJsonSheet } from '../util/StyleJson.js';
 import { FontCache } from './svg/FontCache.js';
 import { unicodeChars } from '../util/string.js';
 import * as LENGTHS from '../util/lengths.js';
@@ -203,6 +203,18 @@ export class SVG<N, T, D> extends CommonOutputJax<
     const sheet = (this.svgStyles = super.styleSheet(html));
     this.adaptor.setAttribute(sheet, 'id', SVG.STYLESHEETID);
     return sheet;
+  }
+
+  /**
+   * @override
+   */
+  public insertStyles(styles: StyleJson) {
+    if (this.svgStyles) {
+      this.adaptor.insertRules(
+        this.svgStyles,
+        new StyleJsonSheet(styles).getStyleRules()
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds support for an extension having styles.  E.g., the explorer has styles, and if it is loaded by the menu after the page is already running, those style wouldn't get set.  This PR fixes that.