### PR TITLE
Update use of SPEECH and BRAILLE strings where they were missed earlier

### DIFF
--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -28,7 +28,7 @@ import { Explorer, AbstractExplorer } from './Explorer.js';
 import { ExplorerPool } from './ExplorerPool.js';
 import { HILITE, SAVED_HREF } from './strings.js';
 import { SEM } from '../semantic-enrich/strings.js';
-import { SPEECH } from '../speech/strings.js';
+import { SPEECH, BRAILLE } from '../speech/strings.js';
 import { MACTION } from '../semantic-enrich/maction.js';
 import { MmlNode } from '../../core/MmlTree/MmlNode.js';
 import { honk, SemAttr } from '../speech/SpeechUtil.js';
@@ -1206,10 +1206,10 @@ export class SpeechExplorer
     ssml: string[] = null,
     description: string = this.none
   ) {
-    if (!this.node.getAttribute('data-speech-attached') && speech) {
+    if (!this.node.getAttribute(SPEECH.ATTACHED) && speech) {
       speech = localize('Word/Math');
     }
-    if (!this.node.getAttribute('data-braille-attached') && braille) {
+    if (!this.node.getAttribute(BRAILLE.ATTACHED) && braille) {
       braille = localize('Word/Math');
     }
     const oldspeech = this.speech;

--- a/ts/a11y/semantic-enrich/strings.ts
+++ b/ts/a11y/semantic-enrich/strings.ts
@@ -22,7 +22,7 @@
  */
 
 export const SEM = {
-  ADDED: 'data-semanitic-added',
+  ADDED: 'data-semantic-added',
   ATTRIBUTES: 'data-semantic-attributes',
   CHILDREN: 'data-semantic-children',
   COLLAPSIBLE: 'data-semantic-collapsible',


### PR DESCRIPTION
This PR changes to explicit strings for their `SPEECH` and BRAILLE` visions, and corrects a typo in one `SEM` string.  Should be a quick one.