### PR TITLE
Fix incorrect removal of braces in template macros

### DIFF
--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -552,6 +552,28 @@ describe('Newcommand', () => {
 
   /********************************************************************************/
 
+  it('Def Template Brace Removal', () => {
+    toXmlMatch(
+      tex2mml('\\def\\test#1\\end{\\text{#1}} \\test{a b}\\end'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\test#1\\end{\\text{#1}} \\test{a b}\\end" display="block">
+        <mtext data-latex="\\text{a b}">a b</mtext>
+      </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Def Template Brace Retention', () => {
+    toXmlMatch(
+      tex2mml('\\def\\test#1\\end{\\text{#1}} \\test{a}{b}\\end'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\def\\test#1\\end{\\text{#1}} \\test{a}{b}\\end" display="block">
+        <mtext data-latex="\\text{{a}{b}}">{a}{b}</mtext>
+      </math>`
+    );
+  });
+
+  /********************************************************************************/
+
   it('Def Hash Replacement', () => {
     toXmlMatch(
       tex2mml('\\def\\x#1{\\def\\y##1#1{[##1]}\\y} \\x\\X abc \\X'),

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -200,16 +200,13 @@ export const NewcommandUtil = {
     }
     let i = parser.i;
     let j = 0;
-    let hasBraces = 0;
+    let hasBraces = false;
     while (parser.i < parser.string.length) {
       const c = parser.string.charAt(parser.i);
       // @test Def Let, Def Optional Brace, Def Options CS
       if (c === '{') {
         // @test Def Optional Brace, Def Options CS
-        if (parser.i === i) {
-          // @test Def Optional Brace
-          hasBraces = 1;
-        }
+        hasBraces = parser.i === i;
         parser.GetArgument(name);
         j = parser.i - i;
       } else if (this.MatchParam(parser, param)) {
@@ -224,7 +221,7 @@ export const NewcommandUtil = {
         // @test Def Options CS
         parser.i++;
         j++;
-        hasBraces = 0;
+        hasBraces = false;
         const match = parser.string.substring(parser.i).match(/[a-z]+|./i);
         if (match) {
           // @test Def Options CS
@@ -235,7 +232,7 @@ export const NewcommandUtil = {
         // @test Def Let
         parser.i++;
         j++;
-        hasBraces = 0;
+        hasBraces = false;
       }
     }
     // @test Runaway Argument


### PR DESCRIPTION
This PR fixes a problem with parsing the arguments of a macro with template where braces could be removed incorrectly.  For example, with `\def\text#1\stop{#1}`, if used with `\text{a}{b}\stop`, you currently will get an error about missing open braces.  That is because the parameter `#1` will end up containing `a}{b` rather than `{a}{b}` as expected.

The solution is to set `hasBraces` to false when a second braced argument is used.  I also changed `hasBraces` to a boolean rather than a number.

Two new tests are added to check for this issue.  There should probably be some more tests for when `hasBraces` gets unset, for completeness.