### PR TITLE
Update build and ui/menu so its builds with new highligher

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -36,7 +36,7 @@ const INDENT = '  ';
  * The pattern to use when looking for explort commands to process
  */
 const EXPORTPATTERN =
-      /(^export(?:\s+default)?(?:\s+abstract)?\s+(?:[^ {*}]+\s+(?:enum\s+)?[a-zA-Z0-9_.$]+|\{.* as .*\}))/m;
+      /(^export(?:\s+(?:default|abstract|async))?\s+(?:[^ {*}]+\s+(?:enum\s+)?[a-zA-Z0-9_.$]+|\{.* as .*\}))/m;
 
 const EXPORT_IGNORE = ['type', 'interface'];
 const EXPORT_PROCESS = ['let', 'const', 'var', 'function', 'class', 'namespace', 'enum', 'as'];

--- a/ts/a11y/explorer/Highlighter.ts
+++ b/ts/a11y/explorer/Highlighter.ts
@@ -482,4 +482,5 @@ export function getHighlighter(
 const highlighterMapping: { [key: string]: new () => Highlighter } = {
   SVG: SvgHighlighter,
   CHTML: ChtmlHighlighter,
+  generic: ChtmlHighlighter,
 };

--- a/ts/a11y/sre.ts
+++ b/ts/a11y/sre.ts
@@ -26,10 +26,10 @@ import { Engine } from '#sre/common/engine.js';
 import { parseInput } from '#sre/common/dom_util.js';
 import { Variables } from '#sre/common/variables.js';
 import { semanticMathmlSync } from '#sre/enrich_mathml/enrich.js';
-export {
-  addPreference,
-  fromPreference,
-  toPreference,
+import {
+  addPreference as addPref,
+  fromPreference as fromPref,
+  toPreference as toPref,
 } from '#sre/speech_rules/clearspeak_preference_string.js';
 
 export const locales = Variables.LOCALES;
@@ -42,9 +42,17 @@ export const engineSetup = () => {
   return Engine.getInstance().json();
 };
 
-// export const toEnriched = Api.toEnriched;
 export const toEnriched = (mml: string) => {
   return semanticMathmlSync(mml, Engine.getInstance().options);
 };
 
 export const parseDOM = parseInput;
+
+//
+// webpack doesn't seem to pick these up when building the ui/menu
+// component when they are exported directly, so import first
+// and then export.
+//
+export const addPreference = addPref;
+export const fromPreference = fromPref;
+export const toPreference = toPref;

--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -33,7 +33,7 @@ import { HTMLMathList } from './HTMLMathList.js';
 import { HTMLDomStrings } from './HTMLDomStrings.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { InputJax } from '../../core/InputJax.js';
-import { STATE, ProtoItem, Location } from '../../core/MathItem.js';
+import { STATE, newState, ProtoItem, Location } from '../../core/MathItem.js';
 import { StyleJson } from '../../util/StyleJson.js';
 
 /*****************************************************************/
@@ -48,6 +48,11 @@ import { StyleJson } from '../../util/StyleJson.js';
  * @template T  The Text node class
  */
 export type HTMLNodeArray<N, T> = [N | T, number][][];
+
+/**
+ * Add STATE value for adding the stylesheets (after INSERTED)
+ */
+newState('STYLES', STATE.INSERTED + 1);
 
 /*****************************************************************/
 /**
@@ -71,7 +76,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     ...AbstractMathDocument.OPTIONS,
     renderActions: expandable({
       ...AbstractMathDocument.OPTIONS.renderActions,
-      styles: [STATE.INSERTED + 1, '', 'updateStyleSheet', false]  // update styles on a rerender() call
+      styles: [STATE.STYLES, '', 'updateStyleSheet', false]  // update styles on a rerender() call
     }),
     MathList: HTMLMathList,           // Use the HTMLMathList for MathLists
     MathItem: HTMLMathItem,           // Use the HTMLMathItem for MathItem


### PR DESCRIPTION
This PR fixes a problem with building the `ui/menu` component.  The `components/bin/build` command is modified to handle `export async function` which was causing an error during the build phase.  The `ts/a11y/sre.ts` function also was causing problems when webpacking the `ui/menu` component.  The the SRE functions for the preferences were not being found by webpack for some reason that I could not fully determine.  I don't see anything wrong in any of the files, but it seems to be connected to the direct `export` of those methods in `ts/a11y/res.ts`, so I've change those to an import followed by exports, which seems to do the trick.

In addition, I've added a generic highlighter in `ts/a11y/explorer/Highlighter.ts` so that it can work in the absense of an output jax (I have an example in the documentation of a a role-you-own output jax for native MathML that causes an error otherwise).

I also add a new named `STATE` value in `ts/handler/html/HTMLDocument.ts` just for convenience, and so that all the default render actions have a named state value.