### PR TITLE
Allow spaces after `@` in CD environment, as in real LaTeX.  (mathjax/MathJax#3425)

### DIFF
--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -752,6 +752,35 @@ describe('AmsCD', () => {
 
   /********************************************************************************/
 
+  it('Spaces', () => {
+    toXmlMatch(
+      tex2mml('\\begin{CD}A @ > x > > B \\end{CD}'),
+      `<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\begin{CD}A @ &gt; x &gt; &gt; B \\end{CD}" display="block">
+         <mtable columnspacing="5pt" rowspacing="5pt" displaystyle="true" data-latex-item="{CD}" data-latex="\\begin{CD}A @ &gt; x &gt; &gt; B \\end{CD}">
+           <mtr>
+             <mtd>
+               <mi data-latex="A">A</mi>
+               <mpadded height="8.5pt" depth="2pt"></mpadded>
+             </mtd>
+             <mtd>
+               <mover>
+                 <mo minsize="2.75em">&#x2192;</mo>
+                 <mpadded width="+.67em" lspace=".33em" voffset=".1em">
+                   <mi data-latex="x">x</mi>
+                 </mpadded>
+               </mover>
+             </mtd>
+             <mtd>
+               <mi data-latex="B">B</mi>
+             </mtd>
+           </mtr>
+         </mtable>
+       </math>`
+    );
+  });
+
+  /********************************************************************************/
+
   it('Suspicious Return', () => {
     toXmlMatch(
       tex2mml('\\begin{CD}A @Ra>> BaD\\end{CD}'),

--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -64,9 +64,11 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
    * @returns {void} No value.
    */
   arrow(parser: TexParser, name: string): void {
-    const c = parser.string.charAt(parser.i);
+    const i = parser.i;
+    const c = parser.GetNext();
     if (!c.match(/[><VA.|=]/)) {
       // TODO: This return is suspicious.
+      parser.i = i;
       return Other(parser, name);
     } else {
       parser.i++;


### PR DESCRIPTION
This PR allows spaces after `@` in the `CD` environment, and adds a test for that.

Resolves issue mathjax/MathJax#3425.

