### PR TITLE
Filter \t from URL protocols, same as \n and \r

### DIFF
--- a/ts/ui/safe/SafeMethods.ts
+++ b/ts/ui/safe/SafeMethods.ts
@@ -40,8 +40,8 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
    * @template D  The Document class
    */
   filterURL<N, T, D>(safe: Safe<N, T, D>, url: string): string | null {
-    const protocol = (url.match(/^\s*([a-z\n\r]+):/i) || [null, ''])[1]
-      .replace(/[\n\r]/g, '')
+    const protocol = (url.match(/^\s*([a-z\t\n\r]+):/i) || [null, ''])[1]
+      .replace(/[\t\n\r]/g, '')
       .toLowerCase();
     const allow = safe.allow.URLs;
     return allow === 'all' ||


### PR DESCRIPTION
This PR adds `\t` to the characters that are filtered by the Safe extension in URL protocols.  This prevents using `\t` to bypass the safe filtering.
