### PR TITLE
Remove use of aria-level

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -829,7 +829,7 @@ export class SpeechExplorer
     const parts = [
       [
         this.node.getAttribute('data-semantic-level') ?? 'Level',
-        this.current.getAttribute('aria-level') ?? '0',
+        this.current.getAttribute('data-semantic-level-number') ?? '0',
       ]
         .join(' ')
         .trim(),

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -209,6 +209,7 @@ export function EnrichedMathItemMixin<
           //
           math.math = math.math
             .replace(/ role="treeitem"/g, ' data-speech-node="true"')
+            .replace(/ aria-level/g, ' data-semantic-level-number')
             .replace(/ aria-(?:posinset|owns|setsize)=".*?"/g, '');
           math.display = this.display;
           math.compile(document);


### PR DESCRIPTION
This PR changes the `aria-level` attribute from the semantic enrichment to `data-semantic-level-number` to avoid ARIA errors with level number 0, since this really isn't being used as an actual aria level anyway.