### PR TITLE
Don't add invisible funciton apply after an empty mathop

### DIFF
--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -12198,6 +12198,33 @@ describe('Character Class Changes', () => {
 
   /********************************************************************************/
 
+  it('Mathop Apply', () => {
+    toXmlMatch(
+      tex2mml('\\mathop{F} x'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathop{F} x" display="block">
+         <mrow data-mjx-texclass="OP" data-latex="\\mathop{F}">
+           <mi data-latex="F">F</mi>
+         </mrow>
+         <mo data-mjx-texclass="NONE">&#x2061;</mo>
+         <mi data-latex="x">x</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
+  it('Mathop No Apply', () => {
+    toXmlMatch(
+      tex2mml('\\mathop{} x'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\mathop{} x" display="block">
+         <mrow data-mjx-texclass="OP" data-latex="\\mathop{}"></mrow>
+         <mi data-latex="x">x</mi>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
   it('Mathrel', () => {
     toXmlMatch(
       tex2mml('\\mathrel{R}'),

--- a/ts/input/tex/base/BaseItems.ts
+++ b/ts/input/tex/base/BaseItems.ts
@@ -787,6 +787,10 @@ export class FnItem extends BaseItem {
           return [[top, item], true];
         }
       }
+      // @test Mathop Apply, Mathop No Apply
+      if (top.isKind('TeXAtom') && top.childNodes[0]?.childNodes?.length === 0) {
+        return [[top, item], true];
+      }
       // @test Named Function, Named Function Arg
       const node = this.create(
         'token',


### PR DESCRIPTION
This PR prevents the invisible function apply from being added after an empty `\mathop`.   See Speech-Rule-Engine/speech-rule-engine#817.  I include two new tests for this situation.