### PR TITLE
Fix addClass() and similar to not add extra blank in class

### DIFF
--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -606,8 +606,9 @@ export class LiteBase extends AbstractDOMAdaptor<
    * @override
    */
   public addClass(node: LiteElement, name: string) {
-    const classes = ((node.attributes['class'] as string) || '').split(/ /);
-    if (!classes.find((n) => n === name)) {
+    const classString = node.attributes['class'] as string;
+    const classes = classString?.split(/ /) || [];
+    if (!classes.includes(name)) {
       classes.push(name);
       node.attributes['class'] = classes.join(' ');
     }
@@ -617,8 +618,9 @@ export class LiteBase extends AbstractDOMAdaptor<
    * @override
    */
   public removeClass(node: LiteElement, name: string) {
-    const classes = ((node.attributes['class'] as string) || '').split(/ /);
-    const i = classes.findIndex((n) => n === name);
+    const classString = node.attributes['class'] as string;
+    const classes = classString?.split(/ /) || [];
+    const i = classes.indexOf(name);
     if (i >= 0) {
       classes.splice(i, 1);
       node.attributes['class'] = classes.join(' ');
@@ -630,7 +632,7 @@ export class LiteBase extends AbstractDOMAdaptor<
    */
   public hasClass(node: LiteElement, name: string) {
     const classes = ((node.attributes['class'] as string) || '').split(/ /);
-    return !!classes.find((n) => n === name);
+    return classes.includes(name);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a problem where the LiteDOM incorrectly adds a space at the beginning of the `className` of LiteElements.  That is because when the `className` is empty, the split produces `['']`, not an empty list, so when more classes are added or removed, and the joined with a space, there is an empty name at the beginning, giving a space at the front of the list.

This also uses `indexOf()` and `includes()` rather than `find()` and `findIndex()`, as these should be more efficient.