### PR TITLE
Remove locale warning that is no longer needed, and fix a prettier issue.

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -38,7 +38,6 @@ import { BitField, BitFieldClass } from '../util/BitField.js';
 import { PrioritizedList } from '../util/PrioritizedList.js';
 import { handleRetriesFor } from '../util/Retries.js';
 import { localize } from './__locales__/Component.js';
-import { Locale } from '../util/Locale.js';
 import { mathjax } from '../mathjax.js';
 
 /*****************************************************************/
@@ -800,12 +799,6 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @class
    */
   constructor(document: D, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
-    if (!Locale.initialized) {
-      // FIXME: add URL when we have one.
-      console.error(
-        'MathJax locales not loaded.  You may receive cryptic error messages.'
-      );
-    }
     const CLASS = this.constructor as typeof AbstractMathDocument;
     this.document = document;
     this.options = userOptions(defaultOptions({}, CLASS.OPTIONS), options);

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -388,7 +388,10 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public convert(document: MathDocument<N, T, D>, end: number = STATE.LAST): MmlNode | N {
+  public convert(
+    document: MathDocument<N, T, D>,
+    end: number = STATE.LAST
+  ): MmlNode | N {
     return document.renderActions.renderConvert(this, document, end);
   }
 

--- a/ts/util/Locale.ts
+++ b/ts/util/Locale.ts
@@ -41,10 +41,6 @@ export const COMPONENT = 'locale';
  */
 export class Locale {
   /**
-   * Whether setLocale() has been called or not.
-   */
-  public static initialized: boolean = false;
-  /**
    * The current locale
    */
   public static current: string = locale;
@@ -271,7 +267,6 @@ export class Locale {
       }
     }
     this.current = locale;
-    this.initialized = true;
     const promises = [];
     for (const [component, [directory, loaded]] of Object.entries(
       this.locations


### PR DESCRIPTION
This PR removes the locale warning, now that the `en` definitions are loaded automatically, even for direct loading of the MathJax modules.  It also fixes a prettier issue from a previous PR.