### PR TITLE
Allow Chrome to load speech worker from CDN in a page from a file:// URL

### DIFF
--- a/components/mjs/a11y/speech/speech.js
+++ b/components/mjs/a11y/speech/speech.js
@@ -14,7 +14,7 @@ if (MathJax.loader) {
   } else {
     const REQUIRE = typeof require !== 'undefined' ? require : MathJax.config.loader.require;
     if (REQUIRE?.resolve) {
-      path = REQUIRE.resolve(`${path}/package.json`).replace(/\/[^\/]*$/, '');
+      path = REQUIRE.resolve(`${path}/require.mjs`).replace(/\/[^\/]*$/, '');
       maps = REQUIRE.resolve(`${maps}/base.json`).replace(/\/[^\/]*$/, '');
     } else {
       path = maps = '';

--- a/components/mjs/a11y/sre/worker/config.json
+++ b/components/mjs/a11y/sre/worker/config.json
@@ -6,7 +6,6 @@
     "to": "../../../../../bundle/sre",
     "from": "../../../../../ts/a11y/sre",
     "copy": [
-      "package.json",
       "require.mjs",
       "require.d.mts"
     ]

--- a/components/mjs/a11y/sre/worker/webpack.cjs
+++ b/components/mjs/a11y/sre/worker/webpack.cjs
@@ -1,8 +1,6 @@
 const webpack = require('webpack');
 
 module.exports = (pkg) => {
-  pkg.experiments = {outputModule: true};
-  pkg.output.library = {type: 'module'};
   pkg.plugins.push(
     new webpack.optimize.LimitChunkCountPlugin({
       maxChunks: 1,

--- a/ts/a11y/sre/package.json
+++ b/ts/a11y/sre/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -110,11 +110,12 @@ declare const SRE: any;
   //
   // Load SRE
   //
-  await import('./sre.js')
-    .catch((_) => import(/* webpackIgnore: true */ './sre-lab.js')) // for use in the lab
-    .then((SRE) => {
-      global.SRE = SRE;
-    });
+  await (
+    global.isLab
+      ? import(/* webpackIgnore: true */ './sre-lab.js') // for use in the lab
+      : import('./sre.js')
+  )
+    .then((SRE) => (global.SRE = SRE));
 
   /*****************************************************************/
 

--- a/ts/a11y/sre/speech-worker.ts
+++ b/ts/a11y/sre/speech-worker.ts
@@ -114,8 +114,7 @@ declare const SRE: any;
     global.isLab
       ? import(/* webpackIgnore: true */ './sre-lab.js') // for use in the lab
       : import('./sre.js')
-  )
-    .then((SRE) => (global.SRE = SRE));
+  ).then((SRE) => (global.SRE = SRE));
 
   /*****************************************************************/
 

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -627,12 +627,12 @@ export class HTMLAdaptor<
     const file = `${path}/${worker}`;
     const content = `
       self.maps = '${quoted(maps)}';
-      import('${quoted(file)}');
+      importScripts('${quoted(file)}');
     `;
     const url = URL.createObjectURL(
       new Blob([content], { type: 'text/javascript' })
     );
-    const webworker = new Worker(url, { type: 'module' });
+    const webworker = new Worker(url);
     webworker.onmessage = listener;
     URL.revokeObjectURL(url);
     return webworker;


### PR DESCRIPTION
This PR fixes a problem with importing the worker code from a page the was loaded from a `file://` URL with Mathjax coming from the CDN.  The problem only seems to affect Chrome, which won't allow the cross-origin load, even though the CDN marks the script as allowed.

The solution is to use `importScripts()` rather than `import()` to get the worker code.  That means the worker can't be loaded as a module, as `importScripts()` isn't allowed there.  

The `package.json` file is no longer needed, and the worker doesn't need to be a module anymore (that could have been removed when the worker-pool was removed, as that was only needed for the iframe hack to the liteDOM).

The v4-lab needs a new way to detect the need for the `sre-lab.js` file, as the `importScripts()` can't load an ES6 module, and the compiled `speech-worker.js` is such a module.  So we need to use `import()` in the lab.   The `ww-v4-lab` branch in the MathJax-dev repository has the needed changes:  the HTML adaptor is subclassed and the `createWorker()` method is overridden with one that uses `import()`, and also sets `self.isLab = true` to mark the fact that the worker is running int he lab.  The worker now uses that value to determine whether to load `sre-lab.js` or `sre.js`, so that is a bit cleaner than having to test for the failure of SRE loading.