### PR TITLE
Update CSS used to clip stretchy characters in CHTML. (mathjax/MathJax#3032)

### DIFF
--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -108,11 +108,15 @@ export class CHTML<N, T, D> extends CommonOutputJax<
       'mjx-mn > mjx-c',
       'mjx-ms > mjx-c',
       'mjx-mtext > mjx-c',
-      'mjx-stretchy-h',
-      'mjx-stretchy-v',
     ].join(', ')]: {
       'clip-path':
         'padding-box xywh(-1em -2px calc(100% + 2em) calc(100% + 4px))',
+    },
+    'mjx-stretchy-h': {
+      'clip-path': 'padding-box xywh(0 -2px 100% calc(100% + 4px))',
+    },
+    'mjx-stretchy-v': {
+      'clip-path': 'padding-box xywh(-2px 0 calc(100% + 4px) 100%)',
     },
 
     'mjx-container [space="1"]': { 'margin-left': '.111em' },


### PR DESCRIPTION
The CSS for stretchy characters was not correct (it used the `mjx-c` clip-path, which includes some slop on all sides, and that means the stretches aren't clipped well).  This uses proper widths for horizontal stretches and proper heights for vertical ones.  It may be that we need to put a little slop in the stretch direction, but I haven't seen it needed yet.

Resolves issue mathjax/MathJax#3032.