### PR TITLE
Fix regex for quoting file names to include

### DIFF
--- a/components/bin/pack
+++ b/components/bin/pack
@@ -42,7 +42,7 @@ const bundle = (process.argv[3] || 'bundle');
  * @return {RegExp}        The regular expression for the name,
  */
 function fileRegExp(name) {
-  return new RegExp(name.replace(/([\\.{}[\]()?*^$])/g, '\\$1'), 'g');
+  return new RegExp(name.replace(/([\\.{}[\]()?*+^$])/g, '\\$1'), 'g');
 }
 
 /**

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -35,7 +35,7 @@ const DIRNAME = __dirname;
  * @return {string}        The string with regex special characters escaped
  */
 function quoteRE(string) {
-  return string.replace(/([\\.{}[\]()?*^$])/g, '\\$1');
+  return string.replace(/([\\.{}[\]()?*+^$])/g, '\\$1');
 }
 
 /****************************************************************/


### PR DESCRIPTION
The `+` was missing from the regex for quoting file and directory names (argh!).

This causes these to not properly match directories in `node_modules` when pnpm is used to install dependencies, since it uses hidden directories in `.pnpm` that include plus signs.