### PR TITLE
Add components for jsdom and linkedom for easier use in node

### DIFF
--- a/components/mjs/adaptors/jsdom/config.json
+++ b/components/mjs/adaptors/jsdom/config.json
@@ -1,0 +1,10 @@
+{
+  "build": {
+    "component": "adaptors/jsdom",
+    "targets": ["adaptors/jsdomAdaptor.ts"]
+  },
+  "webpack": {
+    "name": "adaptors/jsdom",
+    "libs": ["components/src/core/lib"]
+  }
+}

--- a/components/mjs/adaptors/jsdom/jsdom.js
+++ b/components/mjs/adaptors/jsdom/jsdom.js
@@ -1,0 +1,11 @@
+import './lib/jsdom.js';
+
+import {jsdomAdaptor} from '#js/adaptors/jsdomAdaptor.js';
+
+if (MathJax.startup) {
+  MathJax.startup.registerConstructor(
+    'jsdomAdaptor',
+    (options) => jsdomAdaptor(MathJax.config.JSDOM, options)
+  );
+  MathJax.startup.useAdaptor('jsdomAdaptor', true);
+}

--- a/components/mjs/adaptors/linkedom/config.json
+++ b/components/mjs/adaptors/linkedom/config.json
@@ -1,0 +1,10 @@
+{
+  "build": {
+    "component": "adaptors/linkedom",
+    "targets": ["adaptors/linkedomAdaptor.ts"]
+  },
+  "webpack": {
+    "name": "adaptors/linkedom",
+    "libs": ["components/src/core/lib"]
+  }
+}

--- a/components/mjs/adaptors/linkedom/linkedom.js
+++ b/components/mjs/adaptors/linkedom/linkedom.js
@@ -1,0 +1,11 @@
+import './lib/linkedom.js';
+
+import {linkedomAdaptor} from '#js/adaptors/linkedomAdaptor.js';
+
+if (MathJax.startup) {
+  MathJax.startup.registerConstructor(
+    'linkedomAdaptor',
+    (options) => linkedomAdaptor(MathJax.config.LINKEDOM, options)
+  );
+  MathJax.startup.useAdaptor('linkedomAdaptor', true);
+}

--- a/components/mjs/source.js
+++ b/components/mjs/source.js
@@ -19,6 +19,8 @@ import {src} from '#source/source.cjs';
 
 export const source = {
   'core': `${src}/core/core.js`,
+  'adaptors/jsdom': `${src}/adaptors/jsdom/jsdom.js`,
+  'adaptors/linkedom': `${src}/adaptors/linkedom/linkedom.js`,
   'adaptors/liteDOM': `${src}/adaptors/liteDOM/liteDOM.js`,
   'input/tex': `${src}/input/tex/tex.js`,
   'input/tex-base': `${src}/input/tex-base/tex-base.js`,


### PR DESCRIPTION
This PR adds two new adaptor components (for jsdom and linkedom).  This makes it easier to use those adaptors in node application that use components, otherwise, you have to build your own component, and although that is not hard, it is an extra step.  These are small, and makes the node demos easier to generate.