### PR TITLE
Only stop the worker if it has been started

### DIFF
--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -316,7 +316,7 @@ export function SpeechMathDocumentMixin<
      * @override
      */
     public async done() {
-      await this.webworker.Stop();
+      await this.webworker?.Stop();
       return super.done();
     }
   };

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -468,8 +468,10 @@ export class WorkerHandler<N, T, D> {
 
   /**
    * Terminates the worker.
+   *
+   * @returns {Promise<any>}  The promise for the worker termination.
    */
-  public Terminate() {
+  public Terminate(): Promise<any> | void {
     this.debug('Terminating pending tasks');
     for (const task of this.tasks) {
       task.reject(
@@ -478,18 +480,18 @@ export class WorkerHandler<N, T, D> {
     }
     this.tasks = [];
     this.debug('Terminating worker');
-    this.worker.terminate();
+    return this.worker.terminate();
   }
 
   /**
    * Stop the worker and clear the values so that the worker can be
    * restarted, if desired.
    */
-  public Stop() {
+  public async Stop() {
     if (!this.worker) {
       throw Error('Worker has not been started');
     }
-    this.Terminate();
+    await this.Terminate();
     this.worker = null;
     this.ready = false;
   }

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -47,7 +47,7 @@ export type PageBBox = {
 export interface minWorker {
   addEventListener(kind: string, listener: (event: Event) => void): void;
   postMessage(msg: any): void;
-  terminate(): void;
+  terminate(): Promise<any> | void;
 }
 
 /*****************************************************************/


### PR DESCRIPTION
This PR fixes a problem where `MathJax.done()` could throw an error if used in a situation where the speech web worked has not been started.  It also fixes some typing issues and properly handles promises.