### PR TITLE
Make node-main init() wait for the startup promise to resolve

### DIFF
--- a/components/mjs/node-main/node-main.js
+++ b/components/mjs/node-main/node-main.js
@@ -82,6 +82,7 @@ const init = (config = {}) => {
   combineConfig(MathJax.config, config);
   return Loader.load(...CONFIG.load)
     .then(() => CONFIG.ready())
+    .then(() => MathJax.startup.promise)    // Wait for MathJax to finish starting up
     .then(() => MathJax)                    // Pass MathJax global as argument to subsequent .then() calls
     .catch(error => CONFIG.failed(error));
 }


### PR DESCRIPTION
This PR modifies the `node-main` file's `init()` method to wait for the MathJax startup promise to resolve rather than completing while MathJax may be doing more startup tasks.  This means node applications that use `require('mathjax').init()` (or the equivalent for `import`) don't have to wait on `MathJax.startup.promise` themselves.

This simplifies some of the node examples I'm working on.