### PR TITLE
Fix problem with overline with subscript with space after the underscore. (mathjax/MathJax#3372)

### DIFF
--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -4127,6 +4127,25 @@ describe('Moving limits', () => {
 
   /********************************************************************************/
 
+  it('Subscripted overline with space (#3372)', () => {
+    toXmlMatch(
+      tex2mml('\\overline{X}_ {y}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\overline{X}_ {y}" display="block">
+         <msub data-latex="\\overline{X}_ {y}">
+           <mover data-latex="\\overline{X}">
+             <mi data-latex="X">X</mi>
+             <mo accent="true">&#x2015;</mo>
+           </mover>
+           <mrow data-mjx-texclass="ORD">
+             <mi data-latex="y">y</mi>
+           </mrow>
+         </msub>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
   it('Overbrace 1', () => {
     toXmlMatch(
       tex2mml('\\overbrace{abc}'),

--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -733,7 +733,7 @@ export default class TexParser {
     const children = atom.childNodes[0]?.childNodes || [];
     let expr = '';
     for (const child of children) {
-      const att = (child.attributes?.get(TexConstant.Attr.LATEX) ||
+      const att = (child?.attributes?.get(TexConstant.Attr.LATEX) ||
         '') as string;
       if (!att) continue;
       expr +=


### PR DESCRIPTION
This PR fixes the crash that occurs when `\overline` or `\underline` is used with a braced subscript that has a space between the underscore and the open brace.  It also adds a test for that condition.

Resolves issue mathjax/MathJax#3372.