### PR TITLE
Autovoicing and Clearspeak menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@xmldom/xmldom": "^0.8.10",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "^5.0.0-alpha.3",
+    "speech-rule-engine": "^5.0.0-alpha.4",
     "wicked-good-xpath": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@xmldom/xmldom": "^0.8.10",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "^5.0.0-alpha.2",
+    "speech-rule-engine": "^5.0.0-alpha.3",
     "wicked-good-xpath": "^1.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       speech-rule-engine:
-        specifier: ^5.0.0-alpha.3
-        version: 5.0.0-alpha.3
+        specifier: ^5.0.0-alpha.4
+        version: 5.0.0-alpha.4
       wicked-good-xpath:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1245,8 +1245,8 @@ packages:
   spdx-license-ids@3.0.18:
     resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
 
-  speech-rule-engine@5.0.0-alpha.3:
-    resolution: {integrity: sha512-IZi+cUiCw4mSNt+VBcMP77DOES6QuxhlfDfmvoS5VZhRPLgx8hm9B/BHMhJ9SFsDrhSMP07Dh9e4jj6py4hlMQ==}
+  speech-rule-engine@5.0.0-alpha.4:
+    resolution: {integrity: sha512-88kD4YbtjFuU1YudCgMXOw8HoN2lcrrEDBG6GsraWg7I0s8ltUGrWYpoegyV2nic5ZHs6IzwOFOs5Ai+yxnQzw==}
     hasBin: true
 
   string-argv@0.3.2:
@@ -2633,7 +2633,7 @@ snapshots:
 
   spdx-license-ids@3.0.18: {}
 
-  speech-rule-engine@5.0.0-alpha.3:
+  speech-rule-engine@5.0.0-alpha.4:
     dependencies:
       '@xmldom/xmldom': 0.9.8
       commander: 13.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       speech-rule-engine:
-        specifier: ^5.0.0-alpha.2
-        version: 5.0.0-alpha.2
+        specifier: ^5.0.0-alpha.3
+        version: 5.0.0-alpha.3
       wicked-good-xpath:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1245,8 +1245,8 @@ packages:
   spdx-license-ids@3.0.18:
     resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
 
-  speech-rule-engine@5.0.0-alpha.2:
-    resolution: {integrity: sha512-+MNNRlIxGx59mkWcmDb+Y8pGMiINt2wEWImxpqviLCEAoNB/OM0ZjuZlmVzm1bcbnFfjumSscOCKOTQxsCr2Bw==}
+  speech-rule-engine@5.0.0-alpha.3:
+    resolution: {integrity: sha512-IZi+cUiCw4mSNt+VBcMP77DOES6QuxhlfDfmvoS5VZhRPLgx8hm9B/BHMhJ9SFsDrhSMP07Dh9e4jj6py4hlMQ==}
     hasBin: true
 
   string-argv@0.3.2:
@@ -2633,7 +2633,7 @@ snapshots:
 
   spdx-license-ids@3.0.18: {}
 
-  speech-rule-engine@5.0.0-alpha.2:
+  speech-rule-engine@5.0.0-alpha.3:
     dependencies:
       '@xmldom/xmldom': 0.9.8
       commander: 13.1.0

