### PR TITLE
Use the ui/safe data URL filter for the values used in `\data` TeX macros

### DIFF
--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -250,8 +250,8 @@ export class HTMLDomStrings<N, T, D> {
   /**
    * Handle an arbitrary DOM node:
    *   Check the class to see if it matches the processHtmlClass regex
-   *   If the node has a child and is not marked as created by MathJax (data-MJX)
-   *       and either it is marked as restarting processing or is not a tag to be skipped, then
+   *   If the node has a child and either it is marked as restarting processing
+   *       or is not a tag to be skipped, then
    *     Save the next node (if there is one) and whether we are currently ignoring content
    *     Move to the first child node
    *     Update whether we are ignoring content
@@ -271,7 +271,6 @@ export class HTMLDomStrings<N, T, D> {
     let next;
     if (
       this.adaptor.firstChild(node) &&
-      !this.adaptor.getAttribute(node, 'data-MJX') &&
       (process || !this.skipHtmlTags.exec(tname))
     ) {
       if (this.adaptor.next(node)) {

--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -153,6 +153,19 @@ export class MathML<N, T, D> extends AbstractInputJax<
   }
 
   /**
+   * Set the filter functions for the Safe extension in the MathCompile class.
+   *
+   * @param {(string, string) => string} filterAttribute     The function to filter attributes
+   * @param {(list: string[]) => string[]} filterClassList   The function to filter classes
+   */
+  public setFilters(
+    filterAttribute: (name: string, value: string) => string,
+    filterClassList: (list: string[]) => string[],
+  ) : void {
+    this.mathml.setFilters(filterAttribute, filterClassList);
+  }
+
+  /**
    * Don't process strings (process nodes)
    *
    * @override

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -288,6 +288,20 @@ export class MathMLCompile<N, T, D> {
   }
 
   /**
+   * Set the filter functions for the Safe extension.
+   *
+   * @param {(string, string) => string} filterAttribute     The function to filter attributes
+   * @param {(list: string[]) => string[]} filterClassList   The function to filter classes
+   */
+  public setFilters(
+    filterAttribute: (name: string, value: string) => string,
+    filterClassList: (list: string[]) => string[],
+  ) : void {
+    this.filterAttribute = filterAttribute;
+    this.filterClassList = filterClassList;
+  }
+
+  /**
    * Convert the children of the MathML node and add them to the MmlNode
    *
    * @param {MmlNode} mml  The MmlNode to which children will be added

--- a/ts/input/tex/html/HtmlMethods.ts
+++ b/ts/input/tex/html/HtmlMethods.ts
@@ -67,7 +67,12 @@ const HtmlMethods: { [key: string]: ParseMethod } = {
       if (!isLegalAttributeName(key)) {
         texError(COMPONENT, 'InvalidHTMLAttr', `data-${key}`);
       }
-      NodeUtil.setAttribute(arg, `data-${key}`, data[key]);
+      const safe = parser.configuration.packageData.get('safe');
+      const id = `data-${key}`;
+      const value = safe ? safe.filterMethods.filterData(safe, data[key], id) : data[key];
+      if (value) {
+        NodeUtil.setAttribute(arg, id, value);
+      }
     }
     parser.Push(arg);
   },

--- a/ts/ui/safe/SafeHandler.ts
+++ b/ts/ui/safe/SafeHandler.ts
@@ -29,6 +29,8 @@ import {
 } from '../../core/MathDocument.js';
 import { Handler } from '../../core/Handler.js';
 import { DOM, DOM_TYPES, Constructor } from '../../types/Types.js';
+import type { MathML } from '../../input/mathml.js';
+import type { TeX } from '../../input/tex.js';
 
 import { Safe } from './safe.js';
 
@@ -140,13 +142,12 @@ export function SafeMathDocumentMixin<
       this.safe = new this.options.SafeClass(this, this.options.safeOptions);
       for (const jax of this.inputJax) {
         if (jax.name.match(/MathML/)) {
-          (jax as any).mathml.filterAttribute = this.safe.mmlAttribute.bind(
-            this.safe
-          );
-          (jax as any).mathml.filterClassList = this.safe.mmlClassList.bind(
-            this.safe
+          (jax as MathML<N, T, D>).setFilters(
+            this.safe.mmlAttribute.bind(this.safe),
+            this.safe.mmlClassList.bind(this.safe)
           );
         } else if (jax.name.match(/TeX/)) {
+          (jax as TeX<N, T, D>).parseOptions.packageData.set('safe', this.safe);
           jax.postFilters.add(this.sanitize.bind(jax), -5.5);
         }
       }
@@ -156,7 +157,7 @@ export function SafeMathDocumentMixin<
      * @param {object} data The argument containing math item and document
      * @param {MathItem<N, T, D>} data.math The math item to sanitize
      * @param {SafeMathDocument<N, T, D>} data.document The document to use for the
-     *     filter (note: this has been bound to the input jax)
+     *     filter (note: `this` has been bound to the input jax)
      */
     protected sanitize(data: {
       math: MathItem<N, T, D>;

--- a/ts/ui/safe/SafeMethods.ts
+++ b/ts/ui/safe/SafeMethods.ts
@@ -319,7 +319,7 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
    * @param {Safe<N,T,D>} safe  The Safe object being used
    * @param {string} value      The attribute's value
    * @param {string} id         The attribute's id (e.g., data-mjx-variant)
-   * @returns {number|null}     The sanitized value or null
+   * @returns {string|null}     The sanitized value or null
    *
    * @template N  The HTMLElement node class
    * @template T  The Text node class


### PR DESCRIPTION
This PR causes the `\data` macro in TeX to use the `ui/safe` data filter when the safe extension is loaded.  This prevents the `\data` macro from entering data attributes that could be harmful within frameworks that use data attributes for code control.

It also removes a reference that looks up a `data-MJX` attribute that is never actually set anywhere in the code.

In addition, it cleans up the mechanism used to set the MathML attribute and class filters by adding a service method to the MathML and MathMLCompile objects to set those values rather that casting the jax to `any` and setting them by hand.

Finally, it corrects an incorrect type that appears in the jsDoc for one of the safe methods.