### PR TITLE
Prevent unwanted forced inline breaks in SVG semantics elements.  (mathjax/MathJax#3428)

### DIFF
--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -709,7 +709,7 @@ export class CommonWrapper<
     if (this.node.isEmbellished) {
       return [this, this.coreMO()] as any as [WW, WW];
     }
-    const childNodes = this.childNodes[0]?.node?.isInferred
+    const childNodes = this.childNodes[0]?.node?.isInferred || this.node.isKind('semantics')
       ? this.childNodes[0].childNodes
       : this.childNodes;
     if (this.node.isToken || !childNodes[i]) {


### PR DESCRIPTION
This PR prevents the temporarily forced line breaks used for making potential line breaks in SVG in-line expressions from always causing line breaks.  The semantics element doesn't have an inferred `mrow`, so it was missed when looking through its children for the proper breakpoint element.

Resolves issue mathjax/MathJax#3428.