### PR TITLE
Don't increase the spacing size for MathML spacing if it is 0

### DIFF
--- a/ts/core/MmlTree/MmlNodes/mo.ts
+++ b/ts/core/MmlTree/MmlNodes/mo.ts
@@ -463,8 +463,8 @@ export class MmlMo extends AbstractMmlTokenNode {
     for (const name of Object.keys(def[3] || {})) {
       this.attributes.setInherited(name, def[3][name]);
     }
-    this.lspace = (def[0] + 1) / 18;
-    this.rspace = (def[1] + 1) / 18;
+    this.lspace = ((def[0] || -1) + 1) / 18;
+    this.rspace = ((def[1] || -1) + 1) / 18;
   }
 
   /**


### PR DESCRIPTION
This PR fixes a problem with `mathmlSpacing` when an `mo` element has a default spacing of 0, a with `<mo>&#x2062;</mo>`.  In the past, this would get extra spacing that it should not have.  Now, if the default spacing is 0, we take away the extra `+ 1` that is being added to get the proper number of 1/18th ems from the operator dictionary.