### PR TITLE
Changes the TAG and ATTR patterns to be more in line with HTML5 (#1297)

### DIFF
--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -32,12 +32,13 @@ import { LiteAdaptor } from '../liteAdaptor.js';
 /**
  * Patterns used in parsing serialized HTML
  */
-const TAGNAME = '[a-z][^\\s\\n>]*';
-const ATTNAME = '[a-z][^\\s\\n>=]*';
-const VALUE = `(?:'[^']*'|"[^"]*"|[^\\s\\n]+)`;
-const VALUESPLIT = `(?:'([^']*)'|"([^"]*)"|([^\\s\\n]+))`;
-const SPACE = '(?:\\s|\\n)+';
-const OPTIONALSPACE = '(?:\\s|\\n)*';
+
+const SPACE = '[ \\n]+';
+const OPTIONALSPACE = '[ \\n]*';
+const TAGNAME = `[A-Za-z][^\u0000-\u001F "'>/=\u007F-\u009F]*`;
+const ATTNAME = `[^\u0000-\u001F "'>/=\u007F-\u009F]+`;
+const VALUE = `(?:'[^']*'|"[^"]*"|${SPACE})`;
+const VALUESPLIT = `(?:'([^']*)'|"([^"]*)"|(${SPACE}))`;
 const ATTRIBUTE = `${ATTNAME}(?:${OPTIONALSPACE}=${OPTIONALSPACE}${VALUE})?`;
 const ATTRIBUTESPLIT = `(${ATTNAME})(?:${OPTIONALSPACE}=${OPTIONALSPACE}${VALUESPLIT})?`;
 const TAG =
@@ -45,9 +46,9 @@ const TAG =
   `${OPTIONALSPACE}/?|/${TAGNAME}|!--[^]*?--|![^]*?)(?:>|$))`;
 
 export const PATTERNS = {
-  tag: new RegExp(TAG, 'i'),
-  attr: new RegExp(ATTRIBUTE, 'i'),
-  attrsplit: new RegExp(ATTRIBUTESPLIT, 'i'),
+  tag: new RegExp(TAG, 'u'),
+  attr: new RegExp(ATTRIBUTE, 'u'),
+  attrsplit: new RegExp(ATTRIBUTESPLIT, 'u'),
 };
 
 /************************************************************/


### PR DESCRIPTION
This PR makes the parsing of tags and attributes more compliant with he HTML5 spec, which has much looser parameters for tag and attribute names.  XML parsing is more restrictive, but since the parser must work for both (it is not very sophisticated), it needs to use the less restrictive version (HTML5).

The main change is that attribute names don't have to start with a letter.  The other restrictions remove the control characters and the other disallowed characters.  See #1297 for some discussion of the specs.