### PR TITLE
Add configuration options for pre- and post-filters

### DIFF
--- a/testsuite/tests/util/FunctionList.test.ts
+++ b/testsuite/tests/util/FunctionList.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
-import {FunctionList} from '#js/util/FunctionList.js';
+import {FunctionList, AnyFunction} from '#js/util/FunctionList.js';
 
 //
 //  Set up a function list with 6 functions that captures output
@@ -41,6 +41,15 @@ describe('FunctionList functionality', () => {
     const item = list.add(fn);
     expect(Array.from(list)).toEqual([{item: item, priority: 5}]);
     expect(item).toBe(fn);
+  });
+
+  test('Adding a list of items', () => {
+    const fns = [(_: any) => {}, [(_: any) => {}, 1]] as [AnyFunction, [AnyFunction, number]];
+    const list = new FunctionList(fns);
+    expect(Array.from(list)).toEqual([
+      {item: fns[1][0], priority: 1},
+      {item: fns[0], priority: 5},
+    ]);
   });
 
   test('Removing one item', () => {

--- a/ts/core/InputJax.ts
+++ b/ts/core/InputJax.ts
@@ -129,7 +129,10 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
   /**
    * The default options for the input jax
    */
-  public static OPTIONS: OptionList = {};
+  public static OPTIONS: OptionList = {
+    preFilters: [],
+    postFilters: [],
+  };
 
   /**
    * The actual options supplied to the input jax
@@ -163,8 +166,8 @@ export abstract class AbstractInputJax<N, T, D> implements InputJax<N, T, D> {
   constructor(options: OptionList = {}) {
     const CLASS = this.constructor as typeof AbstractInputJax;
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
-    this.preFilters = new FunctionList();
-    this.postFilters = new FunctionList();
+    this.preFilters = new FunctionList(this.options.preFilters);
+    this.postFilters = new FunctionList(this.options.postFilters);
   }
 
   /**

--- a/ts/core/OutputJax.ts
+++ b/ts/core/OutputJax.ts
@@ -47,12 +47,12 @@ export interface OutputJax<N, T, D> {
   options: OptionList;
 
   /**
-   * Lists of pre-filters to call after typesetting the math
+   * List of pre-filters to call after typesetting the math
    */
   preFilters: FunctionList;
 
   /**
-   * Lists of post-filters to call before typesetting the math
+   * List of post-filters to call before typesetting the math
    */
   postFilters: FunctionList;
 

--- a/ts/core/OutputJax.ts
+++ b/ts/core/OutputJax.ts
@@ -47,7 +47,12 @@ export interface OutputJax<N, T, D> {
   options: OptionList;
 
   /**
-   * Lists of post-filters to call after typesetting the math
+   * Lists of pre-filters to call after typesetting the math
+   */
+  preFilters: FunctionList;
+
+  /**
+   * Lists of post-filters to call before typesetting the math
    */
   postFilters: FunctionList;
 
@@ -130,12 +135,20 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
   /**
    * The default options for the output jax
    */
-  public static OPTIONS: OptionList = {};
+  public static OPTIONS: OptionList = {
+    preFilters: [],
+    postFilters: [],
+  };
 
   /**
    * The actual options supplied to the output jax
    */
   public options: OptionList;
+
+  /**
+   * Filters to run before the output is processed
+   */
+  public preFilters: FunctionList;
 
   /**
    * Filters to run after the output is processed
@@ -153,7 +166,8 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
   constructor(options: OptionList = {}) {
     const CLASS = this.constructor as typeof AbstractOutputJax;
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);
-    this.postFilters = new FunctionList();
+    this.preFilters = new FunctionList(this.options.preFilters);
+    this.postFilters = new FunctionList(this.options.postFilters);
   }
 
   /**

--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -57,6 +57,7 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
   public static OPTIONS: OptionList = defaultOptions({
     parseAs: 'html',         // Whether to use HTML or XML parsing for the MathML string
     forceReparse: false,     // Whether to force the string to be reparsed, or use the one from the document DOM
+    mmlFilters: [],          // Filters to add to the mmlFilters lost
     FindMathML: null,        // The FindMathML instance to override the default one
     MathMLCompile: null,     // The MathMLCompile instance to override the default one
     /*
@@ -92,11 +93,10 @@ export class MathML<N, T, D> extends AbstractInputJax<N, T, D> {
       MathMLCompile.OPTIONS
     );
     super(mml);
-    this.findMathML =
-      this.options['FindMathML'] || new FindMathML<N, T, D>(find);
+    this.findMathML = this.options.FindMathML || new FindMathML<N, T, D>(find);
     this.mathml =
-      this.options['MathMLCompile'] || new MathMLCompile<N, T, D>(compile);
-    this.mmlFilters = new FunctionList();
+      this.options.MathMLCompile || new MathMLCompile<N, T, D>(compile);
+    this.mmlFilters = new FunctionList(this.options.mmlFilters);
   }
 
   /**

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -157,13 +157,15 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D> {
     userOptions(parseOptions.options, rest);
     configuration.config(this);
     TeX.tags(parseOptions, configuration);
-    this.postFilters.add(FilterUtil.cleanSubSup, -7);
-    this.postFilters.add(FilterUtil.setInherited, -6);
-    this.postFilters.add(FilterUtil.checkScriptlevel, -5);
-    this.postFilters.add(FilterUtil.moveLimits, -4);
-    this.postFilters.add(FilterUtil.cleanStretchy, -3);
-    this.postFilters.add(FilterUtil.cleanAttributes, -2);
-    this.postFilters.add(FilterUtil.combineRelations, -1);
+    this.postFilters.addList([
+      [FilterUtil.cleanSubSup, -7],
+      [FilterUtil.setInherited, -6],
+      [FilterUtil.checkScriptlevel, -5],
+      [FilterUtil.moveLimits, -4],
+      [FilterUtil.cleanStretchy, -3],
+      [FilterUtil.cleanAttributes, -2],
+      [FilterUtil.combineRelations, -1],
+    ]);
   }
 
   /**

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -414,6 +414,7 @@ export abstract class CommonOutputJax<
     this.math = math;
     this.container = node;
     this.pxPerEm = math.metrics.ex / this.font.params.x_height;
+    this.executeFilters(this.preFilters, math, html, node);
     this.nodeMap = new Map<MmlNode, WW>();
     math.root.attributes.getAllInherited().overflow =
       this.options.displayOverflow;

--- a/ts/util/FunctionList.ts
+++ b/ts/util/FunctionList.ts
@@ -23,7 +23,9 @@
 
 import { PrioritizedList, PrioritizedListItem } from './PrioritizedList.js';
 
-type AnyFunction = (...args: unknown[]) => unknown;
+export type AnyFunction = (...args: unknown[]) => unknown;
+export type AnyFunctionDef = AnyFunction | [AnyFunction, number];
+export type AnyFunctionList = AnyFunctionDef[];
 
 /*****************************************************************/
 /**
@@ -38,6 +40,32 @@ export interface FunctionListItem extends PrioritizedListItem<AnyFunction> {}
  */
 
 export class FunctionList extends PrioritizedList<AnyFunction> {
+  /**
+   * @override
+   * @param {AnyFunctionList} list   The initial list of functions to add
+   */
+  constructor(list: AnyFunctionList = null) {
+    super();
+    if (list) {
+      this.addList(list);
+    }
+  }
+
+  /**
+   * Add a list of filter functions, possibly with priorities.
+   *
+   * @param {AnyFunctionList} list   The list of functions to add
+   */
+  public addList(list: AnyFunctionList) {
+    for (const item of list) {
+      if (Array.isArray(item)) {
+        this.add(item[0], item[1]);
+      } else {
+        this.add(item);
+      }
+    }
+  }
+
   /**
    * Executes the functions in the list (in prioritized order),
    *   passing the given data to the functions.  If any return


### PR DESCRIPTION
This PR adds the ability to have pre- and post-filters for the input and output jax be included in their configuration objects, rather than having to use the `startup.ready()` function to add them.  It also adds a pre-filter to the output jax, for symmetry (and because it may be easier to do filtering there than to have to add a post-filter onto each of the input jax if there are multiple input formats).

To facilitate this, a new `addList()` method is added to the `FunctionList` object, and for good measure this is used in the TeX input jax to add its filters.  You can also now pass a function list to the `FunctionList` constructor.  A new test is added to the `FunctionList` tests to cover the new code.