### PR TITLE
Use retryAfter() and handleRetriesFor() from `mathjax` so they are easier to override

### DIFF
--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -36,7 +36,6 @@ import { MmlFactory } from '../core/MmlTree/MmlFactory.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
 import { BitField, BitFieldClass } from '../util/BitField.js';
 import { PrioritizedList } from '../util/PrioritizedList.js';
-import { handleRetriesFor } from '../util/Retries.js';
 import { localize } from './__locales__/Component.js';
 import { Locale } from '../util/Locale.js';
 import { mathjax } from '../mathjax.js';
@@ -883,7 +882,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   public renderPromise() {
     return this.whenReady(() =>
-      handleRetriesFor(async () => {
+      mathjax.handleRetriesFor(async () => {
         this.render();
         await this.actionPromises();
         this.clearPromises();
@@ -906,7 +905,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   public rerenderPromise(start: number = STATE.RERENDER) {
     return this.whenReady(() =>
-      handleRetriesFor(async () => {
+      mathjax.handleRetriesFor(async () => {
         this.rerender(start);
         await this.actionPromises();
         this.clearPromises();
@@ -962,7 +961,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   public convertPromise(math: string, options: OptionList = {}) {
     return this.whenReady(() =>
-      handleRetriesFor(async () => {
+      mathjax.handleRetriesFor(async () => {
         const node = this.convert(math, options);
         await this.actionPromises();
         this.clearPromises();

--- a/ts/input/tex/textmacros/TextMacrosMethods.ts
+++ b/ts/input/tex/textmacros/TextMacrosMethods.ts
@@ -21,9 +21,9 @@
  * @author dpvc@mathjax.org (Davide P. Cervone)
  */
 
+import { mathjax } from '../../../mathjax.js';
 import { HandlerType } from '../HandlerTypes.js';
 import TexParser from '../TexParser.js';
-import { retryAfter } from '../../../util/Retries.js';
 import { TextParser } from './TextParser.js';
 import BaseMethods from '../base/BaseMethods.js';
 
@@ -290,7 +290,7 @@ export const TextMacrosMethods = {
     if (!macro || (autoload && macro._func === autoload.Autoload)) {
       texParser.parse(HandlerType.MACRO, [texParser, name]);
       if (!macro) return;
-      retryAfter(Promise.resolve());
+      mathjax.retryAfter(Promise.resolve());
     }
     texParser.parse(HandlerType.MACRO, [parser, name]);
   },

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -1313,7 +1313,7 @@ export class FontData<
     if (!dynamic.promise) {
       dynamic.promise = Promise.resolve();
       try {
-        asyncLoad(this.dynamicFileName(dynamic));
+        mathjax.asyncLoad(this.dynamicFileName(dynamic));
       } catch (err) {
         dynamic.failed = true;
         console.warn(err);

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -26,7 +26,6 @@ import { mathjax } from '../../mathjax.js';
 import { OptionList, defaultOptions, userOptions } from '../../util/Options.js';
 import { StyleJson } from '../../util/StyleJson.js';
 import { asyncLoad } from '../../util/AsyncLoad.js';
-import { retryAfter } from '../../util/Retries.js';
 import { Locale } from '../../util/Locale.js';
 import { COMPONENT, localize } from '../../core/__locales__/Component.js';
 import { DIRECTION } from './Direction.js';
@@ -1314,7 +1313,7 @@ export class FontData<
     if (!dynamic.promise) {
       dynamic.promise = Promise.resolve();
       try {
-        mathjax.asyncLoad(this.dynamicFileName(dynamic));
+        asyncLoad(this.dynamicFileName(dynamic));
       } catch (err) {
         dynamic.failed = true;
         console.warn(err);
@@ -1343,7 +1342,7 @@ export class FontData<
         this.loadDynamicFileSync(delim);
         return this.getDelimiter(n);
       }
-      retryAfter(this.loadDynamicFile(delim));
+      mathjax.retryAfter(this.loadDynamicFile(delim));
       return null;
     }
     return delim as DelimiterData;
@@ -1395,7 +1394,7 @@ export class FontData<
         this.loadDynamicFileSync(char);
         return this.getChar(name, n);
       }
-      retryAfter(this.loadDynamicFile(char));
+      mathjax.retryAfter(this.loadDynamicFile(char));
       return null;
     }
     return char as CharDataArray<C>;

--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -30,7 +30,6 @@ import { HTMLDocument } from '../../handlers/html/HTMLDocument.js';
 import { HTMLHandler } from '../../handlers/html/HTMLHandler.js';
 // import { EnrichedMathItem } from '../../a11y/semantic-enrich.js';
 import { SpeechMathItem } from '../../a11y/speech.js';
-import { handleRetriesFor } from '../../util/Retries.js';
 import { OptionList } from '../../util/Options.js';
 import { StyleJson } from '../../util/StyleJson.js';
 
@@ -568,7 +567,7 @@ export function LazyMathDocumentMixin<
       //  Typeset the math and put back the font cache when done.
       //
       this.reset();
-      return handleRetriesFor(() => this.render()).then(() => {
+      return this.renderPromise().then(() => {
         if (fontCache) this.outputJax.options.fontCache = fontCache;
       });
     }
@@ -622,16 +621,14 @@ export function LazyMathDocumentMixin<
     protected lazyHandleSet() {
       const set = this.lazySet;
       this.lazySet = new Set();
-      this.lazyPromise = this.lazyPromise.then(() => {
+      this.lazyPromise = this.lazyPromise.then(async () => {
         let state = this.compileEarlierItems(set)
           ? STATE.COMPILED
           : STATE.TYPESET;
         state = this.resetStates(set, state);
         this.state(state - 1, null); // reset processed bits to allow reprocessing
-        return handleRetriesFor(() => {
-          this.render();
-          this.lazyIdle = false;
-        });
+        await this.renderPromise();
+        this.lazyIdle = false;
       });
     }
 

--- a/ts/util/Entities.ts
+++ b/ts/util/Entities.ts
@@ -22,7 +22,6 @@
  */
 
 import { mathjax } from '../mathjax.js';
-import { asyncLoad } from './AsyncLoad.js';
 import { OptionList } from './Options.js';
 
 /**

--- a/ts/util/Entities.ts
+++ b/ts/util/Entities.ts
@@ -22,6 +22,7 @@
  */
 
 import { mathjax } from '../mathjax.js';
+import { asyncLoad } from './AsyncLoad.js';
 import { OptionList } from './Options.js';
 
 /**
@@ -507,7 +508,7 @@ function replace(match: string, entity: string): string {
       entity.charAt(0).toLowerCase();
     if (!loaded[file]) {
       loaded[file] = true;
-      const promise = mathjax.asyncLoad(`./util/entities/${file}.js`);
+      const promise = asyncLoad(`./util/entities/${file}.js`);
       if (mathjax.asyncIsSynchronous) {
         return replace(match, entity);
       }

--- a/ts/util/Entities.ts
+++ b/ts/util/Entities.ts
@@ -508,7 +508,7 @@ function replace(match: string, entity: string): string {
       entity.charAt(0).toLowerCase();
     if (!loaded[file]) {
       loaded[file] = true;
-      const promise = asyncLoad(`./util/entities/${file}.js`);
+      const promise = mathjax.asyncLoad(`./util/entities/${file}.js`);
       if (mathjax.asyncIsSynchronous) {
         return replace(match, entity);
       }


### PR DESCRIPTION
This PR moves the references to `retryAfter()` and `handleRetriesFor()` to the version in the `mathjax` variable rather than from the `Retries.ts` module directly.  This makes it easier to override them.  I have an example of making MathJax load tex extensions synchronously that would be helped by this, as that means there would be fewer methods that need to be overridden.  Together with the synchronous loading of dynamic font data and of entity definitions, this would allow MathJax to be run synchronously in node applications, where synchronous file loading can be achieved.

Note that `asyncLoad` uses `mathjax.asyncLoad` internally, so we don't have to use `mathjax` for that.