### PR TITLE
Make the retry error message more descriptive

### DIFF
--- a/ts/util/Retries.ts
+++ b/ts/util/Retries.ts
@@ -113,7 +113,10 @@ export function handleRetriesFor(code: () => any): Promise<any> {
  *                            actions will continue
  */
 export function retryAfter(promise: Promise<any>) {
-  const err = new Error('MathJax retry') as RetryError;
+  const err = new Error(
+    'MathJax retry -- an asynchronous action is required; ' +
+      'try using one of the promise-based functions and await its resolution.'
+  ) as RetryError;
   err.retry = promise;
   throw err;
 }


### PR DESCRIPTION
This PR adds more detail to the "MathJax retry" error message so that programmers who use the synchronous functions and don't trap this error will get more details about what is happening.  (There is also a completely new section in the v4 documentation about this error, so I'm hoping this PR and that new page will reduce the questions about this.)

The error message is never actually used internally (just the `.retry` property), so the actual message is immaterial from the standpoint of the code.