### PR TITLE
Add explorer key actions and improve auto-voice handling

### DIFF
--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -195,6 +195,7 @@ export class Collapse {
       (node, complexity) => {
         complexity = this.uncollapseChild(complexity, node, 0);
         if (complexity > (this.cutoff.sqrt as number)) {
+          node.setProperty('collapse-variant', true);
           complexity = this.recordCollapse(
             node,
             complexity,
@@ -209,6 +210,7 @@ export class Collapse {
       (node, complexity) => {
         complexity = this.uncollapseChild(complexity, node, 0, 2);
         if (complexity > (this.cutoff.sqrt as number)) {
+          node.setProperty('collapse-variant', true);
           complexity = this.recordCollapse(
             node,
             complexity,
@@ -582,6 +584,9 @@ export class Collapse {
     const factory = this.complexity.factory;
     const marker = node.getProperty('collapse-marker') as string;
     const parent = node.parent;
+    const variant = node.getProperty('collapse-variant')
+      ? { mathvariant: '-tex-variant' }
+      : {};
     const maction = factory.create(
       'maction',
       {
@@ -594,7 +599,7 @@ export class Collapse {
         ),
       },
       [
-        factory.create('mtext', { mathcolor: 'blue' }, [
+        factory.create('mtext', { mathcolor: 'blue', ...variant }, [
           (factory.create('text') as TextNode).setText(marker),
         ]),
       ]

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -463,6 +463,32 @@ export function ExplorerMathDocumentMixin<
       'mjx-help-dialog > input': {
         margin: '.5em 2em',
       },
+      'mjx-help-dialog kbd': {
+        display: 'inline-block',
+        padding: '3px 5px',
+        'font-size': '11px',
+        'line-height': '10px',
+        color: '#444d56',
+        'vertical-align': 'middle',
+        'background-color': '#fafbfc',
+        border: 'solid 1.5px #c6cbd1',
+        'border-bottom-color': '#959da5',
+        'border-radius': '3px',
+        'box-shadow': 'inset -.5px -1px 0 #959da5',
+      },
+      'mjx-help-dialog ul': {
+        'list-style-type': 'none',
+      },
+      'mjx-help-dialog li': {
+        'margin-bottom': '.5em',
+      },
+      'mjx-help-background': {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      },
     };
 
     /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -125,44 +125,60 @@ generates both the text spoken by screen readers, as well as the
 visual layout for sighted users.</p>
 
 <p>Expressions typeset by MathJax can be explored interactively, and
-are focusable.  You can use the TAB key to move to a typeset
+are focusable.  You can use the <kbd>Tab</kbd> key to move to a typeset
 expression${select}.  Initially, the expression will be read in full,
 but you can use the following keys to explore the expression
 further:<p>
 
 <ul>
 
-<li><b>Down Arrow</b> moves one level deeper into the expression to
+<li><kbd>Down Arrow</kbd> moves one level deeper into the expression to
 allow you to explore the current subexpression term by term.</li>
 
-<li><b>Up Arrow</b> moves back up a level within the expression.</li>
+<li><kbd>Up Arrow</kbd> moves back up a level within the expression.</li>
 
-<li><b>Right Arrow</b> moves to the next term in the current
+<li><kbd>Right Arrow</kbd> moves to the next term in the current
 subexpression.</li>
 
-<li><b>Left Arrow</b> moves to the next term in the current
+<li><kbd>Left Arrow</kbd> moves to the next term in the current
 subexpression.</li>
 
-<li><b>Enter</b> or <b>Return</b> clicks a link or activates an active
+<li><kbd>Shift</kbd>+<kbd>Arrow</kbd> moves to a neighboring cell within a table.
+
+<li><kbd>0-9</kbd>+<kbd>0-9</kbd> jumps to a cell by its index in the table, where 0 = 10.
+
+<li><kbd>Home</kbd> takes you to the top of the expression.</li>
+
+<li><kbd>Enter</kbd> or <kbd>Return</kbd> clicks a link or activates an active
 subexpression.</li>
 
-<li><b>Space</b> opens the MathJax contextual menu where you can view
+<li><kbd>Space</kbd> opens the MathJax contextual menu where you can view
 or copy the source format of the expression, or modify MathJax's
 settings.</li>
 
-<li><b>Escape</b> exits the expression explorer.</li>
+<li><kbd>Escape</kbd> exits the expression explorer.</li>
 
-<li><b>x</b> gives a summary of the current subexpression.</li>
+<li><kbd>x</kbd> gives a summary of the current subexpression.</li>
 
-<li><b>d</b> gives the current depth within the expression.</li>
+<li><kbd>z</kbd> gives the full text of a collapsed expression.</li>
 
-<li><b>&gt;</b> cycles through the available speech rule sets
+<li><kbd>d</kbd> gives the current depth within the expression.</li>
+
+<li><kbd>s</kbd> starts or stops auto-voicing with synchronized highlighting.</li>
+
+<li><kbd>v</kbd> marks the current position in the expression.</li>
+
+<li><kbd>p</kbd> cycles through the marked positions in the expression.</li>
+
+<li><kbd>u</kbd> clears all marked positions and returns to the starting position.</li>
+
+<li><kbd>&gt;</kbd> cycles through the available speech rule sets
 (MathSpeak, ClearSpeak).</li>
 
-<li><b>&lt;</b> cycles through the verbosity levels for the current
+<li><kbd>&lt;</kbd> cycles through the verbosity levels for the current
 rule set.</li>
 
-<li><b>h</b> produces this help listing.</li>
+<li><kbd>h</kbd> produces this help listing.</li>
 </ul>
 
 <p>The MathJax contextual menu allows you to enable or disable speech
@@ -191,7 +207,7 @@ const helpData: Map<string, [string, string]> = new Map([
   [
     'MacOS',
     [
-      'on Mac OS and iOS using VoiceOver',
+      'on MacOS and iOS using VoiceOver',
       ', or the VoiceOver arrow keys to select an expression',
     ],
   ],
@@ -236,28 +252,40 @@ export class SpeechExplorer
   /*
    * The explorer key mapping
    */
-  protected static keyMap: Map<string, keyMapping> = new Map([
-    ['Tab', () => true],
-    ['Control', (explorer) => explorer.controlKey()],
-    ['Escape', (explorer) => explorer.escapeKey()],
-    ['Enter', (explorer, event) => explorer.enterKey(event)],
-    ['ArrowDown', (explorer) => (explorer.active ? explorer.moveDown() : true)],
-    ['ArrowUp', (explorer) => (explorer.active ? explorer.moveUp() : true)],
-    ['ArrowLeft', (explorer) => (explorer.active ? explorer.moveLeft() : true)],
+  protected static keyMap: Map<string, [keyMapping, boolean?]> = new Map([
+    ['Tab', [() => true]],
+    ['Escape', [(explorer) => explorer.escapeKey()]],
+    ['Enter', [(explorer, event) => explorer.enterKey(event)]],
+    ['Home', [(explorer) => explorer.homeKey()]],
+    [
+      'ArrowDown',
+      [(explorer, event) => explorer.moveDown(event.shiftKey), true],
+    ],
+    ['ArrowUp', [(explorer, event) => explorer.moveUp(event.shiftKey), true]],
+    [
+      'ArrowLeft',
+      [(explorer, event) => explorer.moveLeft(event.shiftKey), true],
+    ],
     [
       'ArrowRight',
-      (explorer) => (explorer.active ? explorer.moveRight() : true),
+      [(explorer, event) => explorer.moveRight(event.shiftKey), true],
     ],
-    [' ', (explorer) => explorer.spaceKey()],
-    ['h', (explorer) => explorer.hKey()],
-    ['H', (explorer) => explorer.hKey()],
-    ['>', (explorer) => (explorer.active ? explorer.nextRules() : false)],
-    ['<', (explorer) => (explorer.active ? explorer.nextStyle() : false)],
-    ['x', (explorer) => (explorer.active ? explorer.summary() : false)],
-    ['X', (explorer) => (explorer.active ? explorer.summary() : false)],
-    ['d', (explorer) => (explorer.active ? explorer.depth() : false)],
-    ['D', (explorer) => (explorer.active ? explorer.depth() : false)],
-  ] as [string, keyMapping][]);
+    [' ', [(explorer) => explorer.spaceKey()]],
+    ['h', [(explorer) => explorer.hKey()]],
+    ['>', [(explorer) => explorer.nextRules(), false]],
+    ['<', [(explorer) => explorer.nextStyle(), false]],
+    ['x', [(explorer) => explorer.summary(), false]],
+    ['z', [(explorer) => explorer.details(), false]],
+    ['d', [(explorer) => explorer.depth(), false]],
+    ['v', [(explorer) => explorer.addMark(), false]],
+    ['p', [(explorer) => explorer.prevMark(), false]],
+    ['u', [(explorer) => explorer.clearMarks(), false]],
+    ['s', [(explorer) => explorer.autoVoice(), false]],
+    ...[...'0123456789'].map((n) => [
+      n,
+      [(explorer: SpeechExplorer) => explorer.numberKey(parseInt(n)), false],
+    ]),
+  ] as [string, [keyMapping, boolean?]][]);
 
   /**
    * Switches on or off the use of sound on this explorer.
@@ -350,6 +378,27 @@ export class SpeechExplorer
    */
   private eventsAttached: boolean = false;
 
+  /**
+   * The array of saved positions.
+   */
+  protected marks: HTMLElement[] = [];
+
+  /**
+   * The index of the current position in the array.
+   */
+  protected currentMark: number = -1;
+
+  /**
+   * The last explored position from previously exploring this
+   * expression.
+   */
+  protected lastMark: HTMLElement = null;
+
+  /**
+   * First index of cell to jump to
+   */
+  protected pendingIndex: number[] = [];
+
   /********************************************************************/
   /*
    * The event handlers
@@ -401,13 +450,21 @@ export class SpeechExplorer
    * @override
    */
   public KeyDown(event: KeyboardEvent) {
+    this.pendingIndex.shift();
+    this.region.cancelVoice();
+    //
     if (hasModifiers(event, false)) return;
     //
     // Get the key action, if there is one and perform it
     //
     const CLASS = this.constructor as typeof SpeechExplorer;
-    const action = CLASS.keyMap.get(event.key);
-    const result = action ? action(this, event) : this.undefinedKey(event);
+    const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+    const [action, value] = CLASS.keyMap.get(key) || [];
+    const result = action
+      ? value === undefined || this.active
+        ? action(this, event)
+        : value
+      : this.undefinedKey(event);
     //
     // If result is true, propagate event,
     // Otherwise stop the event, and if false, play the honk sound
@@ -426,6 +483,9 @@ export class SpeechExplorer
    * @param {MouseEvent} event   The mouse down event
    */
   private MouseDown(event: MouseEvent) {
+    this.pendingIndex = [];
+    this.region.cancelVoice();
+    //
     if (hasModifiers(event) || event.buttons === 2) {
       this.item.outputData.nofocus = true;
       return;
@@ -539,16 +599,6 @@ export class SpeechExplorer
   }
 
   /**
-   * Stop speaking.
-   *
-   * @returns {boolean}  Don't cancel the event
-   */
-  protected controlKey(): boolean {
-    speechSynthesis.cancel();
-    return true;
-  }
-
-  /**
    * Open the help dialog, and refocus when it closes.
    */
   protected hKey() {
@@ -591,39 +641,58 @@ export class SpeechExplorer
   }
 
   /**
+   * Select top-level of expression
+   */
+  protected homeKey() {
+    this.setCurrent(this.node.querySelector(nav));
+  }
+
+  /**
    * Move to deeper level in the expression
    *
+   * @param {boolean} shift     True if shift is pressed
    * @returns {boolean | void}  False if no node, void otherwise
    */
-  protected moveDown(): boolean | void {
-    return this.moveTo(this.current.querySelector(nav));
+  protected moveDown(shift: boolean): boolean | void {
+    return shift
+      ? this.moveToNeighborCell(1, 0)
+      : this.moveTo(this.current.querySelector(nav));
   }
 
   /**
    * Move to higher level in expression
    *
+   * @param {boolean} shift     True if shift is pressed
    * @returns {boolean | void}  False if no node, void otherwise
    */
-  protected moveUp(): boolean | void {
-    return this.moveTo(this.current.parentElement.closest(nav));
+  protected moveUp(shift: boolean): boolean | void {
+    return shift
+      ? this.moveToNeighborCell(-1, 0)
+      : this.moveTo(this.current.parentElement.closest(nav));
   }
 
   /**
    * Move to next term in the expression
    *
+   * @param {boolean} shift     True if shift is pressed
    * @returns {boolean | void}  False if no node, void otherwise
    */
-  protected moveRight(): boolean | void {
-    return this.moveTo(this.nextSibling(this.current));
+  protected moveRight(shift: boolean): boolean | void {
+    return shift
+      ? this.moveToNeighborCell(0, 1)
+      : this.moveTo(this.nextSibling(this.current));
   }
 
   /**
    * Move to previous term in the expression
    *
+   * @param {boolean} shift     True if shift is pressed
    * @returns {boolean | void}  False if no node, void otherwise
    */
-  protected moveLeft(): boolean | void {
-    return this.moveTo(this.prevSibling(this.current));
+  protected moveLeft(shift: boolean): boolean | void {
+    return shift
+      ? this.moveToNeighborCell(0, -1)
+      : this.moveTo(this.prevSibling(this.current));
   }
 
   /**
@@ -638,6 +707,23 @@ export class SpeechExplorer
   }
 
   /**
+   * Move to an adjacent table cell
+   *
+   * @param {number} di          Change in row number
+   * @param {number} dj          Change in column number
+   * @returns {boolean | void}   False if no such cell, void otherwise
+   */
+  protected moveToNeighborCell(di: number, dj: number): boolean | void {
+    const cell = this.tableCell(this.current);
+    if (!cell) return false;
+    const [i, j] = this.cellPosition(cell);
+    if (i == null) return false;
+    const move = this.cellAt(this.cellTable(cell), i + di, j + dj);
+    if (!move) return false;
+    this.setCurrent(move);
+  }
+
+  /**
    * Determine if an event that is not otherwise mapped should be
    * allowed to propagate.
    *
@@ -646,6 +732,83 @@ export class SpeechExplorer
    */
   protected undefinedKey(event: KeyboardEvent): boolean {
     return !this.active || hasModifiers(event);
+  }
+
+  /**
+   * Mark a location so we can return to it later
+   */
+  protected addMark() {
+    if (this.current === this.marks[this.marks.length - 1]) {
+      this.setCurrent(this.current);
+    } else {
+      this.currentMark = this.marks.length - 1;
+      this.marks.push(this.current);
+      this.speak('Position marked');
+    }
+  }
+
+  /**
+   * Return to a previous location (loop through them).
+   * If no saved marks, go to the last previous position,
+   * or if not, the top level.
+   */
+  protected prevMark() {
+    if (this.currentMark < 0) {
+      if (this.marks.length === 0) {
+        this.setCurrent(this.lastMark || this.node.querySelector(nav));
+        return;
+      }
+      this.currentMark = this.marks.length - 1;
+    }
+    const current = this.currentMark;
+    this.setCurrent(this.marks[current]);
+    this.currentMark = current - 1;
+  }
+
+  /**
+   * Clear all saved positions and return to the last explored position.
+   */
+  protected clearMarks() {
+    this.marks = [];
+    this.currentMark = -1;
+    this.prevMark();
+  }
+
+  /**
+   * Toggle auto voicing.
+   */
+  protected autoVoice() {
+    const value = !this.document.options.a11y.voicing;
+    if (this.document.menu) {
+      this.document.menu.menu.pool.lookup('voicing').setValue(value);
+    } else {
+      this.document.options.a11y.voicing = value;
+    }
+    this.Update();
+  }
+
+  /**
+   * Get index for cell to jump to.
+   *
+   * @param {number} n         The number key that was pressed
+   * @returns {boolean|void}   False if not in a table or no such cell to jump to.
+   */
+  protected numberKey(n: number): boolean | void {
+    if (!this.tableCell(this.current)) return false;
+    if (n === 0) {
+      n = 10;
+    }
+    if (this.pendingIndex.length) {
+      const table = this.cellTable(this.tableCell(this.current));
+      const cell = this.cellAt(table, this.pendingIndex[0] - 1, n - 1);
+      this.pendingIndex = [];
+      this.speak(String(n));
+      if (!cell) return false;
+      setTimeout(() => this.setCurrent(cell), 500);
+    } else {
+      this.pendingIndex = [null, n];
+      this.speak(`Jump to row ${n} and column`);
+    }
   }
 
   /**
@@ -715,10 +878,64 @@ export class SpeechExplorer
   }
 
   /**
+   * Speak the expanded version of a collapsed expression.
+   */
+  public details() {
+    //
+    // If the current node is not collapsible and collapsed, just speak it
+    //
+    const action = this.actionable(this.current);
+    if (
+      !action ||
+      !action.getAttribute('data-collapsible') ||
+      action.getAttribute('toggle') !== '1' ||
+      this.speechType === 'z'
+    ) {
+      this.setCurrent(this.current);
+      return;
+    }
+    this.speechType = 'z';
+    //
+    // Otherwise, look for the current node in the MathML tree
+    //
+    const id = this.nodeId(this.current);
+    let current: MmlNode;
+    this.item.root.walkTree((node) => {
+      if (node.attributes.get('data-semantic-id') === id) {
+        current = node;
+      }
+    });
+    //
+    // Create a new MathML string from the subtree
+    //
+    let mml = this.item.toMathML(current, this.item);
+    if (!current.isKind('math')) {
+      mml = `<math>${mml}</math>`;
+    }
+    mml = mml.replace(
+      / (?:data-semantic-|aria-|data-speech-|data-latex).*?=".*?"/g,
+      ''
+    );
+    //
+    // Get the speech for the new subtree and speak it.
+    //
+    this.item
+      .speechFor(mml)
+      .then(([speech, braille]) => this.speak(speech, braille));
+  }
+
+  /**
    * Displays the help dialog.
    */
   protected help() {
     const adaptor = this.document.adaptor;
+    const helpBackground = adaptor.node('mjx-help-background');
+    const close = (event: Event) => {
+      helpBackground.remove();
+      this.node.focus();
+      this.stopEvent(event);
+    };
+    helpBackground.addEventListener('click', close);
     const helpSizer = adaptor.node('mjx-help-sizer', {}, [
       adaptor.node(
         'mjx-help-dialog',
@@ -732,28 +949,18 @@ export class SpeechExplorer
         ]
       ),
     ]);
-    document.body.append(helpSizer);
+    helpBackground.append(helpSizer);
     const help = helpSizer.firstChild as HTMLElement;
+    help.addEventListener('click', (event) => this.stopEvent(event));
+    help.lastChild.addEventListener('click', close);
     help.addEventListener('keydown', (event: KeyboardEvent) => {
       if (event.code === 'Escape') {
-        help.remove();
-        this.node.focus();
-        this.stopEvent(event);
+        close(event);
       }
-    });
-    help.addEventListener('focusout', () => {
-      setTimeout(() => {
-        if (!help.contains(document.activeElement)) {
-          help.remove();
-        }
-      }, 10);
-    });
-    help.lastChild.addEventListener('click', () => {
-      help.remove();
-      this.node.focus();
     });
     const [title, select] = helpData.get(context.os);
     (help.childNodes[1] as HTMLElement).innerHTML = helpMessage(title, select);
+    document.body.append(helpBackground);
     help.focus();
   }
 
@@ -789,16 +996,18 @@ export class SpeechExplorer
       if (this.document.options.a11y.tabSelects === 'last') {
         this.refocus = this.current;
       }
-      this.current = null;
       if (!node) {
+        this.lastMark = this.current;
         this.removeSpeech();
       }
+      this.current = null;
     }
     //
     // If there is a current node
     //   Select it and add its speech, if requested
     //
     this.current = node;
+    this.currentMark = -1;
     if (this.current) {
       this.current.classList.add('mjx-selected');
       this.pool.highlight([this.current]);
@@ -874,9 +1083,6 @@ export class SpeechExplorer
     ssml: string[] = null,
     description: string = this.none
   ) {
-    if (!speech) {
-      speech = 'blank';
-    }
     const oldspeech = this.speech;
     this.speech = document.createElement('mjx-speech');
     this.speech.setAttribute('role', this.role);
@@ -950,6 +1156,90 @@ export class SpeechExplorer
   /*
    * Utility functions
    */
+
+  /**
+   * @param {HTMLElement} node  The node whose ID we want
+   * @returns {string}          The node's semantic ID
+   */
+  protected nodeId(node: HTMLElement): string {
+    return node.getAttribute('data-semantic-id');
+  }
+
+  /**
+   * @param {HTMLElement} node  The node whose parent ID we want
+   * @returns {string}          The node's parent's semantic ID
+   */
+  protected parentId(node: HTMLElement): string {
+    return node.getAttribute('data-semantic-parent');
+  }
+
+  /**
+   * @param {string} id       The semantic ID of the node we want
+   * @returns {HTMLElement}   The HTML node with that id
+   */
+  protected getNode(id: string): HTMLElement {
+    return id ? this.node.querySelector(`[data-semantic-id="${id}"]`) : null;
+  }
+
+  /**
+   * @param {HTMLElement} node   The node whose child array we want
+   * @returns {string[]}         The array of semantic IDs of its children
+   */
+  protected childArray(node: HTMLElement): string[] {
+    return node ? node.getAttribute('data-semantic-children').split(/,/) : [];
+  }
+
+  /**
+   * @param {HTMLElement} node   A node that may be in a table cell
+   * @returns {HTMLElement}      The HTML node for the table cell containing it, or null
+   */
+  protected tableCell(node: HTMLElement): HTMLElement {
+    while (node && node !== this.node) {
+      if (node.getAttribute('data-semantic-role') === 'table') {
+        return node;
+      }
+      node = node.parentNode as HTMLElement;
+    }
+    return null;
+  }
+
+  /**
+   * @param {HTMLElement} node   An HTML node that is a cell of a table
+   * @returns {HTMLElement}      The HTML node for semantic table element containing the cell
+   */
+  protected cellTable(node: HTMLElement): HTMLElement {
+    while (node && node !== this.node) {
+      if (node.getAttribute('data-semantic-type') === 'table') {
+        return node;
+      }
+      node = node.parentNode as HTMLElement;
+    }
+    return null;
+  }
+
+  /**
+   * @param {HTMLElement} cell     The HTML node for a semantic table cell
+   * @returns {[number, number]}   The row and column numbers for the cell in its table (0-based)
+   */
+  protected cellPosition(cell: HTMLElement): [number, number] {
+    const row = this.getNode(this.parentId(cell));
+    const j = this.childArray(row).indexOf(this.nodeId(cell));
+    const table = this.getNode(this.parentId(row));
+    const i = this.childArray(table).indexOf(this.nodeId(row));
+    return [i, j];
+  }
+
+  /**
+   * @param {HTMLElement} table   An HTML node for a semantic table element
+   * @param {number} i            The row number of the desired cell in the table
+   * @param {number} j            The column numnber of the desired cell in the table
+   * @returns {HTMLElement}       The HTML element for the (i,j)-th cell of the table
+   */
+  protected cellAt(table: HTMLElement, i: number, j: number): HTMLElement {
+    const row = this.getNode(this.childArray(table)[i]);
+    const cell = this.getNode(this.childArray(row)[j]);
+    return cell;
+  }
 
   /**
    * Navigate one step to the right on the same level.

--- a/ts/a11y/explorer/Region.ts
+++ b/ts/a11y/explorer/Region.ts
@@ -409,7 +409,12 @@ export class SpeechRegion extends LiveRegion {
   /**
    * Have we already requested voices from the browser?
    */
-  private voiceRequest = false;
+  private voiceRequest: boolean = false;
+
+  /**
+   * Has the auto voicing been cancelled?
+   */
+  private voiceCancelled: boolean = false;
 
   /**
    * @override
@@ -463,6 +468,7 @@ export class SpeechRegion extends LiveRegion {
    * @param {string} locale The locale to use.
    */
   protected makeUtterances(ssml: SsmlElement[], locale: string) {
+    this.voiceCancelled = false;
     let utterance = null;
     for (const utter of ssml) {
       if (utter.mark) {
@@ -472,7 +478,9 @@ export class SpeechRegion extends LiveRegion {
           continue;
         }
         utterance.addEventListener('end', (_event: Event) => {
-          this.highlightNode(utter.mark);
+          if (!this.voiceCancelled) {
+            this.highlightNode(utter.mark);
+          }
         });
         continue;
       }
@@ -511,8 +519,17 @@ export class SpeechRegion extends LiveRegion {
    * @override
    */
   public Hide() {
-    speechSynthesis.cancel();
+    this.cancelVoice();
     super.Hide();
+  }
+
+  /**
+   * Cancel the auto-voicing
+   */
+  public cancelVoice() {
+    this.voiceCancelled = true;
+    speechSynthesis.cancel();
+    this.highlighter.unhighlight();
   }
 
   /**

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -122,6 +122,12 @@ export interface EnrichedMathItem<N, T, D> extends MathItem<N, T, D> {
    * @param {MathDocument} document   The MathDocument for the MathItem
    */
   unEnrich(document: MathDocument<N, T, D>): void;
+
+  /**
+   * @param {string} mml  The MathML string to enrich
+   * @returns {string}    The enriched MathML
+   */
+  toEnriched(mml: string): string;
 }
 
 /**
@@ -212,6 +218,14 @@ export function EnrichedMathItemMixin<
         }
       }
       this.state(STATE.ENRICHED);
+    }
+
+    /**
+     * @param {string} mml  The MathML string to enrich
+     * @returns {string}    The enriched MathML
+     */
+    public toEnriched(mml: string): string {
+      return this.serializeMml(Sre.toEnriched(mml));
     }
 
     /**

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -73,6 +73,12 @@ export interface SpeechMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
    * @param {MathDocument} document The MathDocument for the MathItem
    */
   detachSpeech(document: MathDocument<N, T, D>): void;
+
+  /**
+   * @param {string} mml The MathML whose speech is needed.
+   * @returns {Promise<[string,string]>}  A promise for the speech and braille strings
+   */
+  speechFor(mml: string): Promise<[string, string]>;
 }
 
 /**
@@ -132,6 +138,16 @@ export function SpeechMathItemMixin<
      */
     public detachSpeech(document: SpeechMathDocument<N, T, D>) {
       document.webworker.Detach(this);
+    }
+
+    /**
+     * @param {string} mml The MathML whose speech is needed.
+     * @returns {Promise<[string,string]>}  A promise for the speech and braille strings
+     */
+    public async speechFor(mml: string): Promise<[string, string]> {
+      mml = this.toEnriched(mml);
+      const data = await this.generatorPool.SpeechFor(this, mml);
+      return [data.label, data.braillelabel];
     }
 
     /**

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -121,6 +121,11 @@ export class GeneratorPool<N, T, D> {
     return (this.promise = this.webworker.Speech(mml, options, item));
   }
 
+  public SpeechFor(item: SpeechMathItem<N, T, D>, mml: string): Promise<any> {
+    const options = Object.assign({}, this.options, { modality: 'speech' });
+    return (this.promise = this.webworker.speechFor(mml, options, item));
+  }
+
   /**
    * Cancel a pending speech task
    *

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -274,6 +274,29 @@ export class WorkerHandler<N, T, D> {
   }
 
   /**
+   * Return speech structure for an arbitrary MathML string
+   *
+   * @param {string} math The linearized mml expression.
+   * @param {OptionList} options The options list.
+   * @param {SpeechMathItem} item The mathitem for reattaching the speech.
+   * @returns {Promise<Structure>} A promise that resolves when the command completes
+   */
+  public async speechFor(
+    math: string,
+    options: OptionList,
+    item: SpeechMathItem<N, T, D>
+  ): Promise<Structure> {
+    const data = await this.Post(
+      {
+        cmd: 'speech',
+        data: { mml: math, options: options },
+      },
+      item
+    );
+    return JSON.parse(data);
+  }
+
+  /**
    * Attach the speech structure to an item's DOM
    *
    * @param {SpeechMathItem} item       The SpeechMathItem to attach to
@@ -350,7 +373,8 @@ export class WorkerHandler<N, T, D> {
   ) {
     const adaptor = this.adaptor;
     const id = adaptor.getAttribute(node, 'data-semantic-id');
-    if (speech) {
+    adaptor.removeAttribute(node, 'data-speech-node');
+    if (speech && data.speech[id]['speech-none']) {
       adaptor.setAttribute(node, 'data-speech-node', 'true');
       for (let [key, value] of Object.entries(data.speech[id])) {
         key = key.replace(/-ssml$/, '');
@@ -359,9 +383,9 @@ export class WorkerHandler<N, T, D> {
         }
       }
     }
-    if (braille && data.braille?.[id]) {
+    if (braille && data.braille?.[id]?.['braille-none']) {
       adaptor.setAttribute(node, 'data-speech-node', 'true');
-      const value = data.braille[id]['braille-none'] || '';
+      const value = data.braille[id]['braille-none'];
       adaptor.setAttribute(node, SemAttr.BRAILLE, value);
     }
   }


### PR DESCRIPTION
# Overview

This PR adds a number of explorer keyboard actions from v3 that were left out in the rewrite for v4.  These include:

* `Z` to get the full speech for a collapsed subexpression.
* `V` to mark a position for later retrieval.
* `P` to cycle through the marked positions.
* `U` to remove all marks and go to the initial location where the explorer was started.
* `Shift` + `Arrow` for moving in a table
* `0-9` + `0-9` to move to a specific table cell by index.
* `Home` to go to the top level of the expression.

Plus the new

* `s` to start or stop auto-voicing.

There are also changes to improve the collapse symbol for roots (since the surd character in mathjax-newcm is not centered by default).  This requires a new version of the font that includes a variant that is centered; I have made the modifications, but haven't pushed a new version of the fonts yet.

I updated the help dialog to include the new keys, and changed how the modal dialog is handled: the old version used focus-out to close the dialog, but some screen readers end up giving focus out events when reading the links, so that would close the dialog prematurely.  So now it uses a transparent background element to trap clicks outside the dialog box and closes on that.

The handling of auto-voicing has been improved, not only by the addition of the `s` key, but also by allowing any keypress or mouse down to stop the auto-voicing.  That means the control key doesn't need to be mapped explicitly, since any keypress cancels the speech.

Finally, I remove the `blank` speech that I had included earlier, and now any node with no speech is skipped by the explorer (the `data-speech-node` attribute is removed, so it is never found by the explorer).

-----

# Details

The changes to `collapse.ts` are to set the `mathvariant` to the tex variant font so that the surd will be properly placed.  It requires a new version of the font, which isn't public yet.

The `explorer.ts` changes are just additional CSS to handle the help dialog better (I put the keys into a `kbd` element with the styling that you had in the documentation pages, and I changed the `ul` list ot not have bullets, which were being read).

The main changes are in `KeyExplorer.ts`:

The changes to the dialog text is mostly addition of the new keyboard commands.

The key mappings are changed to handle the shift key for the arrows, to add the new commands, and to remove the upper-case versions of the keys, which are handled now in the key-press event handler.  The map value is now an array consisting of a keymapping and a boolean, rather than having lots of `explorer.active ? explorer.fn() : boolean` constructs.  The `explorer.active` test is now done in the keydown event handler when there ius a boolean in the array.

The `marks`, `currentMark`, and `lastMark` are used by the `V`, `P`, and `U` keys to handle the position marks.  

The `pendindIndex` array is used for the cell index processing.  When the number key `n` is pressed, this array is set to `[0, n]`.  It works this way:  when a key is pressed, the array is shifted to the left, making it `[n]` if the previous key was a number key, and `[]` if not.  So if a number key is followed by a nother number key, `pendingIndex` will be `[n]` for the previous number and the new key will be the second number, and we can use these to get the indices for the cell to jumo to.  If a number key is not followed by another number, then the `[n]` will be shifted off the array when the next key is pressed, so pressing a number key will only have a value in `pendingIndex` when it immediately follows a number key.

The `Keydown` event handler shifts the `pendingIndex` array, as described above, and cancels any auto-voicing in progress.  The other change is to handle upper-case letters by converting them to lower-case so we don't have to have duplicate entries in the key map.

The `Mousedown` events clear the pending index array and cancels any auto-voicing in progress.

The `controlKey()` method is removed, as it is now redundant.

The `homeKey()` action is added.

The arrow key functions are modified to check if the shift is pressed, and  if so, they call `moveToNeighborCell()` with index offsets, otherwise do the usual move.

The new `moveToNeighborCell()` function finds the cell (if any) containing the current node, and gets the indices of the cell within its table.  Then it get the cell at the correct offset from that position and selects that.

Next come the position marking functions.  The `addMark()` method pushes the current position onto the mark list and keeps the index into the list as `currentMark`, unless the current position is the same as the current mark, in which case, the usual text for that position is read again.  That allows the "Position marked" text to be replaced by the usual speech at that point.

The `prevMark()` function checks if `currentMark` is unset (`-1`), and if so, sets `currentMark` to the last mark in the list, and if there is none, it reads either the initial position when we started exploring this expression (`lastMark`) or the top level of the expression.  If there is a mark to be read, we jump to that mark and move `currentMark` to be the next one in the list, so that if we hit `P` multiple times in a row, we cycle through the positions.  Because `setCurrent()` clears `currentMark`, we save it before setting the new position.

The `clearMarks()` function does what it says, clears the marks and then goes to the initial position by calling `prevMark()`.

the `autoVoice()` method toggles the auto-voicing option either in the menu if there is one, or in the document options if not, then updates (to start the voicing).

The `numberKey()` function handles jumping to a specific cell by index.  Here, if we aren't in a table, we quit with a honk.  Then we change 0 to 10, if needed.  Then, if there is no pending index (the "else" clause), this is the first index, so we save it in the `pendingIndex` as `[0, n]`, as described above (it will shift into `[n]` when the next number is pressed).  We speak a phrase to indicate that we have the row number and are waiting for the column number.  Otherwise, if there is a pending index, that means we have a previous index and are ready to jump.  We look up the table for where we are, and the get the cell with the proper index.  We speak the column index (to complete the "jump to row n and column" phrase, clear the index array, and finally select the new cell after a slight delay to allow the column number to be read.

You may not like the extra "jump to..." speech, but I think there needs to be feedback for the numbers being pressed so the user knows they are being processed.  It could be that they just say the number and not the whole phrase.  Perhaps another menu option needs to be made for that?

The `details()` function implements speaking the full text of a collapsed expression.  Since that test is not available in the attributes of the tree, we have to work a little bit to get this text.

First, we check if this is a collapsed node, and if not, we jsut speek the current node again.  Otherwise, we look through the internal MathML for the item with the current node's semantic ID.  We use that node to create a new MathML string from the subtree at that node, and add `<math>` around it, if needed, removing any previous `data-semantic` elements.  Finally, we call the (new) `speechFor()` method of the MathItem (described below) to get the top-level speech and Braille strings for the MathML, and speak them when they arrive.

The `help()` function is modified to include the new transparent background (used to trap clicks outside the dialog), and to use a common dynamic `close()` function for the event handlers that close the dialog.

The `setCurrent()` function has additions to track the `lastMark` position and to clear the `currentMark` so that `P` will start cycling from the taop of the mark list if we do anything other than `P`.

The `nodeId()` and `parentId()` functions are just service functions to make getting `data-semantic` ids easier.  The `getNode()` function returns the HTML node with the given semantic ID, while the `childArray()` method returns an array of child IDs for the given HTML node.

The `tableCell()` function looks through the parents of a node for the first one with role `table` (the cell that contains the node, if any), while `cellTable()` returns the HTML node for the table that contains the given cell node.

The `cellPosition()` function returns the (row,column) indices of a cell within a table, while `cellAt()` returns the HTML node for the cell at a given (row,column) position within the table, if any.

The changes to `region.ts` are for cancelling the auto-voicing.  In particular, we want to make sure that the synchronous highlighting is removed if the speech is interrupted.  (It had been being left with a permanent red background.)  We add a `cancelVoice()` function that can be called from the KeyExplorer.

In `semantic-enrich.ts`, we add a `toEnriched()` function that can be called to enrich an arbitrary MathML string.  This is used by the `Z` explorer key to get the full speech for a collapsed node.

Similarly, in `speech.ts`, we add a `speechFor()` function that returns the speech and Braille strings for an arbitrary mathML string.  Again, this is for the `Z` explorer key.  The `speechFor()` method uses a new `SpeechFor() method in the `GeneratorPool.ts` file, which in turn calls a new `speechFor()` function in `WebWorker.ts`, that returns a promise for the when worker prodiuces the speech structure.

Finally, `WebWorker.ts` includes the changes to not mark nodes with blank speech or blank braille.

