### PR TITLE
Fix problem with sliders and add keyboard controls.

### DIFF
--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -43,6 +43,7 @@ import { SVG } from '../../output/svg.js';
 import * as AnnotationMenu from './AnnotationMenu.js';
 import { MJContextMenu } from './MJContextMenu.js';
 import { RadioCompare } from './RadioCompare.js';
+import { mjSlider } from './Slider.js';
 import { MmlVisitor } from './MmlVisitor.js';
 import { MenuMathDocument } from './MenuHandler.js';
 import * as MenuUtil from './MenuUtil.js';
@@ -602,6 +603,7 @@ export class Menu {
     const parser = new Parser([
       ['contextMenu', MJContextMenu.fromJson.bind(MJContextMenu)],
       ['radioCompare', RadioCompare.fromJson.bind(RadioCompare)],
+      ['slider', mjSlider.fromJson.bind(mjSlider)],
     ]);
     this.menu = parser.parse({
       type: 'contextMenu',
@@ -857,7 +859,7 @@ export class Menu {
                 ['Black'],
               ])
             ),
-            { type: 'slider', variable: 'backgroundOpacity', content: ' ' },
+            this.slider('backgroundOpacity'),
             this.submenu(
               'Foreground',
               'Foreground',
@@ -872,7 +874,7 @@ export class Menu {
                 ['Blue'],
               ])
             ),
-            { type: 'slider', variable: 'foregroundOpacity', content: ' ' },
+            this.slider('foregroundOpacity'),
             this.rule(),
             this.radioGroup('highlight', [['None'], ['Hover'], ['Flame']]),
             this.rule(),
