### PR TITLE
Fix timing of hasTypeset and make defaultOptionError for easier configuration

### DIFF
--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -114,6 +114,7 @@ export interface MathJaxObject extends MJObject {
     toMML(node: MmlNode): string;
     defaultReady(): void;
     defaultPageReady(): Promise<void>;
+    defaultOptionError(message: string, key: string): void;
     getComponents(): void;
     makeMethods(): void;
     makeTypesetMethods(): void;
@@ -333,17 +334,22 @@ export abstract class Startup {
   }
 
   /**
+   * The default OptionError function
+   */
+  public static defaultOptionError = OPTIONS.optionError;
+
+  /**
    * Perform the typesetting with handling of retries
    *
    * @param {any[]} elements The list of elements to typeset
    * @returns {Promise<any>} The promise that resolves when elements are typeset
    */
   public static typesetPromise(elements: any[]): Promise<any> {
+    this.hasTypeset = true;
     return Startup.document.whenReady(async () => {
       Startup.document.options.elements = elements;
       Startup.document.reset();
       await Startup.document.renderPromise();
-      this.hasTypeset = true;
     });
   }
 
@@ -408,10 +414,10 @@ export abstract class Startup {
    */
   public static makeTypesetMethods() {
     MathJax.typeset = (elements: any[] = null) => {
+      this.hasTypeset = true;
       Startup.document.options.elements = elements;
       Startup.document.reset();
       Startup.document.render();
-      this.hasTypeset = true;
     };
     MathJax.typesetPromise = (elements: any[] = null) => {
       return Startup.typesetPromise(elements);


### PR DESCRIPTION
This PR adds a `defaultOptionError` that can be used if the `optionError` configuration option is used so that the original action can be taken after the user's actions are performed (e.g., recording the error).

It also moves the `hasTypeset` indicator to be outside the promise call in `typesetPromise()`, so that if the promise code is put off for later, the inidicator still knows that the typeset has been queued.  (This gets used in the menu to tell if a rerender is needed.)