### PR TITLE
Fix font-extension URLs to include @mathjax (mathjax/MathJax#3387)

### DIFF
--- a/components/mjs/input/tex/extension.js
+++ b/components/mjs/input/tex/extension.js
@@ -3,7 +3,7 @@ import {hasWindow} from '#js/util/context.js';
 
 export function fontExtension(id, name, pkg = `@mathjax/${name}`) {
   if (MathJax.loader) {
-    const FONTPATH = hasWindow ? `https://cdn.jsdelivr.net/npm/${name}` : pkg;
+    const FONTPATH = hasWindow ? `https://cdn.jsdelivr.net/npm/${pkg}` : pkg;
     const path = name.replace(/-font-extension$/, '-extension');
     const jax = (MathJax.config?.startup?.output || 'chtml');
     combineDefaults(MathJax.config.loader, 'paths', {[path]: FONTPATH});


### PR DESCRIPTION
This PR fixes an error with the font-extension URLs, which failed to include the `@mathjax` scope.

Resolves issue mathjax/MathJax#3387.