### PR TITLE
Use #src/index.js rather than #helpers in tests to avoid problem with typescript errors

### DIFF
--- a/testsuite/tests/input/tex/Action.test.ts
+++ b/testsuite/tests/input/tex/Action.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/action/ActionConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'action']));

--- a/testsuite/tests/input/tex/Ams.test.ts
+++ b/testsuite/tests/input/tex/Ams.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'ams']));

--- a/testsuite/tests/input/tex/Amscd.test.ts
+++ b/testsuite/tests/input/tex/Amscd.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/amscd/AmsCdConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'amscd']));

--- a/testsuite/tests/input/tex/Autoload.test.ts
+++ b/testsuite/tests/input/tex/Autoload.test.ts
@@ -4,7 +4,7 @@ import {
   setupTexTypeset,
   typeset2mml,
   setupComponents,
-} from '#helpers';
+} from '#src/index.js';
 
 setupComponents({ loader: { load: ['input/tex-base', '[tex]/autoload'] } });
 

--- a/testsuite/tests/input/tex/Base-browser.test.ts
+++ b/testsuite/tests/input/tex/Base-browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals';
+ import { describe, test, expect } from '@jest/globals';
 
 const FILE = 'https://testing.com/testing.html';
 

--- a/testsuite/tests/input/tex/Base.test.ts
+++ b/testsuite/tests/input/tex/Base.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, it, expect } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import ParseOptions from '#js/input/tex/ParseOptions.js';
 
 beforeEach(() => setupTex(['base']));

--- a/testsuite/tests/input/tex/Bbm.test.ts
+++ b/testsuite/tests/input/tex/Bbm.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, setupComponents, tex2mml } from '#helpers';
+import { getTokens, setupTex, setupComponents, tex2mml } from '#src/index.js';
 import '#js/input/tex/bbm/BbmConfiguration.js';
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/Bboldx.test.ts
+++ b/testsuite/tests/input/tex/Bboldx.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/bboldx/BboldxConfiguration.js';
 import '#js/input/tex/textmacros/TextMacrosConfiguration.js';
 

--- a/testsuite/tests/input/tex/Bbox.test.ts
+++ b/testsuite/tests/input/tex/Bbox.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/bbox/BboxConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'bbox']));

--- a/testsuite/tests/input/tex/Begingroup.test.ts
+++ b/testsuite/tests/input/tex/Begingroup.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, test, expect } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/begingroup/BegingroupConfiguration.js';
 import '#js/input/tex/newcommand/NewcommandConfiguration.js';
 

--- a/testsuite/tests/input/tex/Boldsymbol.test.ts
+++ b/testsuite/tests/input/tex/Boldsymbol.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/boldsymbol/BoldsymbolConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'boldsymbol']));

--- a/testsuite/tests/input/tex/Braket.test.ts
+++ b/testsuite/tests/input/tex/Braket.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/braket/BraketConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'braket']));

--- a/testsuite/tests/input/tex/Bussproofs.test.ts
+++ b/testsuite/tests/input/tex/Bussproofs.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTexWithOutput, tex2mml } from '#helpers';
+import { getTokens, setupTexWithOutput, tex2mml } from '#src/index.js';
 import '#js/input/tex/bussproofs/BussproofsConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 import '#js/input/tex/newcommand/NewcommandConfiguration.js';

--- a/testsuite/tests/input/tex/Cancel.test.ts
+++ b/testsuite/tests/input/tex/Cancel.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/cancel/CancelConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'cancel']));

--- a/testsuite/tests/input/tex/Cases.test.ts
+++ b/testsuite/tests/input/tex/Cases.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/cases/CasesConfiguration.js';
 import '#js/input/tex/empheq/EmpheqConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';

--- a/testsuite/tests/input/tex/Centernot.test.ts
+++ b/testsuite/tests/input/tex/Centernot.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/centernot/CenternotConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'centernot']));

--- a/testsuite/tests/input/tex/Color.test.ts
+++ b/testsuite/tests/input/tex/Color.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/color/ColorConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'color']));

--- a/testsuite/tests/input/tex/Colortbl.test.ts
+++ b/testsuite/tests/input/tex/Colortbl.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import { ColorArrayItem } from '#js/input/tex/colortbl/ColortblConfiguration.js';
 import '#js/input/tex/color/ColorConfiguration.js';
 

