### PR TITLE
Fix problem with MathJax reference in liteDOM

### DIFF
--- a/ts/adaptors/lite/Element.ts
+++ b/ts/adaptors/lite/Element.ts
@@ -172,7 +172,7 @@ export class LiteIFrame extends LiteElement {
       this.options.debug,
     ];
     const pool = `${this.options.path}/speech-workerpool.js`;
-    if (MathJax?.loader) {
+    if (typeof MathJax !== 'undefined' && MathJax.loader) {
       MathJax.loader.versions.set(pool, mathjax.version);
     }
     const { WorkerPool, setContext } = await asyncLoad(pool);


### PR DESCRIPTION
This PR fixes a problem with the changes in b7f1942 that cause an error in node applications that use direct loading of the MathJax modules, where the `MathJax` variable is not defined.  I thought the `MathJax?.loader` would check for that, but it turns out that isn't the case, and  a more explicit check for being defined is needed.