### PR TITLE
Fix/cs preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@xmldom/xmldom": "^0.8.10",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "^5.0.0-alpha.3",
+    "speech-rule-engine": "^5.0.0-alpha.4",
     "wicked-good-xpath": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@xmldom/xmldom": "^0.8.10",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "^5.0.0-alpha.2",
+    "speech-rule-engine": "^5.0.0-alpha.3",
     "wicked-good-xpath": "^1.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       speech-rule-engine:
-        specifier: ^5.0.0-alpha.3
-        version: 5.0.0-alpha.3
+        specifier: ^5.0.0-alpha.4
+        version: 5.0.0-alpha.4
       wicked-good-xpath:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1245,8 +1245,8 @@ packages:
   spdx-license-ids@3.0.18:
     resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
 
-  speech-rule-engine@5.0.0-alpha.3:
-    resolution: {integrity: sha512-IZi+cUiCw4mSNt+VBcMP77DOES6QuxhlfDfmvoS5VZhRPLgx8hm9B/BHMhJ9SFsDrhSMP07Dh9e4jj6py4hlMQ==}
+  speech-rule-engine@5.0.0-alpha.4:
+    resolution: {integrity: sha512-88kD4YbtjFuU1YudCgMXOw8HoN2lcrrEDBG6GsraWg7I0s8ltUGrWYpoegyV2nic5ZHs6IzwOFOs5Ai+yxnQzw==}
     hasBin: true
 
   string-argv@0.3.2:
@@ -2633,7 +2633,7 @@ snapshots:
 
   spdx-license-ids@3.0.18: {}
 
-  speech-rule-engine@5.0.0-alpha.3:
+  speech-rule-engine@5.0.0-alpha.4:
     dependencies:
       '@xmldom/xmldom': 0.9.8
       commander: 13.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       speech-rule-engine:
-        specifier: ^5.0.0-alpha.1
-        version: 5.0.0-alpha.1
+        specifier: ^5.0.0-alpha.3
+        version: 5.0.0-alpha.3
       wicked-good-xpath:
         specifier: ^1.3.0
         version: 1.3.0
@@ -59,7 +59,7 @@ importers:
         version: 5.0.5
       terser-webpack-plugin:
         specifier: ^5.3.10
