### PR TITLE
Update key explorer to use dialog element for help dialog. (mathjax/MathJax#3405)

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -420,21 +420,30 @@ export function ExplorerMathDocumentMixin<
 
       'mjx-help-sizer': {
         position: 'fixed',
-        width: '40%',
+        width: '45%',
         'max-width': '30em',
         top: '3em',
         left: '50%',
       },
-      'mjx-help-dialog': {
+      'mjx-help-sizer > .mjx-help-dialog': {
         position: 'absolute',
         width: '200%',
         left: '-100%',
+        'max-width': 'initial',
+      },
+      '.mjx-help-dialog': {
+        'max-width': 'calc(min(60em, 90%))',
         border: '3px outset',
         'border-radius': '15px',
         color: 'black',
         'background-color': '#DDDDDD',
-        'z-index': '301',
+        'box-shadow': '0px 10px 20px #808080',
         'text-align': 'right',
+      },
+      '.mjx-help-dialog::backdrop': {
+        opacity: .75,
+      },
+      'mjx-help-dialog': {
         'font-style': 'normal',
         'text-indent': 0,
         'text-transform': 'none',
@@ -443,8 +452,6 @@ export function ExplorerMathDocumentMixin<
         'word-spacing': 'normal',
         'word-wrap': 'normal',
         float: 'none',
-        'box-shadow': '0px 10px 20px #808080',
-        outline: 'none',
       },
       'mjx-help-dialog > h1': {
         'font-size': '24px',
@@ -453,7 +460,7 @@ export function ExplorerMathDocumentMixin<
       },
       'mjx-help-dialog > div': {
         margin: '0 1em',
-        padding: '3px',
+        padding: '3px 10px',
         overflow: 'auto',
         height: '20em',
         border: '2px inset black',
@@ -488,6 +495,7 @@ export function ExplorerMathDocumentMixin<
         left: 0,
         right: 0,
         bottom: 0,
+        'z-index': 1001,
       },
     };
 

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -441,7 +441,7 @@ export function ExplorerMathDocumentMixin<
         'text-align': 'right',
       },
       '.mjx-help-dialog::backdrop': {
-        opacity: .75,
+        opacity: 0.75,
       },
       'mjx-help-dialog': {
         'font-style': 'normal',

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -935,7 +935,9 @@ export class SpeechExplorer
   protected help() {
     const isDialog = !!window.HTMLDialogElement;
     const adaptor = this.document.adaptor;
-    const helpBackground = isDialog ? null : adaptor.node('mjx-help-background');
+    const helpBackground = isDialog
+      ? null
+      : adaptor.node('mjx-help-background');
     const close = (event: Event) => {
       if (isDialog) {
         helpDialog.close();
@@ -946,19 +948,23 @@ export class SpeechExplorer
       this.node.focus();
       this.stopEvent(event);
     };
-    const helpDialog = adaptor.node('dialog', {closedby: 'any', class: 'mjx-help-dialog'}, [
-      adaptor.node(
-        'mjx-help-dialog',
-        { role: 'dialog', 'aria-labeledby': 'mjx-help-label' },
-        [
-          adaptor.node('h1', { id: 'mjx-help-label' }, [
-            adaptor.text('MathJax Expression Explorer Help'),
-          ]),
-          adaptor.node('div'),
-          adaptor.node('input', { type: 'button', value: 'Close' }),
-        ]
-      )
-    ]) as HTMLDialogElement;
+    const helpDialog = adaptor.node(
+      'dialog',
+      { closedby: 'any', class: 'mjx-help-dialog' },
+      [
+        adaptor.node(
+          'mjx-help-dialog',
+          { role: 'dialog', 'aria-labeledby': 'mjx-help-label' },
+          [
+            adaptor.node('h1', { id: 'mjx-help-label' }, [
+              adaptor.text('MathJax Expression Explorer Help'),
+            ]),
+            adaptor.node('div'),
+            adaptor.node('input', { type: 'button', value: 'Close' }),
+          ]
+        ),
+      ]
+    ) as HTMLDialogElement;
     const help = helpDialog.firstChild as HTMLElement;
     const [title, select] = helpData.get(context.os);
     (help.childNodes[1] as HTMLElement).innerHTML = helpMessage(title, select);
@@ -972,7 +978,7 @@ export class SpeechExplorer
       document.body.append(helpDialog);
       helpDialog.showModal();
     } else {
-      helpDialog.setAttribute('tabindex', 0);
+      helpDialog.setAttribute('tabindex', '0');
       help.addEventListener('click', (event) => this.stopEvent(event));
       helpBackground.addEventListener('click', close);
       const helpSizer = adaptor.node('mjx-help-sizer', {}, [helpDialog]);


### PR DESCRIPTION
This PR allows the KeyExplorer to use a `<dialog>` element when the browser supports that, and uses the current method when that isn't available.  In the latter case, we still create a `dialog` element, but it acts like a custom element in that case, since it isn't implemented directly.

This resolve the `z-index` issue reported in mathjax/MathJax#3405.