### PR TITLE
Fix explorer navigation to handle linebreaks, for both display and in-line math.  (mathjax/MathJax#3394)

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -577,7 +577,7 @@ export class SpeechExplorer
       this.FocusOut(null);
     } else {
       this.stopEvent(event);
-      this.refocus = this.node.querySelector(nav);
+      this.refocus = this.firstNode(this.node);
       this.Start();
     }
   }
@@ -644,7 +644,7 @@ export class SpeechExplorer
    * Select top-level of expression
    */
   protected homeKey() {
-    this.setCurrent(this.node.querySelector(nav));
+    this.setCurrent(this.firstNode(this.node));
   }
 
   /**
@@ -656,7 +656,7 @@ export class SpeechExplorer
   protected moveDown(shift: boolean): boolean | void {
     return shift
       ? this.moveToNeighborCell(1, 0)
-      : this.moveTo(this.current.querySelector(nav));
+      : this.moveTo(this.firstNode(this.current));
   }
 
   /**
@@ -755,7 +755,7 @@ export class SpeechExplorer
   protected prevMark() {
     if (this.currentMark < 0) {
       if (this.marks.length === 0) {
-        this.setCurrent(this.lastMark || this.node.querySelector(nav));
+        this.setCurrent(this.lastMark || this.firstNode(this.node));
         return;
       }
       this.currentMark = this.marks.length - 1;
@@ -991,7 +991,9 @@ export class SpeechExplorer
     //   (i.e., we are focusing out)
     //
     if (this.current) {
-      this.current.classList.remove('mjx-selected');
+      for (const part of this.getSplitNodes(this.current)) {
+        part.classList.remove('mjx-selected');
+      }
       this.pool.unhighlight();
       if (this.document.options.a11y.tabSelects === 'last') {
         this.refocus = this.current;
@@ -1009,14 +1011,31 @@ export class SpeechExplorer
     this.current = node;
     this.currentMark = -1;
     if (this.current) {
-      this.current.classList.add('mjx-selected');
-      this.pool.highlight([this.current]);
+      const parts = this.getSplitNodes(this.current);
+      for (const part of parts) {
+        part.classList.add('mjx-selected');
+      }
+      this.pool.highlight(parts);
       this.addSpeech(node, addDescription);
     }
     //
     // Done making changes
     //
     this.node.removeAttribute('aria-busy');
+  }
+
+  /**
+   * Get all nodes with the same semantic id (multiple nodes if there are line breaks).
+   *
+   * @param {HTMLElement} node  The node to check if it is split
+   * @returns {HTMLElement[]}   All the nodes for the given id
+   */
+  protected getSplitNodes(node: HTMLElement): HTMLElement[] {
+    const id = this.nodeId(node);
+    if (!id) {
+      return [node];
+    }
+    return Array.from(this.node.querySelectorAll(`[data-semantic-id="${id}"]`));
   }
 
   /**
@@ -1242,51 +1261,43 @@ export class SpeechExplorer
   }
 
   /**
+   * Get an element's first speech child.
+   *
+   * @param {HTMLElement} node   The parent element to get a child from
+   * @returns {HTMLElement}      The first speech child of the node
+   */
+  protected firstNode(node: HTMLElement): HTMLElement {
+    return node.querySelector(nav) as HTMLElement;
+  }
+
+  /**
    * Navigate one step to the right on the same level.
    *
-   * @param {HTMLElement} el The current element.
-   * @returns {HTMLElement} The next element.
+   * @param {HTMLElement} node   The current element.
+   * @returns {HTMLElement}      The next element.
    */
-  protected nextSibling(el: HTMLElement): HTMLElement {
-    if (!this.current.getAttribute('data-semantic-parent')) {
-      return null;
-    }
-    const sib = el.nextElementSibling as HTMLElement;
-    if (sib) {
-      if (sib.matches(nav)) {
-        return sib;
-      }
-      const sibChild = sib.querySelector(nav) as HTMLElement;
-      return sibChild ?? this.nextSibling(sib);
-    }
-    if (!isContainer(el) && !el.parentElement.matches(nav)) {
-      return this.nextSibling(el.parentElement);
-    }
-    return null;
+  protected nextSibling(node: HTMLElement): HTMLElement {
+    const id = this.parentId(node);
+    if (!id) return null;
+    const owns = this.getNode(id).getAttribute('data-semantic-owns')?.split(/ /);
+    if (!owns) return null;
+    const i = owns.indexOf(this.nodeId(node));
+    return this.getNode(owns[i + 1]);
   }
 
   /**
    * Navigate one step to the left on the same level.
    *
-   * @param {HTMLElement} el The current element.
-   * @returns {HTMLElement} The next element.
+   * @param {HTMLElement} node   The current element.
+   * @returns {HTMLElement}      The next element.
    */
-  protected prevSibling(el: HTMLElement): HTMLElement {
-    if (!this.current.getAttribute('data-semantic-parent')) {
-      return null;
-    }
-    const sib = el.previousElementSibling as HTMLElement;
-    if (sib) {
-      if (sib.matches(nav)) {
-        return sib;
-      }
-      const sibChild = sib.querySelector(nav) as HTMLElement;
-      return sibChild ?? this.prevSibling(sib);
-    }
-    if (!isContainer(el) && !el.parentElement.matches(nav)) {
-      return this.prevSibling(el.parentElement);
-    }
-    return null;
+  protected prevSibling(node: HTMLElement): HTMLElement {
+    const id = this.parentId(node);
+    if (!id) return null;
+    const owns = this.getNode(id).getAttribute('data-semantic-owns')?.split(/ /);
+    if (!owns) return null;
+    const i = owns.indexOf(this.nodeId(node));
+    return this.getNode(owns[i - 1]);
   }
 
   /**
@@ -1455,7 +1466,7 @@ export class SpeechExplorer
     // current node (which creates the speech) and start the explorer.
     //
     const node = this.findStartNode();
-    this.setCurrent(node || this.node.querySelector(nav), !node);
+    this.setCurrent(node || this.firstNode(this.node), !node);
     super.Start();
     //
     // Show any needed regions


### PR DESCRIPTION
This PR improves the key explorer navigation so that it handles line breaks (explicit and automatic) in both display math and in-line math.  This is particularly important for SVG in-line breaks. 

The `.querySelector(nav)` calls have been replaced by the new `firstNode()` call, to make it a bit more clear what is happening.

There is also a new `getSplitNodes()` method for finding all the nodes that have the same `data-semantic-id`.  This allows the highlighting of all the nodes for a given element, even if it has been split into several DOM nodes.

The `nextSibling()` and `prevSibling()` functions are simplified, and now use the `data-semantic-owns` property of the parent node in order to locate the next and previous speech nodes.

Resolves issue mathjax/MathJax#3394.