### PR TITLE
Allow the no-font components to still have a default font, just not a packed one.

### DIFF
--- a/components/mjs/output/chtml/nofont.js
+++ b/components/mjs/output/chtml/nofont.js
@@ -1,8 +1,0 @@
-import {ChtmlFontData} from '#js/output/chtml/FontData.js';
-
-export class DefaultFont extends ChtmlFontData {};
-export const fontName = 'nofont';
-
-DefaultFont.OPTIONS = {fontURL: '.'};
-
-export const Font = {fontName, DefaultFont};

--- a/components/mjs/output/svg/nofont.js
+++ b/components/mjs/output/svg/nofont.js
@@ -1,6 +1,0 @@
-import {SvgFontData} from '#js/output/svg/FontData.js';
-
-export class DefaultFont extends SvgFontData {};
-export const fontName = 'nofont';
-
-export const Font = {fontName, DefaultFont};

--- a/components/mjs/output/util.js
+++ b/components/mjs/output/util.js
@@ -5,7 +5,6 @@ import {hasWindow} from '#js/util/context.js';
 export const FONTPATH = hasWindow ?
                         'https://cdn.jsdelivr.net/npm/@mathjax/%%FONT%%-font':
                         '@mathjax/%%FONT%%-font';
-
 export const OutputUtil = {
   config(jax, jaxClass, defaultFont, fontClass) {
 
@@ -14,7 +13,7 @@ export const OutputUtil = {
       combineDefaults(MathJax.config, jax, MathJax.config.output || {});
 
       let config = MathJax.config[jax];
-      let font = config.font || defaultFont;
+      let font = config.font || config.fontData || defaultFont;
       if (typeof(font) !== 'string') {
         config.fontData = font;
         config.font = font = font.NAME;
@@ -30,7 +29,7 @@ export const OutputUtil = {
       }
       const name = font.substring(1, font.length - 1);
 
-      if (name !== defaultFont) {
+      if (name !== defaultFont || !fontClass) {
 
         MathJax.loader.addPackageData(`output/${jax}`, {extraLoads: [`${font}/${jax}`]});
 

--- a/components/webpack.common.cjs
+++ b/components/webpack.common.cjs
@@ -84,13 +84,11 @@ const PLUGINS = function (js, dir, target, font, jax, name) {
   // Replace default font with the no-font file
   //
   if (!font) {
-    const jax = (name.match(/chtml|svg/) || ['chtml'])[0];
-    const nofont = path.resolve(DIRNAME, target, 'output', jax, 'nofont.js');
     plugins.push(
       new webpack.NormalModuleReplacementPlugin(
-        /DefaultFont.js/,
+        /-font\/.*?\/default\.js/,
         function (resource) {
-          resource.request = path.relative(resource.context, nofont).replace(/^([^.])/, './$1');
+          resource.request = resource.request.replace(/\/.*?\/default\.js/, '/nofont.js');
         }
       )
     );


### PR DESCRIPTION
This PR fixes an issue that occurs when you load the `output/chtml` or `output/svg` components by hand (using `startup.js`) rather than using a combined component.  Currently, these output components are built with no font (so they can be used with any of the fonts without incurring the cost of downloading the default font), and they are the basis of the `-nofont` combined components.  Unfortunately, being built with no font means that you have to specify or load a font explicitly if you load the output component by hand.

This PR fixes this problem by configuring the font to load the default font (`mathjax-newcm`) when `output/chtml` or `output/svg` is loaded without specifying another font while still not having to include the font data for the default font. 

The old approach worked by having webpack replace the reference to `DefaultFont.js` by a `nofont.js` file in the output directory.  This PR changes that to instead replace the font's `default.js` file (which is loaded by `Default.js` to instead call a new `nofont.js` file in the font directory itself.  This new file returns the font name and a null font class object, and the `components/mjs/output/util.js` file uses the null font class to cause the default font to load if another font wasn't specified.

I will need to rebuild the fonts to include the new `nofont.js` files, but for testing, you can just add `node_modules/@mathjax/mathjax-newcm-font/mjs/nofont.js` containing:

``` js
export const Font = {
    fontName: 'mathjax-newcm',
    DefaultFont: null
};
```

and that should allow you to pack the output components and the combined components.  Note that this only affects the packed components, not loading components or modules from source.

This is not critical in the sense that you can get around the problem by specifying `mathjax-newcm` explicitly in the configuration, but it will make things easier for people.