### PR TITLE
Check that enrichment is enabled before starting webworker

### DIFF
--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -109,7 +109,8 @@ export function SpeechMathItemMixin<
       this.state(STATE.ATTACHSPEECH);
       if (
         this.isEscaped ||
-        !(document.options.enableSpeech || document.options.enableBraille)
+        !(document.options.enableSpeech || document.options.enableBraille) ||
+        !document.options.enableEnrichment
       ) {
         return;
       }
@@ -274,7 +275,8 @@ export function SpeechMathDocumentMixin<
      */
     public attachSpeech(): SpeechMathDocument<N, T, D> {
       if (!this.processed.isSet('attach-speech')) {
-        if (this.options.enableSpeech || this.options.enableBraille) {
+        const options = this.options;
+        if (options.enableEnrichment && (options.enableSpeech || options.enableBraille)) {
           this.getWebworker();
           for (const math of this.math) {
             (math as SpeechMathItem<N, T, D>).attachSpeech(this);

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -276,7 +276,10 @@ export function SpeechMathDocumentMixin<
     public attachSpeech(): SpeechMathDocument<N, T, D> {
       if (!this.processed.isSet('attach-speech')) {
         const options = this.options;
-        if (options.enableEnrichment && (options.enableSpeech || options.enableBraille)) {
+        if (
+          options.enableEnrichment &&
+          (options.enableSpeech || options.enableBraille)
+        ) {
           this.getWebworker();
           for (const math of this.math) {
             (math as SpeechMathItem<N, T, D>).attachSpeech(this);


### PR DESCRIPTION
This PR makes sure that enrichment is being performed before trying to add speech or Braille.  This avoids an error in node applications that load a combined configuration with speech, but turn off enrichment while leaving the speech or Braille defaults (which are on).
