### PR TITLE
Make sure SRE options are set if only a convert call is used.

### DIFF
--- a/ts/a11y/complexity/collapse.ts
+++ b/ts/a11y/complexity/collapse.ts
@@ -49,7 +49,7 @@ export type CollapseFunctionMap = Map<string, CollapseFunction>;
 export type TypeRole<T> = { [type: string]: T | { [role: string]: T } };
 
 /**
- * The class for determining of a subtree can be collapsed
+ * The class for determining if a subtree can be collapsed
  */
 export class Collapse {
   /**

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -2097,7 +2097,7 @@ function buildMap(tree: SexpTree, map: Map<string, Set<string>>): Set<string> {
   return descendants;
 }
 
-// Can be replaced with ES2024 implementation of Set.prototyp.difference
+// Can be replaced with ES2024 implementation of Set.prototype.difference
 /**
  * Set difference between two sets A and B: A\B.
  *

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -202,6 +202,9 @@ export function EnrichedMathItemMixin<
           } else {
             mml = this.adjustSelections();
           }
+          if (!document.processed.isSet('enriched')) {
+            Sre.setupEngine(document.options.sre);
+          }
           const enriched = Sre.toEnriched(mml);
           this.inputData.enrichedMml = math.math = this.serializeMml(enriched);
           //
@@ -351,7 +354,7 @@ export function EnrichedMathDocumentMixin<
 
     /**
      * Enrich the MathItem class used for this MathDocument, and create the
-     *   temporary MathItem used for enrchment
+     *   temporary MathItem used for enrichment
      *
      * @override
      * @class


### PR DESCRIPTION
This PR fixes some comment typos, and makes sure that the SRE options are in place if a conversion action is taken before the page is typeset.  E.g., if `MathJax.tex2chtml()` or `doc.convert()` is called from a command-line application that just converts math strings without processing a page as a whole.