--- a/ts/a11y/explorer/Explorer.ts
+++ b/ts/a11y/explorer/Explorer.ts
@@ -118,9 +118,7 @@ export class AbstractExplorer<T> implements Explorer {
   protected events: [string, (x: Event) => void][] = [];
 
   /**
-   * The Sre highlighter associated with the walker.
-   *
-   * @type {Sre.highlighter}
+   * @returns {Highlighter} The Sre highlighter associated with the walker.
    */
   protected get highlighter(): Highlighter {
     return this.pool.highlighter;

--- a/ts/a11y/explorer/Explorer.ts
+++ b/ts/a11y/explorer/Explorer.ts
@@ -22,7 +22,7 @@
  */
 
 import { A11yDocument, Region } from './Region.js';
-import * as Sre from '../sre.js';
+import { Highlighter } from './Highlighter.js';
 
 import type { ExplorerPool } from './ExplorerPool.js';
 
@@ -122,7 +122,7 @@ export class AbstractExplorer<T> implements Explorer {
    *
    * @type {Sre.highlighter}
    */
-  protected get highlighter(): Sre.highlighter {
+  protected get highlighter(): Highlighter {
     return this.pool.highlighter;
   }
 

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -29,7 +29,7 @@ import { SpeechExplorer } from './KeyExplorer.js';
 import * as me from './MouseExplorer.js';
 import { TreeColorer, FlameColorer } from './TreeExplorer.js';
 
-import { Highlighter, getHighlighter, updateHighlighter } from './Highlighter.js';
+import { Highlighter, getHighlighter } from './Highlighter.js';
 // import * as Sre from '../sre.js';
 
 /**
@@ -248,7 +248,7 @@ export class ExplorerPool {
       return this._highlighter;
     }
     const [foreground, background] = this.colorOptions();
-    updateHighlighter(background, foreground, this._highlighter);
+    this._highlighter.setColor(background, foreground);
     return this._highlighter;
   }
 
@@ -359,8 +359,11 @@ export class ExplorerPool {
    */
   protected setPrimaryHighlighter() {
     const [foreground, background] = this.colorOptions();
-    this._highlighter = getHighlighter(background, foreground,
-                                       this.document.outputJax.name);
+    this._highlighter = getHighlighter(
+      background,
+      foreground,
+      this.document.outputJax.name
+    );
   }
 
   /**

--- a/ts/a11y/explorer/ExplorerPool.ts
+++ b/ts/a11y/explorer/ExplorerPool.ts
@@ -1,6 +1,6 @@
 /*************************************************************
  *
- *  Copyright (c) 2022-2024 The MathJax Consortium
+ *  COPYRIGHT (c) 2022-2024 The MathJax Consortium
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ import { SpeechExplorer } from './KeyExplorer.js';
 import * as me from './MouseExplorer.js';
 import { TreeColorer, FlameColorer } from './TreeExplorer.js';
 
-import * as Sre from '../sre.js';
+import { Highlighter, getHighlighter, updateHighlighter } from './Highlighter.js';
+// import * as Sre from '../sre.js';
 
 /**
  * The regions objects needed for the explorers.
@@ -195,7 +196,7 @@ export class ExplorerPool {
   /**
    * A highlighter that is used to mark nodes during auto voicing.
    */
-  public secondaryHighlighter: Sre.highlighter;
+  public secondaryHighlighter: Highlighter;
 
   /**
    * The explorer dictionary.
@@ -225,7 +226,7 @@ export class ExplorerPool {
   /**
    * The primary highlighter shared by all explorers.
    */
-  private _highlighter: Sre.highlighter;
+  private _highlighter: Highlighter;
 
   /**
    * The name of the current output jax.
@@ -238,16 +239,16 @@ export class ExplorerPool {
   private _restart: string[] = [];
 
   /**
-   * @returns {Sre.highlighter} The primary highlighter shared by all explorers.
+   * @returns {Highlighter} The primary highlighter shared by all explorers.
    */
-  public get highlighter(): Sre.highlighter {
+  public get highlighter(): Highlighter {
     if (this._renderer !== this.document.outputJax.name) {
       this._renderer = this.document.outputJax.name;
       this.setPrimaryHighlighter();
       return this._highlighter;
     }
     const [foreground, background] = this.colorOptions();
-    Sre.updateHighlighter(background, foreground, this._highlighter);
+    updateHighlighter(background, foreground, this._highlighter);
     return this._highlighter;
   }
 
@@ -358,20 +359,18 @@ export class ExplorerPool {
    */
   protected setPrimaryHighlighter() {
     const [foreground, background] = this.colorOptions();
-    this._highlighter = Sre.getHighlighter(background, foreground, {
-      renderer: this.document.outputJax.name,
-      browser: 'v3',
-    });
+    this._highlighter = getHighlighter(background, foreground,
+                                       this.document.outputJax.name);
   }
 
   /**
    * Sets the secondary highlighter for marking nodes during autovoicing.
    */
   protected setSecondaryHighlighter() {
-    this.secondaryHighlighter = Sre.getHighlighter(
+    this.secondaryHighlighter = getHighlighter(
       { color: 'red' },
       { color: 'black' },
-      { renderer: this.document.outputJax.name, browser: 'v3' }
+      this.document.outputJax.name
     );
     (this.speech.region as SpeechRegion).highlighter =
       this.secondaryHighlighter;

--- a/ts/a11y/explorer/Highlighter.ts
+++ b/ts/a11y/explorer/Highlighter.ts
@@ -1,0 +1,590 @@
+//
+// Copyright 2025 Volker Sorge
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Highlighter for exploring nodes.
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+
+interface NamedColor {
+  color: string;
+  alpha?: number;
+}
+
+interface ChannelColor {
+  red: number;
+  green: number;
+  blue: number;
+  alpha?: number;
+}
+
+export interface StringColor {
+  background: string;
+  alphaback?: string;
+  foreground: string;
+  alphafore?: string;
+}
+
+export type Color = ChannelColor | NamedColor;
+
+const namedColors: { [key: string]: ChannelColor } = {
+  red: { red: 255, green: 0, blue: 0 },
+  green: { red: 0, green: 255, blue: 0 },
+  blue: { red: 0, green: 0, blue: 255 },
+  yellow: { red: 255, green: 255, blue: 0 },
+  cyan: { red: 0, green: 255, blue: 255 },
+  magenta: { red: 255, green: 0, blue: 255 },
+  white: { red: 255, green: 255, blue: 255 },
+  black: { red: 0, green: 0, blue: 0 }
+};
+
+/**
+ * Turns a color definition a channel color definition. Augments it if
+ * necessary.
+ *
+ * @param color The definition.
+ * @param deflt The default color if color does not exist.
+ * @returns The augmented color definition.
+ */
+function getChannelColor(color: Color, deflt: string): ChannelColor {
+  const col = color || { color: deflt };
+  let channel = Object.prototype.hasOwnProperty.call(col, 'color')
+    ? namedColors[(col as NamedColor).color]
+    : col;
+  if (!channel) {
+    channel = namedColors[deflt];
+  }
+  channel.alpha = Object.prototype.hasOwnProperty.call(col, 'alpha')
+    ? col.alpha
+    : 1;
+  return normalizeColor(channel as ChannelColor);
+}
+
+/**
+ * Normalizes the color channels, i.e., rgb in [0,255] and alpha in [0,1].
+ *
+ * @param color The color definition.
+ * @returns The normalized color definition.
+ */
+function normalizeColor(color: ChannelColor): ChannelColor {
+  const normalizeCol = (col: number) => {
+    col = Math.max(col, 0);
+    col = Math.min(255, col);
+    return Math.round(col);
+  };
+  color.red = normalizeCol(color.red);
+  color.green = normalizeCol(color.green);
+  color.blue = normalizeCol(color.blue);
+  color.alpha = Math.max(color.alpha, 0);
+  color.alpha = Math.min(1, color.alpha);
+  return color;
+}
+
+export class ColorPicker {
+  /**
+   * The default background color if a none existing color is provided.
+   */
+  private static DEFAULT_BACKGROUND_ = 'blue';
+
+  /**
+   * The default color if a none existing color is provided.
+   */
+  private static DEFAULT_FOREGROUND_ = 'black';
+
+  /**
+   * The foreground color in RGBa.
+   */
+  public foreground: ChannelColor;
+
+  /**
+   * The background color in RGBa.
+   */
+  public background: ChannelColor;
+
+  /**
+   * Color picker class.
+   *
+   * @param background The background color definition.
+   * @param foreground The optional foreground color definition.
+   */
+  constructor(background: Color, foreground?: Color) {
+    this.foreground = getChannelColor(
+      foreground,
+      ColorPicker.DEFAULT_FOREGROUND_
+    );
+    this.background = getChannelColor(
+      background,
+      ColorPicker.DEFAULT_BACKGROUND_
+    );
+  }
+
+  /**
+   * RGBa version of the colors.
+   *
+   * @returns The color in RGBa format.
+   */
+  public rgba(): StringColor {
+    const rgba = function (col: ChannelColor) {
+      return (
+        'rgba(' +
+        col.red +
+        ',' +
+        col.green +
+        ',' +
+        col.blue +
+        ',' +
+        col.alpha +
+        ')'
+      );
+    };
+    return {
+      background: rgba(this.background),
+      foreground: rgba(this.foreground)
+    };
+  }
+
+  // /**
+  //  * RGB version of the colors.
+  //  *
+  //  * @returns The color in Rgb format.
+  //  */
+  // public rgb(): StringColor {
+  //   const rgb = function (col: ChannelColor) {
+  //     return 'rgb(' + col.red + ',' + col.green + ',' + col.blue + ')';
+  //   };
+  //   return {
+  //     background: rgb(this.background),
+  //     alphaback: this.background.alpha.toString(),
+  //     foreground: rgb(this.foreground),
+  //     alphafore: this.foreground.alpha.toString()
+  //   };
+  // }
+
+}
+
+export interface Highlighter {
+  /**
+   * Sets highlighting on a node.
+   *
+   * @param nodes The nodes to highlight.
+   */
+  highlight(nodes: HTMLElement[]): void;
+
+  /**
+   * Unhighlights the last nodes that were highlighted.
+   */
+  unhighlight(): void;
+
+  /**
+   * Sets highlighting on all maction-like sub nodes of the given node.
+   *
+   * @param node The node to highlight.
+   */
+  highlightAll(node: HTMLElement): void;
+
+  /**
+   * Unhighlights all currently highlighted nodes.
+   */
+  unhighlightAll(): void;
+
+  /**
+   * Predicate to check if a node is an maction node.
+   *
+   * @param node A DOM node.
+   * @returns True if the node is an maction node.
+   */
+  isMactionNode(node: Element): boolean;
+
+  /**
+   * Sets of the color the highlighter is using.
+   *
+   * @param color The new color to use.
+   */
+  setColor(color: ColorPicker): void;
+
+  /**
+   * Turns the current color into a string representation.
+   *
+   * @returns The color string, by default as rgba.
+   */
+  colorString(): StringColor;
+
+}
+
+/**
+ * Highlight information consisting of node, opacity, fore and background color.
+ */
+export interface Highlight {
+  node: HTMLElement;
+  opacity?: string;
+  background?: string;
+  foreground?: string;
+  // The following is for the CSS highlighter
+  box?: HTMLElement;
+  position?: string;
+}
+
+let counter = 0;
+
+export abstract class AbstractHighlighter implements Highlighter {
+  public counter = counter++;
+
+  /**
+   * The Attribute for marking highlighted nodes.
+   */
+  protected ATTR = 'sre-highlight-' + this.counter.toString();
+
+  /**
+   * The color picker.
+   */
+  protected color: ColorPicker = null;
+
+  /**
+   * The maction name/class for a highlighter.
+   */
+  protected mactionName = '';
+
+  /**
+   * List of currently highlighted nodes and their original background color.
+   */
+  private currentHighlights: Highlight[][] = [];
+
+  /**
+   * Highlights a single node.
+   *
+   * @param node The node to be highlighted.
+   * @returns The old node information.
+   */
+  protected abstract highlightNode(node: HTMLElement): Highlight;
+
+  /**
+   * Unhighlights a single node.
+   *
+   * @param highlight The highlight info for the node to be unhighlighted.
+   */
+  protected abstract unhighlightNode(highlight: Highlight): void;
+
+  /**
+   * @override
+   */
+  public highlight(nodes: HTMLElement[]) {
+    this.currentHighlights.push(
+      nodes.map((node) => {
+        const info = this.highlightNode(node);
+        this.setHighlighted(node);
+        return info;
+      })
+    );
+  }
+
+  /**
+   * @override
+   */
+  public highlightAll(node: HTMLElement) {
+    const mactions = this.getMactionNodes(node);
+    for (let i = 0, maction; (maction = mactions[i]); i++) {
+      this.highlight([maction]);
+    }
+  }
+
+  /**
+   * @override
+   */
+  public unhighlight() {
+    const nodes = this.currentHighlights.pop();
+    if (!nodes) {
+      return;
+    }
+    nodes.forEach((highlight: Highlight) => {
+      if (this.isHighlighted(highlight.node)) {
+        this.unhighlightNode(highlight);
+        this.unsetHighlighted(highlight.node);
+      }
+    });
+  }
+
+  /**
+   * @override
+   */
+  public unhighlightAll() {
+    while (this.currentHighlights.length > 0) {
+      this.unhighlight();
+    }
+  }
+
+  /**
+   * @override
+   */
+  public setColor(color: ColorPicker) {
+    this.color = color;
+  }
+
+  /**
+   * @override
+   */
+  public colorString(): StringColor {
+    return this.color.rgba();
+  }
+
+  /**
+   * Returns the maction sub nodes of a given node.
+   *
+   * @param node The root node.
+   * @returns The list of maction sub nodes.
+   */
+  public getMactionNodes(node: HTMLElement): HTMLElement[] {
+    return Array.from(
+      node.getElementsByClassName(this.mactionName)
+    ) as HTMLElement[];
+  }
+
+  /**
+   * @override
+   */
+  public isMactionNode(node: Element): boolean {
+    const className = node.className || node.getAttribute('class');
+    return className ? !!className.match(new RegExp(this.mactionName)) : false;
+  }
+
+  /**
+   * Check if a node is already highlighted.
+   *
+   * @param node The node.
+   * @returns True if already highlighted.
+   */
+  public isHighlighted(node: HTMLElement): boolean {
+    return node.hasAttribute(this.ATTR);
+  }
+
+  /**
+   * Sets the indicator attribute that node is already highlighted.
+   *
+   * @param node The node.
+   */
+  public setHighlighted(node: HTMLElement) {
+    node.setAttribute(this.ATTR, 'true');
+  }
+
+  /**
+   * Removes the indicator attribute that node is already highlighted.
+   *
+   * @param node The node.
+   */
+  public unsetHighlighted(node: HTMLElement) {
+    node.removeAttribute(this.ATTR);
+  }
+
+}
+
+export class SvgHighlighter extends AbstractHighlighter {
+  /**
+   * @override
+   */
+  constructor() {
+    super();
+    this.mactionName = 'maction';
+  }
+
+  /**
+   * @override
+   */
+  public highlightNode(node: HTMLElement) {
+    let info: Highlight;
+    if (this.isHighlighted(node)) {
+      info = {
+        node: node,
+        background: this.colorString().background,
+        foreground: this.colorString().foreground
+      };
+      return info;
+    }
+    if (node.tagName === 'svg' || node.tagName === 'MJX-CONTAINER') {
+      info = {
+        node: node,
+        background: node.style.backgroundColor,
+        foreground: node.style.color
+      };
+      node.style.backgroundColor = this.colorString().background;
+      node.style.color = this.colorString().foreground;
+      return info;
+    }
+    // This is a hack for v4.
+    // TODO: v4 Change
+    // const rect = (document ?? DomUtil).createElementNS(
+    const rect = (document).createElementNS(
+      'http://www.w3.org/2000/svg',
+      'rect'
+    );
+    rect.setAttribute(
+      'sre-highlighter-added', // Mark highlighting rect.
+      'true'
+    );
+    const padding = 40;
+    const bbox: SVGRect = (node as any as SVGGraphicsElement).getBBox();
+    rect.setAttribute('x', (bbox.x - padding).toString());
+    rect.setAttribute('y', (bbox.y - padding).toString());
+    rect.setAttribute('width', (bbox.width + 2 * padding).toString());
+    rect.setAttribute('height', (bbox.height + 2 * padding).toString());
+    const transform = node.getAttribute('transform');
+    if (transform) {
+      rect.setAttribute('transform', transform);
+    }
+    rect.setAttribute('fill', this.colorString().background);
+    node.setAttribute(this.ATTR, 'true');
+    node.parentNode.insertBefore(rect, node);
+    info = { node: node, foreground: node.getAttribute('fill') };
+    if (node.nodeName !== 'rect') {
+      // We currently do not change foreground of collapsed nodes.
+      node.setAttribute('fill', this.colorString().foreground);
+    }
+    return info;
+  }
+
+  /**
+   * @override
+   */
+  public setHighlighted(node: HTMLElement) {
+    if (node.tagName === 'svg') {
+      super.setHighlighted(node);
+    }
+  }
+
+  /**
+   * @override
+   */
+  public unhighlightNode(info: Highlight) {
+    const previous = info.node.previousSibling as HTMLElement;
+    if (previous && previous.hasAttribute('sre-highlighter-added')) {
+      info.foreground
+        ? info.node.setAttribute('fill', info.foreground)
+        : info.node.removeAttribute('fill');
+      info.node.parentNode.removeChild(previous);
+      return;
+    }
+    info.node.style.backgroundColor = info.background;
+    info.node.style.color = info.foreground;
+  }
+
+  /**
+   * @override
+   */
+  public isMactionNode(node: HTMLElement) {
+    return node.getAttribute('data-mml-node') === this.mactionName;
+  }
+
+  /**
+   * @override
+   */
+  public getMactionNodes(node: HTMLElement) {
+    return Array.from(
+      node.querySelectorAll(`[data-mml-node="${this.mactionName}"]`)
+    ) as HTMLElement[];
+  }
+}
+
+export class ChtmlHighlighter extends AbstractHighlighter {
+
+  /**
+   * @override
+   */
+  constructor() {
+    super();
+    this.mactionName = 'mjx-maction';
+  }
+
+  /**
+   * @override
+   */
+  public highlightNode(node: HTMLElement) {
+    const info = {
+      node: node,
+      background: node.style.backgroundColor,
+      foreground: node.style.color
+    };
+    if (!this.isHighlighted(node)) {
+      const color = this.colorString();
+      node.style.backgroundColor = color.background;
+      node.style.color = color.foreground;
+    }
+    return info;
+  }
+
+  /**
+   * @override
+   */
+  public unhighlightNode(info: Highlight) {
+    info.node.style.backgroundColor = info.background;
+    info.node.style.color = info.foreground;
+  }
+
+  /**
+   * @override
+   */
+  public isMactionNode(node: HTMLElement) {
+    return node.tagName?.toUpperCase() === this.mactionName.toUpperCase();
+  }
+
+  /**
+   * @override
+   */
+  public getMactionNodes(node: HTMLElement) {
+    return Array.from(
+      node.getElementsByTagName(this.mactionName)
+    ) as HTMLElement[];
+  }
+}
+
+/**
+ * Produces a highlighter that goes with the current Mathjax renderer if
+ * highlighting is possible.
+ *
+ * @param back A background color specification.
+ * @param fore A foreground color specification.
+ * @param rendererInfo Information on renderer,
+ * browser. Has to at least contain the renderer field.
+ * @param rendererInfo.renderer The renderer name.
+ * @param rendererInfo.browser The browser name.
+ * @returns A new highlighter.
+ */
+export function getHighlighter(
+  back: Color,
+  fore: Color,
+  renderer: string
+): Highlighter {
+  const colorPicker = new ColorPicker(back, fore);
+  const highlighter = new (highlighterMapping[renderer] ||
+    highlighterMapping['NativeMML'])();
+  highlighter.setColor(colorPicker);
+  return highlighter;
+}
+
+/**
+ * Updates the color setting for the given highlighter using named colors.
+ * Note, this is only used outside SRE, hence exported!
+ *
+ * @param back Background color as a named color.
+ * @param fore Foreground color as a named color.
+ * @param highlighter The highlighter to update.
+ */
+export function updateHighlighter(back: Color, fore: Color, highlighter: Highlighter) {
+  const colorPicker = new ColorPicker(back, fore);
+  highlighter.setColor(colorPicker);
+}
+
+const highlighterMapping: { [key: string]: new () => Highlighter } = {
+  SVG: SvgHighlighter,
+  CHTML: ChtmlHighlighter
+};

--- a/ts/a11y/explorer/Highlighter.ts
+++ b/ts/a11y/explorer/Highlighter.ts
@@ -127,11 +127,10 @@ export interface Highlighter {
 }
 
 /**
- * Highlight information consisting of node, opacity, fore and background color.
+ * Highlight information consisting of node, fore and background color.
  */
 interface Highlight {
   node: HTMLElement;
-  opacity?: string;
   background?: string;
   foreground?: string;
 }

--- a/ts/a11y/explorer/Highlighter.ts
+++ b/ts/a11y/explorer/Highlighter.ts
@@ -44,9 +44,9 @@ const namedColors: { [key: string]: ChannelColor } = {
 /**
  * Turns a named color into a channel color.
  *
- * @param color The definition.
- * @param deflt The default color name if the named color does not exist.
- * @returns The channel color.
+ * @param {NamedColor} color The definition.
+ * @param {NamedColor} deflt The default color name if the named color does not exist.
+ * @returns {string} The channel color.
  */
 function getColorString(color: NamedColor, deflt: NamedColor): string {
   const channel = namedColors[color.color] || namedColors[deflt.color];
@@ -58,7 +58,7 @@ function getColorString(color: NamedColor, deflt: NamedColor): string {
  * RGBa string version of the channel color.
  *
  * @param {ChannelColor} color The channel color.
- * @returns The color in RGBa format.
+ * @returns {string} The color in RGBa format.
  */
 function rgba(color: ChannelColor): string {
   return `rgba(${color.red},${color.green},${color.blue},${color.alpha ?? 1})`;
@@ -259,8 +259,8 @@ abstract class AbstractHighlighter implements Highlighter {
   /**
    * Returns the maction sub nodes of a given node.
    *
-   * @param node The root node.
-   * @returns The list of maction sub nodes.
+   * @param {HTMLElement} node The root node.
+   * @returns {HTMLElement[]} The list of maction sub nodes.
    */
   public getMactionNodes(node: HTMLElement): HTMLElement[] {
     return Array.from(
@@ -279,8 +279,8 @@ abstract class AbstractHighlighter implements Highlighter {
   /**
    * Check if a node is already highlighted.
    *
-   * @param node The node.
-   * @returns True if already highlighted.
+   * @param {HTMLElement} node The node.
+   * @returns {boolean} True if already highlighted.
    */
   public isHighlighted(node: HTMLElement): boolean {
     return node.hasAttribute(this.ATTR);
@@ -289,7 +289,7 @@ abstract class AbstractHighlighter implements Highlighter {
   /**
    * Sets the indicator attribute that node is already highlighted.
    *
-   * @param node The node.
+   * @param {HTMLElement} node The node.
    */
   public setHighlighted(node: HTMLElement) {
     node.setAttribute(this.ATTR, 'true');
@@ -298,7 +298,7 @@ abstract class AbstractHighlighter implements Highlighter {
   /**
    * Removes the indicator attribute that node is already highlighted.
    *
-   * @param node The node.
+   * @param {HTMLElement} node The node.
    */
   public unsetHighlighted(node: HTMLElement) {
     node.removeAttribute(this.ATTR);
@@ -462,10 +462,10 @@ class ChtmlHighlighter extends AbstractHighlighter {
  * Highlighter factory that returns the highlighter that goes with the current
  * Mathjax renderer.
  *
- * @param back A background color specification.
- * @param fore A foreground color specification.
- * @param renderer The renderer name.
- * @returns A new highlighter.
+ * @param {NamedColor} back A background color specification.
+ * @param {NamedColor} fore A foreground color specification.
+ * @param {string} renderer The renderer name.
+ * @returns {Highlighter} A new highlighter.
  */
 export function getHighlighter(
   back: NamedColor,

--- a/ts/a11y/explorer/Highlighter.ts
+++ b/ts/a11y/explorer/Highlighter.ts
@@ -129,19 +129,21 @@ export interface Highlighter {
 /**
  * Highlight information consisting of node, opacity, fore and background color.
  */
-export interface Highlight {
+interface Highlight {
   node: HTMLElement;
   opacity?: string;
   background?: string;
   foreground?: string;
-  // The following is for the CSS highlighter
-  box?: HTMLElement;
-  position?: string;
 }
 
 let counter = 0;
 
-export abstract class AbstractHighlighter implements Highlighter {
+abstract class AbstractHighlighter implements Highlighter {
+  /**
+   * This counter creates a unique highlighter name. This is important in case
+   * we have more than a single highlighter on a node, e.g., during auto voicing
+   * with synchronised highlighting.
+   */
   public counter = counter++;
 
   /**
@@ -303,7 +305,7 @@ export abstract class AbstractHighlighter implements Highlighter {
   }
 }
 
-export class SvgHighlighter extends AbstractHighlighter {
+class SvgHighlighter extends AbstractHighlighter {
   /**
    * @override
    */
@@ -406,7 +408,7 @@ export class SvgHighlighter extends AbstractHighlighter {
   }
 }
 
-export class ChtmlHighlighter extends AbstractHighlighter {
+class ChtmlHighlighter extends AbstractHighlighter {
   /**
    * @override
    */
@@ -457,16 +459,12 @@ export class ChtmlHighlighter extends AbstractHighlighter {
 }
 
 /**
- * Produces a highlighter that goes with the current Mathjax renderer if
- * highlighting is possible.
+ * Highlighter factory that returns the highlighter that goes with the current
+ * Mathjax renderer.
  *
  * @param back A background color specification.
  * @param fore A foreground color specification.
- * @param rendererInfo Information on renderer,
- * browser. Has to at least contain the renderer field.
- * @param rendererInfo.renderer The renderer name.
- * @param rendererInfo.browser The browser name.
- * @param renderer
+ * @param renderer The renderer name.
  * @returns A new highlighter.
  */
 export function getHighlighter(
@@ -480,21 +478,8 @@ export function getHighlighter(
 }
 
 /**
- * Updates the color setting for the given highlighter using named colors.
- * Note, this is only used outside SRE, hence exported!
- *
- * @param back Background color as a named color.
- * @param fore Foreground color as a named color.
- * @param highlighter The highlighter to update.
+ * Mapping renderer names to highlighter constructor.
  */
-export function updateHighlighter(
-  back: NamedColor,
-  fore: NamedColor,
-  highlighter: Highlighter
-) {
-  highlighter.setColor(back, fore);
-}
-
 const highlighterMapping: { [key: string]: new () => Highlighter } = {
   SVG: SvgHighlighter,
   CHTML: ChtmlHighlighter,

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -791,10 +791,8 @@ export class SpeechExplorer
       }
       this.current = null;
       if (!node) {
-        this.restarted = this.semanticFocus();
         this.removeSpeech();
       }
-      this.current = null;
     }
     //
     // If there is a current node

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -1054,8 +1054,8 @@ export class SpeechExplorer
    * Get the SSML attribute array
    *
    * @param {HTMLElement} node  The node whose SSML attributes are to be obtained
-   * @param center
-   * @returns {string[]}        The prefix/summary/postfix array
+   * @param {SemAttr} center    The name of the SSML attribute between pre and postfix
+   * @returns {string[]}        The prefix/speech or summary/postfix array
    */
   protected SsmlAttributes(node: HTMLElement, center: SemAttr): string[] {
     return [

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -791,8 +791,10 @@ export class SpeechExplorer
       }
       this.current = null;
       if (!node) {
+        this.restarted = this.semanticFocus();
         this.removeSpeech();
       }
+      this.current = null;
     }
     //
     // If there is a current node

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -692,7 +692,7 @@ export class SpeechExplorer
     this.speak(
       summary,
       this.current.getAttribute(SemAttr.BRAILLE),
-      this.SsmlAttributes(this.current)
+      this.SsmlAttributes(this.current, SemAttr.SUMMARY_SSML)
     );
   }
 
@@ -834,7 +834,11 @@ export class SpeechExplorer
       }
       speech += description;
     }
-    this.speak(speech, node.getAttribute(SemAttr.BRAILLE));
+    this.speak(
+      speech,
+      node.getAttribute(SemAttr.BRAILLE),
+      this.SsmlAttributes(node, SemAttr.SPEECH_SSML)
+    );
     this.node.setAttribute('tabindex', '-1');
   }
 
@@ -1050,12 +1054,13 @@ export class SpeechExplorer
    * Get the SSML attribute array
    *
    * @param {HTMLElement} node  The node whose SSML attributes are to be obtained
+   * @param center
    * @returns {string[]}        The prefix/summary/postfix array
    */
-  protected SsmlAttributes(node: HTMLElement): string[] {
+  protected SsmlAttributes(node: HTMLElement, center: SemAttr): string[] {
     return [
       node.getAttribute(SemAttr.PREFIX_SSML),
-      node.getAttribute(SemAttr.SUMMARY_SSML),
+      node.getAttribute(center),
       node.getAttribute(SemAttr.POSTFIX_SSML),
     ];
   }

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -157,7 +157,7 @@ settings.</li>
 <li><b>d</b> gives the current depth within the expression.</li>
 
 <li><b>&gt;</b> cycles through the available speech rule sets
-(MathSpeak, ClearSpeak, ChromeVox).</li>
+(MathSpeak, ClearSpeak).</li>
 
 <li><b>&lt;</b> cycles through the verbosity levels for the current
 rule set.</li>

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -508,6 +508,14 @@ export class SpeechRegion extends LiveRegion {
   }
 
   /**
+   * @override
+   */
+  public Hide() {
+    speechSynthesis.cancel();
+    super.Hide();
+  }
+
+  /**
    * Highlighting the node that is being marked in the SSML.
    *
    * @param {string} id The id of the node to highlight.

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -303,9 +303,8 @@ export class StringRegion extends AbstractRegion<string> {
    */
   protected highlight(highlighter: Highlighter) {
     if (!this.div) return;
-    const color = highlighter.colorString();
-    this.inner.style.backgroundColor = color.background;
-    this.inner.style.color = color.foreground;
+    this.inner.style.backgroundColor = highlighter.background;
+    this.inner.style.color = highlighter.foreground;
   }
 }
 
@@ -602,9 +601,8 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
     ) {
       return;
     }
-    const color = highlighter.colorString();
-    this.inner.style.backgroundColor = color.background;
-    this.inner.style.color = color.foreground;
+    this.inner.style.backgroundColor = highlighter.background;
+    this.inner.style.color = highlighter.foreground;
   }
 
   /**

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -23,7 +23,7 @@
 
 import { MathDocument } from '../../core/MathDocument.js';
 import { StyleJsonSheet } from '../../util/StyleJson.js';
-import * as Sre from '../sre.js';
+import { Highlighter, getHighlighter } from './Highlighter.js';
 import { SsmlElement, buildSpeech } from '../speech/SpeechUtil.js';
 
 export type A11yDocument = MathDocument<HTMLElement, Text, Document>;
@@ -43,9 +43,9 @@ export interface Region<T> {
    * Shows the live region in the document.
    *
    * @param {HTMLElement} node
-   * @param {Sre.highlighter} highlighter
+   * @param {Highlighter} highlighter
    */
-  Show(node: HTMLElement, highlighter: Sre.highlighter): void;
+  Show(node: HTMLElement, highlighter: Highlighter): void;
 
   /**
    * Takes the element out of the document flow.
@@ -151,7 +151,7 @@ export abstract class AbstractRegion<T> implements Region<T> {
   /**
    * @override
    */
-  public Show(node: HTMLElement, highlighter: Sre.highlighter) {
+  public Show(node: HTMLElement, highlighter: Highlighter) {
     this.AddElement();
     this.position(node);
     this.highlight(highlighter);
@@ -168,9 +168,9 @@ export abstract class AbstractRegion<T> implements Region<T> {
   /**
    * Highlights the region.
    *
-   * @param {Sre.highlighter} highlighter The Sre highlighter.
+   * @param {Highlighter} highlighter The Sre highlighter.
    */
-  protected abstract highlight(highlighter: Sre.highlighter): void;
+  protected abstract highlight(highlighter: Highlighter): void;
 
   /**
    * @override
@@ -264,7 +264,7 @@ export class DummyRegion extends AbstractRegion<void> {
   /**
    * @override
    */
-  public highlight(_highlighter: Sre.highlighter) {}
+  public highlight(_highlighter: Highlighter) {}
 }
 
 export class StringRegion extends AbstractRegion<string> {
@@ -301,7 +301,7 @@ export class StringRegion extends AbstractRegion<string> {
   /**
    * @override
    */
-  protected highlight(highlighter: Sre.highlighter) {
+  protected highlight(highlighter: Highlighter) {
     if (!this.div) return;
     const color = highlighter.colorString();
     this.inner.style.backgroundColor = color.background;
@@ -392,16 +392,16 @@ export class SpeechRegion extends LiveRegion {
   /**
    * The highlighter to use.
    */
-  public highlighter: Sre.highlighter = Sre.getHighlighter(
+  public highlighter: Highlighter = getHighlighter(
     { color: 'red' },
     { color: 'black' },
-    { renderer: this.document.outputJax.name, browser: 'v3' }
+    this.document.outputJax.name
   );
 
   /**
    * @override
    */
-  public Show(node: HTMLElement, highlighter: Sre.highlighter) {
+  public Show(node: HTMLElement, highlighter: Highlighter) {
     super.Update('\u00a0'); // Ensures region shown and cannot be overwritten.
     this.node = node;
     super.Show(node, highlighter);
@@ -593,7 +593,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
   /**
    * @override
    */
-  protected highlight(highlighter: Sre.highlighter) {
+  protected highlight(highlighter: Highlighter) {
     if (!this.div) return;
     // TODO Do this with styles to avoid the interaction of SVG/CHTML.
     if (
@@ -610,7 +610,7 @@ export class HoverRegion extends AbstractRegion<HTMLElement> {
   /**
    * @override
    */
-  public Show(node: HTMLElement, highlighter: Sre.highlighter) {
+  public Show(node: HTMLElement, highlighter: Highlighter) {
     this.AddElement();
     this.div.style.fontSize = this.document.options.a11y.magnify;
     this.Update(node);

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -218,6 +218,12 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
+  /**
+   * Computes the braille label from the node.
+   *
+   * @param {N} node            The typeset node.
+   * @returns {string}          The assembled label.
+   */
   public getBraille(node: N): string {
     const adaptor = this.adaptor;
     return (
@@ -226,25 +232,44 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
-  public getLocalePreferences(prefs: {
-    [key: string]: { [prop: string]: string[] };
-  }): Promise<void> {
+  /*********************************************************/
+  /**
+   * Menu related functions.
+   */
+  /**
+   * Computes the clearspeak preferences for the current locale.
+   *
+   * @param {Map<string, { [prop: string]: string[] }>} prefs Map to store the compute preferences.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
+  public getLocalePreferences(
+    prefs: Map<string, { [prop: string]: string[] }>
+  ): Promise<void> {
     return (this.promise = this.webworker.clearspeakLocalePreferences(
       this.options,
       prefs
     ));
   }
 
+  /**
+   * Computes the clearspeak preferences that are semantically relevant for the
+   * currently focused node.
+   *
+   * @param {SpeechMathItem} item The SpeechMathItem where is menu is opened.
+   * @param {string} semantic The semantic id of the last focused node.
+   * @param {Map<number, string>} prefs Map for recording the computed preference.
+   * @param {number} counter Counter for storing the result in the map.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
   public getRelevantPreferences(
     item: SpeechMathItem<N, T, D>,
     semantic: string,
-    prefs: { [key: number]: string },
+    prefs: Map<number, string>,
     counter: number
   ): Promise<void> {
     const mml = item.outputData.mml;
     return (this.promise = this.webworker.clearspeakRelevantPreferences(
       mml,
-      this.options,
       semantic,
       prefs,
       counter

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -226,7 +226,14 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
-  public getLocalePreferences(item: SpeechMathItem<N, T, D>): Promise<void> {
-    return (this.promise = this.webworker.clearspeakLocalePreferences(item));
+  public getLocalePreferences(
+    item: SpeechMathItem<N, T, D>,
+    prefs: { [key: string]: { [prop: string]: string[] } }
+  ): Promise<void> {
+    return (this.promise = this.webworker.clearspeakLocalePreferences(
+      item,
+      this.options,
+      prefs
+    ));
   }
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -158,6 +158,8 @@ export class GeneratorPool<N, T, D> {
       locale: this.adaptor.getAttribute(node, 'data-semantic-locale') ?? '',
       domain: this.adaptor.getAttribute(node, 'data-semantic-domain') ?? '',
       style: this.adaptor.getAttribute(node, 'data-semantic-style') ?? '',
+      domain2style:
+        this.adaptor.getAttribute(node, 'data-semantic-domain2style') ?? '',
     };
   }
 

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -226,14 +226,28 @@ export class GeneratorPool<N, T, D> {
     );
   }
 
-  public getLocalePreferences(
-    item: SpeechMathItem<N, T, D>,
-    prefs: { [key: string]: { [prop: string]: string[] } }
-  ): Promise<void> {
+  public getLocalePreferences(prefs: {
+    [key: string]: { [prop: string]: string[] };
+  }): Promise<void> {
     return (this.promise = this.webworker.clearspeakLocalePreferences(
-      item,
       this.options,
       prefs
+    ));
+  }
+
+  public getRelevantPreferences(
+    item: SpeechMathItem<N, T, D>,
+    semantic: string,
+    prefs: { [key: number]: string },
+    counter: number
+  ): Promise<void> {
+    const mml = item.outputData.mml;
+    return (this.promise = this.webworker.clearspeakRelevantPreferences(
+      mml,
+      this.options,
+      semantic,
+      prefs,
+      counter
     ));
   }
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -225,4 +225,8 @@ export class GeneratorPool<N, T, D> {
       adaptor.getAttribute(node, SemAttr.BRAILLE)
     );
   }
+
+  public getLocalePreferences(item: SpeechMathItem<N, T, D>): Promise<void> {
+    return (this.promise = this.webworker.clearspeakLocalePreferences(item));
+  }
 }

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -50,7 +50,7 @@ function currentPreference(settings?: string) {
  */
 function csPrefsVariables(menu: MJContextMenu, prefs: string[]) {
   const srVariable = menu.pool.lookup('speechRules');
-  const previous = currentPreference();
+  const previous = currentPreference(menu.settings.speechRules);
   csPrefsSetting = Sre.clearspeakPreferences.fromPreference(previous); // Do here
   for (const pref of prefs) {
     menu.factory.get('variable')(
@@ -102,7 +102,7 @@ async function csSelectionBox(
   if (!localePreferences.has(locale)) {
     await item.generatorPool.getLocalePreferences(localePreferences);
   }
-  if (localePreferences.has(locale)) {
+  if (!localePreferences.has(locale)) {
     const csEntry = menu.findID('Accessibility', 'Speech', 'Clearspeak');
     if (csEntry) {
       csEntry.disable();

--- a/ts/a11y/speech/SpeechMenu.ts
+++ b/ts/a11y/speech/SpeechMenu.ts
@@ -33,10 +33,13 @@ let csPrefsSetting: { [pref: string]: string } = {};
 let previousPrefs: string = null;
 
 /**
+ * Computes the current ClearSpeak preference, by either extracting it from the
+ * settings, returning the previously stored one, or returning the default.
  *
- * @param settings
+ * @param {string} settings The current speech rule options setting.
+ * @returns {string} The current ClearSpeak preference.
  */
-function currentPreference(settings?: string) {
+function currentPreference(settings?: string): string {
   const matcher = settings?.match(/^clearspeak-(.*)/);
   previousPrefs = (matcher && matcher[1]) ?? previousPrefs ?? 'default';
   return previousPrefs;
@@ -74,19 +77,21 @@ function csPrefsVariables(menu: MJContextMenu, prefs: string[]) {
 
 /**
  * Map for storing clearspeak preferences per locale, which can vary. They need
- * to becomputed only once as they should not change during a single run.
+ * to be computed only once as they should not change during a single run.
  */
 const localePreferences: Map<string, { [prop: string]: string[] }> = new Map();
 
 /**
+ * Computes the clearspeak preferences for the given locale via the worker.
  *
- * @param menu
- * @param locale
+ * @param {MJContextMenu} menu The parent menu.
+ * @param {string} locale The locale to get.
  */
 async function getLocalePreferences(menu: MJContextMenu, locale: string) {
-  const item = menu.mathItem as ExplorerMathItem;
   if (!localePreferences.has(locale)) {
-    await item.generatorPool.getLocalePreferences(localePreferences);
+    await (
+      menu.mathItem as ExplorerMathItem
+    ).generatorPool.getLocalePreferences(localePreferences);
   }
 }
 
@@ -172,7 +177,6 @@ function basePreferences(previous: string): object[] {
 /**
  * Generates the items for smart preference choices, depending on the top most
  *
- * @param item
  * @param {string} previous The currently set preferences.
  * @param {string} smart The semantic type of the smart preferences.
  * @param {string} locale The current locale.

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -586,7 +586,6 @@ export class WorkerHandler<N, T, D> {
 
 
   public async clearspeakLocalePreferences(
-    item: SpeechMathItem<N, T, D>,
     options: OptionList,
     prefs: {[key: string]: {[prop: string]: string[] }}
   ) {
@@ -600,10 +599,34 @@ export class WorkerHandler<N, T, D> {
             options: options
           },
         },
-      },
-      item
+      }
     ).then((e) => {
       prefs[options.locale] = e;
+    });
+  }
+
+  public async clearspeakRelevantPreferences(
+    math: string,
+    options: OptionList,
+    semantic: string,
+    prefs: { [key: number]: string },
+    counter: number
+  ) {
+    await this.Post(
+      {
+        cmd: 'Worker',
+        data: {
+          cmd: 'relevantPreferences',
+          debug: this.options.debug,
+          data: {
+            mml: math,
+            options: options,
+            id: semantic,
+          },
+        },
+      }
+    ).then((e) => {
+      prefs[counter] = e;
     });
   }
 

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -584,11 +584,17 @@ export class WorkerHandler<N, T, D> {
     this.ready = false;
   }
 
-
+  /**
+   * Worker call to compute clearspeak preferences for the current locale.
+   *
+   * @param {OptionList} options The options list.
+   * @param {Map<string, { [prop: string]: string[] }>} prefs Map to store the compute preferences.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
   public async clearspeakLocalePreferences(
     options: OptionList,
-    prefs: {[key: string]: {[prop: string]: string[] }}
-  ) {
+    prefs: Map<string, {[prop: string]: string[] }>
+  ): Promise<void> {
     await this.Post(
       {
         cmd: 'Worker',
@@ -601,17 +607,26 @@ export class WorkerHandler<N, T, D> {
         },
       }
     ).then((e) => {
-      prefs[options.locale] = e;
+      prefs.set(options.locale, e);
     });
   }
 
+  /**
+   * Computes the clearspeak preference category that are semantically relevant
+   * for the currently focused node.
+   *
+   * @param {string} math The linearized mml expression.
+   * @param {string} nodeId The semantic id of node to compute the preference for.
+   * @param {Map<number, string>} prefs Map for recording the computed preference.
+   * @param {number} counter Counter for storing the result in the map.
+   * @returns {Promise<void>} The promise that resolves when the command is complete
+   */
   public async clearspeakRelevantPreferences(
     math: string,
-    options: OptionList,
-    semantic: string,
-    prefs: { [key: number]: string },
+    nodeId: string,
+    prefs: Map<number, string>,
     counter: number
-  ) {
+  ): Promise<void> {
     await this.Post(
       {
         cmd: 'Worker',
@@ -620,13 +635,12 @@ export class WorkerHandler<N, T, D> {
           debug: this.options.debug,
           data: {
             mml: math,
-            options: options,
-            id: semantic,
+            id: nodeId,
           },
         },
       }
     ).then((e) => {
-      prefs[counter] = e;
+      prefs.set(counter, e);
     });
   }
 

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -381,7 +381,7 @@ export class WorkerHandler<N, T, D> {
       'locale',
       'domain',
       'style',
-      'domain2style'
+      'domain2style',
     ]);
     const adaptor = this.adaptor;
     this.setSpecialAttributes(container, data.translations, 'data-semantic-');
@@ -593,20 +593,18 @@ export class WorkerHandler<N, T, D> {
    */
   public async clearspeakLocalePreferences(
     options: OptionList,
-    prefs: Map<string, {[prop: string]: string[] }>
+    prefs: Map<string, { [prop: string]: string[] }>
   ): Promise<void> {
-    await this.Post(
-      {
-        cmd: 'Worker',
+    await this.Post({
+      cmd: 'Worker',
+      data: {
+        cmd: 'localePreferences',
+        debug: this.options.debug,
         data: {
-          cmd: 'localePreferences',
-          debug: this.options.debug,
-          data: {
-            options: options
-          },
+          options: options,
         },
-      }
-    ).then((e) => {
+      },
+    }).then((e) => {
       prefs.set(options.locale, e);
     });
   }
@@ -627,19 +625,17 @@ export class WorkerHandler<N, T, D> {
     prefs: Map<number, string>,
     counter: number
   ): Promise<void> {
-    await this.Post(
-      {
-        cmd: 'Worker',
+    await this.Post({
+      cmd: 'Worker',
+      data: {
+        cmd: 'relevantPreferences',
+        debug: this.options.debug,
         data: {
-          cmd: 'relevantPreferences',
-          debug: this.options.debug,
-          data: {
-            mml: math,
-            id: nodeId,
-          },
+          mml: math,
+          id: nodeId,
         },
-      }
-    ).then((e) => {
+      },
+    }).then((e) => {
       prefs.set(counter, e);
     });
   }

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -584,6 +584,22 @@ export class WorkerHandler<N, T, D> {
     this.ready = false;
   }
 
+
+  public async clearspeakLocalePreferences(item: SpeechMathItem<N, T, D>) {
+    console.log(43);
+    await this.Post(
+      {
+        cmd: 'Worker',
+        data: {
+          cmd: 'localePreferences',
+          debug: this.options.debug,
+          data: { },
+        },
+      },
+      item
+    ).then((e) => console.log(e));
+  }
+
   /**
    * The list of valid commands from the WorkerPool in the iframe.
    */

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -381,6 +381,7 @@ export class WorkerHandler<N, T, D> {
       'locale',
       'domain',
       'style',
+      'domain2style'
     ]);
     const adaptor = this.adaptor;
     this.setSpecialAttributes(container, data.translations, 'data-semantic-');

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -585,19 +585,26 @@ export class WorkerHandler<N, T, D> {
   }
 
 
-  public async clearspeakLocalePreferences(item: SpeechMathItem<N, T, D>) {
-    console.log(43);
+  public async clearspeakLocalePreferences(
+    item: SpeechMathItem<N, T, D>,
+    options: OptionList,
+    prefs: {[key: string]: {[prop: string]: string[] }}
+  ) {
     await this.Post(
       {
         cmd: 'Worker',
         data: {
           cmd: 'localePreferences',
           debug: this.options.debug,
-          data: { },
+          data: {
+            options: options
+          },
         },
       },
       item
-    ).then((e) => console.log(e));
+    ).then((e) => {
+      prefs[options.locale] = e;
+    });
   }
 
   /**

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -404,6 +404,7 @@ export class WorkerHandler<N, T, D> {
     if (speech) {
       if (data.label) {
         adaptor.setAttribute(container, SemAttr.SPEECH, data.label);
+        adaptor.setAttribute(container, SemAttr.SPEECH_SSML, data.ssml);
         item.outputData.speech = data.label;
       }
       adaptor.setAttribute(container, 'data-speech-attached', 'true');

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -29,7 +29,7 @@ import { semanticMathmlSync } from '#sre/enrich_mathml/enrich.js';
 export {
   addPreference,
   fromPreference,
-  toPreference
+  toPreference,
 } from '#sre/speech_rules/clearspeak_preference_string.js';
 
 export const locales = Variables.LOCALES;

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -24,13 +24,9 @@
 
 import { Engine } from '#sre/common/engine.js';
 import { ClearspeakPreferences } from '#sre/speech_rules/clearspeak_preferences.js';
-import { Highlighter } from '#sre/highlighter/highlighter.js';
-import * as HighlighterFactory from '#sre/highlighter/highlighter_factory.js';
 import { parseInput } from '#sre/common/dom_util.js';
 import { Variables } from '#sre/common/variables.js';
 import { semanticMathmlSync } from '#sre/enrich_mathml/enrich.js';
-
-export type highlighter = Highlighter;
 
 export const locales = Variables.LOCALES;
 
@@ -48,9 +44,5 @@ export const toEnriched = (mml: string) => {
 };
 
 export const clearspeakPreferences = ClearspeakPreferences;
-
-export const getHighlighter = HighlighterFactory.highlighter;
-
-export const updateHighlighter = HighlighterFactory.update;
 
 export const parseDOM = parseInput;

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -23,10 +23,14 @@
  */
 
 import { Engine } from '#sre/common/engine.js';
-import { ClearspeakPreferences } from '#sre/speech_rules/clearspeak_preferences.js';
 import { parseInput } from '#sre/common/dom_util.js';
 import { Variables } from '#sre/common/variables.js';
 import { semanticMathmlSync } from '#sre/enrich_mathml/enrich.js';
+export {
+  addPreference,
+  fromPreference,
+  toPreference
+} from '#sre/speech_rules/clearspeak_preference_string.js';
 
 export const locales = Variables.LOCALES;
 
@@ -42,7 +46,5 @@ export const engineSetup = () => {
 export const toEnriched = (mml: string) => {
   return semanticMathmlSync(mml, Engine.getInstance().options);
 };
-
-export const clearspeakPreferences = ClearspeakPreferences;
 
 export const parseDOM = parseInput;

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -193,7 +193,12 @@ declare const SRE: any;
       return Speech(SRE.workerNextStyle, data.mml, data.options, data.nodeId);
     },
 
-
+    /**
+     * Compute clearspeak preferences for a given locale
+     *
+     * @param {Message} data The data object
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
+     */
     async localePreferences(data: Message): WorkerResult {
       const structure = (await SRE.workerLocalePreferences(data.options)) ?? {};
       // Not strictly necessary for the menu as there should not be one in node.
@@ -201,6 +206,12 @@ declare const SRE: any;
       return global.copyStructure(structure);
     },
 
+    /**
+     * Compute relevant clearspeak preference category for a semantic node.
+     *
+     * @param {Message} data The data object
+     * @returns {WorkerResult} Promise fulfilled when computation is complete.
+     */
     async relevantPreferences(data: Message): WorkerResult {
       return await SRE.workerRelevantPreferences(data.mml, data.id) ?? '';
     },

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -194,10 +194,8 @@ declare const SRE: any;
     },
 
 
-    localePreferences(_data: Message): WorkerResult {
-      console.log(44);
-      console.log(SRE.workerLocalePreferences);
-      return Menu(SRE.workerLocalePreferences);
+    localePreferences(data: Message): WorkerResult {
+      return Menu(SRE.workerLocalePreferences, data.options);
     },
 
   };
@@ -260,9 +258,10 @@ declare const SRE: any;
   }
 
   async function Menu(
-    func: () => StructureData,
+    func: (options: OptionList) => StructureData,
+    options: OptionList
   ): Promise<StructureData> {
-    const structure = (await func.call(null)) ?? {};
+    const structure = (await func.call(null, options)) ?? {};
     return global.copyStructure(structure);
   }
 

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -194,8 +194,15 @@ declare const SRE: any;
     },
 
 
-    localePreferences(data: Message): WorkerResult {
-      return Menu(SRE.workerLocalePreferences, data.options);
+    async localePreferences(data: Message): WorkerResult {
+      const structure = (await SRE.workerLocalePreferences(data.options)) ?? {};
+      // Not strictly necessary for the menu as there should not be one in node.
+      // However, it allows for getting the preferences in a different context.
+      return global.copyStructure(structure);
+    },
+
+    async relevantPreferences(data: Message): WorkerResult {
+      return await SRE.workerRelevantPreferences(data.mml, data.id) ?? '';
     },
 
   };
@@ -256,15 +263,6 @@ declare const SRE: any;
     const structure = (await func.call(null, mml, options, ...rest)) ?? {};
     return global.copyStructure(structure);
   }
-
-  async function Menu(
-    func: (options: OptionList) => StructureData,
-    options: OptionList
-  ): Promise<StructureData> {
-    const structure = (await func.call(null, options)) ?? {};
-    return global.copyStructure(structure);
-  }
-
 
   /**
    * Make a copy of an Error object (since those can't be stringified).

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -200,7 +200,7 @@ declare const SRE: any;
      * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
     async localePreferences(data: Message): WorkerResult {
-      const structure = (await SRE.workerLocalePreferences(data.options));
+      const structure = await SRE.workerLocalePreferences(data.options);
       // Not strictly necessary for the menu as there should not be one in node.
       // However, it allows for getting the preferences in a different context.
       return structure ? global.copyStructure(structure) : structure;
@@ -213,9 +213,8 @@ declare const SRE: any;
      * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
     async relevantPreferences(data: Message): WorkerResult {
-      return await SRE.workerRelevantPreferences(data.mml, data.id) ?? '';
+      return (await SRE.workerRelevantPreferences(data.mml, data.id)) ?? '';
     },
-
   };
 
   /**

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -200,10 +200,10 @@ declare const SRE: any;
      * @returns {WorkerResult} Promise fulfilled when computation is complete.
      */
     async localePreferences(data: Message): WorkerResult {
-      const structure = (await SRE.workerLocalePreferences(data.options)) ?? {};
+      const structure = (await SRE.workerLocalePreferences(data.options));
       // Not strictly necessary for the menu as there should not be one in node.
       // However, it allows for getting the preferences in a different context.
-      return global.copyStructure(structure);
+      return structure ? global.copyStructure(structure) : structure;
     },
 
     /**

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -192,6 +192,14 @@ declare const SRE: any;
     nextStyle(data: Message): WorkerResult {
       return Speech(SRE.workerNextStyle, data.mml, data.options, data.nodeId);
     },
+
+
+    localePreferences(_data: Message): WorkerResult {
+      console.log(44);
+      console.log(SRE.workerLocalePreferences);
+      return Menu(SRE.workerLocalePreferences);
+    },
+
   };
 
   /**
@@ -250,6 +258,14 @@ declare const SRE: any;
     const structure = (await func.call(null, mml, options, ...rest)) ?? {};
     return global.copyStructure(structure);
   }
+
+  async function Menu(
+    func: () => StructureData,
+  ): Promise<StructureData> {
+    const structure = (await func.call(null)) ?? {};
+    return global.copyStructure(structure);
+  }
+
 
   /**
    * Make a copy of an Error object (since those can't be stringified).

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -47,7 +47,8 @@ export class MJContextMenu extends ContextMenu {
    */
   public static DynamicSubmenus: Map<
     string,
-    [(menu: MJContextMenu, sub: Submenu) => SubMenu, string]
+    [(menu: MJContextMenu, sub: Submenu,
+      callback: (sub: SubMenu) => void) => void, string]
   > = new Map();
 
   /**
@@ -223,13 +224,16 @@ export class MJContextMenu extends ContextMenu {
     for (const [id, [method, option]] of MJContextMenu.DynamicSubmenus) {
       const menu = this.find(id) as Submenu;
       if (!menu) continue;
-      const sub = method(this, menu);
-      menu.submenu = sub;
-      if (sub.items.length && (!option || this.settings[option])) {
-        menu.enable();
-      } else {
-        menu.disable();
-      }
+      method(this, menu,
+             (sub: SubMenu) => {
+               menu.submenu = sub;
+               if (sub?.items?.length && (!option || this.settings[option])) {
+                 menu.enable();
+               } else {
+                 menu.disable();
+               }
+             }
+            );
     }
   }
 }

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -47,8 +47,14 @@ export class MJContextMenu extends ContextMenu {
    */
   public static DynamicSubmenus: Map<
     string,
-    [(menu: MJContextMenu, sub: Submenu,
-      callback: (sub: SubMenu) => void) => void, string]
+    [
+      (
+        menu: MJContextMenu,
+        sub: Submenu,
+        callback: (sub: SubMenu) => void
+      ) => void,
+      string,
+    ]
   > = new Map();
 
   /**
@@ -224,16 +230,14 @@ export class MJContextMenu extends ContextMenu {
     for (const [id, [method, option]] of MJContextMenu.DynamicSubmenus) {
       const menu = this.find(id) as Submenu;
       if (!menu) continue;
-      method(this, menu,
-             (sub: SubMenu) => {
-               menu.submenu = sub;
-               if (sub?.items?.length && (!option || this.settings[option])) {
-                 menu.enable();
-               } else {
-                 menu.disable();
-               }
-             }
-            );
+      method(this, menu, (sub: SubMenu) => {
+        menu.submenu = sub;
+        if (sub?.items?.length && (!option || this.settings[option])) {
+          menu.enable();
+        } else {
+          menu.disable();
+        }
+      });
     }
   }
 }

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -757,14 +757,6 @@ export class Menu {
             'Clearspeak',
             this.radioGroup('speechRules', [['clearspeak-default', 'Auto']])
           ),
-          this.submenu(
-            'ChromeVox',
-            'ChromeVox',
-            this.radioGroup('speechRules', [
-              ['chromevox-default', 'Standard'],
-              ['chromevox-alternative', 'Alternative'],
-            ])
-          ),
           this.rule(),
           this.submenu('A11yLanguage', 'Language'),
         ]),


### PR DESCRIPTION
**Only works with the latest versions of SRE, v5-alpha.3 and above. Make sure to run `pnpm install` first!**

The PR does 4 main things:
1) Fixes the auto voicing option
2) Reinstates the functionality of the Clearspeak submenu
3) Ensures that consistent ruleset/preference changes on an element. 
4) Removes `ChromeVox` menu entry

## Auto Voicing Option

Auto voicing with synchronised highlighting uses the `SemAttr.SPEECH_SSML` attributes to compute speech, pauses and the highlighting marks. It also depends on these being available at all levels of the expression.
* The container gets the ssml attribute form the speech structure from SRE (latest version!)
* We compute SSML not just for summary but also for regular speech in `SsmlAttributes`.
* Hiding the `SpeechRegion` cancels the speech.

## Clearspeak Submenu

Since some of the functionality of the Clearspeak submenu depends on locales being loaded we now need to route this through the worker. In particular we need to call the worker in two functions:
* `getLocalePreferences` computes the clearspeak preferences for a locale; they need to be computed only once are stored in a dedicated `localePreferences` map
* `getRelevantPreferences` computes the category of preferences that is useful for the currently focused node. E.g., if it is a fraction then the fraction related preferences are computed (this is similar somewhat similar `nextStyle`). Results are passed back via the `relevantPreferences` map.
 
To support this I have added two methods in `GeneratorPool`, `WebWorker`, and `speech-worker`, respectively.
In addition 
* `DynamicSubmenus` now work asynchronously.
* SRE previously kept the global state of styles/preferences for `MathSpeak` and `ClearSpeak`. These are now kept in `previousPrefs`. There is still an issue when a locale has no clearspeak, going back to one that does still leaves it on Mathspeak.

## Conistent rule and preference changes

Now items also have a `data-semantic-domain2style` that remembers the last style used when swapping styles/rules with the `>` and `<` keys. This avoids bleed through from one expression to the other, as SRE no longer maintains a global state for elements.

## ChromeVox Menu

I removed the `ChromeVox` menu entry as this only exists in English and is no longer maintained.