### PR TITLE
Fix a number of explorer and menu issues, and update to work with Orca 46

### DIFF
--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -616,6 +616,7 @@ export class Collapse {
     for (const name of Object.keys(attributes)) {
       if (
         name.substring(0, 14) === 'data-semantic-' ||
+        name.substring(0, 12) === 'data-speech-' ||
         name.substring(0, 5) === 'aria-' ||
         name === 'role'
       ) {

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -768,10 +768,7 @@ export class SpeechExplorer
    * @param {HTMLElement} node         The node that should become current
    * @param {boolean} addDescription   True if the speech node should get a description
    */
-  protected setCurrent(
-    node: HTMLElement,
-    addDescription: boolean = false
-  ) {
+  protected setCurrent(node: HTMLElement, addDescription: boolean = false) {
     this.speechType = '';
     if (!document.hasFocus()) {
       this.refocus = this.current;
@@ -912,7 +909,9 @@ export class SpeechExplorer
       container.setAttribute('has-speech', 'true');
     }
     const description = item.roleDescription;
-    const speech = (container.getAttribute(SemAttr.SPEECH) || '') + (description ? ', ' + description : '');
+    const speech =
+      (container.getAttribute(SemAttr.SPEECH) || '') +
+      (description ? ', ' + description : '');
     this.img?.remove();
     this.img = this.document.adaptor.node('mjx-speech', {
       'aria-label': speech,

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -436,6 +436,7 @@ export class WorkerHandler<N, T, D> {
     const adaptor = this.adaptor;
     const id = adaptor.getAttribute(node, 'data-semantic-id');
     if (speech) {
+      adaptor.setAttribute(node, 'data-speech-node', 'true');
       for (let [key, value] of Object.entries(data.speech[id])) {
         key = key.replace(/-ssml$/, '');
         if (value) {
@@ -444,6 +445,7 @@ export class WorkerHandler<N, T, D> {
       }
     }
     if (braille && data.braille?.[id]) {
+      adaptor.setAttribute(node, 'data-speech-node', 'true');
       const value = data.braille[id]['braille-none'] || '';
       adaptor.setAttribute(node, SemAttr.BRAILLE, value);
     }
@@ -605,7 +607,7 @@ export class WorkerHandler<N, T, D> {
      * Signals that the worker has finished its last task.
      *
      * @param {WorkerHandler} pool The active handler for the worker.
-     * @param {Message} data The data received from the worker. Ignored.
+     * @param {Message} data The data received from the worker.
      */
     Finished(pool: WorkerHandler<N, T, D>, data: Message) {
       const task = pool.tasks.shift();
@@ -615,6 +617,18 @@ export class WorkerHandler<N, T, D> {
         task.reject(data.error);
       }
       pool.postNext();
+    },
+
+    /**
+     * Logs a message from the worker
+     *
+     * @param {WorkerHandler} pool The active handler for the worker.
+     * @param {Message} data The data received from the worker.
+     */
+    Log(pool: WorkerHandler<N, T, D>, data: Message) {
+      if (pool.options.debug) {
+        console.log(data.msg);
+      }
     },
   };
 }

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -153,7 +153,6 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
       },
       'mjx-math[breakable]': {
         display: 'inline',
-        'font-family': 'inherit',
       },
       //
       //  For inline breakpoints, use a space that is 1em width, make it breakable,

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -110,7 +110,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
       fill: 'blue',
       stroke: 'blue',
     },
-    'rect[sre-highlighter-added]': {
+    'rect[sre-highlighter-added]:has(+ .mjx-selected)': {
       stroke: 'black',
       'stroke-width': '80px',
     },

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -527,6 +527,7 @@ export class Menu {
       this.document.options.a11y,
       this.settings
     );
+    this.setA11y({ roleDescription: this.settings.roleDescription });
   }
 
   /**
@@ -926,16 +927,20 @@ export class Menu {
    */
   protected checkLoadableItems() {
     if (MathJax && MathJax._ && MathJax.loader && MathJax.startup) {
+      const settings = this.settings;
+      const options = this.document.options;
       if (
-        (this.settings.enrich ||
-          this.settings.collapsible ||
-          this.settings.speech ||
-          this.settings.braille) &&
+        (settings.enrich ||
+          (settings.speech && options.enableSpeech) ||
+          (settings.braille && options.enableBraille)) &&
         !MathJax._?.a11y?.explorer
       ) {
         this.loadA11y('explorer');
       }
-      if (this.settings.assistiveMml && !MathJax._?.a11y?.['assistive-mml']) {
+      if (settings.collapsible && !MathJax._?.a11y?.complexity) {
+        this.loadA11y('complexity');
+      }
+      if (settings.assistiveMml && !MathJax._?.a11y?.['assistive-mml']) {
         this.loadA11y('assistive-mml');
       }
     } else {
@@ -1072,7 +1077,7 @@ export class Menu {
   protected setOverflow(overflow: string) {
     this.document.outputJax.options.displayOverflow = overflow.toLowerCase();
     if (!Menu.loading) {
-      this.document.rerender();
+      this.document.rerenderPromise();
     }
   }
 
@@ -1082,7 +1087,7 @@ export class Menu {
   protected setInlineBreaks(breaks: boolean) {
     this.document.outputJax.options.linebreaks.inline = breaks;
     if (!Menu.loading) {
-      this.document.rerender();
+      this.document.rerenderPromise();
     }
   }
 
@@ -1092,7 +1097,7 @@ export class Menu {
   protected setScale(scale: string) {
     this.document.outputJax.options.scale = parseFloat(scale);
     if (!Menu.loading) {
-      this.document.rerender();
+      this.document.rerenderPromise();
     }
   }
 
@@ -1397,11 +1402,11 @@ export class Menu {
       .then(() => {
         Menu.loading--;
         Menu.loadingPromises.delete(name);
-        callback();
         if (Menu.loading === 0 && Menu._loadingPromise) {
           Menu._loadingPromise = null;
           Menu._loadingOK();
         }
+        callback();
       })
       .catch((err) => {
         if (Menu._loadingPromise) {
@@ -1439,6 +1444,9 @@ export class Menu {
       const document = this.document;
       this.document = startup.document = startup.getDocument();
       this.document.menu = this;
+      if (document.webworker) {
+        this.document.webworker = document.webworker;
+      }
       this.setA11y(this.settings);
       this.defaultSettings = Object.assign(
         {},
@@ -1711,8 +1719,14 @@ export class Menu {
    * @param {HTMLMATHITEM} math   The math to attach the context menu and zoom triggers to
    */
   public addMenu(math: HTMLMATHITEM) {
-    const element = math.typesetRoot;
-    element.addEventListener(
+    this.addEvents(math);
+    this.menu.store.insert(math.typesetRoot);
+    math.typesetRoot.tabIndex = this.settings.inTabOrder ? 0 : -1;
+  }
+
+  public addEvents(math: HTMLMATHITEM) {
+    const node = math.typesetRoot;
+    node.addEventListener(
       'mousedown',
       () => {
         this.menu.mathItem = math;
@@ -1720,7 +1734,7 @@ export class Menu {
       },
       true
     );
-    element.addEventListener(
+    node.addEventListener(
       'contextmenu',
       () => {
         this.menu.mathItem = math;
@@ -1732,23 +1746,17 @@ export class Menu {
       },
       true
     );
-    element.addEventListener(
-      'keydown',
-      () => (this.menu.mathItem = math),
-      true
-    );
-    element.addEventListener(
+    node.addEventListener('keydown', () => (this.menu.mathItem = math), true);
+    node.addEventListener(
       'click',
       (event) => this.zoom(event, 'Click', math),
       true
     );
-    element.addEventListener(
+    node.addEventListener(
       'dblclick',
       (event) => this.zoom(event, 'DoubleClick', math),
       true
     );
-    this.menu.store.insert(element);
-    element.tabIndex = this.settings.inTabOrder ? 0 : -1;
   }
 
   /**

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -219,7 +219,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
           STATE.UNPROCESSED + 1,
           (doc: MenuMathDocument) => doc.checkLoading(),
           '',
-          false
+          false,
         ],
       }),
     };

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -30,7 +30,6 @@ import {
   ComplexityMathDocument,
   ComplexityMathItem,
 } from '../../a11y/complexity.js';
-import { ExplorerMathDocument, ExplorerMathItem } from '../../a11y/explorer.js';
 import {
   AssistiveMmlMathDocument,
   AssistiveMmlMathItem,
@@ -51,7 +50,6 @@ export type Constructor<T> = new (...args: any[]) => T;
  * Generic A11Y MathItem type
  */
 export type A11yMathItem = ComplexityMathItem<HTMLElement, Text, Document> &
-  ExplorerMathItem &
   AssistiveMmlMathItem<HTMLElement, Text, Document>;
 
 /**
@@ -69,7 +67,6 @@ export type A11yMathDocument = ComplexityMathDocument<
   Text,
   Document
 > &
-  ExplorerMathDocument &
   AssistiveMmlMathDocument<HTMLElement, Text, Document>;
 
 /**
@@ -152,8 +149,7 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
  * The properties needed in the MathDocument for context menus
  */
 export interface MenuMathDocument
-  extends ComplexityMathDocument<HTMLElement, Text, Document>,
-    ExplorerMathDocument {
+  extends ComplexityMathDocument<HTMLElement, Text, Document> {
   /**
    * The menu associated with this document
    */

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -34,6 +34,7 @@ import {
   AssistiveMmlMathDocument,
   AssistiveMmlMathItem,
 } from '../../a11y/assistive-mml.js';
+import { SpeechMathDocument } from '../../a11y/speech.js';
 import { expandable } from '../../util/Options.js';
 
 import { Menu } from './Menu.js';
@@ -67,6 +68,7 @@ export type A11yMathDocument = ComplexityMathDocument<
   Text,
   Document
 > &
+  SpeechMathDocument<HTMLElement, Text, Document> &
   AssistiveMmlMathDocument<HTMLElement, Text, Document>;
 
 /**
@@ -149,7 +151,8 @@ export function MenuMathItemMixin<B extends A11yMathItemConstructor>(
  * The properties needed in the MathDocument for context menus
  */
 export interface MenuMathDocument
-  extends ComplexityMathDocument<HTMLElement, Text, Document> {
+  extends ComplexityMathDocument<HTMLElement, Text, Document>,
+    SpeechMathDocument<HTMLElement, Text, Document> {
   /**
    * The menu associated with this document
    */


### PR DESCRIPTION
This PR implements some changes to the explorer that makes it work better with Orca in Linux, particularly with Orca 46.1 in Ubuntu 24.04.  It removes the need to clone the container element that was part of #1249 and #1251, and makes the process used more browser and OS independent (the only OS dependency now is the role used on the temporary speech elements).  I will close the two older PRs in favor of this one.

The details about the changes will be added below, but I wanted to get it out for testing and not wait for that.