### PR TITLE
Improve mathmap configuration

### DIFF
--- a/components/mjs/a11y/speech/speech.js
+++ b/components/mjs/a11y/speech/speech.js
@@ -7,18 +7,21 @@ import {SpeechHandler} from '#js/a11y/speech.js';
 
 if (MathJax.loader) {
   let path = Package.resolvePath('[sre]', false);
+  let maps = Package.resolvePath('[mathmaps]', false);
   if (hasWindow) {
     path = new URL(path, location).href;
+    maps = new URL(maps, location).href;
   } else {
     const REQUIRE = typeof require !== 'undefined' ? require : MathJax.config.loader.require;
     if (REQUIRE?.resolve) {
-      path = REQUIRE.resolve(`${path}/require.mjs`).replace(/\/[^\/]*$/, '');
+      path = REQUIRE.resolve(`${path}/package.json`).replace(/\/[^\/]*$/, '');
+      maps = REQUIRE.resolve(`${maps}/base.json`).replace(/\/[^\/]*$/, '');
     } else {
-      path = '';
+      path = maps = '';
     }
   }
   if (path) {
-    combineDefaults(MathJax.config, 'options', { worker: { path } });
+    combineDefaults(MathJax.config, 'options', { worker: { path, maps } });
   }
 }
 

