### PR TITLE
Handle mml spacing for mo with no parent (like surd for root).

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -1059,6 +1059,8 @@ export class CommonWrapper<
     if (!parent || !parent.isKind('mrow') || parent.childNodes.length === 1) {
       return;
     }
+    const n = parent.childIndex(child);
+    if (n === null) return;
     //
     // Get the lspace and rspace
     //
@@ -1075,8 +1077,7 @@ export class CommonWrapper<
     // If there are two adjacent <mo>, use enough left space to make it
     //   the maximum of the rspace of the first and lspace of the second
     //
-    const n = parent.childIndex(child);
-    if (n === 0) return;
+    if (!n) return;
     const prev = parent.childNodes[n - 1] as AbstractMmlNode;
     if (!prev.isEmbellished) return;
     const bbox = this.jax.nodeMap.get(prev).getBBox();


### PR DESCRIPTION
Currently, when `mathmlSpacing` is used, an error can be thrown for an `mo` that doesn't have a parent node.  Such elements occur when special characters are needed, like the surd for a square root.  Changing original line 1079 to use `(!n)` rather than `n !== 0` would prevent the error message, but in that case the default spacing for `mo` elements would give the surd spacing on the left and right, which throws off the display.  Instead, we move the test for no parent to before when the MathML spacing is added to avoid both the error message and the wrong display.