### PR TITLE
Fix script spacing when MathML spacing is used. (mathjax/MathJax#1224)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -76,7 +76,7 @@ const MOSPACE = 5 / 18;
  * @returns {number}         The size clamped to SMALLSIZE when scriptlevel > 0
  */
 function MathMLSpace(script: boolean, nodict: boolean, size: number): number {
-  return nodict ? MOSPACE : script ? (size < SMALLSIZE ? 0 : SMALLSIZE) : size;
+  return nodict ? (script ? SMALLSIZE : MOSPACE) : script ? (size < SMALLSIZE ? 0 : SMALLSIZE) : size;
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue with MathML spacing where an `mo` whose content is not in the operator dictionary and when it is used with `scriptlevel` greater than 0.  In that situation, it should use the reduced space size of `SMALLSIZE.