--- a/testsuite/tests/input/tex/Colorv2.test.ts
+++ b/testsuite/tests/input/tex/Colorv2.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/colorv2/ColorV2Configuration.js';
 
 beforeEach(() => setupTex(['base', 'colorv2']));

--- a/testsuite/tests/input/tex/ConfigMacros.test.ts
+++ b/testsuite/tests/input/tex/ConfigMacros.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { setupTex, tex2mml } from '#helpers';
+import { setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/configmacros/ConfigMacrosConfiguration.js';
 
 beforeEach(() => {});

--- a/testsuite/tests/input/tex/Dsfont.test.ts
+++ b/testsuite/tests/input/tex/Dsfont.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/dsfont/DsfontConfiguration.js';
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/Empheq.test.ts
+++ b/testsuite/tests/input/tex/Empheq.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/empheq/EmpheqConfiguration.js';
 import '#js/input/tex/cases/CasesConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';

--- a/testsuite/tests/input/tex/Enclose.test.ts
+++ b/testsuite/tests/input/tex/Enclose.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/enclose/EncloseConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'enclose']));

--- a/testsuite/tests/input/tex/Extpfeil.test.ts
+++ b/testsuite/tests/input/tex/Extpfeil.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/extpfeil/ExtpfeilConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'extpfeil']));

--- a/testsuite/tests/input/tex/Gensymb.test.ts
+++ b/testsuite/tests/input/tex/Gensymb.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/gensymb/GensymbConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'gensymb']));

--- a/testsuite/tests/input/tex/Html.test.ts
+++ b/testsuite/tests/input/tex/Html.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/html/HtmlConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'html']));

--- a/testsuite/tests/input/tex/Mathtools.test.ts
+++ b/testsuite/tests/input/tex/Mathtools.test.ts
@@ -5,7 +5,7 @@ import {
   tex2mml,
   expectTexError,
   trapErrors,
-} from '#helpers';
+} from '#src/index.js';
 import '#js/input/tex/mathtools/MathtoolsConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 import '#js/input/tex/boldsymbol/BoldsymbolConfiguration.js';

--- a/testsuite/tests/input/tex/Mhchem.test.ts
+++ b/testsuite/tests/input/tex/Mhchem.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/mhchem/MhchemConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 

--- a/testsuite/tests/input/tex/Newcommand.test.ts
+++ b/testsuite/tests/input/tex/Newcommand.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/newcommand/NewcommandConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 import '#js/input/tex/colorv2/ColorV2Configuration.js';

--- a/testsuite/tests/input/tex/Noerrors.test.ts
+++ b/testsuite/tests/input/tex/Noerrors.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { setupTex, tex2mml } from '#helpers';
+import { setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/noerrors/NoErrorsConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'noerrors']));

--- a/testsuite/tests/input/tex/Noundefined.test.ts
+++ b/testsuite/tests/input/tex/Noundefined.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { setupTex, tex2mml } from '#helpers';
+import { setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/noundefined/NoUndefinedConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'noundefined']));

--- a/testsuite/tests/input/tex/Physics.test.ts
+++ b/testsuite/tests/input/tex/Physics.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/physics/PhysicsConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'physics']));

--- a/testsuite/tests/input/tex/Require.test.ts
+++ b/testsuite/tests/input/tex/Require.test.ts
@@ -5,7 +5,7 @@ import {
   typeset2mml,
   setupComponents,
   expectTypesetError,
-} from '#helpers';
+} from '#src/index.js';
 
 import { Configuration } from '#js/input/tex/Configuration.js';
 import { HandlerType, ConfigurationType } from '#js/input/tex/HandlerTypes.js';

--- a/testsuite/tests/input/tex/SetOptions.test.ts
+++ b/testsuite/tests/input/tex/SetOptions.test.ts
@@ -6,7 +6,7 @@ import {
   typeset2mml,
   setupComponents,
   expectTexError,
-} from '#helpers';
+} from '#src/index.js';
 import '#js/input/tex/setoptions/SetOptionsConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 import '#js/input/tex/units/UnitsConfiguration.js';

