### PR TITLE
Place the hidden svg/defs elements at the beginning of the document, not the end.

### DIFF
--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -278,10 +278,16 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    *  Add any elements needed for the document
    */
   protected addPageElements() {
-    const body = this.adaptor.body(this.document);
+    const adaptor = this.adaptor;
+    const body = adaptor.body(this.document);
     const node = this.documentPageElements();
     if (node) {
-      this.adaptor.append(body, node);
+      const child = adaptor.firstChild(body);
+      if (child) {
+        adaptor.insert(node, child);
+      } else {
+        adaptor.append(body, node);
+      }
     }
   }
 


### PR DESCRIPTION
This PR changes where the `MathDocument` puts additional elements into the page.  Currently, only the SVG output has any of these, and they are the `svg` element used to store the global font cache (in a `defs` element).  This should be at the top of the document, not the bottom, so that the definitions are in place before the elements that use them (important when the document is preprocessed on the server).