### PR TITLE
Fix `registerTex()` to handle `tex.packages` that is already an array

### DIFF
--- a/components/mjs/input/tex/register.js
+++ b/components/mjs/input/tex/register.js
@@ -12,6 +12,9 @@ export function registerTeX(packageList = [], tex = true) {
     let packages = MathJax.config.tex.packages;
     MathJax.config.tex.packages = packageList;
     if (packages) {
+      if (Array.isArray(packages)) {
+        packages = {'[+]': packages};
+      }
       insert(MathJax.config.tex, {packages});
     }
   }


### PR DESCRIPTION
This PR fixes the component utility that marks preloaded TeX packages so that it will properly merge the new packages into the existing package list if the old list was an array (rather than `{'[+]': [...]}`).