--- a/components/mjs/dependencies.js
+++ b/components/mjs/dependencies.js
@@ -67,7 +67,8 @@ export const dependencies = {
 export const paths = {
   tex: '[mathjax]/input/tex/extensions',
   mml: '[mathjax]/input/mml/extensions',
-  sre: '[mathjax]/sre'
+  sre: '[mathjax]/sre',
+  mathmaps: '[sre]/mathmaps',
 };
 
 export const provides = {

--- a/components/mjs/source.js
+++ b/components/mjs/source.js
@@ -75,6 +75,7 @@ export const source = {
   'a11y/complexity': `${src}/a11y/complexity/complexity.js`,
   'a11y/explorer': `${src}/a11y/explorer/explorer.js`,
   'a11y/sre': `${src}/a11y/sre/sre.js`,
+  '[mathmaps]': `${src}/../../bundle/sre/mathmaps`,
   'ui/lazy': `${src}/ui/lazy/lazy.js`,
   'ui/menu': `${src}/ui/menu/menu.js`,
   'ui/safe': `${src}/ui/safe/safe.js`,

--- a/lab/build/init.js
+++ b/lab/build/init.js
@@ -1,1 +1,0 @@
-global.SREfeature.json = global.SREfeature.json.replace(/mjs\/a11y/, 'bundle');

--- a/lab/build/sre.js
+++ b/lab/build/sre.js
@@ -1,2 +1,1 @@
-import './init.js';
 export * from '#js/a11y/sre/sre.js';

--- a/package.json
+++ b/package.json
@@ -170,6 +170,6 @@
     "@mathjax/mathjax-newcm-font": "4.0.0-rc.2",
     "mhchemparser": "^4.2.1",
     "mj-context-menu": "^0.9.1",
-    "speech-rule-engine": "5.0.0-alpha.6"
+    "speech-rule-engine": "5.0.0-alpha.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       speech-rule-engine:
-        specifier: 5.0.0-alpha.6
-        version: 5.0.0-alpha.6
+        specifier: 5.0.0-alpha.7
+        version: 5.0.0-alpha.7
     devDependencies:
       '@eslint/js':
         specifier: ^9.28.0
@@ -1302,8 +1302,8 @@ packages:
   spdx-license-ids@3.0.21:
     resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
 
-  speech-rule-engine@5.0.0-alpha.6:
-    resolution: {integrity: sha512-B+D5HnT372/uP3ZpdPB5/NjOvzUAfMbglf4Ca+RTm46FPJIQosx8CpgLOTdc8Z9wDrYCU43b9nWnU7OuHsv6/A==}
+  speech-rule-engine@5.0.0-alpha.7:
+    resolution: {integrity: sha512-kGOuaKOj3p0IVWMmQz2YCxKNA3b+uqoiIFtbLhlX/2hjZcImMcws1+cRLWtA7nVpukCseeBnFOC2kQT4tE2V2w==}
     hasBin: true
 
   string-argv@0.3.2:
@@ -2764,7 +2764,7 @@ snapshots:
 
   spdx-license-ids@3.0.21: {}
 
-  speech-rule-engine@5.0.0-alpha.6:
+  speech-rule-engine@5.0.0-alpha.7:
     dependencies:
       '@xmldom/xmldom': 0.9.8
       commander: 13.1.0

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -221,6 +221,7 @@ export function SpeechMathDocumentMixin<
       }),
       worker: {
         path: sreRoot(),
+        maps: sreRoot().replace(/[cm]js\/a11y\/sre$/, 'bundle/sre/mathmaps'),
         worker: 'speech-worker.js',
         debug: false,
       },

--- a/ts/a11y/sre/worker_threads.d.ts
+++ b/ts/a11y/sre/worker_threads.d.ts
@@ -1,7 +1,6 @@
 declare module 'node:worker_threads' {
   const parentPort: {
     on(kind: string, listener: (event: Event) => void): void;
-    once(kind: string, listener: (event: Event) => void): void;
     postMessage(msg: any): void;
   };
   const workerData: any;

--- a/ts/a11y/sre/worker_threads.d.ts
+++ b/ts/a11y/sre/worker_threads.d.ts
@@ -1,6 +1,8 @@
 declare module 'node:worker_threads' {
   const parentPort: {
     on(kind: string, listener: (event: Event) => void): void;
+    once(kind: string, listener: (event: Event) => void): void;
     postMessage(msg: any): void;
   };
+  const workerData: any;
 }

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -625,7 +625,6 @@ export class HTMLAdaptor<
   ) {
     const { path, maps, worker } = options;
     const file = `${path}/${worker}`;
-    const quoted = (text: string) => text.replace(/(\\*)([\\'])/g, '$1$1\\$2');
     const content = `
       self.maps = '${quoted(maps)}';
       import('${quoted(file)}');
@@ -638,4 +637,25 @@ export class HTMLAdaptor<
     URL.revokeObjectURL(url);
     return webworker;
   }
+}
+
+/**
+ * Quote any backslashes or single quotes, and turn non-ASCII
+ * characters into \u{...}  so that the result can be inserted into
+ * single quotes and return the original string when evaluated.
+ *
+ * @param {string} text   The text to be quoted
+ * @returns {string}      The quoted text
+ */
+function quoted(text: string): string {
+  return [...text]
+    .map((c) => {
+      if (c === '\\' || c === "'") {
+        c = '\\' + c;
+      } else if (c < ' ' || c > '\u007e') {
+        c = `\\u{${c.codePointAt(0).toString(16)}}`;
+      }
+      return c;
+    })
+    .join('');
 }

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -707,6 +707,9 @@ export class LiteBase extends AbstractDOMAdaptor<
     return { left: 0, right: 0, top: 0, bottom: 0 };
   }
 
+  /**
+   * @override
+   */
   public async createWorker(
     listener: (event: any) => void,
     options: OptionList
@@ -721,15 +724,18 @@ export class LiteBase extends AbstractDOMAdaptor<
         this.worker.on(kind, listener);
       }
       postMessage(msg: any) {
-        this.worker.postMessage({ data: msg, origin: '*' });
+        this.worker.postMessage({ data: msg });
       }
       terminate() {
         this.worker.terminate();
       }
     }
-    const path = options.path;
+    const { path, maps } = options;
     const url = `${path}/${options.worker}`;
-    const worker = new LiteWorker(url, { type: 'module' });
+    const worker = new LiteWorker(url, {
+      type: 'module',
+      workerData: { maps },
+    });
     worker.addEventListener('message', listener);
     return worker;
   }


### PR DESCRIPTION
This PR adds a `worker.maps` configuration option that specifies where the mathmaps are located.  This allows node applications that are using direct loading of MathJax or loading the MathJax components from source to get the correct location for the maps.  It also also gives the ability to specify an alternate location for the maps during testing and development, if needed.

The defaults are set so that even when loading from the `mjs/a11y/sre` or `cjs/a11y/sre`, the mathmaps will be taken from the `bundle/sre` directory, since they don't exist in the `[mc]js/a11y/sre` directories.  For the web, or when components are used, the `[sre]` and the new `[mathmaps]` prefixes determine these.  When loading components from source (with the `source.js` file), the `[mathmaps]` are directed to the bundle directory again.  So this works without special configuration in all the use cases that I have tried.  Also, it means that the `lab:sre` build doesn't need its `init.js` file any more, since that was doing the work of redirecting the maps, which is now done in MathJax proper.

I've also moved the setup for `SREfeature` into the `speech-worker.ts`; I hope that addresses your concerns about that.  So all the SRE stuff is in that one file now.  The adaptors that set up the workers pass the mathmaps location on to the worker (for the web, that is done in the blob script that first sets the `mathmaps` value and then loads the worker script, and for node, it is passed in the `workerData` object).

Since both the web and node versions now use a custom map loader, that is moved to the common section of `speech-worker.ts`, with a new `getMap()` function in the web/node-specific code that uses `fetch()` for the web and `require()` for node.

Finally, in the HTML adaptor, I do some extra work to make sure that `` ` `` and `\` characters are properly quoted before inserting them into the `content` script in order to avoid any problems if the paths use these characters for some reason (like Windows paths, for example).

I think this should be it, and can be used for an rc.3 release.