### PR TITLE
Fix a problem with substyles generating undefined base styles.

### DIFF
--- a/testsuite/tests/util/Styles.test.ts
+++ b/testsuite/tests/util/Styles.test.ts
@@ -248,6 +248,13 @@ describe('CssStyles object', () => {
       'border-top': 'red',
       'border-top-color': 'red',
     }, 'border-top: red; border-right: red; border-bottom: red;');
+    cssTest('border-radius: 3px', {
+      'border-radius': '3px',
+    });
+    cssTest('background: red; background-clip: none', {
+      'background': 'red',
+      'background-clip': 'none',
+    });
   });
 
   test('font', () => {

--- a/ts/util/Styles.ts
+++ b/ts/util/Styles.ts
@@ -501,8 +501,16 @@ export class Styles {
     // it with its parent's other children
     //
     while (name.match(/-/)) {
+      const cname = name;
       name = this.parentName(name);
-      if (!Styles.connect[name]) break;
+      if (
+        !Styles.connect[cname] &&
+        !Styles.connect[name]?.children?.includes(
+          cname.substring(name.length + 1)
+        )
+      ) {
+        break;
+      }
       Styles.connect[name].combine.call(this, name);
     }
   }


### PR DESCRIPTION
This PR fixes a problem with the `util/Styles.ts` file where the use of a sub-style could cause a parent style to be created with an undefined value.  For example, defining `border-radius: 3px` causes `border` to be created but be undefined.  That leads `Styles.cssText` to produce `border-radius: 3px; border: undefined;`.

The fix checks that the sub-style is one of the child styles of the parent style before trying to connect it to the parent (which creates the parent style).