### PR TITLE
Add \providecommand and tests

### DIFF
--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -31,6 +31,12 @@ describe('Newcommand', () => {
     ).toMatchSnapshot();
   });
 
+  it('Providecommand', () => {
+    expect(
+      tex2mml('\\providecommand{\\a}{A}\\providecommand{\\a}{B}\\a')
+    ).toMatchSnapshot();
+  });
+
   it('Newenvironment Optional', () => {
     expect(
       tex2mml(

--- a/testsuite/tests/input/tex/__snapshots__/Newcommand.test.ts.snap
+++ b/testsuite/tests/input/tex/__snapshots__/Newcommand.test.ts.snap
@@ -717,3 +717,9 @@ exports[`Newcommand Overrides Let overrides existing macro as delimiter 1`] = `
   </mrow>
 </math>"
 `;
+
+exports[`Newcommand Providecommand 1`] = `
+"<math xmlns="http://www.w3.org/1998/Math/MathML" data-latex="\\providecommand{\\a}{A}\\providecommand{\\a}{B}\\a" display="block">
+  <mi data-latex="A">A</mi>
+</math>"
+`;

--- a/ts/input/tex/newcommand/NewcommandMappings.ts
+++ b/ts/input/tex/newcommand/NewcommandMappings.ts
@@ -30,6 +30,7 @@ import { CommandMap } from '../TokenMap.js';
 new CommandMap('Newcommand-macros', {
   newcommand: NewcommandMethods.NewCommand,
   renewcommand: NewcommandMethods.NewCommand,
+  providecommand: [NewcommandMethods.NewCommand, true],
   newenvironment: NewcommandMethods.NewEnvironment,
   renewenvironment: NewcommandMethods.NewEnvironment,
   def: NewcommandMethods.MacroDef,

--- a/ts/input/tex/newcommand/NewcommandMethods.ts
+++ b/ts/input/tex/newcommand/NewcommandMethods.ts
@@ -43,14 +43,17 @@ const NewcommandMethods: { [key: string]: ParseMethod } = {
    *
    * @param {TexParser} parser The calling parser.
    * @param {string} name The name of the calling command.
+   * @param {boolean} provide True for \providecommand (to check if command exists before defining)
    */
-  NewCommand(parser: TexParser, name: string) {
+  NewCommand(parser: TexParser, name: string, provide: boolean = false) {
     // @test Newcommand Simple
     const cs = NewcommandUtil.GetCsNameArgument(parser, name);
     const n = NewcommandUtil.GetArgCount(parser, name);
     const opt = parser.GetBrackets(name);
     const def = parser.GetArgument(name);
-    NewcommandUtil.addMacro(parser, cs, NewcommandMethods.Macro, [def, n, opt]);
+    if (!provide || (!parser.lookup(HandlerType.MACRO, cs) && !parser.lookup(HandlerType.DELIMITER, '\\' + cs))) {
+      NewcommandUtil.addMacro(parser, cs, NewcommandMethods.Macro, [def, n, opt]);
+    }
     parser.Push(parser.itemFactory.create('null'));
   },
 


### PR DESCRIPTION
This PR implements the `\providecommand` macro requested in mathjax/MathJax#3603.  This is an easy addition to the `newcommand` package.  I added a test for it as well.

Resolves issue mathjax/MathJax#3603.