-        version: 5.3.10(webpack@5.91.0)
+        version: 5.3.10(webpack@5.91.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -1245,8 +1245,8 @@ packages:
   spdx-license-ids@3.0.18:
     resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
 
-  speech-rule-engine@5.0.0-alpha.1:
-    resolution: {integrity: sha512-aCQ6DJlZssu/TO1HbuRbd9/w7ualG806jFvjTHMqSssXYVYrfY7wR7xFVTp0/bfz4+MCe9gFx6fO3eONoPLTgQ==}
+  speech-rule-engine@5.0.0-alpha.3:
+    resolution: {integrity: sha512-IZi+cUiCw4mSNt+VBcMP77DOES6QuxhlfDfmvoS5VZhRPLgx8hm9B/BHMhJ9SFsDrhSMP07Dh9e4jj6py4hlMQ==}
     hasBin: true
 
   string-argv@0.3.2:
@@ -1753,17 +1753,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.91.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
@@ -2633,7 +2633,7 @@ snapshots:
 
   spdx-license-ids@3.0.18: {}
 
-  speech-rule-engine@5.0.0-alpha.1:
+  speech-rule-engine@5.0.0-alpha.3:
     dependencies:
       '@xmldom/xmldom': 0.9.8
       commander: 13.1.0
@@ -2694,7 +2694,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(webpack@5.91.0):
+  terser-webpack-plugin@5.3.10(webpack@5.91.0(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -2768,9 +2768,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.91.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.91.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -2812,7 +2812,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.91.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.91.0(webpack-cli@5.1.4))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/ts/a11y/explorer/Explorer.ts
+++ b/ts/a11y/explorer/Explorer.ts
@@ -118,9 +118,7 @@ export class AbstractExplorer<T> implements Explorer {
   protected events: [string, (x: Event) => void][] = [];
 
   /**
-   * The Sre highlighter associated with the walker.
-   *
-   * @type {Sre.highlighter}
+   * @returns {Highlighter} The Sre highlighter associated with the walker.
    */
   protected get highlighter(): Highlighter {
     return this.pool.highlighter;

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -1095,8 +1095,8 @@ export class SpeechExplorer
    * Get the SSML attribute array
    *
    * @param {HTMLElement} node  The node whose SSML attributes are to be obtained
-   * @param center
-   * @returns {string[]}        The prefix/summary/postfix array
+   * @param {SemAttr} center    The name of the SSML attribute between pre and postfix
+   * @returns {string[]}        The prefix/speech or summary/postfix array
    */
   protected SsmlAttributes(node: HTMLElement, center: SemAttr): string[] {
     return [

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -796,10 +796,11 @@ export class SpeechExplorer
     if (this.current) {
       this.current.classList.remove('mjx-selected');
       this.pool.unhighlight();
-      this.current = null;
       if (!node) {
+        this.restarted = this.semanticFocus();
         this.removeSpeech();
       }
+      this.current = null;
     }
     //
     // If there is a current node
@@ -933,7 +934,7 @@ export class SpeechExplorer
       'aria-roledescription': item.none,
     });
     container.appendChild(this.img);
-    this.updateAT();
+    // this.updateAT();
   }
 
   /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -796,11 +796,10 @@ export class SpeechExplorer
     if (this.current) {
       this.current.classList.remove('mjx-selected');
       this.pool.unhighlight();
+      this.current = null;
       if (!node) {
-        this.restarted = this.semanticFocus();
         this.removeSpeech();
       }
-      this.current = null;
     }
     //
     // If there is a current node
@@ -934,7 +933,7 @@ export class SpeechExplorer
       'aria-roledescription': item.none,
     });
     container.appendChild(this.img);
-    // this.updateAT();
+    this.updateAT();
   }
 
   /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -697,7 +697,7 @@ export class SpeechExplorer
     this.speak(
       summary,
       this.current.getAttribute(SemAttr.BRAILLE),
-      this.SsmlAttributes(this.current)
+      this.SsmlAttributes(this.current, SemAttr.SUMMARY_SSML)
     );
   }
 
@@ -843,7 +843,11 @@ export class SpeechExplorer
       }
       speech += description;
     }
-    this.speak(speech, node.getAttribute(SemAttr.BRAILLE));
+    this.speak(
+      speech,
+      node.getAttribute(SemAttr.BRAILLE),
+      this.SsmlAttributes(node, SemAttr.SPEECH_SSML)
+    );
     this.node.setAttribute('tabindex', '-1');
   }
 
@@ -1091,12 +1095,13 @@ export class SpeechExplorer
    * Get the SSML attribute array
    *
    * @param {HTMLElement} node  The node whose SSML attributes are to be obtained
+   * @param center
    * @returns {string[]}        The prefix/summary/postfix array
    */
