### PR TITLE
Expand the attribute name matching scope

### DIFF
--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -35,7 +35,7 @@ import {LiteAdaptor} from '../liteAdaptor.js';
  */
 export namespace PATTERNS {
   export const TAGNAME = '[a-z][^\\s\\n>]*';
-  export const ATTNAME = '[a-z][^\\s\\n>=]*';
+  export const ATTNAME = '[^\\s"\'<>/=]+';
   export const VALUE =  `(?:'[^']*'|"[^"]*"|[^\\s\\n]+)`;
   export const VALUESPLIT =  `(?:'([^']*)'|"([^"]*)"|([^\\s\\n]+))`;
   export const SPACE = '(?:\\s|\\n)+';


### PR DESCRIPTION
The following [issue](https://github.com/mathjax/MathJax-src/issues/1297) needs to be addressed:

For example, cases like ---name='value' and __name='value' can be normally handled by browsers, but the Parser in MathJax itself cannot process such situations.

Significance: When rendering in non-browser environments, it can handle more scenarios, reducing the code error "Cannot read properties of undefined (reading 'parent')". I guess others may encounter similar issues in use, because in practical scenarios, HTML is often not perfectly standardized.

