### PR TITLE
Add  `fontExtensions` configuration option. (mathjax/MathJax#3410)

### DIFF
--- a/components/mjs/output/util.js
+++ b/components/mjs/output/util.js
@@ -2,9 +2,29 @@ import {combineDefaults, combineWithMathJax} from '#js/components/global.js';
 import {Package} from '#js/components/package.js';
 import {hasWindow} from '#js/util/context.js';
 
-export const FONTPATH = hasWindow ?
-                        'https://cdn.jsdelivr.net/npm/@mathjax/%%FONT%%-font':
-                        '@mathjax/%%FONT%%-font';
+export const FONTPATH = hasWindow
+  ? 'https://cdn.jsdelivr.net/npm/@mathjax/%%FONT%%-font'
+  : '@mathjax/%%FONT%%-font';
+
+export function configFont(font, jax, config, extension = '') {
+  const path = (config.fontPath || (FONTPATH + extension));
+  const name = (font.match(/^[a-z]+:/) ? (font.match(/[^/:\\]*$/) || [jax])[0] : font);
+  combineDefaults(MathJax.config.loader, 'paths', {
+    [name+extension]: (name === font ? path.replace(/%%FONT%%/g, font) : font)
+  });
+  return `[${name}${extension}]`;
+}
+
+export function configExtensions(jax, config) {
+  const extensions = [];
+  for (const name of (config.fontExtensions || [])) {
+    const font = configFont(name, jax, config, '-extension');
+    const module = `${font}/${jax}`
+    extensions.push(module);
+  }
+  return extensions;
+}
+
 export const OutputUtil = {
   config(jax, jaxClass, defaultFont, fontClass) {
 
@@ -20,14 +40,14 @@ export const OutputUtil = {
       }
 
       if (font.charAt(0) !== '[') {
-        const path = (config.fontPath || FONTPATH);
-        const name = (font.match(/^[a-z]+:/) ? (font.match(/[^/:\\]*$/) || [jax])[0] : font);
-        combineDefaults(MathJax.config.loader, 'paths', {
-          [name]: (name === font ? path.replace(/%%FONT%%/g, font) : font)
-        });
-        font = `[${name}]`;
+        font = configFont(font, jax, config);
       }
       const name = font.substring(1, font.length - 1);
+
+      const extensions = configExtensions(jax, config);
+      if (extensions.length) {
+        MathJax.loader.addPackageData(`${font}/${jax}`, {extraLoads: extensions});
+      }
 
       if (name !== defaultFont || !fontClass) {
 

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -367,7 +367,6 @@ export abstract class CommonOutputJax<
     CLASS.genericFont = this.font.constructor as FontDataClass<CC, VV, DD>;
     this.setDocument(html);
     const node = this.createNode();
-    console.log('here');
     try {
       this.toDOM(math, node, html);
     } finally {

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -144,6 +144,7 @@ export abstract class CommonOutputJax<
       LinebreakVisitor: null,      // The LinebreakVisitor to use
     },
     font: '',                      // the font component to load
+    fontExtensions: [],            // the font extensions to load
     htmlHDW: 'auto',               // 'use', 'force', or 'ignore' data-mjx-hdw attributes
     wrapperFactory: null,          // The wrapper factory to use
     fontData: null,                // The FontData object to use

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -185,6 +185,15 @@ export abstract class CommonOutputJax<
   };
 
   /**
+   * The font to use for generic extensions
+   */
+  public static genericFont: FontDataClass<
+    CharOptions,
+    VariantData<CharOptions>,
+    DelimiterData
+  >;
+
+  /**
    * Used for collecting styles needed for the output jax
    */
   public styleJson: StyleJsonSheet;
@@ -306,6 +315,8 @@ export abstract class CommonOutputJax<
     this.styleJson = this.options.styleJson || new StyleJsonSheet();
     this.font = font || new fontClass(fontOptions);
     this.font.setOptions({ mathmlSpacing: this.options.mathmlSpacing });
+    /* prettier-ignore */
+    (this.constructor as typeof CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>).genericFont = fontClass;
     this.unknownCache = new Map();
     const linebreaks = (this.options.linebreaks.LinebreakVisitor ||
       LinebreakVisitor) as typeof Linebreaks;
@@ -350,9 +361,14 @@ export abstract class CommonOutputJax<
    * @override
    */
   public typeset(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
+    /* prettier-ignore */
+    const CLASS = (this.constructor as typeof CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>);
+    const generic = CLASS.genericFont;
+    CLASS.genericFont = this.font.constructor as FontDataClass<CC, VV, DD>;
     this.setDocument(html);
     const node = this.createNode();
     this.toDOM(math, node, html);
+    CLASS.genericFont = generic;
     return node;
   }
 

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -367,8 +367,12 @@ export abstract class CommonOutputJax<
     CLASS.genericFont = this.font.constructor as FontDataClass<CC, VV, DD>;
     this.setDocument(html);
     const node = this.createNode();
-    this.toDOM(math, node, html);
-    CLASS.genericFont = generic;
+    console.log('here');
+    try {
+      this.toDOM(math, node, html);
+    } finally {
+      CLASS.genericFont = generic;
+    }
     return node;
   }
 


### PR DESCRIPTION
This PR adds a `fontExtensions` configuration that makes it easier to specify a font extension to load (e.g., `mathjax-euler`).  It sets up the `extraLoads` package data to make sure the extension loads after the font itself.  The current method of including the extension in the `loader.load` array doesn't work properly as it can be loaded before the font arrives.  That can be handled by setting up dependencies and paths in the loader configuration, but it is harder than it should be, so this makes it easy.

Resolves issue mathjax/MathJax#3410.

The original section that was used to configure a font has been moved to a `configFont()` function, and a new `configExtensions()` function uses it to set up the font extensions.