-  protected SsmlAttributes(node: HTMLElement): string[] {
+  protected SsmlAttributes(node: HTMLElement, center: SemAttr): string[] {
     return [
       node.getAttribute(SemAttr.PREFIX_SSML),
-      node.getAttribute(SemAttr.SUMMARY_SSML),
+      node.getAttribute(center),
       node.getAttribute(SemAttr.POSTFIX_SSML),
     ];
   }

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -508,6 +508,14 @@ export class SpeechRegion extends LiveRegion {
   }
 
   /**
+   * @override
+   */
+  public Hide() {
+    speechSynthesis.cancel();
+    super.Hide();
+  }
+
+  /**
    * Highlighting the node that is being marked in the SSML.
    *
    * @param {string} id The id of the node to highlight.

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -218,6 +218,12 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
+  /**
+   * Computes the braille label from the node.
+   *
+   * @param {N} node            The typeset node.
+   * @returns {string}          The assembled label.
+   */
   public getBraille(node: N): string {
     const adaptor = this.adaptor;
     return (
@@ -226,25 +232,44 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
-  public getLocalePreferences(prefs: {
-    [key: string]: { [prop: string]: string[] };
-  }): Promise<void> {
+  /*********************************************************/
+  /**
+   * Menu related functions.
+   */
+  /**
+   * Computes the clearspeak preferences for the current locale.
+   *
+   * @param {Map<string, { [prop: string]: string[] }>} prefs Map to store the compute preferences.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
+  public getLocalePreferences(
+    prefs: Map<string, { [prop: string]: string[] }>
+  ): Promise<void> {
     return (this.promise = this.webworker.clearspeakLocalePreferences(
       this.options,
       prefs
     ));
   }
 
+  /**
+   * Computes the clearspeak preferences that are semantically relevant for the
+   * currently focused node.
+   *
+   * @param {SpeechMathItem} item The SpeechMathItem where is menu is opened.
+   * @param {string} semantic The semantic id of the last focused node.
+   * @param {Map<number, string>} prefs Map for recording the computed preference.
+   * @param {number} counter Counter for storing the result in the map.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
   public getRelevantPreferences(
     item: SpeechMathItem<N, T, D>,
     semantic: string,
-    prefs: { [key: number]: string },
+    prefs: Map<number, string>,
     counter: number
   ): Promise<void> {
     const mml = item.outputData.mml;
     return (this.promise = this.webworker.clearspeakRelevantPreferences(
       mml,
-      this.options,
       semantic,
       prefs,
       counter

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -226,7 +226,14 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
-  public getLocalePreferences(item: SpeechMathItem<N, T, D>): Promise<void> {
-    return (this.promise = this.webworker.clearspeakLocalePreferences(item));
+  public getLocalePreferences(
+    item: SpeechMathItem<N, T, D>,
+    prefs: { [key: string]: { [prop: string]: string[] } }
+  ): Promise<void> {
+    return (this.promise = this.webworker.clearspeakLocalePreferences(
+      item,
+      this.options,
+      prefs
+    ));
   }
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -158,6 +158,8 @@ export class GeneratorPool<N, T, D> {
       locale: this.adaptor.getAttribute(node, 'data-semantic-locale') ?? '',
       domain: this.adaptor.getAttribute(node, 'data-semantic-domain') ?? '',
       style: this.adaptor.getAttribute(node, 'data-semantic-style') ?? '',
+      domain2style:
+        this.adaptor.getAttribute(node, 'data-semantic-domain2style') ?? '',
     };
   }
 

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -226,14 +226,28 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
-  public getLocalePreferences(
-    item: SpeechMathItem<N, T, D>,
-    prefs: { [key: string]: { [prop: string]: string[] } }
-  ): Promise<void> {
+  public getLocalePreferences(prefs: {
+    [key: string]: { [prop: string]: string[] };
+  }): Promise<void> {
     return (this.promise = this.webworker.clearspeakLocalePreferences(
-      item,
       this.options,
       prefs
+    ));
+  }
+
+  public getRelevantPreferences(
+    item: SpeechMathItem<N, T, D>,
+    semantic: string,
+    prefs: { [key: number]: string },
+    counter: number
+  ): Promise<void> {
+    const mml = item.outputData.mml;
+    return (this.promise = this.webworker.clearspeakRelevantPreferences(
+      mml,
+      this.options,
+      semantic,
+      prefs,
+      counter
     ));
   }
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -225,4 +225,8 @@ export class GeneratorPool<N, T, D> {
       adaptor.getAttribute(node, SemAttr.BRAILLE)
     );
   }
+
+  public getLocalePreferences(item: SpeechMathItem<N, T, D>): Promise<void> {
+    return (this.promise = this.webworker.clearspeakLocalePreferences(item));
+  }
 }

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -50,7 +50,7 @@ function currentPreference(settings?: string) {
  */
 function csPrefsVariables(menu: MJContextMenu, prefs: string[]) {
   const srVariable = menu.pool.lookup('speechRules');
-  const previous = currentPreference();
+  const previous = currentPreference(menu.settings.speechRules);
   csPrefsSetting = Sre.clearspeakPreferences.fromPreference(previous); // Do here
   for (const pref of prefs) {
     menu.factory.get('variable')(
@@ -102,7 +102,7 @@ async function csSelectionBox(
   if (!localePreferences.has(locale)) {
     await item.generatorPool.getLocalePreferences(localePreferences);
   }
-  if (localePreferences.has(locale)) {
+  if (!localePreferences.has(locale)) {
     const csEntry = menu.findID('Accessibility', 'Speech', 'Clearspeak');
     if (csEntry) {
       csEntry.disable();

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -33,10 +33,13 @@ let csPrefsSetting: { [pref: string]: string } = {};
 let previousPrefs: string = null;
 
 /**
+ * Computes the current ClearSpeak preference, by either extracting it from the
+ * settings, returning the previously stored one, or returning the default.
  *
- * @param settings
+ * @param {string} settings The current speech rule options setting.
+ * @returns {string} The current ClearSpeak preference.
  */
-function currentPreference(settings?: string) {
+function currentPreference(settings?: string): string {
   const matcher = settings?.match(/^clearspeak-(.*)/);
   previousPrefs = (matcher && matcher[1]) ?? previousPrefs ?? 'default';
   return previousPrefs;
@@ -74,19 +77,21 @@ function csPrefsVariables(menu: MJContextMenu, prefs: string[]) {
 
 /**
  * Map for storing clearspeak preferences per locale, which can vary. They need
- * to becomputed only once as they should not change during a single run.
+ * to be computed only once as they should not change during a single run.
  */
 const localePreferences: Map<string, { [prop: string]: string[] }> = new Map();
 
 /**
+ * Computes the clearspeak preferences for the given locale via the worker.
  *
- * @param menu
- * @param locale
+ * @param {MJContextMenu} menu The parent menu.
+ * @param {string} locale The locale to get.
  */
 async function getLocalePreferences(menu: MJContextMenu, locale: string) {
-  const item = menu.mathItem as ExplorerMathItem;
   if (!localePreferences.has(locale)) {
-    await item.generatorPool.getLocalePreferences(localePreferences);
+    await (
+      menu.mathItem as ExplorerMathItem
+    ).generatorPool.getLocalePreferences(localePreferences);
   }
 }
 
@@ -172,7 +177,6 @@ function basePreferences(previous: string): object[] {
 /**
  * Generates the items for smart preference choices, depending on the top most
  *
- * @param item
  * @param {string} previous The currently set preferences.
  * @param {string} smart The semantic type of the smart preferences.
  * @param {string} locale The current locale.

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -586,7 +586,6 @@ export class WorkerHandler<N, T, D> {
 
 
   public async clearspeakLocalePreferences(
-    item: SpeechMathItem<N, T, D>,
     options: OptionList,
     prefs: {[key: string]: {[prop: string]: string[] }}
   ) {
@@ -600,10 +599,34 @@ export class WorkerHandler<N, T, D> {
             options: options
           },
         },
-      },
-      item
+      }
     ).then((e) => {
       prefs[options.locale] = e;
+    });
+  }
+
+  public async clearspeakRelevantPreferences(
+    math: string,
+    options: OptionList,
+    semantic: string,
+    prefs: { [key: number]: string },
+    counter: number
+  ) {
+    await this.Post(
+      {
+        cmd: 'Worker',
+        data: {
+          cmd: 'relevantPreferences',
+          debug: this.options.debug,
+          data: {
+            mml: math,
+            options: options,
+            id: semantic,
+          },
+        },
+      }
+    ).then((e) => {
+      prefs[counter] = e;
     });
   }
 

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -584,11 +584,17 @@ export class WorkerHandler<N, T, D> {
     this.ready = false;
   }
 
-
+  /**
+   * Worker call to compute clearspeak preferences for the current locale.
+   *
+   * @param {OptionList} options The options list.
+   * @param {Map<string, { [prop: string]: string[] }>} prefs Map to store the compute preferences.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
   public async clearspeakLocalePreferences(
     options: OptionList,
-    prefs: {[key: string]: {[prop: string]: string[] }}
-  ) {
+    prefs: Map<string, {[prop: string]: string[] }>
+  ): Promise<void> {
     await this.Post(
       {
         cmd: 'Worker',
@@ -601,17 +607,26 @@ export class WorkerHandler<N, T, D> {
         },
       }
     ).then((e) => {
-      prefs[options.locale] = e;
+      prefs.set(options.locale, e);
     });
   }
 
+  /**
+   * Computes the clearspeak preference category that are semantically relevant
+   * for the currently focused node.
+   *
+   * @param {string} math The linearized mml expression.
+   * @param {string} nodeId The semantic id of node to compute the preference for.
+   * @param {Map<number, string>} prefs Map for recording the computed preference.
+   * @param {number} counter Counter for storing the result in the map.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
   public async clearspeakRelevantPreferences(
     math: string,
-    options: OptionList,
-    semantic: string,
-    prefs: { [key: number]: string },
+    nodeId: string,
+    prefs: Map<number, string>,
     counter: number
-  ) {
+  ): Promise<void> {
     await this.Post(
       {
         cmd: 'Worker',
@@ -620,13 +635,12 @@ export class WorkerHandler<N, T, D> {
           debug: this.options.debug,
           data: {
             mml: math,
-            options: options,
-            id: semantic,
+            id: nodeId,
           },
         },
       }
     ).then((e) => {
-      prefs[counter] = e;
+      prefs.set(counter, e);
     });
   }
 

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -381,7 +381,7 @@ export class WorkerHandler<N, T, D> {
       'locale',
       'domain',
       'style',
-      'domain2style'
+      'domain2style',
     ]);
     const adaptor = this.adaptor;
     this.setSpecialAttributes(container, data.translations, 'data-semantic-');
@@ -593,20 +593,18 @@ export class WorkerHandler<N, T, D> {
    */
   public async clearspeakLocalePreferences(
     options: OptionList,
-    prefs: Map<string, {[prop: string]: string[] }>
+    prefs: Map<string, { [prop: string]: string[] }>
   ): Promise<void> {
-    await this.Post(
-      {
-        cmd: 'Worker',
+    await this.Post({
+      cmd: 'Worker',
+      data: {
+        cmd: 'localePreferences',
+        debug: this.options.debug,
         data: {
-          cmd: 'localePreferences',
-          debug: this.options.debug,
-          data: {
-            options: options
-          },
+          options: options,
         },
-      }
-    ).then((e) => {
+      },
+    }).then((e) => {
       prefs.set(options.locale, e);
     });
   }
@@ -627,19 +625,17 @@ export class WorkerHandler<N, T, D> {
     prefs: Map<number, string>,
     counter: number
   ): Promise<void> {
-    await this.Post(
-      {
-        cmd: 'Worker',
+    await this.Post({
+      cmd: 'Worker',
+      data: {
+        cmd: 'relevantPreferences',
+        debug: this.options.debug,
         data: {
-          cmd: 'relevantPreferences',
-          debug: this.options.debug,
-          data: {
-            mml: math,
-            id: nodeId,
-          },
+          mml: math,
+          id: nodeId,
         },
-      }
-    ).then((e) => {
+      },
+    }).then((e) => {
       prefs.set(counter, e);
     });
   }

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -584,6 +584,22 @@ export class WorkerHandler<N, T, D> {
     this.ready = false;
   }
 
+
+  public async clearspeakLocalePreferences(item: SpeechMathItem<N, T, D>) {
+    console.log(43);
+    await this.Post(
+      {
+        cmd: 'Worker',
+        data: {
+          cmd: 'localePreferences',
+          debug: this.options.debug,
+          data: { },
+        },
+      },
+      item
+    ).then((e) => console.log(e));
+  }
+
   /**
    * The list of valid commands from the WorkerPool in the iframe.
    */

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -381,6 +381,7 @@ export class WorkerHandler<N, T, D> {
       'locale',
       'domain',
       'style',
+      'domain2style'
     ]);
     const adaptor = this.adaptor;
     this.setSpecialAttributes(container, data.translations, 'data-semantic-');

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -585,19 +585,26 @@ export class WorkerHandler<N, T, D> {
   }
 
 
-  public async clearspeakLocalePreferences(item: SpeechMathItem<N, T, D>) {
-    console.log(43);
+  public async clearspeakLocalePreferences(
+    item: SpeechMathItem<N, T, D>,
+    options: OptionList,
+    prefs: {[key: string]: {[prop: string]: string[] }}
+  ) {
     await this.Post(
       {
         cmd: 'Worker',
         data: {
           cmd: 'localePreferences',
           debug: this.options.debug,
-          data: { },
+          data: {
+            options: options
+          },
         },
       },
       item
-    ).then((e) => console.log(e));
+    ).then((e) => {
+      prefs[options.locale] = e;
+    });
   }
 
   /**

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -404,6 +404,7 @@ export class WorkerHandler<N, T, D> {
     if (speech) {
       if (data.label) {
         adaptor.setAttribute(container, SemAttr.SPEECH, data.label);
+        adaptor.setAttribute(container, SemAttr.SPEECH_SSML, data.ssml);
         item.outputData.speech = data.label;
       }
       adaptor.setAttribute(container, 'data-speech-attached', 'true');

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -29,7 +29,7 @@ import { semanticMathmlSync } from '#sre/enrich_mathml/enrich.js';
 export {
   addPreference,
   fromPreference,
-  toPreference
+  toPreference,
 } from '#sre/speech_rules/clearspeak_preference_string.js';
 
 export const locales = Variables.LOCALES;

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -23,10 +23,14 @@
  */
 
 import { Engine } from '#sre/common/engine.js';
-import { ClearspeakPreferences } from '#sre/speech_rules/clearspeak_preferences.js';
 import { parseInput } from '#sre/common/dom_util.js';
 import { Variables } from '#sre/common/variables.js';
 import { semanticMathmlSync } from '#sre/enrich_mathml/enrich.js';
+export {
+  addPreference,
+  fromPreference,
+  toPreference
+} from '#sre/speech_rules/clearspeak_preference_string.js';
 
 export const locales = Variables.LOCALES;
 
@@ -42,7 +46,5 @@ export const engineSetup = () => {
 export const toEnriched = (mml: string) => {
   return semanticMathmlSync(mml, Engine.getInstance().options);
 };
-
-export const clearspeakPreferences = ClearspeakPreferences;
 
 export const parseDOM = parseInput;

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -193,7 +193,12 @@ declare const SRE: any;
       return Speech(SRE.workerNextStyle, data.mml, data.options, data.nodeId);
     },
 
-
+    /**
+     * Compute clearspeak preferences for a given locale
+     *
+     * @param {Message} data The data object
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
+     */
     async localePreferences(data: Message): WorkerResult {
       const structure = (await SRE.workerLocalePreferences(data.options)) ?? {};
       // Not strictly necessary for the menu as there should not be one in node.
@@ -201,6 +206,12 @@ declare const SRE: any;
       return global.copyStructure(structure);
     },
 
+    /**
+     * Compute relevant clearspeak preference category for a semantic node.
+     *
+     * @param {Message} data The data object
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
+     */
     async relevantPreferences(data: Message): WorkerResult {
       return await SRE.workerRelevantPreferences(data.mml, data.id) ?? '';
     },

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -194,10 +194,8 @@ declare const SRE: any;
     },
 
 
-    localePreferences(_data: Message): WorkerResult {
-      console.log(44);
-      console.log(SRE.workerLocalePreferences);
-      return Menu(SRE.workerLocalePreferences);
+    localePreferences(data: Message): WorkerResult {
+      return Menu(SRE.workerLocalePreferences, data.options);
     },
 
   };
@@ -260,9 +258,10 @@ declare const SRE: any;
   }
 
   async function Menu(
-    func: () => StructureData,
+    func: (options: OptionList) => StructureData,
+    options: OptionList
   ): Promise<StructureData> {
-    const structure = (await func.call(null)) ?? {};
+    const structure = (await func.call(null, options)) ?? {};
     return global.copyStructure(structure);
   }
 

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -194,8 +194,15 @@ declare const SRE: any;
     },
 
 
-    localePreferences(data: Message): WorkerResult {
-      return Menu(SRE.workerLocalePreferences, data.options);
+    async localePreferences(data: Message): WorkerResult {
+      const structure = (await SRE.workerLocalePreferences(data.options)) ?? {};
+      // Not strictly necessary for the menu as there should not be one in node.
+      // However, it allows for getting the preferences in a different context.
+      return global.copyStructure(structure);
+    },
+
+    async relevantPreferences(data: Message): WorkerResult {
+      return await SRE.workerRelevantPreferences(data.mml, data.id) ?? '';
     },
 
   };
@@ -256,15 +263,6 @@ declare const SRE: any;
     const structure = (await func.call(null, mml, options, ...rest)) ?? {};
     return global.copyStructure(structure);
   }
-
-  async function Menu(
-    func: (options: OptionList) => StructureData,
-    options: OptionList
-  ): Promise<StructureData> {
-    const structure = (await func.call(null, options)) ?? {};
-    return global.copyStructure(structure);
-  }
-
 
   /**
    * Make a copy of an Error object (since those can't be stringified).

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -200,7 +200,7 @@ declare const SRE: any;
      * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
     async localePreferences(data: Message): WorkerResult {
-      const structure = (await SRE.workerLocalePreferences(data.options));
+      const structure = await SRE.workerLocalePreferences(data.options);
       // Not strictly necessary for the menu as there should not be one in node.
       // However, it allows for getting the preferences in a different context.
       return structure ? global.copyStructure(structure) : structure;
@@ -213,9 +213,8 @@ declare const SRE: any;
      * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
     async relevantPreferences(data: Message): WorkerResult {
-      return await SRE.workerRelevantPreferences(data.mml, data.id) ?? '';
+      return (await SRE.workerRelevantPreferences(data.mml, data.id)) ?? '';
     },
-
   };
 
   /**

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -200,10 +200,10 @@ declare const SRE: any;
      * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
     async localePreferences(data: Message): WorkerResult {
-      const structure = (await SRE.workerLocalePreferences(data.options)) ?? {};
+      const structure = (await SRE.workerLocalePreferences(data.options));
       // Not strictly necessary for the menu as there should not be one in node.
       // However, it allows for getting the preferences in a different context.
-      return global.copyStructure(structure);
+      return structure ? global.copyStructure(structure) : structure;
     },
 
     /**

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -192,6 +192,14 @@ declare const SRE: any;
     nextStyle(data: Message): WorkerResult {
       return Speech(SRE.workerNextStyle, data.mml, data.options, data.nodeId);
     },
+
+
+    localePreferences(_data: Message): WorkerResult {
+      console.log(44);
+      console.log(SRE.workerLocalePreferences);
+      return Menu(SRE.workerLocalePreferences);
+    },
+
   };
 
   /**
@@ -250,6 +258,14 @@ declare const SRE: any;
     const structure = (await func.call(null, mml, options, ...rest)) ?? {};
     return global.copyStructure(structure);
   }
+
+  async function Menu(
+    func: () => StructureData,
+  ): Promise<StructureData> {
+    const structure = (await func.call(null)) ?? {};
+    return global.copyStructure(structure);
+  }
+
 
   /**
    * Make a copy of an Error object (since those can't be stringified).

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -47,7 +47,8 @@ export class MJContextMenu extends ContextMenu {
    */
   public static DynamicSubmenus: Map<
     string,
-    [(menu: MJContextMenu, sub: Submenu) => SubMenu, string]
+    [(menu: MJContextMenu, sub: Submenu,
+      callback: (sub: SubMenu) => void) => void, string]
   > = new Map();
 
   /**
@@ -223,13 +224,16 @@ export class MJContextMenu extends ContextMenu {
     for (const [id, [method, option]] of MJContextMenu.DynamicSubmenus) {
       const menu = this.find(id) as Submenu;
       if (!menu) continue;
-      const sub = method(this, menu);
-      menu.submenu = sub;
-      if (sub.items.length && (!option || this.settings[option])) {
-        menu.enable();
-      } else {
-        menu.disable();
-      }
+      method(this, menu,
+             (sub: SubMenu) => {
+               menu.submenu = sub;
+               if (sub?.items?.length && (!option || this.settings[option])) {
+                 menu.enable();
+               } else {
+                 menu.disable();
+               }
+             }
+            );
     }
   }
 }

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -47,8 +47,14 @@ export class MJContextMenu extends ContextMenu {
    */
   public static DynamicSubmenus: Map<
     string,
-    [(menu: MJContextMenu, sub: Submenu,
-      callback: (sub: SubMenu) => void) => void, string]
+    [
+      (
+        menu: MJContextMenu,
+        sub: Submenu,
+        callback: (sub: SubMenu) => void
+      ) => void,
+      string,
+    ]
   > = new Map();
 
   /**
@@ -224,16 +230,14 @@ export class MJContextMenu extends ContextMenu {
     for (const [id, [method, option]] of MJContextMenu.DynamicSubmenus) {
       const menu = this.find(id) as Submenu;
       if (!menu) continue;
-      method(this, menu,
-             (sub: SubMenu) => {
-               menu.submenu = sub;
-               if (sub?.items?.length && (!option || this.settings[option])) {
-                 menu.enable();
-               } else {
-                 menu.disable();
-               }
-             }
-            );
+      method(this, menu, (sub: SubMenu) => {
+        menu.submenu = sub;
+        if (sub?.items?.length && (!option || this.settings[option])) {
+          menu.enable();
+        } else {
+          menu.disable();
+        }
+      });
     }
   }
 }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -754,14 +754,6 @@ export class Menu {
             'Clearspeak',
             this.radioGroup('speechRules', [['clearspeak-default', 'Auto']])
           ),
-          this.submenu(
-            'ChromeVox',
-            'ChromeVox',
-            this.radioGroup('speechRules', [
-              ['chromevox-default', 'Standard'],
-              ['chromevox-alternative', 'Alternative'],
-            ])
-          ),
           this.rule(),
           this.submenu('A11yLanguage', 'Language'),
         ]),


### PR DESCRIPTION
**Only works with the latest versions of SRE, v5-alpha.3 and above. Make sure to run `pnpm install` first!**

The PR does 4 main things:
1) Fixes the auto voicing option
2) Reinstates the functionality of the Clearspeak submenu
3) Ensures that consistent ruleset/preference changes on an element. 
4) Removes `ChromeVox` menu entry

## Auto Voicing Option

Auto voicing with synchronised highlighting uses the `SemAttr.SPEECH_SSML` attributes to compute speech, pauses and the highlighting marks. It also depends on these being available at all levels of the expression.
* The container gets the ssml attribute form the speech structure from SRE (latest version!)
* We compute SSML not just for summary but also for regular speech in `SsmlAttributes`.
* Hiding the `SpeechRegion` cancels the speech.

## Clearspeak Submenu

Since some of the functionality of the Clearspeak submenu depends on locales being loaded we now need to route this through the worker. In particular we need to call the worker in two functions:
* `getLocalePreferences` computes the clearspeak preferences for a locale; they need to be computed only once are stored in a dedicated `localePreferences` map
* `getRelevantPreferences` computes the category of preferences that is useful for the currently focused node. E.g., if it is a fraction then the fraction related preferences are computed (this is similar somewhat similar `nextStyle`). Results are passed back via the `relevantPreferences` map.
 
To support this I have added two methods in `GeneratorPool`, `WebWorker`, and `speech-worker`, respectively.
In addition 
* `DynamicSubmenus` now work asynchronously.
* SRE previously kept the global state of styles/preferences for `MathSpeak` and `ClearSpeak`. These are now kept in `previousPrefs`. There is still an issue when a locale has no clearspeak, going back to one that does still leaves it on Mathspeak.

## Conistent rule and preference changes

Now items also have a `data-semantic-domain2style` that remembers the last style used when swapping styles/rules with the `>` and `<` keys. This avoids bleed through from one expression to the other, as SRE no longer maintains a global state for elements.

## ChromeVox Menu

I removed the `ChromeVox` menu entry as this only exists in English and is no longer maintained.