### PR TITLE
Make sure AsciiMath text elements are of kind #text

### DIFF
--- a/ts/input/asciimath/legacy/jax/element/MmlNode.js
+++ b/ts/input/asciimath/legacy/jax/element/MmlNode.js
@@ -24,6 +24,7 @@
     toMmlNode: function (factory) {
       var kind = this.type;
       if (kind === 'texatom') kind = 'TeXAtom';
+      if (kind === 'text') kind = '#text';
       var node = this.nodeMake(factory, kind);
       if ("texClass" in this) node.texClass = this.texClass;
       return node;


### PR DESCRIPTION
This makes the legacy AsciiMath internal format to v3/v4 internal format properly mark the text elements as `#text` rather than `text`.

