### PR TITLE
Add menu item to control what tabbing will focus on

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -288,6 +288,7 @@ export function ExplorerMathDocumentMixin<
         voicing: false,                    // switch on speech output
         help: true,                        // include "press h for help" messages on focus
         roleDescription: 'math',           // the role description to use for math expressions
+        tabSelects: 'all',                 // 'all' for whole expression, 'last' for last explored node
       }
     };
 

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -762,6 +762,9 @@ export class SpeechExplorer
     if (this.current) {
       this.current.classList.remove('mjx-selected');
       this.pool.unhighlight();
+      if (this.document.options.a11y.tabSelects === 'last') {
+        this.refocus = this.current;
+      }
       this.current = null;
       if (!node) {
         this.removeSpeech();

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -863,7 +863,7 @@ export class Menu {
           this.submenu('TabSelects', 'Tabbing Focuses on', [
             this.radioGroup('tabSelects', [
               ['all', 'Whole Expression'],
-              ['last', 'Last Explored Node']
+              ['last', 'Last Explored Node'],
             ]),
           ]),
           this.rule(),

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -106,6 +106,7 @@ export interface MenuSettings {
   voicing: boolean;
   help: boolean;
   roleDescription: string;
+  tabSelects: string;
 }
 
 export type HTMLMATHITEM = MathItem<HTMLElement, Text, Document>;
@@ -155,6 +156,7 @@ export class Menu {
       brailleCode: 'nemeth',
       speechRules: 'clearspeak-default',
       roleDescription: 'math',
+      tabSelects: 'all',
     },
     jax: {
       CHTML: null,
@@ -595,6 +597,7 @@ export class Menu {
           this.setEnrichment(enrich)
         ),
         this.variable<boolean>('inTabOrder', (tab) => this.setTabOrder(tab)),
+        this.a11yVar<string>('tabSelects'),
         this.variable<boolean>('assistiveMml', (mml) =>
           this.setAssistiveMml(mml)
         ),
@@ -857,6 +860,13 @@ export class Menu {
           }),
           this.rule(),
           this.checkbox('InTabOrder', 'Include in Tab Order', 'inTabOrder'),
+          this.submenu('TabSelects', 'Tabbing Focuses on', [
+            this.radioGroup('tabSelects', [
+              ['all', 'Whole Expression'],
+              ['last', 'Last Explored Node']
+            ]),
+          ]),
+          this.rule(),
           this.checkbox(
             'AssistiveMml',
             'Include Hidden MathML',
@@ -1166,6 +1176,8 @@ export class Menu {
    * @param {boolean} tab   True for including math in the tab order, false for not
    */
   protected setTabOrder(tab: boolean) {
+    const menu = this.menu.findID('Options', 'TabSelects');
+    tab ? menu.enable() : menu.disable();
     this.menu.store.inTaborder(tab);
   }
 


### PR DESCRIPTION
This PR adds a menu item to control whether tabbing to an expression focuses on the whole expression, or on the last explored node, as per Volker's request.  It is in the *Options* submenu in the accessibility section of the main contextual menu.