### PR TITLE
Update the position of labels on vertical arrows to better match actual LaTeX output

### DIFF
--- a/ts/input/tex/amscd/AmsCdMethods.ts
+++ b/ts/input/tex/amscd/AmsCdMethods.ts
@@ -163,7 +163,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
           if (a) {
             NodeUtil.appendChildren(mml, [
               new TexParser(
-                '\\scriptstyle\\llap{' + a + '}',
+                '\\scriptstyle\\raise.125em{\\vcenter{\\llap{' + a + '}}}',
                 parser.stack.env,
                 parser.configuration
               ).mml(),
@@ -174,7 +174,7 @@ const AmsCdMethods: { [key: string]: ParseMethod } = {
           if (b) {
             NodeUtil.appendChildren(mml, [
               new TexParser(
-                '\\scriptstyle\\rlap{' + b + '}',
+                '\\scriptstyle\\raise.125em{\\vcenter{\\rlap{' + b + '}}}',
                 parser.stack.env,
                 parser.configuration
               ).mml(),


### PR DESCRIPTION
The labels on vertical arrows in the `CD` environment in actual LaTeX implementation are centered and slightly raised from the baseline to be centered on the arrow.  This PR adjusts the placement of the labels to more closely match that.