### PR TITLE
Add option to disable explorer help dialog (mathjax/MathJax#3422)

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -321,6 +321,7 @@ export function ExplorerMathDocumentMixin<
     public static OPTIONS: OptionList = {
       ...BaseDocument.OPTIONS,
       enableExplorer: hasWindow,           // only activate in interactive contexts
+      enableExplorerHelp: true,            // help dialog is enabled
       renderActions: expandable({
         ...BaseDocument.OPTIONS.renderActions,
         explorable: [STATE.EXPLORER]

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -605,8 +605,13 @@ export class SpeechExplorer
 
   /**
    * Open the help dialog, and refocus when it closes.
+   *
+   * @returns {boolean | void}  True cancels the event
    */
-  protected hKey() {
+  protected hKey(): boolean | void {
+    if (!this.document.options.enableExplorerHelp) {
+      return true;
+    }
     this.refocus = this.current;
     this.help();
   }
@@ -933,6 +938,9 @@ export class SpeechExplorer
    * Displays the help dialog.
    */
   protected help() {
+    if (!this.document.options.enableExplorerHelp) {
+      return;
+    }
     const isDialog = !!window.HTMLDialogElement;
     const adaptor = this.document.adaptor;
     const helpBackground = isDialog
@@ -1081,7 +1089,7 @@ export class SpeechExplorer
     if (describe) {
       let description =
         this.description === this.none ? '' : ', ' + this.description;
-      if (this.document.options.a11y.help) {
+      if (this.document.options.a11y.help && this.document.options.enableExplorerHelp) {
         description += ', press h for help';
       }
       speech += description;
@@ -1557,7 +1565,9 @@ export class SpeechExplorer
     // and add the info icon.
     //
     this.node.classList.add('mjx-explorer-active');
-    this.node.append(this.document.infoIcon);
+    if (this.document.options.enableExplorerHelp) {
+      this.node.append(this.document.infoIcon);
+    }
     //
     // Get the node to make current, and determine if we need to add a
     // speech node (or just use the top-level node), then set the
@@ -1593,7 +1603,9 @@ export class SpeechExplorer
         this.node.setAttribute('aria-roledescription', description);
       }
       this.node.classList.remove('mjx-explorer-active');
-      this.document.infoIcon.remove();
+      if (this.document.options.enableExplorerHelp) {
+        this.document.infoIcon.remove();
+      }
       this.pool.unhighlight();
       this.magnifyRegion.Hide();
       this.region.Hide();

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -201,6 +201,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       enableSpeech: true,
       enableBraille: true,
       enableExplorer: true,
+      enableExplorerHelp: true,
       enrichSpeech: 'none',
       enrichError: (_doc: MenuMathDocument, _math: MenuMathItem, err: Error) =>
         console.warn('Enrichment Error:', err),


### PR DESCRIPTION
This PR implements an `enableExplorerHelp` document option to disable the availability of the explorer help dialog and the "press H for help" message.

Resolves issue mathjax/MathJax#3422.