### PR TITLE
Better support for Loader.preLoaded() when used in combined components in node

### DIFF
--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -268,8 +268,8 @@ export const Loader = {
       return result;
     });
     //
-    // Add this load promise to the lsits for any parent load() call that are
-    // pending when this this load() was performed, then return the load promise.
+    // Add this load promise to the lists for any parent load() call that are
+    // pending when this load() was performed, then return the load promise.
     //
     this.nestedLoads
       .slice(1)

--- a/ts/components/loader.ts
+++ b/ts/components/loader.ts
@@ -172,7 +172,7 @@ export const Loader = {
   /**
    * Array of nested load promises so if component performs additional
    * loads (like an output jax with an alternate font), then the
-   * outer load promises wont resolve until the inner ones are complete.
+   * outer load promises won't resolve until the inner ones are complete.
    */
   nestedLoads: [] as Promise<any[]>[],
 
@@ -216,7 +216,7 @@ export const Loader = {
       //
       // Collect the promises for all the named packages,
       // creating the package if needed, and add checks
-      // for the verions numbers used in the components.
+      // for the version numbers used in the components.
       //
       const promises = [];
       for (const name of names) {

--- a/ts/components/package.ts
+++ b/ts/components/package.ts
@@ -159,9 +159,9 @@ export class Package {
    */
   public static loadPromise(name: string): Promise<void> {
     const config = (CONFIG[name] || {}) as PackageConfig;
-    const promise = Promise.all(
-      (config.extraLoads || []).map((name) => Loader.load(name))
-    );
+    const promise = config.extraLoads
+      ? Loader.load(...config.extraLoads)
+      : Promise.resolve();
     const checkReady = config.checkReady || (() => Promise.resolve());
     return promise.then(() => checkReady()) as Promise<void>;
   }


### PR DESCRIPTION
This PR fixes a problem when combined components are loaded via the `loader.load` configuration array in node applications and one of the preloaded components needs to perform additional loads (like when the output jax needs to load a font).  In the past, the load of the combined component would complete before the extra components are loaded, and so MathJax could process the page with the wrong font, for example.

In the current `develop` branch, the code

``` js
#! node

import {init} from '@mathjax/src/source';

await init({
  loader: {load: ['tex-chtml']},
  output: {font: 'mathjax-tex'},
  options: {enableSpeech: false, enableBraille: false},
})

const node = await MathJax.tex2chtmlPromise('x');
console.log(MathJax.startup.adaptor.outerHTML(node));
```

produces

```
<mjx-container class="MathJax" jax="CHTML" overflow="overflow" display="true"><mjx-math data-latex="x" data-semantic-structure="0" display="true" style="margin-left: 0; margin-right: 0;" class=" NCM-N"><mjx-mi data-latex="x" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-id="0" data-semantic-attributes="latex:x" aria-level="0" data-speech-node="true"><mjx-c class="mjx-c1D465">𝑥</mjx-c></mjx-mi></mjx-math></mjx-container>
```

Note the `NCM-N` class on the `mjx-math` element indicating it is still using the `mathjax-newcm` font.

With this patch, it will produce

```
<mjx-container class="MathJax" jax="CHTML" overflow="overflow" display="true"><mjx-math data-latex="x" data-semantic-structure="0" display="true" style="margin-left: 0; margin-right: 0;" class=" TEX-N"><mjx-mi data-latex="x" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-id="0" data-semantic-attributes="latex:x" aria-level="0" data-speech-node="true"><mjx-c class="mjx-c1D465">𝑥</mjx-c></mjx-mi></mjx-math></mjx-container>
```

with the correct `TEX-N` class for `mathjax-tex`.

It took me several days to figure out a means of handling this cleanly.  The `Package` object is quite complicated, and probably deserves a rewrite now that MathJax has matured since it was originally written, but that will have to wait for another release.

The process used here is to have `Loader.load()` keep track of any `Loader.load()` calls that occur before it completes.  this is done using an array created in the `load()` call that is used to store the promises produces by any `load()` calls that are made while the first one is waiting to complete.  We keep an array of these arrays so that if a nested `load()` call causes every *more* `load()` calls, they are stored for the nested call (so it knows when all the calls it initiated are resolved).  They are also added to any higher-up parent `load()` call arrays so that those higher-up loads wait for all the lower-down ones as well.  (This was a key step in getting this to work.)  Then when the initial loading is complete, we check if any additional loads have been added to the nested list, and if so, we wait for those after clearing the list.  If more loads occurred during that wait, we do it again, and keep doing so until no more loads were processed during the wait.  Then we remove our nested list from the list of lists, and finally are able to resolve the load promise.

We could also remove our promise from any higher-up lists at that point, since we now know our load is complete, but since our promise will now be resolved, it doesn't really hurt to leave it in place as it will not add any delay to the `Promise.all()` for any of the higher up loads.  So we don't take time to go through any of the higher lists to remove our promise.  If you think that is a good idea, I can add that it.

Finally, the change to `Package.ts` is to combine the loading of any `extraLoads` components into a single `Loader.load()` call rather than making one for each extra load.  That is a little more efficient.

It may be easier to look at the diff with spaces being ignored, as some of the changes are indentations.