### PR TITLE
Improve loading of @mathjax/src by import and require

### DIFF
--- a/components/mjs/node-main/node-main.cjs
+++ b/components/mjs/node-main/node-main.cjs
@@ -2,4 +2,4 @@ if (!global.MathJax) global.MathJax = {};
 
 global.MathJax.__dirname = __dirname;
 
-module.exports = require('./node-main.js');
+module.exports = require('./node-main.js').MathJax;

--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -27,8 +27,10 @@ import '../core/core.js';
 import '../adaptors/liteDOM/liteDOM.js';
 import {source} from '../source.js';
 
-const path = eval('require("path")');          // get path from node, not webpack
-const dir = global.MathJax.config.__dirname;   // set up by node-main.mjs or node-main.cjs
+const MathJax = global.MathJax;
+
+const path = eval('require("path")');   // get path from node, not webpack
+const dir = MathJax.config.__dirname;   // set up by node-main.mjs or node-main.cjs
 
 /*
  * Set up the initial configuration
@@ -78,7 +80,7 @@ MathJax._.mathjax.mathjax.asyncLoad = function (name) {
  * The init() function returns a promise that is resolved when MathJax is loaded and ready, and that
  * is passed the MathJax global variable when it is called.
  */
-const init = (config = {}) => {
+const init = MathJax.init = (config = {}) => {
   combineConfig(MathJax.config, config);
   return Loader.load(...CONFIG.load)
     .then(() => CONFIG.ready())
@@ -87,6 +89,6 @@ const init = (config = {}) => {
 }
 
 /*
- * Export the init() function
+ * Export MathJax (with its init() function)
  */
-export {init};
+export {MathJax};

--- a/components/mjs/node-main/node-main.mjs
+++ b/components/mjs/node-main/node-main.mjs
@@ -1,2 +1,4 @@
 import './node-main-setup.mjs';
-export * from './node-main.js';
+import {MathJax} from './node-main.js';
+export default MathJax;
+export const init = MathJax.init;

--- a/components/mjs/node-main/webpack.cjs
+++ b/components/mjs/node-main/webpack.cjs
@@ -1,8 +1,8 @@
 module.exports = (pkg) => {
   pkg.output.library = {
-    name: 'init',
+    name: 'MathJax',
     type: 'commonjs',
-    export: 'init'
+    export: ['MathJax'],
   }
   return pkg;
 }


### PR DESCRIPTION
This PR updates `node-main.*` to export not just `init()` but the `MathJax` object as the default object with the `init()` function added to it.  This allows for more meaningful imports, particularly for ES6 modules.

Now you can do

``` js
import MathJax from '@mathjax/src';
await MathJax.init({...});
...
```

rather than

``` js
import {init} from '@mathjax/src';
await init({...});
```

(though both will work).  It also allows

``` js
const MathJax = require('@mathjax/src');
MathJax.init({...}).then(() => {...});
```

while still supporting

``` js
require('@mathjax/src').init({...}).then(() => {...});
```

so this is backward compatible.

This needs to work in several settings:

``` js
import MathJax from '@mathjax/src';               // the bundled mjs version
import MathJax from '@mathjax/src/source';        // the source mjs version
const MathJax = require('@mathjax/src');          // the bundled cjs version
const MathJax = require('@mathjax/src/source');   // the source cjs version
const MathJax = (await import('@mathjax/src')).default;         // the bundled mjs version;
const MathJax = (await import('@mathjax/src/source')).default;  // the source mjs version;
```

with each followed by  `await MathJax.init({...});` or `MathJax.init({...}).then(() => {...});` as appropriate.  Also,

``` js
require('@mathjax/src').init({...}).then(() => {...});
require('@mathjax/src/source').init({...}).then(() => {...});
(await import('@mathjax/src')).init({...}).then(() => {...});
(await import('@mathjax/src/source')).init({...}).then(() => {...});
```

should work.

This gives a more natural definition for the `MathJax` variable to be used later on in the application.