### PR TITLE
Clear forced inline breaks when switching between renderers, when needed

### DIFF
--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -425,7 +425,11 @@ export abstract class CommonOutputJax<
     }
     const makeBreaks = this.options.linebreaks.inline && !math.display;
     let inlineMarked = !!math.root.getProperty('inlineMarked');
-    if (inlineMarked &&  (!makeBreaks || this.forceInlineBreaks !== math.root.getProperty('inlineForced'))) {
+    if (
+      inlineMarked &&
+      (!makeBreaks ||
+        this.forceInlineBreaks !== math.root.getProperty('inlineForced'))
+    ) {
       this.unmarkInlineBreaks(math.root);
       math.root.removeProperty('inlineMarked');
       math.root.removeProperty('inlineForced');

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -423,13 +423,18 @@ export abstract class CommonOutputJax<
     if (linebreak) {
       this.getLinebreakWidth();
     }
-    const inlineMarked = !!math.root.getProperty('inlineMarked');
-    if (this.options.linebreaks.inline && !math.display && !inlineMarked) {
+    const makeBreaks = this.options.linebreaks.inline && !math.display;
+    let inlineMarked = !!math.root.getProperty('inlineMarked');
+    if (inlineMarked &&  (!makeBreaks || this.forceInlineBreaks !== math.root.getProperty('inlineForced'))) {
+      this.unmarkInlineBreaks(math.root);
+      math.root.removeProperty('inlineMarked');
+      math.root.removeProperty('inlineForced');
+      inlineMarked = false;
+    }
+    if (makeBreaks && !inlineMarked) {
       this.markInlineBreaks(math.root.childNodes?.[0]);
       math.root.setProperty('inlineMarked', true);
-    } else if (!this.options.linebreaks.inline && inlineMarked) {
-      this.unmarkInlineBreaks(math.root);
-      math.root.setProperty('inlineMarked', false);
+      math.root.setProperty('inlineForced', this.forceInlineBreaks);
     }
     math.root.setTeXclass(null);
     const wrapper = this.factory.wrap(math.root);


### PR DESCRIPTION
When a page has SVG rendering on by default when loaded, and inline breaks are enabled, then when we switch to CHTML output, all the inline breaks are forced to occur.  The is due to the way the SVG output has to be broken into separate SVG nodes, so it had marked the nodes for forced breaks, and those marks aren't removed.

This refactors the old code to unmark the breaks if they were set before and we don't want breaks (i.e., the inline breaks menu setting has changed) or the force-break setting is changing (i.e., the render changed).  Then we check if breaks are needed and make them again with the new settings.  The unsetting and breaking are no longer one-or-the-other, and only the needed actions are taken.