### PR TITLE
Move toEntry to be a method so that it can be override, if necessary

### DIFF
--- a/ts/core/MmlTree/SerializedMmlVisitor.ts
+++ b/ts/core/MmlTree/SerializedMmlVisitor.ts
@@ -161,7 +161,17 @@ export class SerializedMmlVisitor extends MmlVisitor {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
-      .replace(/[\uD800-\uDBFF]./g, toEntity)
-      .replace(/[\u0080-\uD7FF\uE000-\uFFFF]/g, toEntity);
+      .replace(/[\uD800-\uDBFF]./g, this.toEntity)
+      .replace(/[\u0080-\uD7FF\uE000-\uFFFF]/g, this.toEntity);
+  }
+
+  /**
+   * Access to the toEntity() function that can be overridden in subclasses.
+   *
+   * @param {string} c   The character to encode.
+   * @returns {string}   The numeric entity for the character.
+   */
+  protected toEntity(c: string): string {
+    return toEntity(c);
   }
 }


### PR DESCRIPTION
This PR moves the `toEntry()` call to a method so that it can be overridden if subclassed (I need the in one of the examples in the demos-node update).