### PR TITLE
Have the explorer look harder for the associated anchor node.  (mathjax/MathJax#3398)

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -1303,9 +1303,14 @@ export class SpeechExplorer
       ?.getAttribute('data-semantic-postfix')
       ?.match(/(^| )link($| )/);
     if (focus) {
-      node.parentNode.dispatchEvent(new MouseEvent('click'));
-      setTimeout(() => this.FocusOut(null), 50);
-      return true;
+      while (node && node !== this.node) {
+        if (node instanceof HTMLAnchorElement) {
+          node.dispatchEvent(new MouseEvent('click'));
+          setTimeout(() => this.FocusOut(null), 50);
+          return true;
+        }
+        node = node.parentNode as HTMLElement;
+      }
     }
     return false;
   }


### PR DESCRIPTION
In the key explorer, when enter is pressed on a node with a link, we currently send a click event to the parent node, which is expected to be the anchor taking you to the linked file.  It is possible, however, that the parent may be some other node that the CHTML output needs for the layout, and so the click goes to the wrong node. 

This PR has the explorer look higher up until it finds the associated anchor rather than assume it is the parent element.

Resolves issue mathjax/MathJax#3398.