### PR TITLE
Fix existing linting errors

### DIFF
--- a/ts/input/tex/TexParser.ts
+++ b/ts/input/tex/TexParser.ts
@@ -377,7 +377,7 @@ export default class TexParser {
    * @param {string} _name Name of the current control sequence.
    * @param {string?} def The default value for the optional argument.
    * @param {boolean=} matchBrackets True if indernal brackets must match.
-   * @returns {string} The optional argument.
+   * @returns {string|undefined} The optional argument.
    */
   public GetBrackets(
     _name: string,
@@ -426,7 +426,7 @@ export default class TexParser {
    *
    * @param {string} name Name of the current control sequence.
    * @param {boolean=} braceOK Are braces around the delimiter OK.
-   * @returns {string} The delimiter name.
+   * @returns {string|undefined} The delimiter name.
    */
   public GetDelimiter(name: string, braceOK: boolean = false): string {
     let c = this.GetNext();
@@ -450,7 +450,7 @@ export default class TexParser {
    * Get a dimension (including its units).
    *
    * @param {string} name Name of the current control sequence.
-   * @returns {string} The dimension string.
+   * @returns {string|undefined} The dimension string.
    */
   public GetDimen(name: string): string {
     if (this.GetNext() === '{') {
@@ -478,7 +478,7 @@ export default class TexParser {
    *
    * @param {string} _name Name of the current control sequence.
    * @param {string} token The element until where to parse.
-   * @returns {string} The text between the current position and the given token.
+   * @returns {string|undefined} The text between the current position and the given token.
    */
   public GetUpTo(_name: string, token: string): string {
     while (this.nextIsSpace()) {
@@ -546,7 +546,7 @@ export default class TexParser {
    * Get a delimiter or empty argument
    *
    * @param {string} name Name of the current control sequence.
-   * @returns {string} The delimiter.
+   * @returns {string|undefined} The delimiter.
    */
   public GetDelimiterArg(name: string): string {
     const c = UnitUtil.trimSpaces(this.GetArgument(name));

--- a/ts/input/tex/color/ColorUtil.ts
+++ b/ts/input/tex/color/ColorUtil.ts
@@ -46,7 +46,7 @@ export class ColorModel {
    *
    * @param {string} model The coloring model type: `rgb` `RGB` or `gray`.
    * @param {string} def The color definition: `0.5,0,1`, `128,0,255`, `0.5`.
-   * @returns {string} The color definition in CSS format e.g. `#44ff00`.
+   * @returns {string|undefined} The color definition in CSS format e.g. `#44ff00`.
    */
   private normalizeColor(model: string, def: string): string {
     if (!model || model === 'named') {

--- a/ts/input/tex/newcommand/NewcommandUtil.ts
+++ b/ts/input/tex/newcommand/NewcommandUtil.ts
@@ -114,7 +114,7 @@ export const NewcommandUtil = {
    * @param {TexParser} parser The calling parser.
    * @param {string} cmd The string starting with the template.
    * @param {string} cs The control sequence of the \def.
-   * @returns {number | string[]} The number of parameters or a string array if
+   * @returns {number | string[] | undefined} The number of parameters or a string array if
    *     there is an optional argument.
    */
   GetTemplate(parser: TexParser, cmd: string, cs: string): number | string[] {
@@ -175,7 +175,7 @@ export const NewcommandUtil = {
    * @param {TexParser} parser The calling parser.
    * @param {string} name The name of the calling command.
    * @param {string} param The parameter for the macro.
-   * @returns {string} The parameter.
+   * @returns {string|undefined} The parameter.
    */
   GetParameter(parser: TexParser, name: string, param: string): string {
     if (param == null) {


### PR DESCRIPTION
Fixes existing warning regarding `jsdoc/require-returns-check`. They occur in functions that both return a value or throw an exception, where the latter is hidden in the `texError` method. There are two ways to fix this:
1. Use `return texError(...)`
2. Add `undefined` to the return type in jsdoc, such as 
```TypeScript
@returns {string|undefined} ...
```
Although `texError` has return type `never`,  
```Typescript 
@returns {string|never} ...
``` 
does not fix the error.

3. Final *unrealistic* alternative is to never have `texError` as the final command in a function. Example is `getBraces` in `ColumnParser.ts`, where the first `texError` is ignored by the linter while the last is not (hence there is a `return texError`).

Have a look which if you like the jsdoc solution and we can adapt the `getBraces` similarly.