@@ -2069,6 +2071,16 @@ export class Menu {
    */
   public rule(): object {
     return { type: 'rule' };
+  }
+
+  /**
+   * Create JSON for a slider
+   *
+   * @param {string} variable     The (pool) variable to attach to this slider
+   * @returns {object}            The JSON for the slider item
+   */
+  public slider(variable: string): object {
+    return {type: 'slider', variable, content: ' '};
   }
 
   /*======================================================================*/

--- a/ts/ui/menu/Slider.ts
+++ b/ts/ui/menu/Slider.ts
@@ -18,7 +18,7 @@
 /**
  * @file  Implements a radio button with customizable comparator.
  *
- * @author v.sorge@mathjax.org (Volker Sorge)
+ * @author dpvc@mathjax.org (Davide Cervone)
  */
 
 import {Slider} from './mj-context-menu.js';

--- a/ts/ui/menu/Slider.ts
+++ b/ts/ui/menu/Slider.ts
@@ -24,7 +24,7 @@
 import {Slider} from './mj-context-menu.js';
 
 //
-// Fix slider actions (FIXME: remove when mj-context-menu is mergerd into MathJax-src repo)
+// Fix slider actions (FIXME: remove when mj-context-menu is merged into MathJax-src repo)
 //
 export class mjSlider extends Slider {
   /**

--- a/ts/ui/menu/Slider.ts
+++ b/ts/ui/menu/Slider.ts
@@ -1,0 +1,98 @@
+/*************************************************************
+ *
+ *  Copyright (c) 2022-2026 The MathJax Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * @file  Implements a radio button with customizable comparator.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+import {Slider} from './mj-context-menu.js';
+
+//
+// Fix slider actions (FIXME: remove when mj-context-menu is mergerd into MathJax-src repo)
+//
+export class mjSlider extends Slider {
+  /**
+   * @override
+   */
+  focus() {
+    super.focus();
+    this.html.focus(); // needed since super.focus uses setTimout for this
+    (this as any).input.focus();
+  }
+
+  /**
+   * @override
+   */
+  mouseup(event: MouseEvent) {
+    super.mouseup(event);
+    this.stop(event); // needs to prevent default action
+  }
+
+  /**
+   * @override
+   */
+  keydown(event: KeyboardEvent) {
+    let value = parseInt(((this as any).input as HTMLInputElement).value);
+    switch (event.key) {
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      if (!event.shiftKey) {
+        super.keydown(event);
+        return;
+      }
+    /* @eslint-ignore: no-fallthrough */
+    case '-':
+      value = Math.max(0, value - (event.ctrlKey ? 5 : 1));
+      break;
+
+    case 'ArrowRight':
+    case 'ArrowUp':
+      if (!event.shiftKey) {
+        super.keydown(event);
+        return;
+      }
+    /* @eslint-ignore: no-fallthrough */
+    case '+':
+      value = Math.min(100, value + (event.ctrlKey ? 5 : 1));
+      break
+
+    case 'PageDown':
+      value = Math.max(0, value - 5);
+      break;
+
+    case 'PageUp':
+      value= Math.max(0, value + 5);
+      break;
+
+    case 'Home':
+      value = 0;
+      break;
+
+    case 'End':
+      value = 100;
+      break;
+
+    default:
+      super.keydown(event);
+      return;
+    }
+    this.variable.setValue(String(value));
+    this.stop(event);
+  }
+}

--- a/ts/ui/menu/mj-context-menu.ts
+++ b/ts/ui/menu/mj-context-menu.ts
@@ -27,6 +27,7 @@ export { SubMenu } from '#menu/sub_menu.js';
 export { Submenu } from '#menu/item_submenu.js';
 export { Radio } from '#menu/item_radio.js';
 export { Rule } from '#menu/item_rule.js';
+export { Slider } from '#menu/item_slider.js';
 export { ParserFactory } from '#menu/parser_factory.js';
 export { Parser } from '#menu/parse.js';
 export * as CssStyles from '#menu/css_util.js';


### PR DESCRIPTION
This PR fixes several problems with the opacity sliders in the MathJax contextual menu.

The first is due to the `setTimeout()` that I added to

https://github.com/mathjax/context-menu/blame/2156b7db7cac02ca8451deb4ee6075d55b591d37/ts/menu_element.ts#L88

to address a problem with Firefox on Windows voicing the menu items as they are selected.  This causes the slider value to be reset to the default value after you let it go.  It seems to be caused by the default action of the `mouseup` event.  The solution is to prevent the default action for the `mouseup` event, as it would have been in the default `mouseup()` method, but that is never called by the slider's `mouseup()`.

The second is related, where the value could be reset to the default after moving the slider and then coming back to the highlight menu and moving the mouse from the top entry to the slider so that the mouse is over the slider itself (rather than the background).  This seems to be due to the timing of the focus events on the slider itself versus the `div` that holds it, but I couldn't quite figure out why it would get the default value again.  The solution in this case seems to be to focus the container first, then focus the slider.  I haven't checked if that causes problems in windows Firefox, but since this will only be for the sliders, it is probably not a serious issue even if it does.

These changes are made by using a subclass of the `Slider` class that overrides the needed methods.  This could have been done in a PR for the context menu itself, but I didn't want to make a new context-menu release, as we are planning to move that code into MathJax-src in the future; when that occurs, we can move the subclass methods into the actual `Slider` class.  

The subclass is in `ts/ui/Menu/Slider.ts`, and is imported into `Menu.ts` like the `RadioCompare` extension, and added to the menu parser in the same way.  I also added a `Slider()` method for creating the menu entries for the sliders, similar to the other helper functions for radio buttons, checkboxes, submenus, labels, rules, and so on.

Finally, the new slider subclass also includes support for changing its value via keyboard events.  I could not follow the [suggested key bindings](https://www.w3.org/WAI/ARIA/apg/patterns/slider/) from WAI, since our menus already use the arrow keys for navigation purposes.  So I uses SHIFT-arrow keys to perform those actions that are usually use arrow keys, and also add `+` and `-` for increasing and decreasing the values by 1, with CTRL to move by larger amounts (5).  I also implemented the `Home`, `End`, `PageUp` and `PageDown` key bindings that they recommend.

As we know, the menu code needs to be updated to match some of the other WAI requirements, so this can be revisited when we do that overhaul.