### PR TITLE
Make sure whenReady() ignores previous errors

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -935,37 +935,39 @@ export abstract class AbstractMathDocument<N, T, D>
    * @override
    */
   public whenReady(action: () => any): Promise<any> {
-    return (this._readyPromise = this._readyPromise.catch((_) => {}).then(() => {
-      //
-      // Cache old _readyPromise and replace it with a resolved
-      // promise in case action() calls whenReady(), so we don't get
-      // a circular dependency where the action is waiting on itself.
-      //
-      const ready = this._readyPromise;
-      this._readyPromise = Promise.resolve();
-      //
-      // Do the action and save its result.
-      //
-      const result = action();
-      //
-      // Get a promise that returns the result after
-      // any new _readyPromise resolves (in case action
-      // called whenReady() or another function that does).
-      //
-      const promise = this._readyPromise.then(() => result);
-      //
-      // Put back the original promise.
-      //
-      this._readyPromise = ready;
-      //
-      // Return promise that returns the result.  The original
-      // _readyPromise will wait on it to complete before it resolves,
-      // since promises that return promises automatically chain.
-      // This inserts any new _readyPromise promises into the
-      // original _readyPromise chain at this point.
-      //
-      return promise;
-    }));
+    return (this._readyPromise = this._readyPromise
+      .catch((_) => {})
+      .then(() => {
+        //
+        // Cache old _readyPromise and replace it with a resolved
+        // promise in case action() calls whenReady(), so we don't get
+        // a circular dependency where the action is waiting on itself.
+        //
+        const ready = this._readyPromise;
+        this._readyPromise = Promise.resolve();
+        //
+        // Do the action and save its result.
+        //
+        const result = action();
+        //
+        // Get a promise that returns the result after
+        // any new _readyPromise resolves (in case action
+        // called whenReady() or another function that does).
+        //
+        const promise = this._readyPromise.then(() => result);
+        //
+        // Put back the original promise.
+        //
+        this._readyPromise = ready;
+        //
+        // Return promise that returns the result.  The original
+        // _readyPromise will wait on it to complete before it resolves,
+        // since promises that return promises automatically chain.
+        // This inserts any new _readyPromise promises into the
+        // original _readyPromise chain at this point.
+        //
+        return promise;
+      }));
   }
 
   /**

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -935,7 +935,7 @@ export abstract class AbstractMathDocument<N, T, D>
    * @override
    */
   public whenReady(action: () => any): Promise<any> {
-    return (this._readyPromise = this._readyPromise.then(() => {
+    return (this._readyPromise = this._readyPromise.catch((_) => {}).then(() => {
       //
       // Cache old _readyPromise and replace it with a resolved
       // promise in case action() calls whenReady(), so we don't get


### PR DESCRIPTION
This PR fixes a problem with the `whenReady()` method.  Currently, if the function passed to `whenReady()` throws an error, then any subsequent `whenReady()` will throw the same error, and no further actions will be possible.  Since the typeset and conversion functions all use `whenReady()`, that would mean no further actions could be taken.  For example.

``` js
MathJax.whenReady(() => console.log('A'));
MathJax.whenReady(() => {throw Error("Fail!")});
MathJax.whenReady(() => console.log("B"))
  .catch((err) => console.log('Error: ' + err.message));
```

will print `A`, and then give the message `Error: Fail!` from the last `whenReady()` call, even though the error occurred on the previous `whenReady()` call, and without printing a `B`. 

The reason is that the `_readyPromise` used in `whenReady()` for the third call will and up being rejected by the second call, so it's `then()` is never performed (no `B` is printed), and the returned promise is rejected (leading to the error message in the `catch()`).

This PR inserts a `catch((_) => {})` to clear the rejected status of any previous `whenReady()` calls so that even if a previous `whenReady()` fails, subsequent ones will succeed.

The downside of this is that if the second `whenReady()` doesn't have a `catch()`, then the error message will never be seen, as the `catch()` from the third call will ignore it.  So calls to `whenReady()` should always include a `catch()` if there is a chance of an error occurring.  Note that this is only an issue if an additional `whenReady()` call is made before the previous one produces its error.  For example

``` js
MathJax.whenReady(() => console.log('A'));
MathJax.whenReady(() => {throw Error("Fail!")});
setTimeout(() => MathJax.whenReady(() => console.log("B")), 500);
```

Will print `A`, then given an error message about an uncaught error in a promise, and after half a second print the `B`.  The first code example above will print an `A` and a `B` with no error message, while

``` js
MathJax.whenReady(() => console.log('A'));
MathJax.whenReady(() => {throw Error("Fail!")})
  .catch((err) => console.log('Error: ' + err.message));
MathJax.whenReady(() => console.log("B"));
```

will print `A` followed by `Error: Fail!` followed by `B`.

I don't like the fact that error conditions may be lost, but I don't see any way around it, since the `whenReady()` promises must be tied together.  And there are other places where MathJax can prevent error message, so this isn't entirely new.

