### PR TITLE
Make sure the build command makes the lib directory even if there are no imports

### DIFF
--- a/components/bin/build
+++ b/components/bin/build
@@ -297,6 +297,7 @@ function processGlobal() {
       prefix + indent + packages.join(',\n' + indent) + postfix,
     '}});'
   );
+  makeDir('');
   fs.writeFileSync(path.join(LIB, COMPONENT + '.js'), lines.join('\n') + '\n');
 }
 


### PR DESCRIPTION
This PR makes sure a component's `lib` directory is created so its main control file can be written, even if there are no other imports.  This file contains the version check, and so it is useful to build even when there are no imports, or if all the imports are to other library files.