--- a/testsuite/tests/input/tex/Tag.test.ts
+++ b/testsuite/tests/input/tex/Tag.test.ts
@@ -6,7 +6,7 @@ import {
   page2mml,
   setupComponents,
   expectTexError,
-} from '#helpers';
+} from '#src/index.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/TagFormat.test.ts
+++ b/testsuite/tests/input/tex/TagFormat.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from '@jest/globals';
-import { setupTex, tex2mml } from '#helpers';
+import { setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/tagformat/TagFormatConfiguration.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 

--- a/testsuite/tests/input/tex/Tex.test.ts
+++ b/testsuite/tests/input/tex/Tex.test.ts
@@ -9,7 +9,7 @@ import {
   trapOutput,
   trapErrors,
   expectTexError,
-} from '#helpers';
+} from '#src/index.js';
 import '#js/input/tex/ams/AmsConfiguration.js';
 import '#js/input/tex/newcommand/NewcommandConfiguration.js';
 

--- a/testsuite/tests/input/tex/TexHtml.test.ts
+++ b/testsuite/tests/input/tex/TexHtml.test.ts
@@ -6,7 +6,7 @@ import {
   tex2mml,
   render2mml,
   expectTexError,
-} from '#helpers';
+} from '#src/index.js';
 import '#js/input/tex/texhtml/TexHtmlConfiguration.js';
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/Textcomp.test.ts
+++ b/testsuite/tests/input/tex/Textcomp.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/textcomp/TextcompConfiguration.js';
 import '#js/input/tex/textmacros/TextMacrosConfiguration.js';
 

--- a/testsuite/tests/input/tex/Textmacros.test.ts
+++ b/testsuite/tests/input/tex/Textmacros.test.ts
@@ -8,7 +8,7 @@ import {
   setupComponents,
   expectTexError,
   expectTypesetError,
-} from '#helpers';
+} from '#src/index.js';
 import '#js/input/tex/textmacros/TextMacrosConfiguration.js';
 import '#js/input/tex/newcommand/NewcommandConfiguration.js';
 import '#js/input/tex/color/ColorConfiguration.js';

--- a/testsuite/tests/input/tex/Unicode.test.ts
+++ b/testsuite/tests/input/tex/Unicode.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/unicode/UnicodeConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'unicode']));

--- a/testsuite/tests/input/tex/UnitUtil.test.ts
+++ b/testsuite/tests/input/tex/UnitUtil.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from '@jest/globals';
+ import { describe, it, expect, beforeEach } from '@jest/globals';
 import { UnitUtil } from '#js/input/tex/UnitUtil.js';
 
 // These methods will be rewritten into non-ParseUtil ones.

--- a/testsuite/tests/input/tex/Units.test.ts
+++ b/testsuite/tests/input/tex/Units.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/units/UnitsConfiguration.js';
 
 /**********************************************************************************/

--- a/testsuite/tests/input/tex/Upgreek.test.ts
+++ b/testsuite/tests/input/tex/Upgreek.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { getTokens, setupTex, tex2mml } from '#helpers';
+import { getTokens, setupTex, tex2mml } from '#src/index.js';
 import '#js/input/tex/upgreek/UpgreekConfiguration.js';
 
 beforeEach(() => setupTex(['base', 'upgreek']));

--- a/testsuite/tests/input/tex/Verb.test.ts
+++ b/testsuite/tests/input/tex/Verb.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
-import { getTokens, setupTex, tex2mml, expectTexError } from '#helpers';
+ import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { getTokens, setupTex, tex2mml, expectTexError } from '#src/index.js';
 import '#js/input/tex/verb/VerbConfiguration.js';
 
 beforeEach(async () => setupTex(['base', 'verb']));

--- a/testsuite/tsconfig.json
+++ b/testsuite/tsconfig.json
@@ -8,8 +8,7 @@
     "paths": {
       "#js/*": ["../mjs/*"],
       "#source/*": ["../components/mjs/*"],
-      "#src/*": ["./src/*"],
-      "#helpers": ["./js/src/index.js"]
+      "#src/*": ["./src/*"]
     },
     "isolatedModules": true,
     "skipLibCheck": true,


### PR DESCRIPTION
I'm still getting typescript compile errors locally when I do 

``` shell
pnpm tsc -p testsuite/tsconfig.json
```

due to the `#helpers` imports, so this PR removes the `#helpers` pseudo-module and just loads from `#src/index.js`, since that is what it was trying to load anyway.  That seems to resolve the issue.
