### PR TITLE
Fix problem with maction toggles scrolling to the top of the page.  (mathjax/MathJax#3600)

### DIFF
--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -259,11 +259,10 @@ export function ExplorerMathItemMixin<B extends Constructor<HTMLMATHITEM>>(
       let focus = null;
       if (this.explorers) {
         const speech = this.explorers.speech;
-        focus = speech?.attached ? document.tmpFocus : null;
-        if (focus) {
+        if (speech?.attached) {
+          focus = document.tmpFocus;
           this.refocus = speech.semanticFocus() ?? null;
-          const adaptor = document.adaptor;
-          adaptor.append(adaptor.body(), focus);
+          this.typesetRoot.after(focus);
         }
         this.explorers.reattach();
         focus?.focus();
@@ -535,10 +534,8 @@ export function ExplorerMathDocumentMixin<
         tabIndex: 0,
         style: {
           outline: 'none',
-          display: 'block',
+          display: 'inline-block',
           position: 'absolute',
-          top: 0,
-          left: '-10px',
           width: '1px',
           height: '1px',
           overflow: 'hidden',

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -383,6 +383,8 @@ export class SpeechExplorer
     if (!this.clicked) {
       this.Start();
       this.backTab = event.target === this.img;
+    } else if (!this.focusSpeech) {
+      this.speak('');  // don't speak initial equation until click event
     }
     this.clicked = null;
   }


### PR DESCRIPTION
This PR fixes a problem with the handling of `maction` toggles, where clicking a toggle when the window is scrolled moves the window to the top of the page.  This was due to the temporary focus element that is added so that we don't lose the focus while the expression is re-rendered (which will cause problems for screen readers).

The solution is to insert the temporary element at the location of the math expression itself rather than at the top of the page.  This resolves issue mathjax/MathJax#3600.

While working on this, I also found an issue where clicking on an expression causes the original expression to be read (due to the initial focusing on the mouse down), and then the updated expression when the mouse is released.  That leads to confusing spoken expressions, and can even lead to the updated version not being read (if the focus changes fast enough).

The solution in this case seems to be to remove the main expression's speech string (by speaking a blank string) when the `mousedown` event occurs so that the screen reader doesn't read the whole expression if you click and hold down the mouse button before letting go.