### PR TITLE
Refactor templates to convert <N, T, D> to <DOM> to reduce number of templates.

### DIFF
--- a/components/mjs/output/util.d.ts
+++ b/components/mjs/output/util.d.ts
@@ -1,5 +1,6 @@
 import { OutputJax } from '@mathjax/src/mjs/core/OutputJax.js';
 import { Font } from '@mathjax/src/mjs/output/common/FontData.js';
+import { DOM_TYPES } from '@mathjax/src/mjs/types/Types.js';
 
 export function configFont(
   font: string,
@@ -18,9 +19,9 @@ export function configExtensions(
 
 export const OutputUtil: {
 
-  config<N = any, T = any, D = any>(
+  config<DOM extends DOM_TYPES>(
     jax: string,
-    jaxClass: OutputJax<N, T, D>,
+    jaxClass: OutputJax<DOM>,
     defaultFont: Font,
     fontClass: any,
   ): void,

--- a/testsuite/src/setupTex.ts
+++ b/testsuite/src/setupTex.ts
@@ -28,9 +28,10 @@ import {
   throwTexErrors,
   throwCompileErrors,
 } from './traps.js';
+import { DOM } from '#js/types/Types.js';
 
 declare const MathJax: any;
-type MATHITEM = MathItem<any, any, any>;
+type MATHITEM = MathItem<DOM>;
 type PackageList = (string | [string, number])[];
 
 Locale.asyncLoad = asyncLoad;

--- a/ts/a11y/assistive-mml.ts
+++ b/ts/a11y/assistive-mml.ts
@@ -34,7 +34,7 @@ import { MmlNode } from '../core/MmlTree/MmlNode.js';
 import { SerializedMmlVisitor } from '../core/MmlTree/SerializedMmlVisitor.js';
 import { expandable } from '../util/Options.js';
 import { StyleJson } from '../util/StyleJson.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../types/Types.js';
+import { DOM_TYPES, N, Constructor } from '../types/Types.js';
 
 /*==========================================================================*/
 
@@ -60,46 +60,38 @@ newState('ASSISTIVEMML', 153);
 /**
  * The functions added to MathItem for assistive MathML
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface AssistiveMmlMathItem<N, T, D> extends AbstractMathItem<
-  N,
-  T,
-  D
-> {
+export interface AssistiveMmlMathItem<
+  DOM extends DOM_TYPES,
+> extends AbstractMathItem<DOM> {
   /**
    * @param {MathDocument} document  The document where assistive MathML is being added
    * @param {boolean} force          True to force assistive MathML even if enableAssistiveMml is false
    */
-  assistiveMml(document: MathDocument<N, T, D>, force?: boolean): void;
+  assistiveMml(document: MathDocument<DOM>, force?: boolean): void;
 }
 
 /**
  * The mixin for adding assistive MathML to MathItems
  *
- * @param {B} BaseMathItem      The MathItem class to be extended
+ * @param {B} BaseMathItem          The MathItem class to be extended
  * @returns {AssistiveMmlMathItem}  The augmented MathItem class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathItem class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathItem class to extend
  */
 export function AssistiveMmlMathItemMixin<
-  N,
-  T,
-  D,
-  B extends Constructor<AbstractMathItem<N, T, D>>,
->(BaseMathItem: B): Constructor<AssistiveMmlMathItem<N, T, D>> & B {
+  DOM extends DOM_TYPES,
+  B extends Constructor<AbstractMathItem<DOM>>,
+>(BaseMathItem: B): Constructor<AssistiveMmlMathItem<DOM>> & B {
   return class extends BaseMathItem {
     /**
      * @param {MathDocument} document   The MathDocument for the MathItem
      * @param {boolean} force           True to force assistive MathML evenif enableAssistiveMml is false
      */
     public assistiveMml(
-      document: AssistiveMmlMathDocument<N, T, D>,
+      document: AssistiveMmlMathDocument<DOM>,
       force: boolean = false
     ) {
       if (this.state() >= STATE.ASSISTIVEMML) return;
@@ -133,7 +125,7 @@ export function AssistiveMmlMathItemMixin<
         // Hide the typeset math from assistive technology and append the MathML that is visually
         //   hidden from other users
         //
-        for (const child of adaptor.childNodes(this.typesetRoot) as N[]) {
+        for (const child of adaptor.childNodes(this.typesetRoot) as N<DOM>[]) {
           adaptor.setAttribute(child, 'aria-hidden', 'true');
         }
         adaptor.setStyle(this.typesetRoot, 'position', 'relative');
@@ -158,7 +150,7 @@ export type OPTIONS = {
  */
 export interface ASSISTIVEMML_OPTIONS<DOM extends DOM_TYPES>
   extends OPTIONS, DOCUMENT_OPTIONS<DOM> {
-  MathItem: Constructor<AssistiveMmlMathItem<N<DOM>, T<DOM>, D<DOM>>>;
+  MathItem: Constructor<AssistiveMmlMathItem<DOM>>;
 }
 
 /**
@@ -173,23 +165,19 @@ const options: OPTIONS = {
 /**
  * The functions added to MathDocument for assistive MathML
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
-  N,
-  T,
-  D
-> {
+export interface AssistiveMmlMathDocument<
+  DOM extends DOM_TYPES,
+> extends AbstractMathDocument<DOM> {
   /**
    * @override
    */
-  options: ASSISTIVEMML_OPTIONS<DOM<N, T, D>>;
+  options: ASSISTIVEMML_OPTIONS<DOM>;
 
   /**
    * @param {MmlNode} node   The node to be serializes
-   * @returns {string}        The serialization of the node
+   * @returns {string}       The serialization of the node
    */
   toMML: (node: MmlNode) => string;
 
@@ -204,26 +192,18 @@ export interface AssistiveMmlMathDocument<N, T, D> extends AbstractMathDocument<
 /**
  * The mixin for adding assistive MathML to MathDocuments
  *
- * @param {B} BaseDocument         The MathDocument class to be extended
+ * @param {B} BaseDocument              The MathDocument class to be extended
  * @returns {AssistiveMmlMathDocument}  The Assistive MathML MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathDocument class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathDocument class to extend
  */
 export function AssistiveMmlMathDocumentMixin<
-  N,
-  T,
-  D,
-  B extends MathDocumentConstructor<
-    AbstractMathDocument<N, T, D>,
-    DOM<N, T, D>
-  >,
+  DOM extends DOM_TYPES,
+  B extends MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>,
 >(
   BaseDocument: B
-): MathDocumentConstructor<AssistiveMmlMathDocument<N, T, D>, DOM<N, T, D>> &
-  B {
+): MathDocumentConstructor<AssistiveMmlMathDocument<DOM>, DOM> {
   return class BaseClass extends BaseDocument {
     /**
      * @override
@@ -234,13 +214,13 @@ export function AssistiveMmlMathDocumentMixin<
       renderActions: expandable({
         ...BaseDocument.OPTIONS.renderActions,
         assistiveMml: [STATE.ASSISTIVEMML],
-      }) as RenderActions<N, T, D>,
+      }) as RenderActions<DOM>,
     };
 
     /**
      * @override
      */
-    options: ASSISTIVEMML_OPTIONS<DOM<N, T, D>>;
+    options: ASSISTIVEMML_OPTIONS<DOM>;
 
     /**
      * styles needed for the hidden MathML
@@ -295,10 +275,8 @@ export function AssistiveMmlMathDocumentMixin<
       }
       this.visitor = new LimitedMmlVisitor(this.mmlFactory);
       this.options.MathItem = AssistiveMmlMathItemMixin<
-        N,
-        T,
-        D,
-        Constructor<AbstractMathItem<N, T, D>>
+        DOM,
+        Constructor<AbstractMathItem<DOM>>
       >(this.options.MathItem);
       if ('addStyles' in this) {
         (this as any).addStyles(CLASS.assistiveStyles);
@@ -307,7 +285,7 @@ export function AssistiveMmlMathDocumentMixin<
 
     /**
      * @param {MmlNode} node   The node to be serializes
-     * @returns {string}        The serialization of the node
+     * @returns {string}       The serialization of the node
      */
     public toMML(node: MmlNode): string {
       return this.visitor.visitTree(node);
@@ -316,12 +294,12 @@ export function AssistiveMmlMathDocumentMixin<
     /**
      * Add assistive MathML to the MathItems in this MathDocument
      *
-     * @returns {AssistiveMmlMathDocument<N, T, D>} The assistive mml document.
+     * @returns {AssistiveMmlMathDocument<DOM>} The assistive mml document.
      */
     public assistiveMml(): this {
       if (!this.processed.isSet('assistive-mml')) {
         for (const math of this.math) {
-          (math as AssistiveMmlMathItem<N, T, D>).assistiveMml(this);
+          (math as AssistiveMmlMathItem<DOM>).assistiveMml(this);
         }
         this.processed.set('assistive-mml');
       }
@@ -347,20 +325,16 @@ export function AssistiveMmlMathDocumentMixin<
  * Add assitive MathML support a Handler instance
  *
  * @param {Handler} handler   The Handler instance to enhance
- * @returns {Handler}          The handler that was modified (for purposes of chainging extensions)
+ * @returns {Handler}         The handler that was modified (for purposes of chainging extensions)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export function AssistiveMmlHandler<N, T, D>(
-  handler: Handler<N, T, D>
-): Handler<N, T, D> {
+export function AssistiveMmlHandler<DOM extends DOM_TYPES>(
+  handler: Handler<DOM>
+): Handler<DOM> {
   handler.documentClass = AssistiveMmlMathDocumentMixin<
-    N,
-    T,
-    D,
-    MathDocumentConstructor<AbstractMathDocument<N, T, D>, DOM<N, T, D>>
+    DOM,
+    MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>
   >(handler.documentClass);
   return handler;
 }

--- a/ts/a11y/complexity.ts
+++ b/ts/a11y/complexity.ts
@@ -37,18 +37,22 @@ import {
 } from './semantic-enrich.js';
 import { ComplexityVisitor } from './complexity/visitor.js';
 import { selectOptionsFromKeys, expandable } from '../util/Options.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../types/Types.js';
+import { DOM_TYPES, Constructor } from '../types/Types.js';
 
 /**
  * Shorthands for constructors
  */
-export type EMItemC<N, T, D> = Constructor<EnrichedMathItem<N, T, D>>;
-export type CMItemC<N, T, D> = Constructor<ComplexityMathItem<N, T, D>>;
-export type EMDocC<N, T, D> = MathDocumentConstructor<
-  EnrichedMathDocument<N, T, D>,
-  DOM<N, T, D>
+export type EMItemC<DOM extends DOM_TYPES> = Constructor<EnrichedMathItem<DOM>>;
+export type CMItemC<DOM extends DOM_TYPES> = Constructor<
+  ComplexityMathItem<DOM>
 >;
-export type CMDocC<N, T, D> = Constructor<ComplexityMathDocument<N, T, D>>;
+export type EMDocC<DOM extends DOM_TYPES> = MathDocumentConstructor<
+  EnrichedMathDocument<DOM>,
+  DOM
+>;
+export type CMDocC<DOM extends DOM_TYPES> = Constructor<
+  ComplexityMathDocument<DOM>
+>;
 
 /*==========================================================================*/
 
@@ -60,11 +64,11 @@ newState('COMPLEXITY', 40);
 /**
  * The functions added to MathItem for complexity
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ComplexityMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
+export interface ComplexityMathItem<
+  DOM extends DOM_TYPES,
+> extends EnrichedMathItem<DOM> {
   /**
    * The starting collapse ID for this expression
    */
@@ -74,25 +78,26 @@ export interface ComplexityMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
    * @param {ComplexityMathDocument} document   The MathDocument for the MathItem
    * @param {boolean} force                     True to force the computation even if enableComplexity is false
    */
-  complexity(document: ComplexityMathDocument<N, T, D>, force?: boolean): void;
+  complexity(document: ComplexityMathDocument<DOM>, force?: boolean): void;
 }
 
 /**
  * The mixin for adding complexity to MathItems
  *
- * @param {B} BaseMathItem       The MathItem class to be extended
- * @param {(math: ComplexityMathItem<N,T,D>) => void} computeComplexity Method of complexity computation.
- * @returns {ComplexityMathItem}  The complexity MathItem class
+ * @param {B} BaseMathItem                                         The MathItem class to be extended
+ * @param {(math: ComplexityMathItem) => void} computeComplexity   Method of complexity computation.
+ * @returns {ComplexityMathItem}                                   The complexity MathItem class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathItem class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathItem class to extend
  */
-export function ComplexityMathItemMixin<N, T, D, B extends EMItemC<N, T, D>>(
+export function ComplexityMathItemMixin<
+  DOM extends DOM_TYPES,
+  B extends EMItemC<DOM>,
+>(
   BaseMathItem: B,
-  computeComplexity: (math: ComplexityMathItem<N, T, D>) => void
-): CMItemC<N, T, D> & B {
+  computeComplexity: (math: ComplexityMathItem<DOM>) => void
+): CMItemC<DOM> & B {
   return class extends BaseMathItem {
     /**
      * The starting collapse ID for this expression
@@ -104,7 +109,7 @@ export function ComplexityMathItemMixin<N, T, D, B extends EMItemC<N, T, D>>(
      * @param {boolean} force                     True to force the computation even if enableComplexity is false
      */
     public complexity(
-      document: ComplexityMathDocument<N, T, D>,
+      document: ComplexityMathDocument<DOM>,
       force: boolean = false
     ) {
       if (this.state() >= STATE.COMPLEXITY) return;
@@ -132,7 +137,7 @@ export type OPTIONS = {
  */
 export interface COMPLEXITY_OPTIONS<DOM extends DOM_TYPES>
   extends OPTIONS, ENRICH_OPTIONS<DOM> {
-  MathItem: Constructor<ComplexityMathItem<N<DOM>, T<DOM>, D<DOM>>>;
+  MathItem: Constructor<ComplexityMathItem<DOM>>;
 }
 
 /**
@@ -148,19 +153,15 @@ const options: OPTIONS = {
 /**
  * The functions added to MathDocument for complexity
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ComplexityMathDocument<N, T, D> extends EnrichedMathDocument<
-  N,
-  T,
-  D
-> {
+export interface ComplexityMathDocument<
+  DOM extends DOM_TYPES,
+> extends EnrichedMathDocument<DOM> {
   /**
    * @override
    */
-  options: COMPLEXITY_OPTIONS<DOM<N, T, D>>;
+  options: COMPLEXITY_OPTIONS<DOM>;
 
   /**
    * Perform complexity computations on the MathItems in the MathDocument
@@ -173,17 +174,16 @@ export interface ComplexityMathDocument<N, T, D> extends EnrichedMathDocument<
 /**
  * The mixin for adding complexity to MathDocuments
  *
- * @param {B} BaseDocument     The MathDocument class to be extended
- * @returns {EnrichedMathDocument}  The enriched MathDocument class
+ * @param {B} BaseDocument           The MathDocument class to be extended
+ * @returns {EnrichedMathDocument}   The enriched MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathDocument class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathDocument class to extend
  */
-export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
-  BaseDocument: B
-): CMDocC<N, T, D> & B {
+export function ComplexityMathDocumentMixin<
+  DOM extends DOM_TYPES,
+  B extends EMDocC<DOM>,
+>(BaseDocument: B): CMDocC<DOM> & B {
   return class extends BaseDocument {
     /**
      * The options for this type of document
@@ -192,7 +192,7 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
       ...BaseDocument.OPTIONS,
       ...ComplexityVisitor.OPTIONS,
       ...options,
-      renderActions: expandable<RenderActions<N, T, D>>({
+      renderActions: expandable<RenderActions<DOM>>({
         ...BaseDocument.OPTIONS.renderActions,
         complexity: [STATE.COMPLEXITY],
       }),
@@ -201,7 +201,7 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
     /**
      * @override
      */
-    public options: COMPLEXITY_OPTIONS<DOM<N, T, D>>;
+    public options: COMPLEXITY_OPTIONS<DOM>;
 
     /**
      * The visitor that computes complexities
@@ -228,7 +228,7 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
         this.mmlFactory,
         visitorOptions
       );
-      const computeComplexity = (math: ComplexityMathItem<N, T, D>) => {
+      const computeComplexity = (math: ComplexityMathItem<DOM>) => {
         math.parseSemanticNodes();
         math.initialID = this.complexityVisitor.visitTree(
           math.root,
@@ -236,12 +236,10 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
           math.semanticNodes
         );
       };
-      this.options.MathItem = ComplexityMathItemMixin<
-        N,
-        T,
-        D,
-        EMItemC<N, T, D>
-      >(this.options.MathItem, computeComplexity);
+      this.options.MathItem = ComplexityMathItemMixin<DOM, EMItemC<DOM>>(
+        this.options.MathItem,
+        computeComplexity
+      );
     }
 
     /**
@@ -253,7 +251,7 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
       if (!this.processed.isSet('complexity')) {
         if (this.options.enableComplexity) {
           for (const math of this.math) {
-            (math as ComplexityMathItem<N, T, D>).complexity(this);
+            (math as ComplexityMathItem<DOM>).complexity(this);
           }
         }
         this.processed.set('complexity');
@@ -283,19 +281,17 @@ export function ComplexityMathDocumentMixin<N, T, D, B extends EMDocC<N, T, D>>(
  * @param {MathML} MmlJax     The MathML input jax to use for reading the enriched MathML
  * @returns {Handler}          The handler that was modified (for purposes of chainging extensions)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export function ComplexityHandler<N, T, D>(
-  handler: Handler<N, T, D>,
-  MmlJax: MathML<N, T, D> = null
-): Handler<N, T, D> {
+export function ComplexityHandler<DOM extends DOM_TYPES>(
+  handler: Handler<DOM>,
+  MmlJax: MathML<DOM> = null
+): Handler<DOM> {
   if (!handler.documentClass.prototype.enrich && MmlJax) {
     handler = EnrichHandler(handler, MmlJax);
   }
-  handler.documentClass = ComplexityMathDocumentMixin<N, T, D, EMDocC<N, T, D>>(
-    handler.documentClass as any
+  handler.documentClass = ComplexityMathDocumentMixin<DOM, EMDocC<DOM>>(
+    handler.documentClass as EMDocC<DOM>
   );
   return handler;
 }

--- a/ts/a11y/complexity/visitor.ts
+++ b/ts/a11y/complexity/visitor.ts
@@ -75,22 +75,21 @@ export class ComplexityVisitor extends MmlVisitor {
   /**
    * Values used to compute complexities
    */
-  /* prettier-ignore */
   public complexity = {
-    text: .5,           // each character of a token element adds this to complexity
-    token: .5,          // each token element gets this additional complexity
-    child: 1,           // child nodes add this to their parent node's complexity
+    text: 0.5, //          Each character of a token element adds this to complexity
+    token: 0.5, //         Each token element gets this additional complexity
+    child: 1, //           Child nodes add this to their parent node's complexity
 
-    script: .8,         // script elements reduce their complexity by this factor
-    sqrt: 2,            // sqrt adds this extra complexity
-    subsup: 2,          // sub-sup adds this extra complexity
-    underover: 2,       // under-over adds this extra complexity
-    fraction: 2,        // fractions add this extra complexity
-    enclose: 2,         // menclose adds this extra complexity
-    action: 2,          // maction adds this extra complexity
-    phantom: 0,         // mphantom makes complexity 0?
-    xml: 2,             // Can't really measure complexity of annotation-xml, so punt
-    glyph: 2            // Can't really measure complexity of mglyph, to punt
+    script: 0.8, //        Script elements reduce their complexity by this factor
+    sqrt: 2, //            Sqrt adds this extra complexity
+    subsup: 2, //          Sub-sup adds this extra complexity
+    underover: 2, //       Under-over adds this extra complexity
+    fraction: 2, //        Fractions add this extra complexity
+    enclose: 2, //         Menclose adds this extra complexity
+    action: 2, //          Maction adds this extra complexity
+    phantom: 0, //         Mphantom makes complexity 0?
+    xml: 2, //             Can't really measure complexity of annotation-xml, so punt
+    glyph: 2, //           Can't really measure complexity of mglyph, to punt
   };
 
   /**

--- a/ts/a11y/explorer.ts
+++ b/ts/a11y/explorer.ts
@@ -55,12 +55,12 @@ const isUnix = context.os === 'Unix';
 /**
  * Shorthands for types with HTMLElement, Text, and Document instead of generics
  */
-export type HANDLER = Handler<HTMLElement, Text, Document>;
-export type HTMLDOCUMENT = SpeechMathDocument<HTMLElement, Text, Document> & {
+export type HANDLER = Handler<HTML_DOM>;
+export type HTMLDOCUMENT = SpeechMathDocument<HTML_DOM> & {
   menu?: any;
 };
-export type HTMLMATHITEM = SpeechMathItem<HTMLElement, Text, Document>;
-export type MATHML = MathML<HTMLElement, Text, Document>;
+export type HTMLMATHITEM = SpeechMathItem<HTML_DOM>;
+export type MATHML = MathML<HTML_DOM>;
 
 /*==========================================================================*/
 
@@ -468,7 +468,7 @@ export interface ExplorerMathDocument extends HTMLDOCUMENT {
 /**
  * The mixin for adding the Explorer to MathDocuments
  *
- * @param {B} BaseDocument      The MathDocument class to be extended
+ * @param {B} BaseDocument          The MathDocument class to be extended
  * @returns {ExplorerMathDocument}  The extended MathDocument class
  *
  * @template B  The MathItem class to extend
@@ -482,17 +482,16 @@ export function ExplorerMathDocumentMixin<
     /**
      * @override
      */
-    /* prettier-ignore */
     public static OPTIONS = {
       ...BaseDocument.OPTIONS,
       ...options,
-      renderActions: expandable<RenderActions<HTMLElement, Text, Document>>({
+      renderActions: expandable<RenderActions<HTML_DOM>>({
         ...BaseDocument.OPTIONS.renderActions,
-        explorable: [STATE.EXPLORER]
+        explorable: [STATE.EXPLORER],
       }),
       sre: expandable<SRE_OPTIONS>({
-       ...(BaseDocument.OPTIONS as SPEECH_OPTIONS<HTML_DOM>).sre,
-        speech: 'none',                    // None as speech is explicitly computed
+        ...(BaseDocument.OPTIONS as SPEECH_OPTIONS<HTML_DOM>).sre,
+        speech: 'none', // None as speech is explicitly computed
       }),
       a11y: expandable<A11Y_OPTIONS['a11y']>({
         ...(BaseDocument.OPTIONS as SPEECH_OPTIONS<HTML_DOM>).a11y,

--- a/ts/a11y/explorer/KeyExplorer.ts
+++ b/ts/a11y/explorer/KeyExplorer.ts
@@ -36,6 +36,7 @@ import { GeneratorPool } from '../speech/GeneratorPool.js';
 import { context } from '../../util/context.js';
 import { InfoDialog } from '../../ui/dialog/InfoDialog.js';
 import { localize } from './__locales__/Component.js';
+import { HTML_DOM } from '../../types/dom/html.js';
 
 /**********************************************************************/
 
@@ -217,7 +218,7 @@ export class SpeechExplorer
    *
    * @returns {GeneratorPool} The item's generator pool.
    */
-  private get generators(): GeneratorPool<HTMLElement, Text, Document> {
+  private get generators(): GeneratorPool<HTML_DOM> {
     return this.item?.generatorPool;
   }
 
@@ -383,7 +384,7 @@ export class SpeechExplorer
       this.Start();
       this.backTab = event.target === this.img;
     } else if (!this.focusSpeech) {
-      this.speak('');  // don't speak initial equation until click event
+      this.speak(''); // don't speak initial equation until click event
     }
     this.clicked = null;
   }

--- a/ts/a11y/explorer/MouseExplorer.ts
+++ b/ts/a11y/explorer/MouseExplorer.ts
@@ -22,12 +22,7 @@
  */
 
 import type { ExplorerMathDocument } from '../explorer.js';
-import {
-  DummyRegion,
-  Region,
-  HoverRegion,
-  ToolTip,
-} from './Region.js';
+import { DummyRegion, Region, HoverRegion, ToolTip } from './Region.js';
 import { Explorer, AbstractExplorer } from './Explorer.js';
 import { ExplorerPool } from './ExplorerPool.js';
 import type { ExplorerMathItem } from '../explorer.js';

--- a/ts/a11y/semantic-enrich.ts
+++ b/ts/a11y/semantic-enrich.ts
@@ -47,7 +47,7 @@ import { MACTION } from './semantic-enrich/maction.js';
 import { StructureUtil, SemanticMap } from './speech/StructureUtil.js';
 import { Locale } from '../util/Locale.js';
 import { COMPONENT } from './semantic-enrich/__locales__/Component.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../types/Types.js';
+import { DOM, DOM_TYPES, Constructor } from '../types/Types.js';
 
 /*==========================================================================*/
 
@@ -58,10 +58,10 @@ newState('ENRICHED', STATE.COMPILED + 10);
 
 /*==========================================================================*/
 
-export class enrichVisitor<N, T, D> extends SerializedMmlVisitor {
+export class enrichVisitor<DOM extends DOM_TYPES> extends SerializedMmlVisitor {
   protected mactionId: number;
 
-  public visitTree(node: MmlNode, math?: MathItem<N, T, D>) {
+  public visitTree(node: MmlNode, math?: MathItem<DOM>) {
     this.mactionId = 0;
     const mml = super.visitTree(node);
     if (this.mactionId) {
@@ -104,11 +104,11 @@ export class enrichVisitor<N, T, D> extends SerializedMmlVisitor {
 /**
  * The functions added to MathItem for enrichment
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface EnrichedMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
+export interface EnrichedMathItem<
+  DOM extends DOM_TYPES,
+> extends AbstractMathItem<DOM> {
   /**
    * Maps semantic ids to extra nodes outside the DOM subtree.
    */
@@ -122,18 +122,18 @@ export interface EnrichedMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
   /**
    * The serialization visitor
    */
-  toMathML: (node: MmlNode, math: MathItem<N, T, D>) => string;
+  toMathML: (node: MmlNode, math: MathItem<DOM>) => string;
 
   /**
    * @param {MathDocument} document  The document where enrichment is occurring
    * @param {boolean} force          True to force the enrichment even if not enabled
    */
-  enrich(document: MathDocument<N, T, D>, force?: boolean): void;
+  enrich(document: MathDocument<DOM>, force?: boolean): void;
 
   /**
    * @param {MathDocument} document   The MathDocument for the MathItem
    */
-  unEnrich(document: MathDocument<N, T, D>): void;
+  unEnrich(document: MathDocument<DOM>): void;
 
   /**
    * @param {string} mml  The MathML string to enrich
@@ -150,21 +150,17 @@ export interface EnrichedMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
  * @param {Function} toMathML  The function to serialize the internal MathML
  * @returns {EnrichedMathItem}  The enriched MathItem class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathItem class to extend
+ * @template DOM   The DOM Node types
+ * @template B     The MathItem class to extend
  */
 export function EnrichedMathItemMixin<
-  N,
-  T,
-  D,
-  B extends Constructor<AbstractMathItem<N, T, D>>,
+  DOM extends DOM_TYPES,
+  B extends Constructor<AbstractMathItem<DOM>>,
 >(
   BaseMathItem: B,
-  MmlJax: MathML<N, T, D>,
-  toMathML: (node: MmlNode, math: MathItem<N, T, D>) => string
-): Constructor<EnrichedMathItem<N, T, D>> & B {
+  MmlJax: MathML<DOM>,
+  toMathML: (node: MmlNode, math: MathItem<DOM>) => string
+): Constructor<EnrichedMathItem<DOM>> & B {
   return class extends BaseMathItem {
     /**
      *  The MathML serializer
@@ -215,10 +211,7 @@ export function EnrichedMathItemMixin<
      * @param {EnrichedMathDocument} document   The MathDocument for the MathItem
      * @param {boolean} force                   True to force the enrichment even if not enabled
      */
-    public enrich(
-      document: EnrichedMathDocument<N, T, D>,
-      force: boolean = false
-    ) {
+    public enrich(document: EnrichedMathDocument<DOM>, force: boolean = false) {
       if (this.state() >= STATE.ENRICHED) return;
       if (!this.isEscaped && (document.options.enableEnrichment || force)) {
         this.semanticNodes = null;
@@ -265,7 +258,7 @@ export function EnrichedMathItemMixin<
     /**
      * @param {MathDocument} document   The MathDocument for the MathItem
      */
-    public unEnrich(document: MathDocument<N, T, D>) {
+    public unEnrich(document: MathDocument<DOM>) {
       const mml = this.inputData.originalMml;
       if (!mml) return;
       const math = new document.options.MathItem('', MmlJax);
@@ -334,8 +327,8 @@ const SRE_options: SRE_OPTIONS = {
 export interface OPTIONS<DOM extends DOM_TYPES> {
   enableEnrichment: boolean;
   enrichError: (
-    doc: EnrichedMathDocument<N<DOM>, T<DOM>, D<DOM>>,
-    math: EnrichedMathItem<N<DOM>, T<DOM>, D<DOM>>,
+    doc: EnrichedMathDocument<DOM>,
+    math: EnrichedMathItem<DOM>,
     err: Error
   ) => void;
   sre: SRE_OPTIONS;
@@ -346,7 +339,7 @@ export interface OPTIONS<DOM extends DOM_TYPES> {
  */
 export interface ENRICH_OPTIONS<DOM extends DOM_TYPES>
   extends OPTIONS<DOM>, DOCUMENT_OPTIONS<DOM> {
-  MathItem: Constructor<EnrichedMathItem<N<DOM>, T<DOM>, D<DOM>>>;
+  MathItem: Constructor<EnrichedMathItem<DOM>>;
 }
 
 /**
@@ -363,19 +356,15 @@ const options: OPTIONS<DOM> = {
 /**
  * The functions added to MathDocument for enrichment
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface EnrichedMathDocument<N, T, D> extends AbstractMathDocument<
-  N,
-  T,
-  D
-> {
+export interface EnrichedMathDocument<
+  DOM extends DOM_TYPES,
+> extends AbstractMathDocument<DOM> {
   /**
    * @override
    */
-  options: ENRICH_OPTIONS<DOM<N, T, D>>;
+  options: ENRICH_OPTIONS<DOM>;
 
   /**
    * Perform enrichment on the MathItems in the MathDocument
@@ -390,8 +379,8 @@ export interface EnrichedMathDocument<N, T, D> extends AbstractMathDocument<
    * @param {Error} err                  The error being processed
    */
   enrichError(
-    doc: EnrichedMathDocument<N, T, D>,
-    math: EnrichedMathItem<N, T, D>,
+    doc: EnrichedMathDocument<DOM>,
+    math: EnrichedMathItem<DOM>,
     err: Error
   ): void;
 }
@@ -403,23 +392,16 @@ export interface EnrichedMathDocument<N, T, D> extends AbstractMathDocument<
  * @param {MathML} MmlJax          The MathML input jax used to convert the enriched MathML
  * @returns {EnrichedMathDocument}  The enriched MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathDocument class to extend
+ * @template DOM   The DOM Node types
+ * @template B     The MathDocument class to extend
  */
 export function EnrichedMathDocumentMixin<
-  N,
-  T,
-  D,
-  B extends MathDocumentConstructor<
-    AbstractMathDocument<N, T, D>,
-    DOM<N, T, D>
-  >,
+  DOM extends DOM_TYPES,
+  B extends MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>,
 >(
   BaseDocument: B,
-  MmlJax: MathML<N, T, D>
-): MathDocumentConstructor<EnrichedMathDocument<N, T, D>, DOM<N, T, D>> & B {
+  MmlJax: MathML<DOM>
+): MathDocumentConstructor<EnrichedMathDocument<DOM>, DOM> {
   return class extends BaseDocument {
     /**
      * @override
@@ -427,7 +409,7 @@ export function EnrichedMathDocumentMixin<
     public static OPTIONS = {
       ...BaseDocument.OPTIONS,
       ...options,
-      renderActions: expandable<RenderActions<N, T, D>>({
+      renderActions: expandable<RenderActions<DOM>>({
         ...BaseDocument.OPTIONS.renderActions,
         enrich: [STATE.ENRICHED],
       }),
@@ -436,7 +418,7 @@ export function EnrichedMathDocumentMixin<
     /**
      * @override
      */
-    public options: ENRICH_OPTIONS<DOM<N, T, D>>;
+    public options: ENRICH_OPTIONS<DOM>;
 
     /**
      * Enrich the MathItem class used for this MathDocument, and create the
@@ -453,14 +435,12 @@ export function EnrichedMathDocumentMixin<
       if (!ProcessBits.has('enriched')) {
         ProcessBits.allocate('enriched');
       }
-      const visitor = new enrichVisitor<N, T, D>(this.mmlFactory);
-      const toMathML = (node: MmlNode, math: MathItem<N, T, D>) =>
+      const visitor = new enrichVisitor<DOM>(this.mmlFactory);
+      const toMathML = (node: MmlNode, math: MathItem<DOM>) =>
         visitor.visitTree(node, math);
       this.options.MathItem = EnrichedMathItemMixin<
-        N,
-        T,
-        D,
-        Constructor<AbstractMathItem<N, T, D>>
+        DOM,
+        Constructor<AbstractMathItem<DOM>>
       >(this.options.MathItem, MmlJax, toMathML);
     }
 
@@ -474,7 +454,7 @@ export function EnrichedMathDocumentMixin<
         if (this.options.enableEnrichment) {
           Sre.setupEngine(this.options.sre as any);
           for (const math of this.math) {
-            (math as EnrichedMathItem<N, T, D>).enrich(this);
+            (math as EnrichedMathItem<DOM>).enrich(this);
           }
         }
         this.processed.set('enriched');
@@ -486,8 +466,8 @@ export function EnrichedMathDocumentMixin<
      * @override
      */
     public enrichError(
-      _doc: EnrichedMathDocument<N, T, D>,
-      _math: EnrichedMathItem<N, T, D>,
+      _doc: EnrichedMathDocument<DOM>,
+      _math: EnrichedMathItem<DOM>,
       err: Error
     ) {
       console.warn(Locale.message(COMPONENT, 'EnrichError'), err);
@@ -502,7 +482,7 @@ export function EnrichedMathDocumentMixin<
         this.processed.clear('enriched');
         if (state >= STATE.COMPILED) {
           for (const item of this.math) {
-            (item as EnrichedMathItem<N, T, D>).unEnrich(this);
+            (item as EnrichedMathItem<DOM>).unEnrich(this);
           }
         }
       }
@@ -520,20 +500,16 @@ export function EnrichedMathDocumentMixin<
  * @param {MathML} MmlJax     The MathML input jax to use for reading the enriched MathML
  * @returns {Handler}          The handler that was modified (for purposes of chainging extensions)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export function EnrichHandler<N, T, D>(
-  handler: Handler<N, T, D>,
-  MmlJax: MathML<N, T, D>
-): Handler<N, T, D> {
+export function EnrichHandler<DOM extends DOM_TYPES>(
+  handler: Handler<DOM>,
+  MmlJax: MathML<DOM>
+): Handler<DOM> {
   MmlJax.setAdaptor(handler.adaptor);
   handler.documentClass = EnrichedMathDocumentMixin<
-    N,
-    T,
-    D,
-    MathDocumentConstructor<AbstractMathDocument<N, T, D>, DOM<N, T, D>>
+    DOM,
+    MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>
   >(handler.documentClass, MmlJax);
   return handler;
 }

--- a/ts/a11y/speech.ts
+++ b/ts/a11y/speech.ts
@@ -40,7 +40,7 @@ import { GeneratorPool } from './speech/GeneratorPool.js';
 import { WorkerHandler } from './speech/WebWorker.js';
 import { sreRoot } from '#root/sre-root.js';
 import { localize } from './speech/__locales__/Component.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../types/Types.js';
+import { DOM, DOM_TYPES, Constructor } from '../types/Types.js';
 
 /*==========================================================================*/
 
@@ -54,25 +54,25 @@ newState('ATTACHSPEECH', STATE.INSERTED + 10);
 /**
  * The functions added to MathItem for enrichment
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SpeechMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
+export interface SpeechMathItem<
+  DOM extends DOM_TYPES,
+> extends EnrichedMathItem<DOM> {
   /**
    * The speech generators for this math item.
    */
-  generatorPool: GeneratorPool<N, T, D>;
+  generatorPool: GeneratorPool<DOM>;
 
   /**
    * @param {MathDocument} document  The document where speech is added
    */
-  attachSpeech(document: MathDocument<N, T, D>): void;
+  attachSpeech(document: MathDocument<DOM>): void;
 
   /**
    * @param {MathDocument} document The MathDocument for the MathItem
    */
-  detachSpeech(document: MathDocument<N, T, D>): void;
+  detachSpeech(document: MathDocument<DOM>): void;
 
   /**
    * @param {string} mml The MathML whose speech is needed.
@@ -87,29 +87,25 @@ export interface SpeechMathItem<N, T, D> extends EnrichedMathItem<N, T, D> {
  * @param {B} EnrichedMathItem     The MathItem class to be extended
  * @returns {SpeechMathItem}  The enriched MathItem class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathItem class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathItem class to extend
  */
 export function SpeechMathItemMixin<
-  N,
-  T,
-  D,
-  B extends Constructor<EnrichedMathItem<N, T, D>>,
->(EnrichedMathItem: B): Constructor<SpeechMathItem<N, T, D>> & B {
+  DOM extends DOM_TYPES,
+  B extends Constructor<EnrichedMathItem<DOM>>,
+>(EnrichedMathItem: B): Constructor<SpeechMathItem<DOM>> & B {
   return class extends EnrichedMathItem {
     /**
      * @override
      */
-    public generatorPool = new GeneratorPool<N, T, D>();
+    public generatorPool = new GeneratorPool<DOM>();
 
     /**
      * Attaches the aria labels for speech and braille.
      *
      * @param {MathDocument} document   The MathDocument for the MathItem
      */
-    public attachSpeech(document: SpeechMathDocument<N, T, D>) {
+    public attachSpeech(document: SpeechMathDocument<DOM>) {
       this.outputData.speechPromise = null;
       if (this.state() >= STATE.ATTACHSPEECH) return;
       this.state(STATE.ATTACHSPEECH);
@@ -137,7 +133,7 @@ export function SpeechMathItemMixin<
     /**
      * @param {SpeechMathDocument} document  The MathDocument for the MathItem
      */
-    public detachSpeech(document: SpeechMathDocument<N, T, D>) {
+    public detachSpeech(document: SpeechMathDocument<DOM>) {
       document.webworker.Detach(this);
     }
 
@@ -177,8 +173,8 @@ export type OPTIONS<DOM extends DOM_TYPES> = {
   enableSpeech: boolean;
   enableBraille: boolean;
   speechError: (
-    doc: SpeechMathDocument<N<DOM>, T<DOM>, D<DOM>>,
-    math: SpeechMathItem<N<DOM>, T<DOM>, D<DOM>>,
+    doc: SpeechMathDocument<DOM>,
+    math: SpeechMathItem<DOM>,
     err: string
   ) => void;
   worker: {
@@ -201,7 +197,7 @@ export type A11Y_OPTIONS = {
  */
 export interface SPEECH_OPTIONS<DOM extends DOM_TYPES>
   extends OPTIONS<DOM>, A11Y_OPTIONS, ENRICH_OPTIONS<DOM> {
-  MathItem: Constructor<SpeechMathItem<N<DOM>, T<DOM>, D<DOM>>>;
+  MathItem: Constructor<SpeechMathItem<DOM>>;
 }
 
 /**
@@ -224,24 +220,20 @@ const options: OPTIONS<DOM> = {
 /**
  * The functions added to MathDocument for enrichment
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SpeechMathDocument<N, T, D> extends EnrichedMathDocument<
-  N,
-  T,
-  D
-> {
+export interface SpeechMathDocument<
+  DOM extends DOM_TYPES,
+> extends EnrichedMathDocument<DOM> {
   /**
    * @override
    */
-  options: SPEECH_OPTIONS<DOM<N, T, D>>;
+  options: SPEECH_OPTIONS<DOM>;
 
   /**
    * The webworker handler for the document
    */
-  webworker: WorkerHandler<N, T, D>;
+  webworker: WorkerHandler<DOM>;
 
   /**
    * Attach speech to the MathItems in the MathDocument
@@ -256,8 +248,8 @@ export interface SpeechMathDocument<N, T, D> extends EnrichedMathDocument<
    * @param {string} err               The error message being processed
    */
   speechError(
-    doc: SpeechMathDocument<N, T, D>,
-    math: SpeechMathItem<N, T, D>,
+    doc: SpeechMathDocument<DOM>,
+    math: SpeechMathItem<DOM>,
     err: string
   ): void;
 
@@ -273,22 +265,15 @@ export interface SpeechMathDocument<N, T, D> extends EnrichedMathDocument<
  * @param {B} EnrichedMathDocument The MathDocument class to be extended
  * @returns {SpeechMathDocument}  The enriched MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathDocument class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathDocument class to extend
  */
 export function SpeechMathDocumentMixin<
-  N,
-  T,
-  D,
-  B extends MathDocumentConstructor<
-    EnrichedMathDocument<N, T, D>,
-    DOM<N, T, D>
-  >,
+  DOM extends DOM_TYPES,
+  B extends MathDocumentConstructor<EnrichedMathDocument<DOM>, DOM>,
 >(
   EnrichedMathDocument: B
-): MathDocumentConstructor<SpeechMathDocument<N, T, D>, DOM<N, T, D>> & B {
+): MathDocumentConstructor<SpeechMathDocument<DOM>, DOM> & B {
   return class extends EnrichedMathDocument {
     /**
      * @override
@@ -296,7 +281,7 @@ export function SpeechMathDocumentMixin<
     public static OPTIONS = {
       ...EnrichedMathDocument.OPTIONS,
       ...options,
-      renderActions: expandable<RenderActions<N, T, D>>({
+      renderActions: expandable<RenderActions<DOM>>({
         ...EnrichedMathDocument.OPTIONS.renderActions,
         attachSpeech: [STATE.ATTACHSPEECH],
       }),
@@ -309,12 +294,12 @@ export function SpeechMathDocumentMixin<
     /**
      * @override
      */
-    public options: SPEECH_OPTIONS<DOM<N, T, D>>;
+    public options: SPEECH_OPTIONS<DOM>;
 
     /**
      * The webworker handler for the document
      */
-    public webworker: WorkerHandler<N, T, D> = null;
+    public webworker: WorkerHandler<DOM> = null;
 
     /**
      * Enrich the MathItem class used for this MathDocument, and create the
@@ -331,10 +316,8 @@ export function SpeechMathDocumentMixin<
         ProcessBits.allocate('attach-speech');
       }
       this.options.MathItem = SpeechMathItemMixin<
-        N,
-        T,
-        D,
-        Constructor<EnrichedMathItem<N, T, D>>
+        DOM,
+        Constructor<EnrichedMathItem<DOM>>
       >(this.options.MathItem);
     }
 
@@ -361,7 +344,7 @@ export function SpeechMathDocumentMixin<
         ) {
           this.getWebworker();
           for (const math of this.math) {
-            (math as SpeechMathItem<N, T, D>).attachSpeech(this);
+            (math as SpeechMathItem<DOM>).attachSpeech(this);
           }
         }
         this.processed.set('attach-speech');
@@ -373,8 +356,8 @@ export function SpeechMathDocumentMixin<
      * @override
      */
     public speechError(
-      _doc: SpeechMathDocument<N, T, D>,
-      _math: SpeechMathItem<N, T, D>,
+      _doc: SpeechMathDocument<DOM>,
+      _math: SpeechMathItem<DOM>,
       err: string
     ) {
       if (err) {
@@ -391,7 +374,7 @@ export function SpeechMathDocumentMixin<
         this.processed.clear('attach-speech');
         if (state >= STATE.TYPESET) {
           for (const math of this.math) {
-            (math as SpeechMathItem<N, T, D>).detachSpeech(this);
+            (math as SpeechMathItem<DOM>).detachSpeech(this);
           }
         }
       }
@@ -417,17 +400,18 @@ export function SpeechMathDocumentMixin<
  * @param {MathML} MmlJax     The MathML input jax to use for reading the enriched MathML
  * @returns {Handler}         The handler that was modified (for purposes of chainging extensions)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export function SpeechHandler<N, T, D>(
-  handler: Handler<N, T, D>,
-  MmlJax: MathML<N, T, D>
-): Handler<N, T, D> {
+export function SpeechHandler<DOM extends DOM_TYPES>(
+  handler: Handler<DOM>,
+  MmlJax: MathML<DOM>
+): Handler<DOM> {
   if (!handler.documentClass.prototype.enrich && MmlJax) {
     handler = EnrichHandler(handler, MmlJax);
   }
-  handler.documentClass = SpeechMathDocumentMixin(handler.documentClass as any);
+  handler.documentClass = SpeechMathDocumentMixin<
+    DOM,
+    MathDocumentConstructor<EnrichedMathDocument<DOM>, DOM>
+  >(handler.documentClass as any);
   return handler;
 }

--- a/ts/a11y/speech/GeneratorPool.ts
+++ b/ts/a11y/speech/GeneratorPool.ts
@@ -28,15 +28,14 @@ import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { SpeechMathItem } from '../speech.js';
 import { WorkerHandler } from './WebWorker.js';
 import { SEM } from '../semantic-enrich/strings.js';
+import { DOM_TYPES, N } from '../../types/Types.js';
 import { localize } from '../speech/__locales__/Component.js';
 
 /**
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class GeneratorPool<N, T, D> {
-  private webworker: WorkerHandler<N, T, D>;
+export class GeneratorPool<DOM extends DOM_TYPES> {
+  private webworker: WorkerHandler<DOM>;
   private _element: Element;
 
   set element(element: Element) {
@@ -55,7 +54,7 @@ export class GeneratorPool<N, T, D> {
   /**
    * The adaptor to work with typeset nodes.
    */
-  public adaptor: DOMAdaptor<N, T, D> = null;
+  public adaptor: DOMAdaptor<DOM> = null;
 
   /**
    *  The current speech setting for Sre
@@ -91,8 +90,8 @@ export class GeneratorPool<N, T, D> {
    */
   public init(
     options: OptionList,
-    adaptor: DOMAdaptor<N, T, D>,
-    webworker: WorkerHandler<N, T, D>
+    adaptor: DOMAdaptor<DOM>,
+    webworker: WorkerHandler<DOM>
   ) {
     this.options = options;
     if (this._init) return;
@@ -117,13 +116,13 @@ export class GeneratorPool<N, T, D> {
    * @param {SpeechMathItem} item   The SpeechMathItem to add speech to
    * @returns {Promise<void>}       The promise that resolves when the command is complete
    */
-  public Speech(item: SpeechMathItem<N, T, D>): Promise<void> {
+  public Speech(item: SpeechMathItem<DOM>): Promise<void> {
     const mml = item.outputData.mml;
     const options = Object.assign({}, this.options, { modality: 'speech' });
     return (this.promise = this.webworker.Speech(mml, options, item));
   }
 
-  public SpeechFor(item: SpeechMathItem<N, T, D>, mml: string): Promise<any> {
+  public SpeechFor(item: SpeechMathItem<DOM>, mml: string): Promise<any> {
     const options = Object.assign({}, this.options, { modality: 'speech' });
     return this.webworker.speechFor(mml, options, item);
   }
@@ -133,7 +132,7 @@ export class GeneratorPool<N, T, D> {
    *
    * @param {SpeechMathItem} item   The SpeechMathItem whose task is to be cancelled
    */
-  public cancel(item: SpeechMathItem<N, T, D>) {
+  public cancel(item: SpeechMathItem<DOM>) {
     this.webworker?.Cancel(item);
   }
 
@@ -146,7 +145,7 @@ export class GeneratorPool<N, T, D> {
    * @param {LiveRegion} brailleRegion   The braille region.
    */
   public updateRegions(
-    node: N,
+    node: N<DOM>,
     speechRegion: LiveRegion,
     brailleRegion: LiveRegion
   ) {
@@ -160,7 +159,7 @@ export class GeneratorPool<N, T, D> {
    * @param {N} node         The root node of the expression.
    * @returns {OptionList}   The relevant SRE options.
    */
-  private getOptions(node: N): OptionList {
+  private getOptions(node: N<DOM>): OptionList {
     return {
       locale: this.adaptor.getAttribute(node, SEM.LOCALE) ?? '',
       domain: this.adaptor.getAttribute(node, SEM.DOMAIN) ?? '',
@@ -175,7 +174,7 @@ export class GeneratorPool<N, T, D> {
    * @param {SpeechMathItem} item   The SpeechMathItem whose rule set is changing
    * @returns {Promise<void>}       A promise that resolves when the command completes
    */
-  public nextRules(item: SpeechMathItem<N, T, D>): Promise<void> {
+  public nextRules(item: SpeechMathItem<DOM>): Promise<void> {
     const options = this.getOptions(item.typesetRoot);
     this.update(options);
     return (this.promise = this.webworker.nextRules(
@@ -192,7 +191,7 @@ export class GeneratorPool<N, T, D> {
    * @param {SpeechMathItem} item   The SpeechMathItem whose preferences are changing
    * @returns {Promise<void>}       A promise that resolves when the command completes
    */
-  public nextStyle(node: N, item: SpeechMathItem<N, T, D>): Promise<void> {
+  public nextStyle(node: N<DOM>, item: SpeechMathItem<DOM>): Promise<void> {
     const options = this.getOptions(item.typesetRoot);
     this.update(options);
     return (this.promise = this.webworker.nextStyle(
@@ -211,7 +210,11 @@ export class GeneratorPool<N, T, D> {
    * @param {string=} sep       The speech separator. Defaults to space.
    * @returns {string}          The assembled label.
    */
-  public getLabel(node: N, _center: string = '', sep: string = ' '): string {
+  public getLabel(
+    node: N<DOM>,
+    _center: string = '',
+    sep: string = ' '
+  ): string {
     const adaptor = this.adaptor;
     if (!this.webworker.ready) {
       // return document.querySelector('.mjx-selected').textContent;
@@ -234,7 +237,7 @@ export class GeneratorPool<N, T, D> {
    * @param {N} node            The typeset node.
    * @returns {string}          The assembled label.
    */
-  public getBraille(node: N): string {
+  public getBraille(node: N<DOM>): string {
     const adaptor = this.adaptor;
     if (!this.webworker.ready) {
       // return document.querySelector('.mjx-selected').textContent;
@@ -276,7 +279,7 @@ export class GeneratorPool<N, T, D> {
    * @returns {Promise<void>} The promise that resolves when the command is complete
    */
   public getRelevantPreferences(
-    item: SpeechMathItem<N, T, D>,
+    item: SpeechMathItem<DOM>,
     semantic: string,
     prefs: Map<number, string>,
     counter: number

--- a/ts/a11y/speech/WebWorker.ts
+++ b/ts/a11y/speech/WebWorker.ts
@@ -31,14 +31,17 @@ import { SPEECH, BRAILLE } from './strings.js';
 import { StyleJsonData } from '../../util/StyleJson.js';
 import { Locale } from '../../util/Locale.js';
 import { localize, COMPONENT } from './__locales__/Component.js';
+import { DOM_TYPES, N, NT } from '../../types/Types.js';
 
 /**
  * Class for relevant task information.
+ *
+ * @template DOM   The DOM node types
  */
-class Task<N, T, D> {
+class Task<DOM extends DOM_TYPES> {
   constructor(
     public cmd: ClientCommand,
-    public item: SpeechMathItem<N, T, D>,
+    public item: SpeechMathItem<DOM>,
     public resolve: (value: any) => void,
     public reject: (cmd: string) => void
   ) {}
@@ -47,11 +50,9 @@ class Task<N, T, D> {
 /**
  * The main WorkerHandler class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class WorkerHandler<N, T, D> {
+export class WorkerHandler<DOM extends DOM_TYPES> {
   /**
    * Callback for ready signal
    */
@@ -60,7 +61,7 @@ export class WorkerHandler<N, T, D> {
   /**
    * The task queue
    */
-  private tasks: Task<N, T, D>[] = [];
+  private tasks: Task<DOM>[] = [];
 
   /**
    * The webworker
@@ -87,7 +88,7 @@ export class WorkerHandler<N, T, D> {
    * @param {OptionList} options The worker options.
    */
   constructor(
-    public adaptor: DOMAdaptor<N, T, D>,
+    public adaptor: DOMAdaptor<DOM>,
     private options: OptionList
   ) {}
 
@@ -142,10 +143,7 @@ export class WorkerHandler<N, T, D> {
    *     command name as input.
    * @returns {Promise<any>} A promise that resolves when the command completes
    */
-  public Post(
-    msg: ClientCommand,
-    item?: SpeechMathItem<N, T, D>
-  ): Promise<any> {
+  public Post(msg: ClientCommand, item?: SpeechMathItem<DOM>): Promise<any> {
     const promise = new Promise((resolve, reject) => {
       this.tasks.push(new Task(msg, item, resolve, reject));
     });
@@ -172,7 +170,7 @@ export class WorkerHandler<N, T, D> {
    *
    * @param {SpeechMathItem} item   The item whose task is to be canceled.
    */
-  public Cancel(item: SpeechMathItem<N, T, D>) {
+  public Cancel(item: SpeechMathItem<DOM>) {
     const i = this.tasks.findIndex((task) => task.item === item);
     if (i > 0) {
       this.tasks[i].reject(localize('Worker/Cancelled', this.tasks[i].cmd.cmd));
@@ -209,7 +207,7 @@ export class WorkerHandler<N, T, D> {
   public async Speech(
     math: string,
     options: OptionList,
-    item: SpeechMathItem<N, T, D>
+    item: SpeechMathItem<DOM>
   ): Promise<void> {
     this.Attach(
       item,
@@ -237,7 +235,7 @@ export class WorkerHandler<N, T, D> {
   public async nextRules(
     math: string,
     options: OptionList,
-    item: SpeechMathItem<N, T, D>
+    item: SpeechMathItem<DOM>
   ): Promise<void> {
     this.Attach(
       item,
@@ -273,7 +271,7 @@ export class WorkerHandler<N, T, D> {
     math: string,
     options: OptionList,
     nodeId: string,
-    item: SpeechMathItem<N, T, D>
+    item: SpeechMathItem<DOM>
   ): Promise<void> {
     this.Attach(
       item,
@@ -304,7 +302,7 @@ export class WorkerHandler<N, T, D> {
   public async speechFor(
     math: string,
     options: OptionList,
-    item: SpeechMathItem<N, T, D>
+    item: SpeechMathItem<DOM>
   ): Promise<Structure> {
     const data = await this.Post(
       {
@@ -325,7 +323,7 @@ export class WorkerHandler<N, T, D> {
    * @param {string} structure          The speech JSON structure to attach
    */
   public Attach(
-    item: SpeechMathItem<N, T, D>,
+    item: SpeechMathItem<DOM>,
     speech: boolean,
     braille: boolean,
     structure: string
@@ -347,9 +345,9 @@ export class WorkerHandler<N, T, D> {
       if (!node || !adaptor.childNodes(node)[0]) {
         continue;
       }
-      node = adaptor.childNodes(node)[0] as N;
+      node = adaptor.childNodes(node)[0] as N<DOM>;
       if (adaptor.kind(node) === 'rect') {
-        node = adaptor.next(node) as N;
+        node = adaptor.next(node) as N<DOM>;
       }
       adaptor.setAttribute(node, SEM.TYPE, 'dummy');
       this.setSpecialAttributes(node, sid, '');
@@ -387,7 +385,7 @@ export class WorkerHandler<N, T, D> {
    * @param {boolean} braille  True when Braille should be added
    */
   protected setSpeechAttribute(
-    node: N,
+    node: N<DOM>,
     data: Structure,
     speech: boolean,
     braille: boolean
@@ -414,7 +412,7 @@ export class WorkerHandler<N, T, D> {
   /**
    * Add the speech attributes to a node's DOM tree
    *
-   * @param {N|T} root         The node to add speech to
+   * @param {NT} root          The node to add speech to
    * @param {string} rootId    The root nodes's ID
    * @param {Structure} data   The speech data to use
    * @param {boolean} speech   True when speech should be added
@@ -422,7 +420,7 @@ export class WorkerHandler<N, T, D> {
    * @returns {string}         The updated root ID
    */
   protected setSpeechAttributes(
-    root: N | T,
+    root: NT<DOM>,
     rootId: string,
     data: Structure,
     speech: boolean,
@@ -436,7 +434,7 @@ export class WorkerHandler<N, T, D> {
     ) {
       return rootId;
     }
-    root = root as N;
+    root = root as N<DOM>;
     if (adaptor.hasAttribute(root, SEM.ID)) {
       this.setSpeechAttribute(root, data, speech, braille);
       if (!rootId && !adaptor.hasAttribute(root, SEM.PARENT)) {
@@ -458,7 +456,7 @@ export class WorkerHandler<N, T, D> {
    * @param {string[]} keys An optional list to select only those attributes.
    */
   protected setSpecialAttributes(
-    node: N,
+    node: N<DOM>,
     map: OptionList,
     prefix: string,
     keys?: string[]
@@ -478,7 +476,7 @@ export class WorkerHandler<N, T, D> {
    *
    * @param {SpeechMathItem} item   The MathItem whose speech attributes should be removed.
    */
-  public Detach(item: SpeechMathItem<N, T, D>) {
+  public Detach(item: SpeechMathItem<DOM>) {
     const container = item.typesetRoot;
     this.adaptor.removeAttribute(container, SPEECH.ATTACHED);
     this.adaptor.removeAttribute(container, BRAILLE.ATTACHED);
@@ -490,7 +488,7 @@ export class WorkerHandler<N, T, D> {
    *
    * @param {N} node  The root node of the tree to modify
    */
-  public detachSpeech(node: N) {
+  public detachSpeech(node: N<DOM>) {
     const adaptor = this.adaptor;
     const children = adaptor.childNodes(node);
     if (!children) return;
@@ -507,7 +505,7 @@ export class WorkerHandler<N, T, D> {
       }
     }
     for (const child of children) {
-      this.detachSpeech(child as N);
+      this.detachSpeech(child as N<DOM>);
     }
   }
 
@@ -604,7 +602,7 @@ export class WorkerHandler<N, T, D> {
    * The list of valid commands from the Worker.
    */
   public Commands: {
-    [id: string]: (handler: WorkerHandler<N, T, D>, data: Message) => void;
+    [id: string]: (handler: WorkerHandler<DOM>, data: Message) => void;
   } = {
     /**
      * This signals that the worker in the iframe is loaded and ready
@@ -612,7 +610,7 @@ export class WorkerHandler<N, T, D> {
      * @param {WorkerHandler} handler The active handler for the worker.
      * @param {Message} _data The data received from the worker. Ignored.
      */
-    Ready(handler: WorkerHandler<N, T, D>, _data: Message) {
+    Ready(handler: WorkerHandler<DOM>, _data: Message) {
       handler.ready = true;
       handler.postNext();
     },
@@ -623,7 +621,7 @@ export class WorkerHandler<N, T, D> {
      * @param {WorkerHandler} handler The active handler for the worker.
      * @param {Message} data The data received from the worker.
      */
-    Finished(handler: WorkerHandler<N, T, D>, data: Message) {
+    Finished(handler: WorkerHandler<DOM>, data: Message) {
       const task = handler.tasks.shift();
       if (data.success) {
         task.resolve(data.result);
@@ -639,7 +637,7 @@ export class WorkerHandler<N, T, D> {
      * @param {WorkerHandler} handler The active handler for the worker.
      * @param {Message} data The data received from the worker.
      */
-    Log(handler: WorkerHandler<N, T, D>, data: Message) {
+    Log(handler: WorkerHandler<DOM>, data: Message) {
       if (handler.options.debug) {
         console.log('Log:', data);
       }
@@ -651,7 +649,7 @@ export class WorkerHandler<N, T, D> {
      * @param {WorkerHandler} handler The active handler for the worker.
      * @param {Message} data The data received from the worker.
      */
-    Failed(handler: WorkerHandler<N, T, D>, data: Message) {
+    Failed(handler: WorkerHandler<DOM>, data: Message) {
       const { path, worker } = handler.options;
       Locale.warn(
         COMPONENT,
@@ -669,7 +667,7 @@ export class WorkerHandler<N, T, D> {
      * @param {WorkerHandler} handler The active handler for the worker.
      * @param {Message} data The data received from the worker.
      */
-    Maps(handler: WorkerHandler<N, T, D>, data: Message) {
+    Maps(handler: WorkerHandler<DOM>, data: Message) {
       const { maps } = handler.options;
       Locale.warn(
         COMPONENT,

--- a/ts/adaptors/HTMLAdaptor.ts
+++ b/ts/adaptors/HTMLAdaptor.ts
@@ -30,46 +30,47 @@ import {
 } from '../core/DOMAdaptor.js';
 import { Locale } from '../util/Locale.js';
 import { COMPONENT } from '../core/__locales__/Component.js';
+import { DOM as DOM_OF, DOM_TYPES, N, T, D } from '../types/Types.js';
+
+type NT<DOM extends DOM_TYPES> = N<DOM> | T<DOM>;
 
 /*****************************************************************/
 /**
  * The minimum fields needed for a Document
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM node types
  */
-export interface MinDocument<N, T> {
-  documentElement: N;
-  head: N;
-  body: N;
+export interface MinDocument<DOM extends DOM_TYPES> {
+  documentElement: N<DOM>;
+  head: N<DOM>;
+  body: N<DOM>;
   title: string;
   doctype: { name: string };
-  defaultView: MinWindow<N, MinDocument<N, T>>;
+  defaultView: MinWindow<DOM>;
   location: { protocol: string; host: string };
-  createElement(kind: string): N;
-  createElementNS(ns: string, kind: string): N;
-  createTextNode(text: string): T;
-  querySelectorAll(selector: string): ArrayLike<N>;
-  querySelector(selector: string): N | null;
+  createElement(kind: string): N<DOM>;
+  createElementNS(ns: string, kind: string): N<DOM>;
+  createTextNode(text: string): T<DOM>;
+  querySelectorAll(selector: string): ArrayLike<N<DOM>>;
+  querySelector(selector: string): N<DOM> | null;
 }
 
 /*****************************************************************/
 /**
  * The minimum fields needed for an HTML Element
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM node types
  */
-export interface MinHTMLElement<N, T> {
+export interface MinHTMLElement<DOM extends DOM_TYPES> {
   nodeType: number;
   nodeName: string;
   nodeValue: string;
   textContent: string;
   innerHTML: string;
   outerHTML: string;
-  parentNode: N | Node;
-  nextSibling: N | T | Node;
-  previousSibling: N | T | Node;
+  parentNode: N<DOM> | Node;
+  nextSibling: NT<DOM> | Node;
+  previousSibling: NT<DOM> | Node;
   offsetWidth: number;
   offsetHeight: number;
 
@@ -81,20 +82,20 @@ export interface MinHTMLElement<N, T> {
     insertRule: (rule: string, index?: number) => void;
     cssRules: Array<{ cssText: string }>;
   };
-  childNodes: (N | T)[] | NodeList;
-  firstChild: N | T | Node;
-  lastChild: N | T | Node;
-  getElementsByTagName(name: string): N[] | HTMLCollectionOf<Element>;
+  childNodes: NT<DOM>[] | NodeList;
+  firstChild: NT<DOM> | Node;
+  lastChild: NT<DOM> | Node;
+  getElementsByTagName(name: string): N<DOM>[] | HTMLCollectionOf<Element>;
   getElementsByTagNameNS(
     ns: string,
     name: string
-  ): N[] | HTMLCollectionOf<Element>;
-  contains(child: N | T): boolean;
-  appendChild(child: N | T): N | T | Node;
-  removeChild(child: N | T): N | T | Node;
-  replaceChild(nnode: N | T, onode: N | T): N | T | Node;
-  insertBefore(nchild: N | T, ochild: N | T): void;
-  cloneNode(deep: boolean): N | Node;
+  ): N<DOM>[] | HTMLCollectionOf<Element>;
+  contains(child: NT<DOM>): boolean;
+  appendChild(child: NT<DOM>): NT<DOM> | Node;
+  removeChild(child: NT<DOM>): NT<DOM> | Node;
+  replaceChild(nnode: NT<DOM>, onode: NT<DOM>): NT<DOM> | Node;
+  insertBefore(nchild: NT<DOM>, ochild: NT<DOM>): void;
+  cloneNode(deep: boolean): N<DOM> | Node;
   setAttribute(name: string, value: string): void;
   setAttributeNS(ns: string, name: string, value: string): void;
   getAttribute(name: string): string;
@@ -102,7 +103,7 @@ export interface MinHTMLElement<N, T> {
   hasAttribute(name: string): boolean;
   getBoundingClientRect(): object;
   getBBox?(): { x: number; y: number; width: number; height: number };
-  querySelector(selector: string): N | null;
+  querySelector(selector: string): N<DOM> | null;
   src?: string;
 }
 
@@ -110,60 +111,58 @@ export interface MinHTMLElement<N, T> {
 /**
  * The minimum fields needed for a Text element
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM node types
  */
-export interface MinText<N, T> {
+export interface MinText<DOM extends DOM_TYPES> {
   nodeType: number;
   nodeName: string;
   nodeValue: string;
-  parentNode: N | Node;
-  nextSibling: N | T | Node;
-  previousSibling: N | T | Node;
-  splitText(n: number): T;
+  parentNode: N<DOM> | Node;
+  nextSibling: NT<DOM> | Node;
+  previousSibling: NT<DOM> | Node;
+  splitText(n: number): T<DOM>;
 }
 
 /*****************************************************************/
 /**
  * The minimum fields needed for a DOMParser
  *
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface MinDOMParser<D> {
-  parseFromString(text: string, format?: string): D;
+export interface MinDOMParser<DOM extends DOM_TYPES> {
+  parseFromString(text: string, format?: string): D<DOM>;
 }
 
 /*****************************************************************/
 /**
  * The minimum fields needed for a DOMParser
  *
- * @template N  The HTMLElement node class
+ * @template DOM   The DOM node types
  */
-export interface MinXMLSerializer<N> {
-  serializeToString(node: N): string;
+export interface MinXMLSerializer<DOM extends DOM_TYPES> {
+  serializeToString(node: N<DOM>): string;
 }
 
 /*****************************************************************/
 /**
  * The minimum fields needed for a Window
  *
- * @template N  The HTMLElement node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface MinWindow<N, D> {
-  document: D;
+export interface MinWindow<DOM extends DOM_TYPES> {
+  document: D<DOM>;
   DOMParser: {
-    new (): MinDOMParser<D>;
+    new (): MinDOMParser<DOM>;
   };
   XMLSerializer: {
-    new (): MinXMLSerializer<N>;
+    new (): MinXMLSerializer<DOM>;
   };
   NodeList: any;
   HTMLCollection: any;
   HTMLElement: any;
   DocumentFragment: any;
   Document: any;
-  getComputedStyle(node: N): any;
+  getComputedStyle(node: N<DOM>): any;
   addEventListener(kind: string, listener: (event: any) => void): void;
   postMessage(msg: any, domain: string): void;
 }
@@ -172,12 +171,10 @@ export interface MinWindow<N, D> {
 /**
  * The minimum needed for an HTML Adaptor
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface MinHTMLAdaptor<N, T, D> extends DOMAdaptor<N, T, D> {
-  window: MinWindow<N, D>;
+export interface MinHTMLAdaptor<DOM extends DOM_TYPES> extends DOMAdaptor<DOM> {
+  window: MinWindow<DOM>;
 }
 
 /*****************************************************************/
@@ -185,21 +182,13 @@ export interface MinHTMLAdaptor<N, T, D> extends DOMAdaptor<N, T, D> {
  *  Abstract HTMLAdaptor class for manipulating HTML elements
  *  (subclass of AbstractDOMAdaptor)
  *
- *  N = HTMLElement node class
- *  T = Text node class
- *  D = Document class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM types
  */
 export class HTMLAdaptor<
-  N extends MinHTMLElement<N, T>,
-  T extends MinText<N, T>,
-  D extends MinDocument<N, T>,
+  DOM extends DOM_OF<MinHTMLElement<DOM>, MinText<DOM>, MinDocument<DOM>>,
 >
-  extends AbstractDOMAdaptor<N, T, D>
-  implements MinHTMLAdaptor<N, T, D>
+  extends AbstractDOMAdaptor<DOM>
+  implements MinHTMLAdaptor<DOM>
 {
   /**
    * The font size to use when it can't be measured (e.g., the element
@@ -215,18 +204,18 @@ export class HTMLAdaptor<
   /**
    * The window object for this adaptor
    */
-  public window: MinWindow<N, D>;
+  public window: MinWindow<DOM>;
 
   /**
    * The DOMParser used to parse a string into a DOM tree
    */
-  public parser: MinDOMParser<D>;
+  public parser: MinDOMParser<DOM>;
 
   /**
    * @override
    * @class
    */
-  constructor(window: MinWindow<N, D>) {
+  constructor(window: MinWindow<DOM>) {
     super(window.document);
     this.window = window;
     this.parser = new (window.DOMParser as any)();
@@ -258,58 +247,58 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public head(doc: D = this.document) {
-    return doc.head || (doc as any as N);
+  public head(doc: D<DOM> = this.document) {
+    return doc.head || (doc as any as N<DOM>);
   }
 
   /**
    * @override
    */
-  public body(doc: D = this.document) {
-    return doc.body || (doc as any as N);
+  public body(doc: D<DOM> = this.document) {
+    return doc.body || (doc as any as N<DOM>);
   }
 
   /**
    * @override
    */
-  public root(doc: D = this.document) {
-    return doc.documentElement || (doc as any as N);
+  public root(doc: D<DOM> = this.document) {
+    return doc.documentElement || (doc as any as N<DOM>);
   }
 
   /**
    * @override
    */
-  public doctype(doc: D = this.document) {
+  public doctype(doc: D<DOM> = this.document) {
     return doc.doctype ? `<!DOCTYPE ${doc.doctype.name}>` : '';
   }
 
   /**
    * @override
    */
-  public tags(node: N, name: string, ns: string = null) {
+  public tags(node: N<DOM>, name: string, ns: string = null) {
     const nodes = ns
       ? node.getElementsByTagNameNS(ns, name)
       : node.getElementsByTagName(name);
-    return Array.from(nodes as N[]) as N[];
+    return Array.from(nodes as N<DOM>[]) as N<DOM>[];
   }
 
   /**
    * @override
    */
-  public getElements(nodes: (string | N | N[])[], _document: D) {
-    let containers: N[] = [];
+  public getElements(nodes: (string | N<DOM> | N<DOM>[])[], _document: D<DOM>) {
+    let containers: N<DOM>[] = [];
     for (const node of nodes) {
       if (typeof node === 'string') {
         containers = containers.concat(
           Array.from(this.document.querySelectorAll(node))
         );
       } else if (Array.isArray(node)) {
-        containers = containers.concat(Array.from(node) as N[]);
+        containers = containers.concat(Array.from(node) as N<DOM>[]);
       } else if (
         node instanceof this.window.NodeList ||
         node instanceof this.window.HTMLCollection
       ) {
-        containers = containers.concat(Array.from(node as any as N[]));
+        containers = containers.concat(Array.from(node as any as N<DOM>[]));
       } else {
         containers.push(node);
       }
@@ -320,112 +309,115 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public getElement(selector: string, node: D | N = this.document): N {
+  public getElement(
+    selector: string,
+    node: D<DOM> | N<DOM> = this.document
+  ): N<DOM> {
     return node.querySelector(selector);
   }
 
   /**
    * @override
    */
-  public contains(container: N, node: N | T) {
+  public contains(container: N<DOM>, node: NT<DOM>) {
     return container.contains(node);
   }
 
   /**
    * @override
    */
-  public parent(node: N | T) {
-    return node.parentNode as N;
+  public parent(node: NT<DOM>) {
+    return node.parentNode as N<DOM>;
   }
 
   /**
    * @override
    */
-  public append(node: N, child: N | T) {
-    return node.appendChild(child) as N | T;
+  public append(node: N<DOM>, child: NT<DOM>) {
+    return node.appendChild(child) as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public insert(nchild: N | T, ochild: N | T) {
+  public insert(nchild: NT<DOM>, ochild: NT<DOM>) {
     return this.parent(ochild).insertBefore(nchild, ochild);
   }
 
   /**
    * @override
    */
-  public remove(child: N | T) {
-    return this.parent(child).removeChild(child) as N | T;
+  public remove(child: NT<DOM>) {
+    return this.parent(child).removeChild(child) as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public replace(nnode: N | T, onode: N | T) {
-    return this.parent(onode).replaceChild(nnode, onode) as N | T;
+  public replace(nnode: NT<DOM>, onode: NT<DOM>) {
+    return this.parent(onode).replaceChild(nnode, onode) as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public clone(node: N, deep: boolean = true) {
-    return node.cloneNode(deep) as N;
+  public clone(node: N<DOM>, deep: boolean = true) {
+    return node.cloneNode(deep) as N<DOM>;
   }
 
   /**
    * @override
    */
-  public split(node: T, n: number) {
+  public split(node: T<DOM>, n: number) {
     return node.splitText(n);
   }
 
   /**
    * @override
    */
-  public next(node: N | T) {
-    return node.nextSibling as N | T;
+  public next(node: NT<DOM>) {
+    return node.nextSibling as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public previous(node: N | T) {
-    return node.previousSibling as N | T;
+  public previous(node: NT<DOM>) {
+    return node.previousSibling as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public firstChild(node: N) {
-    return node.firstChild as N | T;
+  public firstChild(node: N<DOM>) {
+    return node.firstChild as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public lastChild(node: N) {
-    return node.lastChild as N | T;
+  public lastChild(node: N<DOM>) {
+    return node.lastChild as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public childNodes(node: N) {
-    return Array.from(node.childNodes as (N | T)[]);
+  public childNodes(node: N<DOM>) {
+    return Array.from(node.childNodes as NT<DOM>[]);
   }
 
   /**
    * @override
    */
-  public childNode(node: N, i: number) {
-    return node.childNodes[i] as N | T;
+  public childNode(node: N<DOM>, i: number) {
+    return node.childNodes[i] as NT<DOM>;
   }
 
   /**
    * @override
    */
-  public kind(node: N | T) {
+  public kind(node: NT<DOM>) {
     const n = node.nodeType;
     return n === 1 || n === 3 || n === 8 ? node.nodeName.toLowerCase() : '';
   }
@@ -433,35 +425,35 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public value(node: N | T) {
+  public value(node: NT<DOM>) {
     return node.nodeValue || '';
   }
 
   /**
    * @override
    */
-  public textContent(node: N) {
+  public textContent(node: N<DOM>) {
     return node.textContent;
   }
 
   /**
    * @override
    */
-  public innerHTML(node: N) {
+  public innerHTML(node: N<DOM>) {
     return node.innerHTML;
   }
 
   /**
    * @override
    */
-  public outerHTML(node: N) {
+  public outerHTML(node: N<DOM>) {
     return node.outerHTML;
   }
 
   /**
    * @override
    */
-  public serializeXML(node: N) {
+  public serializeXML(node: N<DOM>) {
     const serializer = new this.window.XMLSerializer();
     return serializer.serializeToString(node) as string;
   }
@@ -469,7 +461,12 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public setAttribute(node: N, name: string, value: string, ns: string = null) {
+  public setAttribute(
+    node: N<DOM>,
+    name: string,
+    value: string,
+    ns: string = null
+  ) {
     if (!ns) {
       if (name === 'style') {
         value = value.replace(/\n/g, ' ');
@@ -483,28 +480,28 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public getAttribute(node: N, name: string) {
+  public getAttribute(node: N<DOM>, name: string) {
     return node.getAttribute(name);
   }
 
   /**
    * @override
    */
-  public removeAttribute(node: N, name: string) {
+  public removeAttribute(node: N<DOM>, name: string) {
     return node.removeAttribute(name);
   }
 
   /**
    * @override
    */
-  public hasAttribute(node: N, name: string) {
+  public hasAttribute(node: N<DOM>, name: string) {
     return node.hasAttribute(name);
   }
 
   /**
    * @override
    */
-  public allAttributes(node: N) {
+  public allAttributes(node: N<DOM>) {
     return Array.from(node.attributes).map((x: AttributeData) => {
       return { name: x.name, value: x.value } as AttributeData;
     });
@@ -513,7 +510,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public addClass(node: N, name: string) {
+  public addClass(node: N<DOM>, name: string) {
     if (node.classList) {
       node.classList.add(name);
     } else {
@@ -524,7 +521,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public removeClass(node: N, name: string) {
+  public removeClass(node: N<DOM>, name: string) {
     if (node.classList) {
       node.classList.remove(name);
     } else {
@@ -538,7 +535,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public hasClass(node: N, name: string) {
+  public hasClass(node: N<DOM>, name: string) {
     if (node.classList) {
       return node.classList.contains(name);
     }
@@ -548,28 +545,28 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public setStyle(node: N, name: string, value: string) {
+  public setStyle(node: N<DOM>, name: string, value: string) {
     node.style[name] = String(value).replace(/\n/g, ' ');
   }
 
   /**
    * @override
    */
-  public getStyle(node: N, name: string) {
+  public getStyle(node: N<DOM>, name: string) {
     return node.style[name];
   }
 
   /**
    * @override
    */
-  public allStyles(node: N) {
+  public allStyles(node: N<DOM>) {
     return node.style.cssText;
   }
 
   /**
    * @override
    */
-  public insertRules(node: N, rules: string[]) {
+  public insertRules(node: N<DOM>, rules: string[]) {
     for (const rule of rules) {
       try {
         node.sheet.insertRule(rule, node.sheet.cssRules.length);
@@ -582,7 +579,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public cssText(node: N) {
+  public cssText(node: N<DOM>) {
     if (this.kind(node) !== 'style') {
       return '';
     }
@@ -594,7 +591,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public fontSize(node: N) {
+  public fontSize(node: N<DOM>) {
     const style = this.window.getComputedStyle(node);
     return parseFloat(
       style.fontSize ||
@@ -605,7 +602,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public fontFamily(node: N) {
+  public fontFamily(node: N<DOM>) {
     const style = this.window.getComputedStyle(node);
     return style.fontFamily || '';
   }
@@ -613,7 +610,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public nodeSize(node: N, em: number = 1, local: boolean = false) {
+  public nodeSize(node: N<DOM>, em: number = 1, local: boolean = false) {
     if (local && node.getBBox) {
       const { width, height } = node.getBBox();
       return [width / em, height / em] as [number, number];
@@ -624,7 +621,7 @@ export class HTMLAdaptor<
   /**
    * @override
    */
-  public nodeBBox(node: N) {
+  public nodeBBox(node: N<DOM>) {
     const { left, right, top, bottom } =
       node.getBoundingClientRect() as PageBBox;
     return { left, right, top, bottom };

--- a/ts/adaptors/NodeMixin.ts
+++ b/ts/adaptors/NodeMixin.ts
@@ -26,7 +26,7 @@
 import { DOMAdaptor, minWorker } from '../core/DOMAdaptor.js';
 import { userOptions, defaultOptions, OptionList } from '../util/Options.js';
 import { asyncLoad } from '../util/AsyncLoad.js';
-import { Constructor } from '../types/Types.js';
+import { Constructor, DOM_TYPES, N } from '../types/Types.js';
 export { Constructor };
 
 /**
@@ -40,8 +40,12 @@ export interface WebWorker {
 
 /**
  * The type of an Adaptor class
+ *
+ * @template DOM   The DOM node types
  */
-export type AdaptorConstructor<N, T, D> = Constructor<DOMAdaptor<N, T, D>>;
+export type AdaptorConstructor<DOM extends DOM_TYPES> = Constructor<
+  DOMAdaptor<DOM>
+>;
 
 export type MIXIN_OPTIONS = {
   badCSS?: boolean; //     getComputedStyles() is not implemented in the DOM
@@ -72,15 +76,13 @@ export type OPTIONS = {
  * @param {NodeMixinOptions} options The options
  * @returns {A} The NodeAdaptor mixin class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template A  Extension of AdaptorConstructor
+ * @template DOM   The DOM node types
+ * @template A     Extension of AdaptorConstructor
  */
-export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
-  Base: A,
-  options: MIXIN_OPTIONS = {}
-): A {
+export function NodeMixin<
+  DOM extends DOM_TYPES,
+  A extends AdaptorConstructor<DOM>,
+>(Base: A, options: MIXIN_OPTIONS = {}): A {
   options = userOptions(defaultOptions({}, NodeMixinOptions), options);
 
   return class NodeAdaptor extends Base {
@@ -155,7 +157,7 @@ export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
      *
      * @override
      */
-    public fontSize(node: N) {
+    public fontSize(node: N<DOM>) {
       return options.badCSS ? this.options.fontSize : super.fontSize(node);
     }
 
@@ -164,14 +166,14 @@ export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
      *
      * @override
      */
-    public fontFamily(node: N) {
+    public fontFamily(node: N<DOM>) {
       return options.badCSS ? this.options.fontFamily : super.fontFamily(node);
     }
 
     /**
      * @override
      */
-    public nodeSize(node: N, em: number = 1, local: boolean = null) {
+    public nodeSize(node: N<DOM>, em: number = 1, local: boolean = null) {
       if (!options.badSizes) {
         return super.nodeSize(node, em, local);
       }
@@ -187,7 +189,7 @@ export function NodeMixin<N, T, D, A extends AdaptorConstructor<N, T, D>>(
     /**
      * @override
      */
-    public nodeBBox(node: N) {
+    public nodeBBox(node: N<DOM>) {
       return options.badSizes
         ? { left: 0, right: 0, top: 0, bottom: 0 }
         : super.nodeBBox(node);

--- a/ts/adaptors/browserAdaptor.ts
+++ b/ts/adaptors/browserAdaptor.ts
@@ -22,6 +22,7 @@
  */
 
 import { HTMLAdaptor } from './HTMLAdaptor.js';
+import { HTML_DOM } from '../types/dom/html.js';
 
 //
 //  Let Typescript know about these
@@ -43,6 +44,6 @@ declare global {
  *
  * @returns {HTMLAdaptor}  The newly created adaptor
  */
-export function browserAdaptor(): HTMLAdaptor<HTMLElement, Text, Document> {
-  return new HTMLAdaptor<HTMLElement, Text, Document>(window);
+export function browserAdaptor(): HTMLAdaptor<HTML_DOM> {
+  return new HTMLAdaptor<HTML_DOM>(window);
 }

--- a/ts/adaptors/jsdomAdaptor.ts
+++ b/ts/adaptors/jsdomAdaptor.ts
@@ -23,23 +23,19 @@
 
 import { HTMLAdaptor } from './HTMLAdaptor.js';
 import { NodeMixin, MIXIN_OPTIONS, Constructor } from './NodeMixin.js';
+import { HTML_DOM } from '../types/dom/html.js';
 
 /**
  * The constructor for an HTMLAdaptor
  */
-export type HTMLAdaptorConstructor = Constructor<
-  HTMLAdaptor<HTMLElement, Text, Document>
->;
+export type HTMLAdaptorConstructor = Constructor<HTMLAdaptor<HTML_DOM>>;
 
 /**
  * The JsdomAdaptor class
  */
-export class JsdomAdaptor extends NodeMixin<
-  HTMLElement,
-  Text,
-  Document,
-  HTMLAdaptorConstructor
->(HTMLAdaptor) {}
+export class JsdomAdaptor extends NodeMixin<HTML_DOM, HTMLAdaptorConstructor>(
+  HTMLAdaptor
+) {}
 
 /**
  * Function for creating an HTML adaptor using jsdom

--- a/ts/adaptors/linkedomAdaptor.ts
+++ b/ts/adaptors/linkedomAdaptor.ts
@@ -25,21 +25,18 @@ import { HTMLAdaptor } from './HTMLAdaptor.js';
 import { NodeMixin, MIXIN_OPTIONS, Constructor } from './NodeMixin.js';
 import { Locale } from '../util/Locale.js';
 import { COMPONENT } from './linkedom/__locales__/Component.js';
+import { HTML_DOM } from '../types/dom/html.js';
 
 /**
  * The constructor for an HTMLAdaptor
  */
-export type HTMLAdaptorConstructor = Constructor<
-  HTMLAdaptor<HTMLElement, Text, Document>
->;
+export type HTMLAdaptorConstructor = Constructor<HTMLAdaptor<HTML_DOM>>;
 
 /**
  * The LinkedomAdaptor class
  */
 export class LinkedomAdaptor extends NodeMixin<
-  HTMLElement,
-  Text,
-  Document,
+  HTML_DOM,
   HTMLAdaptorConstructor
 >(HTMLAdaptor) {
   /**

--- a/ts/adaptors/lite/Parser.ts
+++ b/ts/adaptors/lite/Parser.ts
@@ -28,6 +28,7 @@ import { LiteDocument } from './Document.js';
 import { LiteElement } from './Element.js';
 import { LiteText, LiteComment } from './Text.js';
 import { LiteAdaptor } from '../liteAdaptor.js';
+import { LITE_DOM } from '../../types/dom/lite.js';
 
 /**
  * Patterns used in parsing serialized HTML
@@ -56,7 +57,7 @@ export const PATTERNS = {
  * Implements a lightweight DOMParser replacement
  * (Not perfect, but handles most well-formed HTML)
  */
-export class LiteParser implements MinDOMParser<LiteDocument> {
+export class LiteParser implements MinDOMParser<LITE_DOM> {
   /**
    * The list of self-closing tags
    */

--- a/ts/adaptors/liteAdaptor.ts
+++ b/ts/adaptors/liteAdaptor.ts
@@ -31,17 +31,14 @@ import { LiteWindow } from './lite/Window.js';
 import { LiteParser } from './lite/Parser.js';
 import { Styles } from '../util/Styles.js';
 import { OptionList } from '../util/Options.js';
+import { LITE_DOM } from '../types/dom/lite.js';
 
 /************************************************************/
 
 /**
  * Implements a lightweight DOMAdaptor on liteweight HTML elements
  */
-export class LiteBase extends AbstractDOMAdaptor<
-  LiteElement,
-  LiteText,
-  LiteDocument
-> {
+export class LiteBase extends AbstractDOMAdaptor<LITE_DOM> {
   /**
    * The document in which the HTML nodes will be created
    */
@@ -711,12 +708,9 @@ export class LiteBase extends AbstractDOMAdaptor<
 /**
  * The LiteAdaptor class (add in the NodeMixin methods and options)
  */
-export class LiteAdaptor extends NodeMixin<
-  LiteElement,
-  LiteText,
-  LiteDocument,
-  Constructor<LiteBase>
->(LiteBase) {}
+export class LiteAdaptor extends NodeMixin<LITE_DOM, Constructor<LiteBase>>(
+  LiteBase
+) {}
 
 /************************************************************/
 /**

--- a/ts/components/package.ts
+++ b/ts/components/package.ts
@@ -55,14 +55,13 @@ export type PackagePromise = (
 /**
  * The configuration data for a package
  */
-/* prettier-ignore */
 export interface PackageConfig {
-  ready?: PackageReady;                // Function to call when package is loaded successfully
-  failed?: PackageFailed;              // Function to call when package fails to load
-  checkReady?: () => Promise<void>;    // Function called to see if package is fully loaded
-                                       //   (may cause additional packages to load, for example)
-  extraLoads?: string[];               // Extra packages to load after this one
-  rendererExtensions?: string[];       // Font extensions to load when renderer changes
+  ready?: PackageReady; //                Function to call when package is loaded successfully
+  failed?: PackageFailed; //              Function to call when package fails to load
+  checkReady?: () => Promise<void>; //    Function called to see if package is fully loaded
+  //                                        (May cause additional packages to load, for example)
+  extraLoads?: string[]; //               Extra packages to load after this one
+  rendererExtensions?: string[]; //       Font extensions to load when renderer changes
 }
 
 /**

--- a/ts/components/startup.ts
+++ b/ts/components/startup.ts
@@ -46,9 +46,7 @@ import { OptionList, OPTIONS } from '../util/Options.js';
 import { context } from '../util/context.js';
 import { Locale } from '../util/Locale.js';
 import { COMPONENT } from '../core/__locales__/Component.js';
-import { DOM, DOM_TYPES, N, T, D, OPTIONAL } from '../types/Types.js';
-
-import { TeX } from '../input/tex.js';
+import { DOM as ANY_DOM, DOM_TYPES, N, OPTIONAL } from '../types/Types.js';
 
 /**
  * The option types for the startup component.
@@ -72,48 +70,31 @@ export type STARTUP_OPTIONS = {
 /**
  * Generic types for the standard MathJax objects
  */
-export type MATHDOCUMENT<DD extends DOM_TYPES = DOM> = MathDocument<
-  N<DD>,
-  T<DD>,
-  D<DD>
-> & {
-  menu?: { loadingPromise: Promise<void> };
-  options: { elements?: N<DD>[] };
-};
-export type HANDLER<DD extends DOM_TYPES = DOM> = Handler<N<DD>, T<DD>, D<DD>>;
-export type DOMADAPTOR<DD extends DOM_TYPES = DOM> = DOMAdaptor<
-  N<DD>,
-  T<DD>,
-  D<DD>
->;
-export type INPUTJAX<DD extends DOM_TYPES = DOM> = InputJax<
-  N<DD>,
-  T<DD>,
-  D<DD>
->;
-export type OUTPUTJAX<DD extends DOM_TYPES = DOM> = OutputJax<
-  N<DD>,
-  T<DD>,
-  D<DD>
->;
+export type MATHDOCUMENT<DOM extends DOM_TYPES = ANY_DOM> =
+  MathDocument<DOM> & {
+    menu?: { loadingPromise: Promise<void> };
+    options: { elements?: N<DOM>[] };
+  };
+export type HANDLER<DOM extends DOM_TYPES = ANY_DOM> = Handler<DOM>;
+export type DOMADAPTOR<DOM extends DOM_TYPES = ANY_DOM> = DOMAdaptor<DOM>;
+export type INPUTJAX<DOM extends DOM_TYPES = ANY_DOM> = InputJax<DOM>;
+export type OUTPUTJAX<DOM extends DOM_TYPES = ANY_DOM> = OutputJax<DOM>;
 /* prettier-ignore */
-export type COMMONJAX<DD extends DOM_TYPES = DOM> =
-  CommonOutputJax<N<DD>, T<DD>, D<DD>, any, any, any, any, any, any, any, any>;
-export type TEX<DD extends DOM_TYPES = DOM> = TeX<N<DD>, T<DD>, D<DD>>;
+export type COMMONJAX<DOM extends DOM_TYPES = ANY_DOM> = CommonOutputJax<DOM, any, any, any, any, any>;
 
 /**
  * Array of InputJax also with keys using name of jax
  */
-export type JAXARRAY<DD extends DOM_TYPES = DOM> = INPUTJAX<DD>[] & {
-  [name: string]: INPUTJAX<DD>;
+export type JAXARRAY<DOM extends DOM_TYPES = ANY_DOM> = INPUTJAX<DOM>[] & {
+  [name: string]: INPUTJAX<DOM>;
 };
 
 /**
  * A function to extend a handler class
  */
-export type HandlerExtension<DD extends DOM_TYPES = DOM> = (
-  handler: HANDLER<DD>
-) => HANDLER<DD>;
+export type HandlerExtension<DOM extends DOM_TYPES = ANY_DOM> = (
+  handler: HANDLER<DOM>
+) => HANDLER<DOM>;
 
 /**
  * The startup object types.
@@ -602,7 +583,7 @@ export abstract class Startup {
    * @param {any=} root        The Document to use as the root document (or null to use the configured document)
    * @returns {MathDocument}   The MathDocument with the configured input and output jax
    */
-  public static getDocument(root: any = null): MathDocument<any, any, any> {
+  public static getDocument(root: any = null): MathDocument<ANY_DOM> {
     return Startup.mathjax.document(root || CONFIG.document, {
       ...MathJax.config.options,
       InputJax: Startup.input,
@@ -655,7 +636,7 @@ export interface MathJaxConfig extends MJConfig {
  */
 export interface MathJaxObject extends MJObject {
   config: MathJaxConfig;
-  startup: STARTUP<DOM>;
+  startup: STARTUP<ANY_DOM>;
   [name: string]: any; // Needed for the methods created by the startup module
 }
 

--- a/ts/core/DOMAdaptor.ts
+++ b/ts/core/DOMAdaptor.ts
@@ -22,6 +22,9 @@
  */
 
 import { OptionList } from '../util/Options.js';
+import { DOM_TYPES, N, T, D } from '../types/Types.js';
+
+type NT<DOM extends DOM_TYPES> = N<DOM> | T<DOM>;
 
 /**
  * The data for an attribute
@@ -42,6 +45,11 @@ export type PageBBox = {
 };
 
 /**
+ * Specifier for a (set of) containers
+ */
+export type ContainerSpec<DOM extends DOM_TYPES> = string | N<DOM> | N<DOM>[];
+
+/**
  * A minimal webworker interface
  */
 export interface minWorker {
@@ -54,15 +62,13 @@ export interface minWorker {
 /**
  *  The interface for the DOMAdaptor
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface DOMAdaptor<N, T, D> {
+export interface DOMAdaptor<DOM extends DOM_TYPES> {
   /**
    * Document in which the nodes are to be created
    */
-  document: D;
+  document: D<DOM>;
 
   /**
    * True when the adaptor can measure DOM node sizes
@@ -72,66 +78,71 @@ export interface DOMAdaptor<N, T, D> {
   /**
    * @param {string} text    The serialized document to be parsed
    * @param {string} format  The format (e.g., 'text/html' or 'text/xhtml')
-   * @returns {D}             The parsed document
+   * @returns {D<DOM>}       The parsed document
    */
-  parse(text: string, format?: string): D;
+  parse(text: string, format?: string): D<DOM>;
 
   /**
    * @param {string} kind      The tag name of the HTML node to be created
    * @param {OptionList} def   The properties to set for the created node
    * @param {(N|T)[]} children The child nodes for the created HTML node
    * @param {string} ns        The namespace in which to create the node
-   * @returns {N}               The generated HTML tree
+   * @returns {N}              The generated HTML tree
    */
-  node(kind: string, def?: OptionList, children?: (N | T)[], ns?: string): N;
+  node(
+    kind: string,
+    def?: OptionList,
+    children?: NT<DOM>[],
+    ns?: string
+  ): N<DOM>;
 
   /**
    * @param {string} text   The text from which to create an HTML text node
-   * @returns {T}            The generated text node with the given text
+   * @returns {T}           The generated text node with the given text
    */
-  text(text: string): T;
+  text(text: string): T<DOM>;
 
   /**
    * @param {D} doc   The document whose head is to be obtained
-   * @returns {N}      The document.head element
+   * @returns {N}     The document.head element
    */
-  head(doc?: D): N;
+  head(doc?: D<DOM>): N<DOM>;
 
   /**
    * @param {D} doc   The document whose body is to be obtained
-   * @returns {N}      The document.body element
+   * @returns {N}     The document.body element
    */
-  body(doc?: D): N;
+  body(doc?: D<DOM>): N<DOM>;
 
   /**
    * @param {D} doc   The document whose documentElement is to be obtained
-   * @returns {N}      The documentElement
+   * @returns {N}     The documentElement
    */
-  root(doc?: D): N;
+  root(doc?: D<DOM>): N<DOM>;
 
   /**
-   * @param {D} doc     The document whose doctype is to be obtained
+   * @param {D} doc      The document whose doctype is to be obtained
    * @returns {string}   The DOCTYPE comment
    */
-  doctype(doc?: D): string;
+  doctype(doc?: D<DOM>): string;
 
   /**
    * @param {N} node        The node to search for tags
    * @param {string} name   The name of the tag to search for
    * @param {string} ns     The namespace to search in (or null for no namespace)
-   * @returns {N[]}          The list of tags found
+   * @returns {N[]}         The list of tags found
    */
-  tags(node: N, name: string, ns?: string): N[];
+  tags(node: N<DOM>, name: string, ns?: string): N<DOM>[];
 
   /**
    * Get a list of containers (to be searched for math).  These can be
    *  specified by CSS selector, or as actual DOM elements or arrays of such.
    *
-   * @param {(string | N | N[])[]} nodes  The array of items to make into a container list
-   * @param {D} document                  The document in which to search
-   * @returns {N[]}                        The array of containers to search
+   * @param {ContainerSpec[]} nodes   The array of items to make into a container list
+   * @param {D} document              The document in which to search
+   * @returns {N[]}                   The array of containers to search
    */
-  getElements(nodes: (string | N | N[])[], document: D): N[];
+  getElements(nodes: ContainerSpec<DOM>[], document: D<DOM>): N<DOM>[];
 
   /**
    * Get an element specified by CSS selector.
@@ -140,148 +151,148 @@ export interface DOMAdaptor<N, T, D> {
    * @param {D | N} node        The document or element in which to search
    * @returns {N | null}        The first matching element
    */
-  getElement(selector: string, node?: D | N): N | null;
+  getElement(selector: string, node?: D<DOM> | N<DOM>): N<DOM> | null;
 
   /**
    * Determine if a container node contains a given node somewhere in its DOM tree
    *
-   * @param {N} container  The container to search
-   * @param {N|T} node     The node to look for
+   * @param {N} container   The container to search
+   * @param {N|T} node      The node to look for
    * @returns {boolean}     True if the node is in the container's DOM tree
    */
-  contains(container: N, node: N | T): boolean;
+  contains(container: N<DOM>, node: NT<DOM>): boolean;
 
   /**
-   * @param {N|T} node  The HTML node whose parent is to be obtained
+   * @param {N|T} node   The HTML node whose parent is to be obtained
    * @returns {N}        The parent node of the given one
    */
-  parent(node: N | T): N;
+  parent(node: NT<DOM>): N<DOM>;
 
   /**
-   * @param {N} node     The HTML node to be appended to
-   * @param {N|T} child  The node or text to be appended
+   * @param {N} node      The HTML node to be appended to
+   * @param {N|T} child   The node or text to be appended
    * @returns {N|T}       The appended node
    */
-  append(node: N, child: N | T): N | T;
+  append(node: N<DOM>, child: NT<DOM>): NT<DOM>;
 
   /**
    * @param {N|T} nchild  The node or text to be inserted
    * @param {N|T} ochild  The node or text where the new child is to be added before it
    */
-  insert(nchild: N | T, ochild: N | T): void;
+  insert(nchild: NT<DOM>, ochild: NT<DOM>): void;
 
   /**
-   * @param {N|T} child  The node or text to be removed from its parent
+   * @param {N|T} child   The node or text to be removed from its parent
    * @returns {N|T}       The removed node
    */
-  remove(child: N | T): N | T;
+  remove(child: NT<DOM>): NT<DOM>;
 
   /**
-   * @param {N|T} nnode  The node to replace with
-   * @param {N|T} onode  The child to be replaced
+   * @param {N|T} nnode   The node to replace with
+   * @param {N|T} onode   The child to be replaced
    * @returns {N|T}       The removed node
    */
-  replace(nnode: N | T, onode: N | T): N | T;
+  replace(nnode: NT<DOM>, onode: NT<DOM>): NT<DOM>;
 
   /**
    * @param {N} node         The HTML node to be cloned
    * @param {boolean} deep   True if children should be cloned
-   * @returns {N}             The copied node
+   * @returns {N}            The copied node
    */
-  clone(node: N, deep?: boolean): N;
+  clone(node: N<DOM>, deep?: boolean): N<DOM>;
 
   /**
    * @param {T} node    The HTML text node to be split
    * @param {number} n  The index of the character where the split will occur
    */
-  split(node: T, n: number): T;
+  split(node: T<DOM>, n: number): T<DOM>;
 
   /**
    * @param {N|T} node   The HTML node whose sibling is to be obtained
-   * @returns {N|T}       The node following the given one (or null)
+   * @returns {N|T}      The node following the given one (or null)
    */
-  next(node: N | T): N | T;
+  next(node: NT<DOM>): NT<DOM>;
 
   /**
    * @param {N|T} node   The HTML node whose sibling is to be obtained
-   * @returns {N|T}       The node preceding the given one (or null)
+   * @returns {N|T}      The node preceding the given one (or null)
    */
-  previous(node: N | T): N | T;
+  previous(node: NT<DOM>): NT<DOM>;
 
   /**
    * @param {N} node   The HTML node whose child is to be obtained
-   * @returns {N|T}     The first child of the given node (or null)
+   * @returns {N|T}    The first child of the given node (or null)
    */
-  firstChild(node: N): N | T;
+  firstChild(node: N<DOM>): NT<DOM>;
 
   /**
    * @param {N} node   The HTML node whose child is to be obtained
-   * @returns {N}       The last child of the given node (or null)
+   * @returns {N}      The last child of the given node (or null)
    */
-  lastChild(node: N): N | T;
+  lastChild(node: N<DOM>): NT<DOM>;
 
   /**
-   * @param {N} node    The HTML node whose children are to be obtained
-   * @returns {(N|T)[]}  Array of children for the given node (not a live list)
+   * @param {N} node      The HTML node whose children are to be obtained
+   * @returns {(N|T)[]}   Array of children for the given node (not a live list)
    */
-  childNodes(node: N): (N | T)[];
+  childNodes(node: N<DOM>): NT<DOM>[];
 
   /**
-   * @param {N} node    The HTML node whose child is to be obtained
-   * @param {number} i  The index of the child to return
+   * @param {N} node     The HTML node whose child is to be obtained
+   * @param {number} i   The index of the child to return
    * @returns {N|T}      The i-th child node of the given node (or null)
    */
-  childNode(node: N, i: number): N | T;
+  childNode(node: N<DOM>, i: number): NT<DOM>;
 
   /**
-   * @param {N | T} node   The HTML node whose tag or node name is to be obtained
-   * @returns {string}      The tag or node name of the given node
+   * @param {N|T} node   The HTML node whose tag or node name is to be obtained
+   * @returns {string}   The tag or node name of the given node
    */
-  kind(node: N | T): string;
+  kind(node: NT<DOM>): string;
 
   /**
-   * @param {N|T} node  The HTML node whose value is to be obtained
+   * @param {N|T} node   The HTML node whose value is to be obtained
    * @returns {string}   The value of the given node
    */
-  value(node: N | T): string;
+  value(node: NT<DOM>): string;
 
   /**
-   * @param {N} node    The HTML node whose text content is to be obtained
+   * @param {N} node     The HTML node whose text content is to be obtained
    * @returns {string}   The text content of the given node
    */
-  textContent(node: N): string;
+  textContent(node: N<DOM>): string;
 
   /**
-   * @param {N} node   The HTML node whose inner HTML string is to be obtained
+   * @param {N} node    The HTML node whose inner HTML string is to be obtained
    * @returns {string}  The serialized content of the node
    */
-  innerHTML(node: N): string;
+  innerHTML(node: N<DOM>): string;
 
   /**
-   * @param {N} node   The HTML node whose outer HTML string is to be obtained
+   * @param {N} node    The HTML node whose outer HTML string is to be obtained
    * @returns {string}  The serialized node and its content
    */
-  outerHTML(node: N): string;
+  outerHTML(node: N<DOM>): string;
 
   /**
-   * @param {N} node   The HTML node whose serialized string is to be obtained
+   * @param {N} node    The HTML node whose serialized string is to be obtained
    * @returns {string}  The serialized node and its content
    */
-  serializeXML(node: N): string;
+  serializeXML(node: N<DOM>): string;
 
   /**
    * @param {N} node        The HTML node whose property is to be set
    * @param {string} name   The property to set
    * @param {any} value     The property's new value
    */
-  setProperty(node: N, name: string, value: any): void;
+  setProperty(node: N<DOM>, name: string, value: any): void;
 
   /**
    * @param {N} node        The HTML node whose property is to be retrieved
    * @param {string} name   The property to get
    * @returns {any}         The property's value
    */
-  getProperty(node: N, name: string): any;
+  getProperty(node: N<DOM>, name: string): any;
 
   /**
    * @param {N} node               The HTML node whose attribute is to be set
@@ -290,7 +301,7 @@ export interface DOMAdaptor<N, T, D> {
    * @param {string=} ns           The namespace to use for the attribute
    */
   setAttribute(
-    node: N,
+    node: N<DOM>,
     name: string,
     value: string | number,
     ns?: string
@@ -300,116 +311,116 @@ export interface DOMAdaptor<N, T, D> {
    * @param {N} node           The HTML element whose attributes are to be set
    * @param {OptionList} def   The attributes to set on that node
    */
-  setAttributes(node: N, def: OptionList): void;
+  setAttributes(node: N<DOM>, def: OptionList): void;
 
   /**
    * @param {N} node        The HTML node whose attribute is to be obtained
    * @param {string} name   The name of the attribute to get
-   * @returns {string}       The value of the given attribute of the given node
+   * @returns {string}      The value of the given attribute of the given node
    */
-  getAttribute(node: N, name: string): string;
+  getAttribute(node: N<DOM>, name: string): string;
 
   /**
    * @param {N} node        The HTML node whose attribute is to be removed
    * @param {string} name   The name of the attribute to remove
    */
-  removeAttribute(node: N, name: string): void;
+  removeAttribute(node: N<DOM>, name: string): void;
 
   /**
    * @param {N} node        The HTML node whose attribute is to be tested
    * @param {string} name   The name of the attribute to test
-   * @returns {boolean}      True of the node has the given attribute defined
+   * @returns {boolean}     True of the node has the given attribute defined
    */
-  hasAttribute(node: N, name: string): boolean;
+  hasAttribute(node: N<DOM>, name: string): boolean;
 
   /**
-   * @param {N} node           The HTML node whose attributes are to be returned
-   * @returns {AttributeData[]} The list of attributes
+   * @param {N} node              The HTML node whose attributes are to be returned
+   * @returns {AttributeData[]}   The list of attributes
    */
-  allAttributes(node: N): AttributeData[];
+  allAttributes(node: N<DOM>): AttributeData[];
 
   /**
    * @param {N} node        The HTML node whose class is to be augmented
    * @param {string} name   The class to be added
    */
-  addClass(node: N, name: string): void;
+  addClass(node: N<DOM>, name: string): void;
 
   /**
    * @param {N} node        The HTML node whose class is to be changed
    * @param {string} name   The class to be removed
    */
-  removeClass(node: N, name: string): void;
+  removeClass(node: N<DOM>, name: string): void;
 
   /**
    * @param {N} node        The HTML node whose class is to be tested
    * @param {string} name   The class to test
-   * @returns {boolean}      True if the node has the given class
+   * @returns {boolean}     True if the node has the given class
    */
-  hasClass(node: N, name: string): boolean;
+  hasClass(node: N<DOM>, name: string): boolean;
 
   /**
-   * @param {N} node        The HTML node whose class list is needed
-   * @returns {string[]}     An array of the class names for this node
+   * @param {N} node       The HTML node whose class list is needed
+   * @returns {string[]}   An array of the class names for this node
    */
-  allClasses(node: N): string[];
+  allClasses(node: N<DOM>): string[];
 
   /**
    * @param {N} node        The HTML node whose style is to be changed
    * @param {string} name   The style to be set
    * @param {string} value  The new value of the style
    */
-  setStyle(node: N, name: string, value: string): void;
+  setStyle(node: N<DOM>, name: string, value: string): void;
 
   /**
    * @param {N} node        The HTML node whose style is to be obtained
    * @param {string} name   The style to be obtained
-   * @returns {string}       The value of the style
+   * @returns {string}      The value of the style
    */
-  getStyle(node: N, name: string): string;
+  getStyle(node: N<DOM>, name: string): string;
 
   /**
-   * @param {N} node        The HTML node whose styles are to be returned
-   * @returns {string}       The cssText for the styles
+   * @param {N} node     The HTML node whose styles are to be returned
+   * @returns {string}   The cssText for the styles
    */
-  allStyles(node: N): string;
+  allStyles(node: N<DOM>): string;
 
   /**
    * @param {N} node           The stylesheet node where the rule will be added
    * @param {string[]} rules   The rule to add at the beginning of the stylesheet
    */
-  insertRules(node: N, rules: string[]): void;
+  insertRules(node: N<DOM>, rules: string[]): void;
 
   /**
-   * @param {N} node        The stylesheet node whose rules are to be returned
-   * @returns {string}       The string version of the stylesheet rules
+   * @param {N} node     The stylesheet node whose rules are to be returned
+   * @returns {string}   The string version of the stylesheet rules
    */
-  cssText(node: N): string;
+  cssText(node: N<DOM>): string;
 
   /**
-   * @param {N} node        The HTML node whose font size is to be determined
-   * @returns {number}       The font size (in pixels) of the node
+   * @param {N} node     The HTML node whose font size is to be determined
+   * @returns {number}   The font size (in pixels) of the node
    */
-  fontSize(node: N): number;
+  fontSize(node: N<DOM>): number;
 
   /**
-   * @param {N} node        The HTML node whose font family is to be determined
-   * @returns {string}       The font family
+   * @param {N} node     The HTML node whose font family is to be determined
+   * @returns {string}   The font family
    */
-  fontFamily(node: N): string;
+  fontFamily(node: N<DOM>): string;
 
   /**
-   * @param {N} node            The HTML node whose dimensions are to be determined
-   * @param {number} em         The number of pixels in an em
-   * @param {boolean} local     True if local coordinates are to be used in SVG elements
-   * @returns {[number, number]} The width and height (in ems) of the element
+   * @param {N} node               The HTML node whose dimensions are to be determined
+   * @param {number} em            The number of pixels in an em
+   * @param {boolean} local        True if local coordinates are to be used in SVG elements
+   * @returns {[number, number]}   The width and height (in ems) of the element
    */
-  nodeSize(node: N, em?: number, local?: boolean): [number, number];
+  nodeSize(node: N<DOM>, em?: number, local?: boolean): [number, number];
 
   /**
-   * @param {N} node            The HTML node whose BBox is to be determined
-   * @returns {PageBBox}         BBox as {left, right, top, bottom} position on the page (in pixels)
+   * @param {N} node       The HTML node whose BBox is to be determined
+   * @returns {PageBBox}   BBox as {left, right, top, bottom} position on the page (in pixels)
    */
-  nodeBBox(node: N): PageBBox;
+  nodeBBox(node: N<DOM>): PageBBox;
 
   /**
    * @param {(event: any) => void} listener  The event listener for messages from the worker
@@ -426,19 +437,15 @@ export interface DOMAdaptor<N, T, D> {
 /**
  *  Abstract DOMAdaptor class for creating HTML elements
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
-  N,
-  T,
-  D
-> {
+export abstract class AbstractDOMAdaptor<
+  DOM extends DOM_TYPES,
+> implements DOMAdaptor<DOM> {
   /**
    * The document in which the HTML nodes will be created
    */
-  public document: D;
+  public document: D<DOM>;
 
   /**
    * True when the adaptor can measure DOM node sizes
@@ -447,16 +454,15 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
 
   /**
    * @param {D} document  The document in which the nodes will be created
-   * @class
    */
-  constructor(document: D = null) {
+  constructor(document: D<DOM> = null) {
     this.document = document;
   }
 
   /**
    * @override
    */
-  public abstract parse(text: string, format?: string): D;
+  public abstract parse(text: string, format?: string): D<DOM>;
 
   /**
    * @override
@@ -464,7 +470,7 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
   public node(
     kind: string,
     def: OptionList = {},
-    children: (N | T)[] = [],
+    children: NT<DOM>[] = [],
     ns?: string
   ) {
     const node = this.create(kind, ns);
@@ -472,32 +478,32 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
     for (const child of children) {
       this.append(node, child);
     }
-    return node as N;
+    return node as N<DOM>;
   }
 
   /**
-   * @param {string} kind  The type of the node to create
-   * @param {string} ns    The optional namespace in which to create the node
+   * @param {string} kind   The type of the node to create
+   * @param {string} ns     The optional namespace in which to create the node
    * @returns {N}           The created node
    */
-  protected abstract create(kind: string, ns?: string): N;
+  protected abstract create(kind: string, ns?: string): N<DOM>;
 
   /**
    * @override
    */
-  public abstract text(text: string): T;
+  public abstract text(text: string): T<DOM>;
 
   /**
    * @override
    */
-  public setProperty(node: N, name: string, value: any) {
+  public setProperty(node: N<DOM>, name: string, value: any) {
     (node as any)[name] = value;
   }
 
   /**
    * @override
    */
-  public getProperty(node: N, name: string): any {
+  public getProperty(node: N<DOM>, name: string): any {
     return (node as any)[name];
   }
 
@@ -505,7 +511,7 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
    * @param {N} node           The HTML element whose attributes are to be set
    * @param {OptionList} def   The attributes to set on that node
    */
-  public setAttributes(node: N, def: OptionList) {
+  public setAttributes(node: N<DOM>, def: OptionList) {
     if (def.style && typeof def.style !== 'string') {
       for (const key of Object.keys(def.style)) {
         this.setStyle(
@@ -533,67 +539,70 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
   /**
    * @override
    */
-  public abstract head(doc?: D): N;
+  public abstract head(doc?: D<DOM>): N<DOM>;
 
   /**
    * @override
    */
-  public abstract body(doc?: D): N;
+  public abstract body(doc?: D<DOM>): N<DOM>;
 
   /**
    * @override
    */
-  public abstract root(doc?: D): N;
+  public abstract root(doc?: D<DOM>): N<DOM>;
 
   /**
    * @override
    */
-  public abstract doctype(doc?: D): string;
+  public abstract doctype(doc?: D<DOM>): string;
 
   /**
    * @override
    */
-  public abstract tags(node: N, name: string, ns?: string): N[];
+  public abstract tags(node: N<DOM>, name: string, ns?: string): N<DOM>[];
 
   /**
    * @override
    */
-  public abstract getElements(nodes: (string | N | N[])[], document: D): N[];
+  public abstract getElements(
+    nodes: ContainerSpec<DOM>[],
+    document: D<DOM>
+  ): N<DOM>[];
 
   /**
    * @override
    */
-  public abstract getElement(selector: string, node?: D | N): N;
+  public abstract getElement(selector: string, node?: D<DOM> | N<DOM>): N<DOM>;
 
   /**
    * @override
    */
-  public abstract contains(container: N, node: N | T): boolean;
+  public abstract contains(container: N<DOM>, node: NT<DOM>): boolean;
 
   /**
    * @override
    */
-  public abstract parent(node: N | T): N;
+  public abstract parent(node: NT<DOM>): N<DOM>;
 
   /**
    * @override
    */
-  public abstract append(node: N, child: N | T): N | T;
+  public abstract append(node: N<DOM>, child: NT<DOM>): NT<DOM>;
 
   /**
    * @override
    */
-  public abstract insert(nchild: N | T, ochild: N | T): void;
+  public abstract insert(nchild: NT<DOM>, ochild: NT<DOM>): void;
 
   /**
    * @override
    */
-  public abstract remove(child: N | T): N | T;
+  public abstract remove(child: NT<DOM>): NT<DOM>;
 
   /**
    * @override
    */
-  public replace(nnode: N | T, onode: N | T) {
+  public replace(nnode: NT<DOM>, onode: NT<DOM>) {
     this.insert(nnode, onode);
     this.remove(onode);
     return onode;
@@ -602,80 +611,80 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
   /**
    * @override
    */
-  public abstract clone(node: N, deep: boolean): N;
+  public abstract clone(node: N<DOM>, deep: boolean): N<DOM>;
 
   /**
    * @override
    */
-  public abstract split(node: T, n: number): T;
+  public abstract split(node: T<DOM>, n: number): T<DOM>;
 
   /**
    * @override
    */
-  public abstract next(node: N | T): N | T;
+  public abstract next(node: NT<DOM>): NT<DOM>;
 
   /**
    * @override
    */
-  public abstract previous(node: N | T): N | T;
+  public abstract previous(node: NT<DOM>): NT<DOM>;
 
   /**
    * @override
    */
-  public abstract firstChild(node: N): N | T;
+  public abstract firstChild(node: N<DOM>): NT<DOM>;
 
   /**
    * @override
    */
-  public abstract lastChild(node: N): N | T;
+  public abstract lastChild(node: N<DOM>): NT<DOM>;
 
   /**
    * @override
    */
-  public abstract childNodes(node: N): (N | T)[];
+  public abstract childNodes(node: N<DOM>): NT<DOM>[];
 
   /**
    * @override
    */
-  public childNode(node: N, i: number) {
+  public childNode(node: N<DOM>, i: number) {
     return this.childNodes(node)[i];
   }
 
   /**
    * @override
    */
-  public abstract kind(node: N | T): string;
+  public abstract kind(node: NT<DOM>): string;
 
   /**
    * @override
    */
-  public abstract value(node: N | T): string;
+  public abstract value(node: NT<DOM>): string;
 
   /**
    * @override
    */
-  public abstract textContent(node: N): string;
+  public abstract textContent(node: N<DOM>): string;
 
   /**
    * @override
    */
-  public abstract innerHTML(node: N): string;
+  public abstract innerHTML(node: N<DOM>): string;
 
   /**
    * @override
    */
-  public abstract outerHTML(node: N): string;
+  public abstract outerHTML(node: N<DOM>): string;
 
   /**
    * @override
    */
-  public abstract serializeXML(node: N): string;
+  public abstract serializeXML(node: N<DOM>): string;
 
   /**
    * @override
    */
   public abstract setAttribute(
-    node: N,
+    node: N<DOM>,
     name: string,
     value: string,
     ns?: string
@@ -684,42 +693,42 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
   /**
    * @override
    */
-  public abstract getAttribute(node: N, name: string): string;
+  public abstract getAttribute(node: N<DOM>, name: string): string;
 
   /**
    * @override
    */
-  public abstract removeAttribute(node: N, name: string): void;
+  public abstract removeAttribute(node: N<DOM>, name: string): void;
 
   /**
    * @override
    */
-  public abstract hasAttribute(node: N, name: string): boolean;
+  public abstract hasAttribute(node: N<DOM>, name: string): boolean;
 
   /**
    * @override
    */
-  public abstract allAttributes(node: N): AttributeData[];
+  public abstract allAttributes(node: N<DOM>): AttributeData[];
 
   /**
    * @override
    */
-  public abstract addClass(node: N, name: string): void;
+  public abstract addClass(node: N<DOM>, name: string): void;
 
   /**
    * @override
    */
-  public abstract removeClass(node: N, name: string): void;
+  public abstract removeClass(node: N<DOM>, name: string): void;
 
   /**
    * @override
    */
-  public abstract hasClass(node: N, name: string): boolean;
+  public abstract hasClass(node: N<DOM>, name: string): boolean;
 
   /**
    * @override
    */
-  public allClasses(node: N) {
+  public allClasses(node: N<DOM>) {
     const classes = this.getAttribute(node, 'class');
     return !classes
       ? ([] as string[])
@@ -733,45 +742,45 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
   /**
    * @override
    */
-  public abstract setStyle(node: N, name: string, value: string): void;
+  public abstract setStyle(node: N<DOM>, name: string, value: string): void;
 
   /**
    * @override
    */
-  public abstract getStyle(node: N, name: string): string;
+  public abstract getStyle(node: N<DOM>, name: string): string;
 
   /**
    * @override
    */
-  public abstract allStyles(node: N): string;
+  public abstract allStyles(node: N<DOM>): string;
 
   /**
    * @override
    */
-  public abstract insertRules(node: N, rules: string[]): void;
+  public abstract insertRules(node: N<DOM>, rules: string[]): void;
 
   /**
    * @override
    */
-  public cssText(node: N) {
+  public cssText(node: N<DOM>) {
     return this.kind(node) === 'style' ? this.textContent(node) : '';
   }
 
   /**
    * @override
    */
-  public abstract fontSize(node: N): number;
+  public abstract fontSize(node: N<DOM>): number;
 
   /**
    * @override
    */
-  public abstract fontFamily(node: N): string;
+  public abstract fontFamily(node: N<DOM>): string;
 
   /**
    * @override
    */
   public abstract nodeSize(
-    node: N,
+    node: N<DOM>,
     em?: number,
     local?: boolean
   ): [number, number];
@@ -779,7 +788,7 @@ export abstract class AbstractDOMAdaptor<N, T, D> implements DOMAdaptor<
   /**
    * @override
    */
-  public abstract nodeBBox(node: N): PageBBox;
+  public abstract nodeBBox(node: N<DOM>): PageBBox;
 
   /**
    * @override

--- a/ts/core/FilterFunctions.ts
+++ b/ts/core/FilterFunctions.ts
@@ -23,26 +23,42 @@
 
 import { MathDocument } from './MathDocument.js';
 import { MathItem } from './MathItem.js';
-import { DOM_TYPES, N, T, D } from '../types/Types.js';
+import { DOM_TYPES } from '../types/Types.js';
 import { FunctionList } from '../util/FunctionList.js';
 
 /**
- * Types for filter functions
+ * Data passed to a filter
  */
 export type FilterData<U, DOM extends DOM_TYPES> = {
-  math: MathItem<N<DOM>, T<DOM>, D<DOM>>;
-  document: MathDocument<N<DOM>, T<DOM>, D<DOM>>;
+  math: MathItem<DOM>;
+  document: MathDocument<DOM>;
   data: U;
 };
+
+/**
+ * A fulter function itself
+ */
 export type FilterFunction<T, D extends DOM_TYPES> = (
   arg: FilterData<T, D>
 ) => boolean | void;
+
+/**
+ * A filter function or one with a priority
+ */
 export type FilterFunctionDef<T, D extends DOM_TYPES> =
   FilterFunction<T, D> | [FilterFunction<T, D>, number];
+
+/**
+ * A list of filter function definitions
+ */
 export type FilterFunctionList<T, D extends DOM_TYPES> = FilterFunctionDef<
   T,
   D
 >[];
+
+/**
+ * A FunctionList of filter functions
+ */
 export type FilterFunctions<T, D extends DOM_TYPES> = FunctionList<
   FilterFunction<T, D>
 >;

--- a/ts/core/FindMath.ts
+++ b/ts/core/FindMath.ts
@@ -23,30 +23,29 @@
 
 import { userOptions, defaultOptions, OptionList } from '../util/Options.js';
 import { ProtoItem } from './MathItem.js';
+import { DOM_TYPES, N } from '../types/Types.js';
 
 /*****************************************************************/
 /**
  *  The FindMath interface
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template _D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface FindMath<N, T, _D> {
+export interface FindMath<DOM extends DOM_TYPES> {
   /**
    * One of two possibilities:  Look through a DOM element,
    *   or look through an array of strings for delimited math.
    *
    * @param {N} node   The node to search for math
-   * @returns {ProtoItem<N, T>[]}
+   * @returns {ProtoItem<DOM>[]}
    */
-  findMath(node: N): ProtoItem<N, T>[];
+  findMath(node: N<DOM>): ProtoItem<DOM>[];
   /**
    *
    * @param {string[]} strings    The strings to search for math
-   * @returns {ProtoItem<N, T>[]}
+   * @returns {ProtoItem<DOM>[]}
    */
-  findMath(strings: string[]): ProtoItem<N, T>[];
+  findMath(strings: string[]): ProtoItem<DOM>[];
 }
 
 /*****************************************************************/
@@ -55,11 +54,11 @@ export interface FindMath<N, T, _D> {
  */
 
 /**
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export abstract class AbstractFindMath<N, T, D> implements FindMath<N, T, D> {
+export abstract class AbstractFindMath<
+  DOM extends DOM_TYPES,
+> implements FindMath<DOM> {
   /**
    * The default options for FindMath
    */
@@ -84,5 +83,5 @@ export abstract class AbstractFindMath<N, T, D> implements FindMath<N, T, D> {
    * @param {Element | string[]} where  The node or string array to search for math
    * @returns {ProtoItem[]}              The array of proto math items found
    */
-  public abstract findMath(where: N | string[]): ProtoItem<N, T>[];
+  public abstract findMath(where: N<DOM> | string[]): ProtoItem<DOM>[];
 }

--- a/ts/core/Handler.ts
+++ b/ts/core/Handler.ts
@@ -28,16 +28,15 @@ import {
 } from './MathDocument.js';
 import { OptionList } from '../util/Options.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
+import { DOM_TYPES } from '../types/Types.js';
 
 /*****************************************************************/
 /**
  *  The Handler interface
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface Handler<N, T, D> {
+export interface Handler<DOM extends DOM_TYPES> {
   /**
    * The name of the handler class
    */
@@ -46,7 +45,7 @@ export interface Handler<N, T, D> {
   /**
    * The DOM Adaptor to use for managing HTML elements
    */
-  adaptor: DOMAdaptor<N, T, D>;
+  adaptor: DOMAdaptor<DOM>;
 
   /**
    * The priority for the handler when handlers are polled
@@ -58,12 +57,12 @@ export interface Handler<N, T, D> {
    * The class implementing the MathDocument for this handler
    *   (so it can be subclassed by extensions as needed)
    */
-  documentClass: MathDocumentConstructor<AbstractMathDocument<N, T, D>>;
+  documentClass: MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>;
 
   /**
    * Checks to see if the handler can process a given document
    *
-   * @param {any} document  The document to be processed (string, window, etc.)
+   * @param {any} document   The document to be processed (string, window, etc.)
    * @returns {boolean}      True if this handler can process the given document
    */
   handlesDocument(document: any): boolean;
@@ -71,32 +70,32 @@ export interface Handler<N, T, D> {
   /**
    * Creates a MathDocument for the given handler
    *
-   * @param {any} document        The document to be handled
-   * @param {OptionList} options  The options for the handling of the document
+   * @param {any} document         The document to be handled
+   * @param {OptionList} options   The options for the handling of the document
    * @returns {MathDocument}       The MathDocument object that manages the processing
    */
-  create(document: any, options: OptionList): MathDocument<N, T, D>;
+  create(document: any, options: OptionList): MathDocument<DOM>;
 }
 
 /*****************************************************************/
 /**
  *  The default MathDocument class (subclasses use their own)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-class DefaultMathDocument<N, T, D> extends AbstractMathDocument<N, T, D> {}
+class DefaultMathDocument<
+  DOM extends DOM_TYPES,
+> extends AbstractMathDocument<DOM> {}
 
 /*****************************************************************/
 /**
  *  The Handler interface
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
+export abstract class AbstractHandler<
+  DOM extends DOM_TYPES,
+> implements Handler<DOM> {
   /**
    * The name of this class
    */
@@ -105,7 +104,7 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
   /**
    * The DOM Adaptor to use for managing HTML elements
    */
-  public adaptor: DOMAdaptor<N, T, D>;
+  public adaptor: DOMAdaptor<DOM>;
 
   /**
    * The priority for this handler
@@ -116,8 +115,10 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
    * The class implementing the MathDocument for this handler
    *   (so it can be subclassed by extensions as needed)
    */
-  public documentClass: MathDocumentConstructor<AbstractMathDocument<N, T, D>> =
-    DefaultMathDocument;
+  public documentClass = DefaultMathDocument as MathDocumentConstructor<
+    AbstractMathDocument<DOM>,
+    DOM
+  >;
 
   /**
    * @param {DOMAdaptor} adaptor The DOM adaptor
@@ -125,7 +126,7 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
    *
    * @class
    */
-  constructor(adaptor: DOMAdaptor<N, T, D>, priority: number = 5) {
+  constructor(adaptor: DOMAdaptor<DOM>, priority: number = 5) {
     this.adaptor = adaptor;
     this.priority = priority;
   }
@@ -152,6 +153,6 @@ export abstract class AbstractHandler<N, T, D> implements Handler<N, T, D> {
       document,
       this.adaptor,
       options
-    ) as MathDocument<N, T, D>;
+    ) as MathDocument<DOM>;
   }
 }

--- a/ts/core/HandlerList.ts
+++ b/ts/core/HandlerList.ts
@@ -27,6 +27,7 @@ import { Handler } from './Handler.js';
 import { MathDocument } from './MathDocument.js';
 import { Locale } from '../util/Locale.js';
 import { COMPONENT } from '../core/__locales__/Component.js';
+import { DOM_TYPES } from '../types/Types.js';
 
 /*****************************************************************/
 /**
@@ -36,23 +37,23 @@ import { COMPONENT } from '../core/__locales__/Component.js';
  *  by asking each handler to test if it can handle the document,
  *  and when one can, it is asked to create its associated MathDocument.
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>> {
+export class HandlerList<DOM extends DOM_TYPES> extends PrioritizedList<
+  Handler<DOM>
+> {
   /**
    * @param {Handler} handler  The handler to register
-   * @returns {Handler}  The list item created for the handler
+   * @returns {Handler}        The list item created for the handler
    */
-  public register(handler: Handler<N, T, D>): Handler<N, T, D> {
+  public register(handler: Handler<DOM>): Handler<DOM> {
     return this.add(handler, handler.priority);
   }
 
   /**
    * @param {Handler} handler  The handler to remove from the list
    */
-  public unregister(handler: Handler<N, T, D>) {
+  public unregister(handler: Handler<DOM>) {
     this.remove(handler);
   }
 
@@ -60,7 +61,7 @@ export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>> {
    * @param {any} document     The document (string, window, DOM element, etc) to be handled
    * @returns {Handler}        The handler from the list that can process the given document
    */
-  public handlesDocument(document: any): Handler<N, T, D> {
+  public handlesDocument(document: any): Handler<DOM> {
     for (const item of this) {
       const handler = item.item;
       if (handler.handlesDocument(document)) {
@@ -71,14 +72,14 @@ export class HandlerList<N, T, D> extends PrioritizedList<Handler<N, T, D>> {
   }
 
   /**
-   * @param {any} document        The document to be processed
-   * @param {OptionList} options  The options for the handler
+   * @param {any} document         The document to be processed
+   * @param {OptionList} options   The options for the handler
    * @returns {MathDocument}       The MathDocument created by the handler for this document
    */
   public document(
     document: any,
     options: OptionList = null
-  ): MathDocument<N, T, D> {
+  ): MathDocument<DOM> {
     return this.handlesDocument(document).create(document, options);
   }
 }

--- a/ts/core/InputJax.ts
+++ b/ts/core/InputJax.ts
@@ -28,18 +28,16 @@ import { MmlFactory } from './MmlTree/MmlFactory.js';
 import { userOptions, defaultOptions, OptionList } from '../util/Options.js';
 import { FunctionList } from '../util/FunctionList.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
-import type { DOM, DOM_TYPES } from '../types/Types.js';
+import type { DOM, DOM_TYPES, N } from '../types/Types.js';
 import type { FilterFunctions, FilterFunctionList } from './FilterFunctions.js';
 
 /*****************************************************************/
 /**
  *  The InputJax interface
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface InputJax<N, T, D> {
+export interface InputJax<DOM extends DOM_TYPES> {
   /**
    * The name of the input jax subclass (e.g,. 'TeX')
    */
@@ -59,13 +57,13 @@ export interface InputJax<N, T, D> {
   /**
    * Lists of pre- and post-filters to call before and after processing the input
    */
-  preFilters: FilterFunctions<any, DOM<N, T, D>>;
-  postFilters: FilterFunctions<any, DOM<N, T, D>>;
+  preFilters: FilterFunctions<any, DOM>;
+  postFilters: FilterFunctions<any, DOM>;
 
   /**
    * The DOM adaptor for managing HTML elements
    */
-  adaptor: DOMAdaptor<N, T, D>;
+  adaptor: DOMAdaptor<DOM>;
 
   /**
    * The MmlFactory for this input jax
@@ -75,7 +73,7 @@ export interface InputJax<N, T, D> {
   /**
    * @param {DOMAdaptor} adaptor The adaptor to use in this jax
    */
-  setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
+  setAdaptor(adaptor: DOMAdaptor<DOM>): void;
 
   /**
    * @param {MmlFactory} mmlFactory The MmlFactory to use in this jax
@@ -97,25 +95,29 @@ export interface InputJax<N, T, D> {
   /**
    * Finds the math within the DOM or the list of strings
    *
-   * @param {N | string[]} which   The element or array of strings to be searched for math
+   * @param {N|string[]} which     The element or array of strings to be searched for math
    * @param {OptionList} options   The options for the search, if any
    * @returns {ProtoItem[]}        Array of proto math items found (further processed by the
    *                               handler to produce actual MathItem objects)
    */
-  findMath(which: N | string[], options?: OptionList): ProtoItem<N, T>[];
+  findMath(which: N<DOM> | string[], options?: OptionList): ProtoItem<DOM>[];
 
   /**
    * Convert the math in a math item into the internal format
    *
-   * @param {MathItem} math  The MathItem whose math content is to processed
-   * @param {MathDocument} document The MathDocument for this input jax.
-   * @returns {MmlNode}      The resulting internal node tree for the math
+   * @param {MathItem} math           The MathItem whose math content is to processed
+   * @param {MathDocument} document   The MathDocument for this input jax.
+   * @returns {MmlNode}               The resulting internal node tree for the math
    */
-  compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>): MmlNode;
+  compile(math: MathItem<DOM>, document: MathDocument<DOM>): MmlNode;
 }
 
 /**
  * The InputJax option types.
+ *
+ * @template DOM   The DOM node types
+ * @template PRE   The type of data passed to the pre-filter functions
+ * @template POST  The type of data passed to the post-filter functions
  */
 export type INPUTJAX_OPTIONS<
   D extends DOM_TYPES = DOM,
@@ -130,19 +132,15 @@ export type INPUTJAX_OPTIONS<
 /**
  *  The abstract InputJax class
  *
- * @template N     The HTMLElement node class
- * @template T     The Text node class
- * @template D     The Document class
+ * @template DOM   The DOM node types
  * @template PRE   The type of data passed to the pre-filter functions
  * @template POST  The type of data passed to the post-filter functions
  */
 export abstract class AbstractInputJax<
-  N,
-  T,
-  D,
+  DOM extends DOM_TYPES,
   PRE = any,
   POST = PRE,
-> implements InputJax<N, T, D> {
+> implements InputJax<DOM> {
   /**
    * The name of the input jax
    */
@@ -164,17 +162,17 @@ export abstract class AbstractInputJax<
   /**
    * Filters to run on the TeX string before it is processed
    */
-  public preFilters: FilterFunctions<PRE, DOM<N, T, D>>;
+  public preFilters: FilterFunctions<PRE, DOM>;
 
   /**
    * Filters to run on the generated MathML after the TeX string is processed
    */
-  public postFilters: FilterFunctions<POST, DOM<N, T, D>>;
+  public postFilters: FilterFunctions<POST, DOM>;
 
   /**
    * The DOMAdaptor for the MathDocument for this input jax
    */
-  public adaptor: DOMAdaptor<N, T, D> = null; // set by the handler
+  public adaptor: DOMAdaptor<DOM> = null; // set by the handler
   /**
    * The MathML node factory
    */
@@ -202,7 +200,7 @@ export abstract class AbstractInputJax<
   /**
    * @override
    */
-  public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
+  public setAdaptor(adaptor: DOMAdaptor<DOM>) {
     this.adaptor = adaptor;
   }
 
@@ -233,16 +231,16 @@ export abstract class AbstractInputJax<
   /**
    * @override
    */
-  public findMath(_node: N | string[], _options?: OptionList) {
-    return [] as ProtoItem<N, T>[];
+  public findMath(_node: N<DOM> | string[], _options?: OptionList) {
+    return [] as ProtoItem<DOM>[];
   }
 
   /**
    * @override
    */
   public abstract compile(
-    math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>
+    math: MathItem<DOM>,
+    document: MathDocument<DOM>
   ): MmlNode;
 
   /**
@@ -255,12 +253,12 @@ export abstract class AbstractInputJax<
    * @param {any} data               Whatever other data is needed
    * @returns {any}                  The (possibly modified) data
    *
-   * @template D  The type of data being passed
+   * @template DATA  The type of data being passed
    */
   protected executeFilters<DATA = PRE | POST>(
     filters: FunctionList,
-    math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>,
+    math: MathItem<DOM>,
+    document: MathDocument<DOM>,
     data: DATA
   ): any {
     const args = { math: math, document: document, data: data };

--- a/ts/core/MathDocument.ts
+++ b/ts/core/MathDocument.ts
@@ -33,12 +33,12 @@ import { MathList, MathListItem, AbstractMathList } from './MathList.js';
 import { MathItem, AbstractMathItem, STATE } from './MathItem.js';
 import { MmlNode, TextNode } from './MmlTree/MmlNode.js';
 import { MmlFactory } from '../core/MmlTree/MmlFactory.js';
-import { DOMAdaptor } from '../core/DOMAdaptor.js';
+import { DOMAdaptor, ContainerSpec } from '../core/DOMAdaptor.js';
 import { BitField, BitFieldClass } from '../util/BitField.js';
 import { PrioritizedList } from '../util/PrioritizedList.js';
 import { localize } from './__locales__/Component.js';
 import { mathjax } from '../mathjax.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../types/Types.js';
+import { DOM, DOM_TYPES, N, D, Constructor } from '../types/Types.js';
 
 /*****************************************************************/
 
@@ -50,39 +50,32 @@ export type RenderResult = Promise<boolean | void> | boolean | void;
 /**
  * A function to call while rendering a document (usually calls a MathDocument method)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export type RenderDoc<N, T, D> = (
-  document: MathDocument<N, T, D>
+export type RenderDoc<DOM extends DOM_TYPES> = (
+  document: MathDocument<DOM>
 ) => RenderResult;
 
 /**
  * A function to call while rendering a MathItem (usually calls one of its methods)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export type RenderMath<N, T, D> = (
-  math: MathItem<N, T, D>,
-  document: MathDocument<N, T, D>
+export type RenderMath<DOM extends DOM_TYPES> = (
+  math: MathItem<DOM>,
+  document: MathDocument<DOM>
 ) => RenderResult;
 
 /**
  * The data for an action to perform during rendering or conversion
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-/* prettier-ignore */
-export type RenderData<N, T, D> = {
-  id: string,                           //  The name for the action
-  renderDoc: RenderDoc<N, T, D>,        //  The action to take during a render() call
-  renderMath: RenderMath<N, T, D>,      //  The action to take during a rerender() or convert() call
-  convert: boolean                      //  Whether the action is to be used during convert()
+export type RenderData<DOM extends DOM_TYPES> = {
+  id: string; //                        The name for the action
+  renderDoc: RenderDoc<DOM>; //         The action to take during a render() call
+  renderMath: RenderMath<DOM>; //       The action to take during a rerender() or convert() call
+  convert: boolean; //                  Whether the action is to be used during convert()
 };
 
 /**
@@ -91,51 +84,50 @@ export type RenderData<N, T, D> = {
  *    the remainind data is as described below; if no boolean is given, convert = true
  *    by default)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-/* prettier-ignore */
-export type RenderAction<N, T, D> =
-  [number] |                                                     // id (i.e., key) is method name to use
-  [number, string] |                                             // string is method to call
-  [number, string, string] |                                     // the strings are methods names for doc and math
-  [number, RenderDoc<N, T, D>, RenderMath<N, T, D>] |            // explicit functions for doc and math
-  [number, boolean] |                                            // same as first above, with boolean for convert
-  [number, string, boolean] |                                    // same as second above, with boolean for convert
-  [number, string, string, boolean] |                            // same as third above, with boolean for convert
-  [number, RenderDoc<N, T, D>, RenderMath<N, T, D>, boolean]; // same as forth above, with boolean for convert
+export type RenderAction<DOM extends DOM_TYPES> =
+  | [number] //                                            Id (i.e., key) is method name to use
+  | [number, string] //                                    String is method to call
+  | [number, string, string] //                            The strings are methods names for doc and math
+  | [number, RenderDoc<DOM>, RenderMath<DOM>] //           Explicit functions for doc and math
+  | [number, boolean] //                                   Same as first above, with boolean for convert
+  | [number, string, boolean] //                           Same as second above, with boolean for convert
+  | [number, string, string, boolean] //                   Same as third above, with boolean for convert
+  | [number, RenderDoc<DOM>, RenderMath<DOM>, boolean]; // Same as forth above, with boolean for convert
 
 /**
  * An object representing a collection of rendering actions (id's tied to priority-and-method data)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export type RenderActions<N, T, D> = { [id: string]: RenderAction<N, T, D> };
+export type RenderActions<DOM extends DOM_TYPES> = {
+  [id: string]: RenderAction<DOM>;
+};
 
 /**
  * Implements a prioritized list of render actions.  Extensions can add actions to the list
  *   to make it easy to extend the normal typesetting and conversion operations.
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
+export class RenderList<DOM extends DOM_TYPES> extends PrioritizedList<
+  RenderData<DOM>
+> {
   /**
    * Creates a new RenderList from an initial list of rendering actions
    *
-   * @param {RenderActions} actions The list of actions to take during render(), rerender(), and convert() calls
-   * @returns {RenderList}    The newly created prioritied list
+   * @param {RenderActions} actions   The list of actions to take during render(), rerender(), and convert() calls
+   * @returns {RenderList}            The newly created prioritied list
+   *
+   * @template DOM   The DOM element types
    */
-  public static create<N, T, D>(
-    actions: RenderActions<N, T, D>
-  ): RenderList<N, T, D> {
-    const list = new this<N, T, D>();
+  public static create<DOM extends DOM_TYPES>(
+    actions: RenderActions<DOM>
+  ): RenderList<DOM> {
+    const list = new this<DOM>();
     for (const id of Object.keys(actions)) {
-      const [action, priority] = this.action<N, T, D>(id, actions[id]);
+      const [action, priority] = this.action<DOM>(id, actions[id]);
       if (priority) {
         list.add(action, priority);
       }
@@ -150,11 +142,13 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @param {string} id               The id of the action
    * @param {RenderAction} action     The RenderAction defining the action
    * @returns {[RenderData,number]}   The corresponding RenderData definition for the action and its priority
+   *
+   * @template DOM   The DOM element types
    */
-  public static action<N, T, D>(
+  public static action<DOM extends DOM_TYPES>(
     id: string,
-    action: RenderAction<N, T, D>
-  ): [RenderData<N, T, D>, number] {
+    action: RenderAction<DOM>
+  ): [RenderData<DOM>, number] {
     let renderDoc, renderMath;
     let convert = true;
     const priority = action[0];
@@ -181,12 +175,12 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
         convert = action[3] as boolean;
       }
       [renderDoc, renderMath] = action.slice(1) as [
-        RenderDoc<N, T, D>,
-        RenderMath<N, T, D>,
+        RenderDoc<DOM>,
+        RenderMath<DOM>,
       ];
     }
     return [
-      { id, renderDoc, renderMath, convert } as RenderData<N, T, D>,
+      { id, renderDoc, renderMath, convert } as RenderData<DOM>,
       priority,
     ];
   }
@@ -224,7 +218,7 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @param {number=} i               The index in the renderAction list to start at
    */
   public renderDoc(
-    document: MathDocument<N, T, D>,
+    document: MathDocument<DOM>,
     start: number = STATE.UNPROCESSED,
     i: number = 0
   ) {
@@ -248,8 +242,8 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @param {number=} i               The index in the renderAction list to start at
    */
   public renderMath(
-    math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>,
+    math: MathItem<DOM>,
+    document: MathDocument<DOM>,
     start: number = STATE.UNPROCESSED,
     i: number = 0
   ) {
@@ -276,11 +270,11 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
    * @returns {N|MmlNode}             The typeset root or the MathML root, whichever is defined
    */
   public renderConvert(
-    math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>,
+    math: MathItem<DOM>,
+    document: MathDocument<DOM>,
     end: number = STATE.LAST,
     i: number = 0
-  ): N | MmlNode {
+  ): N<DOM> | MmlNode {
     let item;
     while ((item = this.items[i++])) {
       if (item.priority > end) break;
@@ -299,10 +293,10 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
   /**
    * Find an entry in the list with a given ID
    *
-   * @param {string} id            The id to search for
+   * @param {string} id           The id to search for
    * @returns {RenderData|null}   The data for the given id, if found, or null
    */
-  public findID(id: string): RenderData<N, T, D> | null {
+  public findID(id: string): RenderData<DOM> | null {
     for (const item of this.items) {
       if (item.item.id === id) {
         return item.item;
@@ -318,9 +312,10 @@ export class RenderList<N, T, D> extends PrioritizedList<RenderData<N, T, D>> {
  * The ways of specifying a container (a selector string, an actual node,
  * or an array of those (e.g., the result of document.getElementsByTagName())
  *
- * @template N  The HTMLElement node class
+ * @template DOM   The DOM element types
  */
-export type ContainerList<N> = string | N | (string | N | N[])[];
+export type ContainerList<DOM extends DOM_TYPES> =
+  ContainerSpec<DOM> | ContainerSpec<DOM>[];
 
 /**
  * The options allowed for the reset() method
@@ -371,15 +366,13 @@ export const resetAllOptions: ResetList = {
  *  The MathDocument is the main interface for page authors to
  *  interact with MathJax.
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export interface MathDocument<N, T, D> {
+export interface MathDocument<DOM extends DOM_TYPES> {
   /**
    * The document being processed (e.g., DOM document, or Markdown string)
    */
-  document: D;
+  document: D<DOM>;
 
   /**
    * The kind of MathDocument (e.g., "HTML")
@@ -389,17 +382,17 @@ export interface MathDocument<N, T, D> {
   /**
    * The options for the document
    */
-  options: DOCUMENT_OPTIONS<DOM<N, T, D>>;
+  options: DOCUMENT_OPTIONS<DOM>;
 
   /**
    * The list of MathItems found in this page
    */
-  math: MathList<N, T, D>;
+  math: MathList<DOM>;
 
   /**
    * The list of actions to take during a render() or convert() call
    */
-  renderActions: RenderList<N, T, D>;
+  renderActions: RenderList<DOM>;
 
   /**
    * This object tracks what operations have been performed, so that (when
@@ -411,17 +404,17 @@ export interface MathDocument<N, T, D> {
   /**
    * An array of input jax to run on the document
    */
-  inputJax: InputJax<N, T, D>[];
+  inputJax: InputJax<DOM>[];
 
   /**
    * The output jax to use for the document
    */
-  outputJax: OutputJax<N, T, D>;
+  outputJax: OutputJax<DOM>;
 
   /**
    * The DOM adaptor to use for input and output
    */
-  adaptor: DOMAdaptor<N, T, D>;
+  adaptor: DOMAdaptor<DOM>;
 
   /**
    * The MmlFactory to be used for input jax and error processing
@@ -474,18 +467,18 @@ export interface MathDocument<N, T, D> {
    *
    * @param {string} math           The math string to convert
    * @param {OptionList} options    The options for the conversion (e.g., format, ex, em, etc.)
-   * @returns {MmlNode|N}           The MmlNode or N node for the converted content
+   * @returns {MmlNode|N<DOM>}      The MmlNode or N node for the converted content
    */
-  convert(math: string, options?: OptionList): MmlNode | N;
+  convert(math: string, options?: OptionList): MmlNode | N<DOM>;
 
   /**
    * Convert a math string to the document's output format
    *
-   * @param {string} math           The math string to convert
-   * @param {OptionList} options    The options for the conversion (e.g., format, ex, em, etc.)
-   * @returns {Promise<MmlNode|N>}  A promise that resolves when the conversion is complete
+   * @param {string} math                 The math string to convert
+   * @param {OptionList} options          The options for the conversion (e.g., format, ex, em, etc.)
+   * @returns {Promise<MmlNode|N<DOM>>}   A promise that resolves when the conversion is complete
    */
-  convertPromise(math: string, options?: OptionList): Promise<MmlNode | N>;
+  convertPromise(math: string, options?: OptionList): Promise<MmlNode | N<DOM>>;
 
   /**
    * Perform an action when previous actions are complete.
@@ -548,8 +541,8 @@ export interface MathDocument<N, T, D> {
   /**
    * Removes the typeset math from the document
    *
-   * @param {boolean} restore  True if the original math should be put
-   *                            back into the document as well
+   * @param {boolean} restore   True if the original math should be put
+   *                              back into the document as well
    * @returns {MathDocument}    The math document instance
    */
   removeFromDocument(restore?: boolean): this;
@@ -558,9 +551,9 @@ export interface MathDocument<N, T, D> {
    * Set the state of the document (allowing you to roll back
    *  the state to a previous one, if needed).
    *
-   * @param {number} state     The new state of the document
-   * @param {boolean} restore  True if the original math should be put
-   *                            back into the document during the rollback
+   * @param {number} state      The new state of the document
+   * @param {boolean} restore   True if the original math should be put
+   *                              back into the document during the rollback
    * @returns {MathDocument}    The math document instance
    */
   state(state: number, restore?: boolean): this;
@@ -569,7 +562,7 @@ export interface MathDocument<N, T, D> {
    * Clear the processed values so that the document can be reprocessed
    *
    * @param {ResetList} options   The things to be reset
-   * @returns {MathDocument}       The math document instance
+   * @returns {MathDocument}      The math document instance
    */
   reset(options?: ResetList): this;
 
@@ -589,10 +582,10 @@ export interface MathDocument<N, T, D> {
   /**
    * Merges a MathList into the list for this document.
    *
-   * @param {MathList} list   The MathList to be merged into this document's list
+   * @param {MathList} list    The MathList to be merged into this document's list
    * @returns {MathDocument}   The math document instance
    */
-  concat(list: MathList<N, T, D>): this;
+  concat(list: MathList<DOM>): this;
 
   /**
    * Clear the typeset MathItems that are within the given container
@@ -600,18 +593,18 @@ export interface MathDocument<N, T, D> {
    *   container has been updated and you want to remove the
    *   associated MathItems)
    *
-   * @param {ContainerList<N>} containers  The container DOM elements whose math items are to be removed
-   * @returns {MathItem<N,T,D>[]}          The removed MathItems
+   * @param {ContainerList<DOM>} containers   The container DOM elements whose math items are to be removed
+   * @returns {MathItem<DOM>[]}               The removed MathItems
    */
-  clearMathItemsWithin(containers: ContainerList<N>): MathItem<N, T, D>[];
+  clearMathItemsWithin(containers: ContainerList<DOM>): MathItem<DOM>[];
 
   /**
    * Get the typeset MathItems that are within a given container.
    *
-   * @param {ContainerList<N>} elements   The container DOM elements whose math items are to be found
-   * @returns {MathItem<N,T,D>[]}          The list of MathItems within that container
+   * @param {ContainerList<DOM>} elements   The container DOM elements whose math items are to be found
+   * @returns {MathItem<DOM>[]}             The list of MathItems within that container
    */
-  getMathItemsWithin(elements: ContainerList<N>): MathItem<N, T, D>[];
+  getMathItemsWithin(elements: ContainerList<DOM>): MathItem<DOM>[];
 }
 
 /*****************************************************************/
@@ -619,15 +612,13 @@ export interface MathDocument<N, T, D> {
 /**
  * Defaults used when input jax isn't specified
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-class DefaultInputJax<N, T, D> extends AbstractInputJax<N, T, D> {
+class DefaultInputJax<DOM extends DOM_TYPES> extends AbstractInputJax<DOM> {
   /**
    * @override
    */
-  public compile(_math: MathItem<N, T, D>) {
+  public compile(_math: MathItem<DOM>) {
     return null as MmlNode;
   }
 }
@@ -635,69 +626,61 @@ class DefaultInputJax<N, T, D> extends AbstractInputJax<N, T, D> {
 /**
  * Defaults used when ouput jax isn't specified
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-class DefaultOutputJax<N, T, D> extends AbstractOutputJax<N, T, D> {
+class DefaultOutputJax<DOM extends DOM_TYPES> extends AbstractOutputJax<DOM> {
   /**
    * @override
    */
-  public typeset(
-    _math: MathItem<N, T, D>,
-    _document: MathDocument<N, T, D> = null
-  ) {
-    return null as N;
+  public typeset(_math: MathItem<DOM>, _document: MathDocument<DOM> = null) {
+    return null as N<DOM>;
   }
   /**
    * @override
    */
-  public escaped(_math: MathItem<N, T, D>, _document?: MathDocument<N, T, D>) {
-    return null as N;
+  public escaped(_math: MathItem<DOM>, _document?: MathDocument<DOM>) {
+    return null as N<DOM>;
   }
 }
 
 /**
  * Default for the MathList when one isn't specified
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-class DefaultMathList<N, T, D> extends AbstractMathList<N, T, D> {}
+class DefaultMathList<DOM extends DOM_TYPES> extends AbstractMathList<DOM> {}
 
 /**
  * Default for the Mathitem when one isn't specified
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-class DefaultMathItem<N, T, D> extends AbstractMathItem<N, T, D> {}
+class DefaultMathItem<DOM extends DOM_TYPES> extends AbstractMathItem<DOM> {}
 
 /*****************************************************************/
 
 /**
  * The MathDocument option types.
+ *
+ * @template DOM   The DOM element types
  */
 export type DOCUMENT_OPTIONS<DOM extends DOM_TYPES> = {
-  OutputJax: OutputJax<N<DOM>, T<DOM>, D<DOM>>; // instance of an OutputJax for the document
-  InputJax:
-    InputJax<N<DOM>, T<DOM>, D<DOM>> | InputJax<N<DOM>, T<DOM>, D<DOM>>[]; // instance of an InputJax or an array of them
-  MmlFactory: MmlFactory; // instance of a MmlFactory for this document
-  MathList: Constructor<MathList<N<DOM>, T<DOM>, D<DOM>>>; // constructor for a MathList to use for the document
-  MathItem: Constructor<AbstractMathItem<N<DOM>, T<DOM>, D<DOM>>>; // constructor for a MathItem to use for the MathList
+  OutputJax: OutputJax<DOM>; //                      Instance of an OutputJax for the document
+  InputJax: InputJax<DOM> | InputJax<DOM>[]; //      Instance of an InputJax or an array of them
+  MmlFactory: MmlFactory; //                         Instance of a MmlFactory for this document
+  MathList: Constructor<MathList<DOM>>; //           Constructor for a MathList to use for the document
+  MathItem: Constructor<AbstractMathItem<DOM>>; //   Constructor for a MathItem to use for the MathList
   compileError: (
-    doc: AbstractMathDocument<N<DOM>, T<DOM>, D<DOM>>,
-    math: MathItem<N<DOM>, T<DOM>, D<DOM>>,
+    doc: AbstractMathDocument<DOM>,
+    math: MathItem<DOM>,
     err: Error
   ) => void;
   typesetError: (
-    doc: AbstractMathDocument<N<DOM>, T<DOM>, D<DOM>>,
-    math: MathItem<N<DOM>, T<DOM>, D<DOM>>,
+    doc: AbstractMathDocument<DOM>,
+    math: MathItem<DOM>,
     err: Error
   ) => void;
-  renderActions: RenderActions<N<DOM>, T<DOM>, D<DOM>>;
+  renderActions: RenderActions<DOM>;
 };
 
 /**
@@ -727,15 +710,11 @@ const options: DOCUMENT_OPTIONS<DOM> = {
 /**
  *  Implements the abstract MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
-  N,
-  T,
-  D
-> {
+export abstract class AbstractMathDocument<
+  DOM extends DOM_TYPES,
+> implements MathDocument<DOM> {
   /**
    * The type of MathDocument
    */
@@ -760,21 +739,21 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * The document managed by this MathDocument
    */
-  public document: D;
+  public document: D<DOM>;
   /**
    * The actual options for this document (with user-supplied ones merged in)
    */
-  public options: DOCUMENT_OPTIONS<DOM<N, T, D>>;
+  public options: DOCUMENT_OPTIONS<DOM>;
 
   /**
    * The list of MathItems for this document
    */
-  public math: MathList<N, T, D>;
+  public math: MathList<DOM>;
 
   /**
    * The list of render actions
    */
-  public renderActions: RenderList<N, T, D>;
+  public renderActions: RenderList<DOM>;
 
   /**
    * The render action promise list
@@ -796,17 +775,17 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * The list of input jax for the document
    */
-  public inputJax: InputJax<N, T, D>[];
+  public inputJax: InputJax<DOM>[];
 
   /**
    * The output jax for the document
    */
-  public outputJax: OutputJax<N, T, D>;
+  public outputJax: OutputJax<DOM>;
 
   /**
    * The DOM adaptor for the document
    */
-  public adaptor: DOMAdaptor<N, T, D>;
+  public adaptor: DOMAdaptor<DOM>;
 
   /**
    * The MathML node factory for the internal MathML representation
@@ -819,7 +798,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @param {OptionList} options     The options for this document
    * @class
    */
-  constructor(document: D, adaptor: DOMAdaptor<N, T, D>, options: OptionList) {
+  constructor(document: D<DOM>, adaptor: DOMAdaptor<DOM>, options: OptionList) {
     const CLASS = this.constructor as typeof AbstractMathDocument;
     this.document = document;
     this.options = userOptions(
@@ -827,12 +806,12 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
       options
     ) as DOCUMENT_OPTIONS<DOM>;
     this.math = new (this.options.MathList ?? DefaultMathList)();
-    this.renderActions = RenderList.create<N, T, D>(this.options.renderActions);
+    this.renderActions = RenderList.create<DOM>(this.options.renderActions);
     this._actionPromises = [];
     this._readyPromise = Promise.resolve();
     this.processed = new AbstractMathDocument.ProcessBits();
-    this.outputJax = this.options.OutputJax ?? new DefaultOutputJax<N, T, D>();
-    let inputJax = this.options.InputJax ?? [new DefaultInputJax<N, T, D>()];
+    this.outputJax = this.options.OutputJax ?? new DefaultOutputJax<DOM>();
+    let inputJax = this.options.InputJax ?? [new DefaultInputJax<DOM>()];
     if (!Array.isArray(inputJax)) {
       inputJax = [inputJax];
     }
@@ -866,10 +845,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @override
    */
   public addRenderAction(id: string, ...action: any[]) {
-    const [fn, p] = RenderList.action<N, T, D>(
-      id,
-      action as RenderAction<N, T, D>
-    );
+    const [fn, p] = RenderList.action<DOM>(id, action as RenderAction<DOM>);
     this.renderActions.add(fn, p);
   }
 
@@ -932,7 +908,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * @override
    */
-  public convert(math: string, options: OptionList = {}): MmlNode | N {
+  public convert(math: string, options: OptionList = {}): MmlNode | N<DOM> {
     let { format, display, end, ex, em, containerWidth, scale, family } =
       userOptions(
         {
@@ -977,7 +953,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   public convertPromise(
     math: string,
     options: OptionList = {}
-  ): Promise<MmlNode | N> {
+  ): Promise<MmlNode | N<DOM>> {
     return this.whenReady(() =>
       mathjax.handleRetriesFor(async () => {
         const node = this.convert(math, options);
@@ -1073,12 +1049,12 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   protected compileAction(
     action: boolean = true,
-    item: MathListItem<N, T, D> = this.math.first(),
-    recompile: MathItem<N, T, D>[] = []
+    item: MathListItem<DOM> = this.math.first(),
+    recompile: MathItem<DOM>[] = []
   ): this | Promise<void> {
     if (this.processed.isSet('compile')) return this;
     while (!item.isEnd) {
-      const math = item.data as MathItem<N, T, D>;
+      const math = item.data as MathItem<DOM>;
       try {
         this.compileMath(math);
       } catch (err) {
@@ -1110,7 +1086,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   protected recompileAction(
     action: boolean,
-    recompile: MathItem<N, T, D>[],
+    recompile: MathItem<DOM>[],
     i: number = 0
   ): Promise<void> | void {
     while (i < recompile.length) {
@@ -1134,7 +1110,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * @param {MathItem} math   The item to compile
    */
-  protected compileMath(math: MathItem<N, T, D>): void {
+  protected compileMath(math: MathItem<DOM>): void {
     try {
       math.compile(this);
     } catch (err) {
@@ -1152,7 +1128,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @param {MathItem} math  The MathItem producing the error
    * @param {Error} err      The Error object for the error
    */
-  public compileError(math: MathItem<N, T, D>, err: Error): void {
+  public compileError(math: MathItem<DOM>, err: Error): void {
     math.root = this.mmlFactory.create('math', null, [
       this.mmlFactory.create(
         'merror',
@@ -1188,11 +1164,11 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    */
   protected typesetAction(
     action: boolean = true,
-    item: MathListItem<N, T, D> = this.math.first()
+    item: MathListItem<DOM> = this.math.first()
   ): this | Promise<void> {
     if (this.processed.isSet('typeset')) return this;
     while (!item.isEnd) {
-      const math = item.data as MathItem<N, T, D>;
+      const math = item.data as MathItem<DOM>;
       try {
         math.typeset(this);
       } catch (err) {
@@ -1217,7 +1193,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
    * @param {MathItem} math  The MathItem producing the error
    * @param {Error} err      The Error object for the error
    */
-  public typesetError(math: MathItem<N, T, D>, err: Error): void {
+  public typesetError(math: MathItem<DOM>, err: Error): void {
     math.typesetRoot = this.adaptor.node(
       'mjx-container',
       {
@@ -1345,7 +1321,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * @override
    */
-  public concat(list: MathList<N, T, D>): this {
+  public concat(list: MathList<DOM>): this {
     this.math.merge(list);
     return this;
   }
@@ -1353,9 +1329,7 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * @override
    */
-  public clearMathItemsWithin(
-    containers: ContainerList<N>
-  ): MathItem<N, T, D>[] {
+  public clearMathItemsWithin(containers: ContainerList<DOM>): MathItem<DOM>[] {
     const items = this.getMathItemsWithin(containers);
     for (const item of items.slice(0).reverse()) {
       item.clear();
@@ -1367,13 +1341,16 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
   /**
    * @override
    */
-  public getMathItemsWithin(elements: ContainerList<N>): MathItem<N, T, D>[] {
+  public getMathItemsWithin(elements: ContainerList<DOM>): MathItem<DOM>[] {
     if (!Array.isArray(elements)) {
       elements = [elements];
     }
     const adaptor = this.adaptor;
-    const items = [] as MathItem<N, T, D>[];
-    const containers = adaptor.getElements(elements, this.document);
+    const items = [] as MathItem<DOM>[];
+    const containers = adaptor.getElements(
+      elements as ContainerSpec<DOM>[],
+      this.document
+    );
     ITEMS: for (const item of this.math) {
       for (const container of containers) {
         if (item.start.node && adaptor.contains(container, item.start.node)) {
@@ -1390,14 +1367,14 @@ export abstract class AbstractMathDocument<N, T, D> implements MathDocument<
  * The constructor type for a MathDocument
  *
  * @template DOC   The MathDocument type this constructor is for
- * @template DD    The DOM types in use
+ * @template D     The DOM types in use
  */
 export interface MathDocumentConstructor<
-  DOC extends MathDocument<N<DD>, T<DD>, D<DD>>,
-  DD extends DOM_TYPES = DOM,
+  DOC extends MathDocument<D>,
+  D extends DOM_TYPES,
 > {
   KIND: string;
-  OPTIONS: DOCUMENT_OPTIONS<DD>;
+  OPTIONS: DOCUMENT_OPTIONS<D>;
   ProcessBits: typeof BitField;
   new (...args: any[]): DOC;
 }

--- a/ts/core/MathItem.ts
+++ b/ts/core/MathItem.ts
@@ -27,6 +27,7 @@ import { OptionList } from '../util/Options.js';
 import { MmlNode } from './MmlTree/MmlNode.js';
 import { Locale } from '../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
+import { DOM_TYPES, N, T } from '../types/Types.js';
 
 /*****************************************************************/
 /**
@@ -35,14 +36,13 @@ import { COMPONENT } from './__locales__/Component.js';
  *  an index into a string array, the character position within
  *  the string, and the delimiter at that location).
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM element types
  */
-export type Location<N, T> = {
+export type Location<DOM extends DOM_TYPES> = {
   i?: number;
   n?: number;
   delim?: string;
-  node?: N | T;
+  node?: N<DOM> | T<DOM>;
 };
 
 /*****************************************************************/
@@ -67,11 +67,9 @@ export type Metrics = {
  *  internal format), its typeset version, its bounding box,
  *  and so on.
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export interface MathItem<N, T, D> {
+export interface MathItem<DOM extends DOM_TYPES> {
   /**
    * The string representing the expression to be processed
    */
@@ -80,7 +78,7 @@ export interface MathItem<N, T, D> {
   /**
    * The input jax used to process the math
    */
-  inputJax: InputJax<N, T, D>;
+  inputJax: InputJax<DOM>;
 
   /**
    * Whether the math is in display mode or inline mode
@@ -96,8 +94,8 @@ export interface MathItem<N, T, D> {
    * The start and ending locations in the document of
    *   this expression
    */
-  start: Location<N, T>;
-  end: Location<N, T>;
+  start: Location<DOM>;
+  end: Location<DOM>;
 
   /**
    * The internal format for this expression (once compiled)
@@ -107,7 +105,7 @@ export interface MathItem<N, T, D> {
   /**
    * The typeset version of the expression (once typeset)
    */
-  typesetRoot: N;
+  typesetRoot: N<DOM>;
 
   /**
    * The metric information at the location of the math
@@ -126,7 +124,7 @@ export interface MathItem<N, T, D> {
    *
    * @param {MathDocument} document  The MathDocument in which the math resides
    */
-  render(document: MathDocument<N, T, D>): void;
+  render(document: MathDocument<DOM>): void;
 
   /**
    * Rerenders an already rendered item and inserts it into the document
@@ -134,7 +132,7 @@ export interface MathItem<N, T, D> {
    * @param {MathDocument} document  The MathDocument in which the math resides
    * @param {number=} start          The state to start rerendering at (default = RERENDER)
    */
-  rerender(document: MathDocument<N, T, D>, start?: number): void;
+  rerender(document: MathDocument<DOM>, start?: number): void;
 
   /**
    * Converts the expression by calling the render actions until the state matches the end state
@@ -143,28 +141,28 @@ export interface MathItem<N, T, D> {
    * @param {number=} end            The state to end rerendering at (default = LAST)
    * @returns {MmlNode | N}          The typesetRoot or root node of the converted MathItem
    */
-  convert(document: MathDocument<N, T, D>, end?: number): MmlNode | N;
+  convert(document: MathDocument<DOM>, end?: number): MmlNode | N<DOM>;
 
   /**
    * Converts the expression into the internal format by calling the input jax
    *
    * @param {MathDocument} document  The MathDocument in which the math resides
    */
-  compile(document: MathDocument<N, T, D>): void;
+  compile(document: MathDocument<DOM>): void;
 
   /**
    * Converts the internal format to the typeset version by calling the output jax
    *
    * @param {MathDocument} document  The MathDocument in which the math resides
    */
-  typeset(document: MathDocument<N, T, D>): void;
+  typeset(document: MathDocument<DOM>): void;
 
   /**
    * Inserts the typeset version in place of the original form in the document
    *
    * @param {MathDocument} document  The MathDocument in which the math resides
    */
-  updateDocument(document: MathDocument<N, T, D>): void;
+  updateDocument(document: MathDocument<DOM>): void;
 
   /**
    * Removes the typeset version from the document, optionally replacing the original
@@ -219,18 +217,16 @@ export interface MathItem<N, T, D> {
  *  MathItem later (e.g., when the position within a string array
  *  is translated back into the actual node location in the DOM).
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM element types
  */
-/* prettier-ignore */
-export type ProtoItem<N, T> = {
-  math: string;            // The math expression itself
-  start: Location<N, T>;   // The starting location of the math
-  end: Location<N, T>;     // The ending location of the math
-  open?: string;           // The opening delimiter
-  close?: string;          // The closing delimiter
-  n?: number;              // The index of the string in which this math is found
-  display: boolean;        // True means display mode, false is inline mode
+export type ProtoItem<DOM extends DOM_TYPES> = {
+  math: string; //            The math expression itself
+  start: Location<DOM>; //    The starting location of the math
+  end: Location<DOM>; //      The ending location of the math
+  open?: string; //           The opening delimiter
+  close?: string; //          The closing delimiter
+  n?: number; //              The index of the string in which this math is found
+  display: boolean; //        True means display mode, false is inline mode
 };
 
 /**
@@ -244,10 +240,10 @@ export type ProtoItem<N, T> = {
  * @param {number} end    The ending location of the math
  * @param {boolean} display True means display mode, false is inline mode
  * @returns {ProtoItem<N, T>} The proto math item
- * @template N   The HTMLElement node class
- * @template T   The Text node class
+ *
+ * @template DOM   The DOM element types
  */
-export function protoItem<N, T>(
+export function protoItem<DOM extends DOM_TYPES>(
   open: string,
   math: string,
   close: string,
@@ -255,8 +251,8 @@ export function protoItem<N, T>(
   start: number,
   end: number,
   display: boolean = null
-): ProtoItem<N, T> {
-  const item: ProtoItem<N, T> = {
+): ProtoItem<DOM> {
+  const item: ProtoItem<DOM> = {
     open: open,
     math: math,
     close: close,
@@ -272,11 +268,11 @@ export function protoItem<N, T>(
 /**
  *  Implements the MathItem class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  */
-export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
+export abstract class AbstractMathItem<
+  DOM extends DOM_TYPES,
+> implements MathItem<DOM> {
   /**
    * The source text for the math (e.g., TeX string)
    */
@@ -286,7 +282,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
    * The input jax associated with this item
    */
 
-  public inputJax: InputJax<N, T, D>;
+  public inputJax: InputJax<DOM>;
 
   /**
    * True when this math is in display mode
@@ -296,11 +292,11 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * Reference to the beginning of the math in the document
    */
-  public start: Location<N, T>;
+  public start: Location<DOM>;
   /**
    * Reference to the end of the math in the document
    */
-  public end: Location<N, T>;
+  public end: Location<DOM>;
 
   /**
    * The compiled internal MathML (result of InputJax)
@@ -309,7 +305,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * The typeset result (result of OutputJax)
    */
-  public typesetRoot: N = null;
+  public typesetRoot: N<DOM> = null;
 
   /**
    * The metric information about the surrounding environment
@@ -348,10 +344,10 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
    */
   constructor(
     math: string,
-    jax: InputJax<N, T, D>,
+    jax: InputJax<DOM>,
     display: boolean = true,
-    start: Location<N, T> = { i: 0, n: 0, delim: '' },
-    end: Location<N, T> = { i: 0, n: 0, delim: '' }
+    start: Location<DOM> = { i: 0, n: 0, delim: '' },
+    end: Location<DOM> = { i: 0, n: 0, delim: '' }
   ) {
     this.math = math;
     this.inputJax = jax;
@@ -368,17 +364,14 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public render(document: MathDocument<N, T, D>) {
+  public render(document: MathDocument<DOM>) {
     document.renderActions.renderMath(this, document);
   }
 
   /**
    * @override
    */
-  public rerender(
-    document: MathDocument<N, T, D>,
-    start: number = STATE.RERENDER
-  ) {
+  public rerender(document: MathDocument<DOM>, start: number = STATE.RERENDER) {
     if (this.state() >= start) {
       this.state(start - 1);
     }
@@ -389,16 +382,16 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
    * @override
    */
   public convert(
-    document: MathDocument<N, T, D>,
+    document: MathDocument<DOM>,
     end: number = STATE.LAST
-  ): MmlNode | N {
+  ): MmlNode | N<DOM> {
     return document.renderActions.renderConvert(this, document, end);
   }
 
   /**
    * @override
    */
-  public compile(document: MathDocument<N, T, D>) {
+  public compile(document: MathDocument<DOM>) {
     if (this.state() < STATE.COMPILED) {
       this.root = this.inputJax.compile(this, document);
       this.state(STATE.COMPILED);
@@ -408,7 +401,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public typeset(document: MathDocument<N, T, D>) {
+  public typeset(document: MathDocument<DOM>) {
     if (this.state() < STATE.TYPESET) {
       this.typesetRoot = document.outputJax[
         this.isEscaped ? 'escaped' : 'typeset'
@@ -420,7 +413,7 @@ export abstract class AbstractMathItem<N, T, D> implements MathItem<N, T, D> {
   /**
    * @override
    */
-  public updateDocument(_document: MathDocument<N, T, D>) {}
+  public updateDocument(_document: MathDocument<DOM>) {}
 
   /**
    * @override

--- a/ts/core/MathList.ts
+++ b/ts/core/MathList.ts
@@ -23,51 +23,48 @@
 
 import { LinkedList, ListItem } from '../util/LinkedList.js';
 import { MathItem } from './MathItem.js';
+import { DOM_TYPES } from '../types/Types.js';
 
 /*****************************************************************/
 /**
  *  The MathListItem type (extends ListItem<MathItem>)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export type MathListItem<N, T, D> = ListItem<MathItem<N, T, D>>;
+export type MathListItem<DOM extends DOM_TYPES> = ListItem<MathItem<DOM>>;
 
 /*****************************************************************/
 /**
  *  The MathList interface (extends LinkedList<MathItem>)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface MathList<N, T, D> extends LinkedList<MathItem<N, T, D>> {
+export interface MathList<DOM extends DOM_TYPES> extends LinkedList<
+  MathItem<DOM>
+> {
   /**
    * Test if one math item is before the other in the document (a < b)
    *
    * @param {MathItem} a   The first MathItem
    * @param {MathItem} b   The second MathItem
    */
-  isBefore(a: MathItem<N, T, D>, b: MathItem<N, T, D>): boolean;
+  isBefore(a: MathItem<DOM>, b: MathItem<DOM>): boolean;
 }
 
 /*****************************************************************/
 /**
  *  The MathList abstract class (extends LinkedList<MathItem>)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export abstract class AbstractMathList<N, T, D>
-  extends LinkedList<MathItem<N, T, D>>
-  implements MathList<N, T, D>
+export abstract class AbstractMathList<DOM extends DOM_TYPES>
+  extends LinkedList<MathItem<DOM>>
+  implements MathList<DOM>
 {
   /**
    * @override
    */
-  public isBefore(a: MathItem<N, T, D>, b: MathItem<N, T, D>) {
+  public isBefore(a: MathItem<DOM>, b: MathItem<DOM>) {
     return (
       a.start.i < b.start.i ||
       (a.start.i === b.start.i && a.start.n < b.start.n)

--- a/ts/core/MmlTree/MathMLVisitor.ts
+++ b/ts/core/MmlTree/MathMLVisitor.ts
@@ -39,9 +39,9 @@ export class MathMLVisitor extends MmlVisitor {
   /**
    * Convert the tree rooted at a particular node into DOM nodes.
    *
-   * @param {MmlNode} node  The node to use as the root of the tree to traverse
+   * @param {MmlNode} node       The node to use as the root of the tree to traverse
    * @param {Document} document  The document in which the nodes are created
-   * @returns {Node}  The MathML DOM nodes representing the internal tree
+   * @returns {Node}             The MathML DOM nodes representing the internal tree
    */
   public visitTree(node: MmlNode, document: Document): Node {
     this.document = document;
@@ -52,7 +52,7 @@ export class MathMLVisitor extends MmlVisitor {
   }
 
   /**
-   * @param {TextNode} node  The text node to visit
+   * @param {TextNode} node   The text node to visit
    * @param {Element} parent  The DOM parent to which this node should be added
    */
   public visitTextNode(node: TextNode, parent: Element) {
@@ -60,7 +60,7 @@ export class MathMLVisitor extends MmlVisitor {
   }
 
   /**
-   * @param {XMLNode} node  The XML node to visit
+   * @param {XMLNode} node    The XML node to visit
    * @param {Element} parent  The DOM parent to which this node should be added
    */
   public visitXMLNode(node: XMLNode, parent: Element) {
@@ -68,7 +68,7 @@ export class MathMLVisitor extends MmlVisitor {
   }
 
   /**
-   * @param {HtmlNode} node  The HTML node to visit
+   * @param {HtmlNode} node   The HTML node to visit
    * @param {Element} parent  The DOM parent to which this node should be added
    */
   public visitHtmlNode(node: HtmlNode<any>, parent: Element) {
@@ -79,7 +79,7 @@ export class MathMLVisitor extends MmlVisitor {
    * Visit an inferred mrow, but don't add the inferred row itself (since
    * it is supposed to be inferred).
    *
-   * @param {MmlNode} node  The inferred mrow to visit
+   * @param {MmlNode} node    The inferred mrow to visit
    * @param {Element} parent  The DOM parent to which this node's children should be added
    */
   public visitInferredMrowNode(node: MmlNode, parent: Element) {
@@ -95,7 +95,7 @@ export class MathMLVisitor extends MmlVisitor {
    *   Append its children nodes.
    *   Append the new node to the DOM parent.
    *
-   * @param {MmlNode} node  The node to visit
+   * @param {MmlNode} node    The node to visit
    * @param {Element} parent  The DOM parent to which this node should be added
    */
   public visitDefault(node: MmlNode, parent: Element) {
@@ -109,7 +109,7 @@ export class MathMLVisitor extends MmlVisitor {
 
   /**
    * @param {MmlNode} node  The node who attributes are to be copied
-   * @param {Element} mml  The MathML DOM node to which attributes are being added
+   * @param {Element} mml   The MathML DOM node to which attributes are being added
    */
   public addAttributes(node: MmlNode, mml: Element) {
     const attributes = this.getAttributeList(node);

--- a/ts/core/MmlTree/MmlNode.ts
+++ b/ts/core/MmlTree/MmlNode.ts
@@ -35,6 +35,7 @@ import { MmlFactory } from './MmlFactory.js';
 import { DOMAdaptor } from '../DOMAdaptor.js';
 import { Locale } from '../../util/Locale.js';
 import { COMPONENT } from '../__locales__/Component.js';
+import { DOM } from '../../types/Types.js';
 
 /**
  *  Used in setInheritedAttributes() to pass originating node kind as well as property value
@@ -1506,7 +1507,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
   /**
    * DOM adaptor for the content
    */
-  protected adaptor: DOMAdaptor<any, any, any> = null;
+  protected adaptor: DOMAdaptor<DOM> = null;
 
   /**
    * @override
@@ -1529,7 +1530,7 @@ export class XMLNode extends AbstractMmlEmptyNode {
    */
   public setXML(
     xml: Object, // eslint-disable-line @typescript-eslint/no-wrapper-object-types
-    adaptor: DOMAdaptor<any, any, any> = null
+    adaptor: DOMAdaptor<DOM> = null
   ): XMLNode {
     this.xml = xml;
     this.adaptor = adaptor;

--- a/ts/core/MmlTree/MmlNodes/HtmlNode.ts
+++ b/ts/core/MmlTree/MmlNodes/HtmlNode.ts
@@ -24,6 +24,7 @@
 import { XMLNode } from '../MmlNode.js';
 import { DOMAdaptor } from '../../DOMAdaptor.js';
 import { PropertyList } from '../../Tree/Node.js';
+import { DOM } from '../../../types/Types.js';
 
 /******************************************************************/
 /**
@@ -49,12 +50,9 @@ export class HtmlNode<N> extends XMLNode {
   /**
    * @param {N} html               The HTML content to be saved
    * @param {DOMAdaptor} adaptor   DOM adaptor for the content
-   * @returns {HtmlNode}            The HTML node (for chaining of method calls)
+   * @returns {HtmlNode}           The HTML node (for chaining of method calls)
    */
-  public setHTML(
-    html: N,
-    adaptor: DOMAdaptor<any, any, any> = null
-  ): HtmlNode<N> {
+  public setHTML(html: N, adaptor: DOMAdaptor<DOM> = null): HtmlNode<N> {
     //
     // Test if the HTML element has attributes and wrap in a <span> if not
     //

--- a/ts/core/MmlTree/TestMmlVisitor.ts
+++ b/ts/core/MmlTree/TestMmlVisitor.ts
@@ -17,7 +17,7 @@
 
 /**
  * @file  A visitor that produces a serilaied MathML string
- *                that contains addition information about inherited
+ *                that contains additional information about inherited
  *                attributes and internal properties.
  *                (For testing purposes only.)
  *

--- a/ts/core/OutputJax.ts
+++ b/ts/core/OutputJax.ts
@@ -26,18 +26,16 @@ import { MathDocument } from './MathDocument.js';
 import { MathItem } from './MathItem.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
 import { FunctionList } from '../util/FunctionList.js';
-import type { DOM, DOM_TYPES } from '../types/Types.js';
+import type { DOM, DOM_TYPES, N } from '../types/Types.js';
 import type { FilterFunctions, FilterFunctionList } from './FilterFunctions.js';
 
 /*****************************************************************/
 /**
  *  The OutputJax interface
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface OutputJax<N, T, D> {
+export interface OutputJax<DOM extends DOM_TYPES> {
   /**
    * The name of this output jax class
    */
@@ -61,12 +59,12 @@ export interface OutputJax<N, T, D> {
   /**
    * The DOM adaptor for managing HTML elements
    */
-  adaptor: DOMAdaptor<N, T, D>;
+  adaptor: DOMAdaptor<DOM>;
 
   /**
    * @param {DOMAdaptor} adaptor The adaptor to use in this jax
    */
-  setAdaptor(adaptor: DOMAdaptor<N, T, D>): void;
+  setAdaptor(adaptor: DOMAdaptor<DOM>): void;
 
   /**
    * Do any initialization that depends on the document being set up
@@ -85,39 +83,39 @@ export interface OutputJax<N, T, D> {
    *
    * @param {MathItem} math          The MathItem to be typeset
    * @param {MathDocument} document  The MathDocument in which the typesetting should occur
-   * @returns {N}                     The DOM tree for the typeset math
+   * @returns {N}                    The DOM tree for the typeset math
    */
-  typeset(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
+  typeset(math: MathItem<DOM>, document?: MathDocument<DOM>): N<DOM>;
 
   /**
    * Handle an escaped character (e.g., \$ from the TeX input jax preventing it from being a delimiter)
    *
    * @param {MathItem} math          The MathItem to be escaped
    * @param {MathDocument} document  The MathDocument in which the math occurs
-   * @returns {N}                     The DOM tree for the escaped item
+   * @returns {N}                    The DOM tree for the escaped item
    */
-  escaped(math: MathItem<N, T, D>, document?: MathDocument<N, T, D>): N;
+  escaped(math: MathItem<DOM>, document?: MathDocument<DOM>): N<DOM>;
 
   /**
    * Get the metric information for all math in the given document
    *
    * @param {MathDocument} document  The MathDocument being processed
    */
-  getMetrics(document: MathDocument<N, T, D>): void;
+  getMetrics(document: MathDocument<DOM>): void;
 
   /**
    * Produce the stylesheet needed for this output jax
    *
    * @param {MathDocument} document  The MathDocument being processed
    */
-  styleSheet(document: MathDocument<N, T, D>): N;
+  styleSheet(document: MathDocument<DOM>): N<DOM>;
 
   /**
    * Produce any page-specific elements needed for this output jax
    *
    * @param {MathDocument} document  The MathDocument being processed
    */
-  pageElements(document: MathDocument<N, T, D>): N;
+  pageElements(document: MathDocument<DOM>): N<DOM>;
 }
 
 /**
@@ -136,11 +134,11 @@ export type OUTPUTJAX_OPTIONS<
 /**
  *  The OutputJax abstract class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
+export abstract class AbstractOutputJax<
+  DOM extends DOM_TYPES,
+> implements OutputJax<DOM> {
   /**
    * The name for the output jax
    */
@@ -162,17 +160,17 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
   /**
    * Filters to run before the output is processed
    */
-  public preFilters: FilterFunctions<N, DOM<N, T, D>>;
+  public preFilters: FilterFunctions<N<DOM>, DOM>;
 
   /**
    * Filters to run after the output is processed
    */
-  public postFilters: FilterFunctions<N, DOM<N, T, D>>;
+  public postFilters: FilterFunctions<N<DOM>, DOM>;
 
   /**
    * The MathDocument's DOMAdaptor
    */
-  public adaptor: DOMAdaptor<N, T, D> = null; // set by the handler
+  public adaptor: DOMAdaptor<DOM> = null; // set by the handler
 
   /**
    * @param {OptionList} options  The options for this instance
@@ -194,7 +192,7 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
   /**
    * @override
    */
-  public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
+  public setAdaptor(adaptor: DOMAdaptor<DOM>) {
     this.adaptor = adaptor;
   }
 
@@ -212,35 +210,35 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
    * @override
    */
   public abstract typeset(
-    math: MathItem<N, T, D>,
-    document?: MathDocument<N, T, D>
-  ): N;
+    math: MathItem<DOM>,
+    document?: MathDocument<DOM>
+  ): N<DOM>;
 
   /**
    * @override
    */
   public abstract escaped(
-    math: MathItem<N, T, D>,
-    document?: MathDocument<N, T, D>
-  ): N;
+    math: MathItem<DOM>,
+    document?: MathDocument<DOM>
+  ): N<DOM>;
 
   /**
    * @override
    */
-  public getMetrics(_document: MathDocument<N, T, D>) {}
+  public getMetrics(_document: MathDocument<DOM>) {}
 
   /**
    * @override
    */
-  public styleSheet(_document: MathDocument<N, T, D>) {
-    return null as N;
+  public styleSheet(_document: MathDocument<DOM>) {
+    return null as N<DOM>;
   }
 
   /**
    * @override
    */
-  public pageElements(_document: MathDocument<N, T, D>) {
-    return null as N;
+  public pageElements(_document: MathDocument<DOM>) {
+    return null as N<DOM>;
   }
 
   /**
@@ -251,12 +249,12 @@ export abstract class AbstractOutputJax<N, T, D> implements OutputJax<N, T, D> {
    * @param {MathItem} math          The math item that is being processed
    * @param {MathDocument} document  The math document contaiing the math item
    * @param {any} data               Whatever other data is needed
-   * @returns {any}                   The (possibly modified) data
+   * @returns {any}                  The (possibly modified) data
    */
   protected executeFilters(
     filters: FunctionList,
-    math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>,
+    math: MathItem<DOM>,
+    document: MathDocument<DOM>,
     data: any
   ): any {
     const args = { math, document, data };

--- a/ts/core/Tree/Factory.ts
+++ b/ts/core/Tree/Factory.ts
@@ -36,8 +36,8 @@ export interface FactoryNode {
 export interface FactoryNodeClass<N extends FactoryNode> {
   /**
    * @param {Factory<N, FactoryNodeClass<N>>} factory  The factory for creating more nodes
-   * @param {any[]} args  Any additional arguments needed by the node
-   * @returns {N}  The newly created node
+   * @param {any[]} args   Any additional arguments needed by the node
+   * @returns {N}          The newly created node
    */
   new (factory: Factory<N, FactoryNodeClass<N>>, ...args: any[]): N;
 }
@@ -59,7 +59,7 @@ export interface FactoryNodeClass<N extends FactoryNode> {
 export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
   /**
    * @param {string} kind  The kind of node to create
-   * @returns {N}  The newly created node of the given kind
+   * @returns {N}          The newly created node of the given kind
    */
   create(kind: string): N;
 
@@ -73,7 +73,7 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
 
   /**
    * @param {string} kind  The kind of node whose class is to be returned
-   * @returns {C}  The class object for the given kind
+   * @returns {C}          The class object for the given kind
    */
   getNodeClass(kind: string): C;
 
@@ -83,14 +83,14 @@ export interface Factory<N extends FactoryNode, C extends FactoryNodeClass<N>> {
   deleteNodeClass(kind: string): void;
 
   /**
-   * @param {N} node  The node to test if it is of a given kind
-   * @param {string} kind  The kind to test for
-   * @returns {boolean}  True if the node is of the given kind, false otherwise
+   * @param {N} node        The node to test if it is of a given kind
+   * @param {string} kind   The kind to test for
+   * @returns {boolean}     True if the node is of the given kind, false otherwise
    */
   nodeIsKind(node: N, kind: string): boolean;
 
   /**
-   * @returns {string[]}  The names of all the available kinds of nodes
+   * @returns {string[]}   The names of all the available kinds of nodes
    */
   getKinds(): string[];
 }

--- a/ts/core/Tree/Node.ts
+++ b/ts/core/Tree/Node.ts
@@ -80,7 +80,7 @@ export interface Node<N extends Node<N, C>, C extends NodeClass<N, C>> {
   removeProperty(...names: string[]): void;
 
   /**
-   * @param {string} kind  The type of node to test for
+   * @param {string} kind   The type of node to test for
    * @returns {boolean}     True when the node is of the given type
    */
   isKind(kind: string): boolean;
@@ -91,27 +91,27 @@ export interface Node<N extends Node<N, C>, C extends NodeClass<N, C>> {
   setChildren(children: N[]): void;
 
   /**
-   * @param {N} child  A node to add to this node's children
+   * @param {N} child   A node to add to this node's children
    * @returns {N}       The child node that was added
    */
   appendChild(child: N): N;
 
   /**
-   * @param {N} newChild  A child node to be inserted
-   * @param {N} oldChild  A child node to be replaced
+   * @param {N} newChild   A child node to be inserted
+   * @param {N} oldChild   A child node to be replaced
    * @returns {N}          The old child node that was removed
    */
   replaceChild(newChild: N, oldChild: N): N;
 
   /**
    * @param {N} child   Child node to be removed
-   * @returns {N}        The old child node that was removed
+   * @returns {N}       The old child node that was removed
    */
   removeChild(child: N): N;
 
   /**
-   * @param {N} child  A child node whose index in childNodes is desired
-   * @returns {number}     The index of the child in childNodes, or null if not found
+   * @param {N} child    A child node whose index in childNodes is desired
+   * @returns {number}   The index of the child in childNodes, or null if not found
    */
   childIndex(child: N): number;
 
@@ -121,8 +121,8 @@ export interface Node<N extends Node<N, C>, C extends NodeClass<N, C>> {
   copy(): N;
 
   /**
-   * @param {string} kind  The kind of nodes to be located in the tree
-   * @returns {N[]}      An array of nodes that are children (at any depth) of the given kind
+   * @param {string} kind   The kind of nodes to be located in the tree
+   * @returns {N[]}         An array of nodes that are children (at any depth) of the given kind
    */
   findNodes(kind: string): N[];
 
@@ -143,10 +143,10 @@ export interface Node<N extends Node<N, C>, C extends NodeClass<N, C>> {
  */
 export interface NodeClass<N extends Node<N, C>, C extends NodeClass<N, C>> {
   /**
-   * @param {NodeFactory} factory  The NodeFactory to use to create new nodes when needed
-   * @param {PropertyList} properties  Any properties to be added to the node, if any
-   * @param {N[]} children  The initial child nodes, if any
-   * @returns {N}  The newly created node
+   * @param {NodeFactory} factory       The NodeFactory to use to create new nodes when needed
+   * @param {PropertyList} properties   Any properties to be added to the node, if any
+   * @param {N[]} children              The initial child nodes, if any
+   * @returns {N}                       The newly created node
    */
   new (
     factory: NodeFactory<N, C>,

--- a/ts/core/Tree/NodeFactory.ts
+++ b/ts/core/Tree/NodeFactory.ts
@@ -36,10 +36,10 @@ export interface NodeFactory<
   C extends FactoryNodeClass<N>,
 > extends Factory<N, C> {
   /**
-   * @param {string} kind  The kind of node to create
-   * @param {PropertyList} properties  The list of initial properties for the node (if any)
-   * @param {N[]} children  The array of initial child nodes (if any)
-   * @returns {N}  The newly created node of the given kind
+   * @param {string} kind               The kind of node to create
+   * @param {PropertyList} properties   The list of initial properties for the node (if any)
+   * @param {N[]} children              The array of initial child nodes (if any)
+   * @returns {N}                       The newly created node of the given kind
    */
   create(kind: string, properties?: PropertyList, children?: N[]): N;
 }

--- a/ts/core/Tree/Visitor.ts
+++ b/ts/core/Tree/Visitor.ts
@@ -56,8 +56,8 @@ export interface Visitor<N extends VisitorNode<N>> {
   /**
    * Visit the tree rooted at the given node (passing along any needed parameters)
    *
-   * @param {N} tree      The node that is the root of the tree
-   * @param {any[]} args  The arguments to pass to the visitNode functions
+   * @param {N} tree       The node that is the root of the tree
+   * @param {any[]} args   The arguments to pass to the visitNode functions
    * @returns {any}        Whatever the visitNode function returns for the root tree node
    */
   visitTree(tree: N, ...args: any[]): any;
@@ -66,8 +66,8 @@ export interface Visitor<N extends VisitorNode<N>> {
    * Visit a node by calling the visitor function for the given type of node
    *  (passing along any needed parameters)
    *
-   * @param {N} node      The node to visit
-   * @param {any[]} args  The arguments to pass to the visitor function for this node
+   * @param {N} node       The node to visit
+   * @param {any[]} args   The arguments to pass to the visitor function for this node
    * @returns {any}        Whatever the visitor function returns for this node
    */
   visitNode(node: N, ...args: any[]): any;
@@ -75,8 +75,8 @@ export interface Visitor<N extends VisitorNode<N>> {
   /**
    * The default visitor function for when no node-specific function is defined
    *
-   * @param {N} node      The node to visit
-   * @param {any[]} args  The arguments to pass to the visitor function for this node
+   * @param {N} node       The node to visit
+   * @param {any[]} args   The arguments to pass to the visitor function for this node
    * @returns {any}        Whatever the visitor function returns for this node
    */
   visitDefault(node: N, ...args: any[]): any;
@@ -121,8 +121,8 @@ export abstract class AbstractVisitor<
    *  Visitor functions are named "visitKindNode" where "Kind" is replaced by
    *    the node kind; e.g., visitTextNode for kind = text.
    *
-   *  @param {string} kind  The node kind whose method name is needed
-   *  @returns {string}  The name of the visitor method for the given node kind
+   *  @param {string} kind   The node kind whose method name is needed
+   *  @returns {string}      The name of the visitor method for the given node kind
    */
   protected static methodName(kind: string): string {
     return (

--- a/ts/core/Tree/Wrapper.ts
+++ b/ts/core/Tree/Wrapper.ts
@@ -84,10 +84,10 @@ export interface WrapperClass<
   W extends Wrapper<N, C, W>,
 > {
   /**
-   * @param {WrapperFactory} factory  The factory used to create more wrappers
-   * @param {N} node  The node to be wrapped
-   * @param {any[]} args  Any additional arguments needed when creating the wrapper
-   * @returns {W}  The wrapped node
+   * @param {WrapperFactory} factory   The factory used to create more wrappers
+   * @param {N} node                   The node to be wrapped
+   * @param {any[]} args               Any additional arguments needed when creating the wrapper
+   * @returns {W}                      The wrapped node
    */
   new (
     factory: WrapperFactory<N, C, W, WrapperClass<N, C, W>>,

--- a/ts/core/Tree/WrapperFactory.ts
+++ b/ts/core/Tree/WrapperFactory.ts
@@ -45,7 +45,7 @@ export interface WrapperFactory<
    *
    * @param {N} node      The node to be wrapped
    * @param {any[]} args  Any additional arguments needed when wrapping the node
-   * @returns {TT}         The newly wrapped node
+   * @returns {TT}        The newly wrapped node
    */
   wrap<TT extends WW = WW>(node: N, ...args: any[]): TT;
 }

--- a/ts/handlers/html.ts
+++ b/ts/handlers/html.ts
@@ -24,21 +24,20 @@
 import { mathjax } from '../mathjax.js';
 import { HTMLHandler } from './html/HTMLHandler.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
+import { DOM_TYPES } from '../types/Types.js';
 
 /**
  * Create the HTML handler object and register it with MathJax.
  *
- * @param {DOMAdaptor<N,T,D>} adaptor  The DOM adaptor to use with HTML
- * @returns {HTMLHandler}               The newly created handler
+ * @param {DOMAdaptor} adaptor   The DOM adaptor to use with HTML
+ * @returns {HTMLHandler}        The newly created handler
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export function RegisterHTMLHandler<N, T, D>(
-  adaptor: DOMAdaptor<N, T, D>
-): HTMLHandler<N, T, D> {
-  const handler = new HTMLHandler<N, T, D>(adaptor);
+export function RegisterHTMLHandler<DOM extends DOM_TYPES>(
+  adaptor: DOMAdaptor<DOM>
+): HTMLHandler<DOM> {
+  const handler = new HTMLHandler<DOM>(adaptor);
   mathjax.handlers.register(handler);
   return handler;
 }

--- a/ts/handlers/html/HTMLDocument.ts
+++ b/ts/handlers/html/HTMLDocument.ts
@@ -39,7 +39,13 @@ import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { InputJax } from '../../core/InputJax.js';
 import { STATE, newState, ProtoItem, Location } from '../../core/MathItem.js';
 import { StyleJson } from '../../util/StyleJson.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../../types/Types.js';
+import {
+  DOM as ANY_DOM,
+  DOM_TYPES,
+  N,
+  NT,
+  Constructor,
+} from '../../types/Types.js';
 
 /*****************************************************************/
 /**
@@ -49,10 +55,9 @@ import { DOM, DOM_TYPES, N, T, D, Constructor } from '../../types/Types.js';
  * string in the list of strings to be searched for math
  * (multiple consecutive Text nodes can form a single string).
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM node types
  */
-export type HTMLNodeArray<N, T> = [N | T, number][][];
+export type HTMLNodeArray<DOM extends DOM_TYPES> = [NT<DOM>, number][][];
 
 /**
  * Add STATE value for adding the stylesheets (after INSERTED)
@@ -65,7 +70,7 @@ newState('STYLES', STATE.INSERTED + 1);
  * The new HTMLDocument option types.
  */
 export type OPTIONS<DOM extends DOM_TYPES> = {
-  DomStrings: HTMLDomStrings<N<DOM>, T<DOM>, D<DOM>>; // The DomStrings parser
+  DomStrings: HTMLDomStrings<DOM>; // The DomStrings parser
 };
 
 /**
@@ -73,13 +78,13 @@ export type OPTIONS<DOM extends DOM_TYPES> = {
  */
 export interface HTMLDOCUMENT_OPTIONS<DOM extends DOM_TYPES>
   extends OPTIONS<DOM>, DOCUMENT_OPTIONS<DOM> {
-  MathItem: Constructor<HTMLMathItem<N<DOM>, T<DOM>, D<DOM>>>;
+  MathItem: Constructor<HTMLMathItem<DOM>>;
 }
 
 /**
  * The HTMLDocument option defaults.
  */
-const options: OPTIONS<DOM> = {
+const options: OPTIONS<ANY_DOM> = {
   DomStrings: null, // Use the default DomString parser
 };
 
@@ -87,11 +92,11 @@ const options: OPTIONS<DOM> = {
 /**
  *  The HTMLDocument class (extends AbstractMathDocument)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
+export class HTMLDocument<
+  DOM extends DOM_TYPES,
+> extends AbstractMathDocument<DOM> {
   /**
    * The kind of document
    */
@@ -103,7 +108,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   public static OPTIONS = {
     ...AbstractMathDocument.OPTIONS,
     ...options,
-    renderActions: expandable<RenderActions<any, any, any>>({
+    renderActions: expandable<RenderActions<ANY_DOM>>({
       ...AbstractMathDocument.OPTIONS.renderActions,
       styles: [STATE.STYLES, '', 'updateStyleSheet', false], // update styles on a rerender() call
     }),
@@ -114,7 +119,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   /**
    * @override
    */
-  public options: HTMLDOCUMENT_OPTIONS<DOM<N, T, D>> & { elements?: N[] };
+  public options: HTMLDOCUMENT_OPTIONS<DOM> & { elements?: N<DOM>[] };
 
   /**
    * Extra styles to be included in the document's stylesheet (added by extensions)
@@ -124,22 +129,17 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   /**
    * The DomString parser for locating the text in DOM trees
    */
-  public domStrings: HTMLDomStrings<N, T, D>;
+  public domStrings: HTMLDomStrings<DOM>;
 
   /**
    * @override
    * @class
    * @augments {AbstractMathDocument}
    */
-  constructor(
-    document: any,
-    adaptor: DOMAdaptor<N, T, D>,
-    options: OptionList
-  ) {
+  constructor(document: any, adaptor: DOMAdaptor<DOM>, options: OptionList) {
     const [html, dom] = separateOptions(options, HTMLDomStrings.OPTIONS);
     super(document, adaptor, html);
-    this.domStrings =
-      this.options.DomStrings || new HTMLDomStrings<N, T, D>(dom);
+    this.domStrings = this.options.DomStrings || new HTMLDomStrings<DOM>(dom);
     this.domStrings.adaptor = adaptor;
     this.styles = [];
   }
@@ -159,8 +159,8 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
     N: number,
     index: number,
     delim: string,
-    nodes: HTMLNodeArray<N, T>
-  ): Location<N, T> {
+    nodes: HTMLNodeArray<DOM>
+  ): Location<DOM> {
     const adaptor = this.adaptor;
     const inc = 1 / (nodes[N].length || 1);
     let i = N;
@@ -184,10 +184,10 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    * @returns {HTMLMathItem}       The MathItem for the given proto item
    */
   protected mathItem(
-    item: ProtoItem<N, T>,
-    jax: InputJax<N, T, D>,
-    nodes: HTMLNodeArray<N, T>
-  ): HTMLMathItem<N, T, D> {
+    item: ProtoItem<DOM>,
+    jax: InputJax<DOM>,
+    nodes: HTMLNodeArray<DOM>
+  ): HTMLMathItem<DOM> {
     const math = item.math;
     const start = this.findPosition(item.n, item.start.n, item.open, nodes);
     const end = this.findPosition(item.n, item.end.n, item.close, nodes);
@@ -197,7 +197,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
       item.display,
       start,
       end
-    ) as HTMLMathItem<N, T, D>;
+    ) as HTMLMathItem<DOM>;
   }
 
   /**
@@ -244,22 +244,22 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   /**
    * Get the MathItems from the containers by searching DOM strings
    *
-   * @param {InputJax<N,T,D>} jax    The jax being used
-   * @param {N[]} containers         The containers to be searched in order
-   * @returns {HTMLMathList<N,T,D>}  The list of MathItems found
+   * @param {InputJax} jax     The jax being used
+   * @param {N[]} containers   The containers to be searched in order
+   * @returns {HTMLMathList}   The list of MathItems found
    */
   protected findMathFromStrings(
-    jax: InputJax<N, T, D>,
-    containers: N[]
-  ): HTMLMathList<N, T, D> {
+    jax: InputJax<DOM>,
+    containers: N<DOM>[]
+  ): HTMLMathList<DOM> {
     const strings = [] as string[];
-    const nodes = [] as HTMLNodeArray<N, T>;
+    const nodes = [] as HTMLNodeArray<DOM>;
     for (const container of containers) {
       const [slist, nlist] = this.domStrings.find(container);
       strings.push(...slist);
       nodes.push(...nlist);
     }
-    const list = new this.options.MathList() as HTMLMathList<N, T, D>;
+    const list = new this.options.MathList() as HTMLMathList<DOM>;
     for (const math of jax.findMath(strings)) {
       list.push(this.mathItem(math, jax, nodes));
     }
@@ -269,15 +269,15 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
   /**
    * Get the MathItems from the containers by searching DOM elements themselves
    *
-   * @param {InputJax<N,T,D>} jax    The jax being used
-   * @param {N[]} containers         The containers to be searched in order
-   * @returns {HTMLMathList<N,T,D>}  The list of MathItems found
+   * @param {InputJax} jax     The jax being used
+   * @param {N[]} containers   The containers to be searched in order
+   * @returns {HTMLMathList}   The list of MathItems found
    */
   protected findMathFromDOM(
-    jax: InputJax<N, T, D>,
-    containers: N[]
-  ): HTMLMathList<N, T, D> {
-    const items = [] as HTMLMathItem<N, T, D>[];
+    jax: InputJax<DOM>,
+    containers: N<DOM>[]
+  ): HTMLMathList<DOM> {
+    const items = [] as HTMLMathItem<DOM>[];
     for (const container of containers) {
       for (const math of jax.findMath(container)) {
         items.push(
@@ -291,7 +291,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         );
       }
     }
-    return new this.options.MathList(...items) as HTMLMathList<N, T, D>;
+    return new this.options.MathList(...items) as HTMLMathList<DOM>;
   }
 
   /**
@@ -346,7 +346,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
    * @param {string} id  The id of the stylesheet to find
    * @returns {N|null}   The stylesheet with the given ID
    */
-  protected findSheet(head: N, id: string): N {
+  protected findSheet(head: N<DOM>, id: string): N<DOM> {
     if (id) {
       for (const sheet of this.adaptor.tags(head, 'style')) {
         if (this.adaptor.getAttribute(sheet, 'id') === id) {
@@ -354,7 +354,7 @@ export class HTMLDocument<N, T, D> extends AbstractMathDocument<N, T, D> {
         }
       }
     }
-    return null as N;
+    return null as N<DOM>;
   }
 
   /**

--- a/ts/handlers/html/HTMLDomStrings.ts
+++ b/ts/handlers/html/HTMLDomStrings.ts
@@ -29,26 +29,21 @@ import {
   expandable,
 } from '../../util/Options.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
-import { DOM, DOM_TYPES, N, T, D } from '../../types/Types.js';
-
+import { DOM, DOM_TYPES, N, T, NT } from '../../types/Types.js';
 /**
  * List of consecutive text nodes and their text lengths
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
+ * @template DOM   The DOM node types
  */
-export type HTMLNodeList<N, T> = [N | T, number][];
+export type HTMLNodeList<DOM extends DOM_TYPES> = [NT<DOM>, number][];
 
 /**
  * The data for HTML to be allowed in TeX expressions
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document node class
+ * @template DOM   The DOM node types
  */
-export type HTMLTagData<N, T, D> =
-  | string
-  | ((node: N, adaptor: DOMAdaptor<N, T, D>) => string);
+export type HTMLTagData<DOM extends DOM_TYPES> =
+  string | ((node: N<DOM>, adaptor: DOMAdaptor<DOM>) => string);
 
 /*****************************************************************/
 
@@ -62,26 +57,36 @@ export type HTMLDOMSTRINGS_OPTIONS<DOM extends DOM_TYPES> = {
   // Tags to be included in the text (and what text to replace them
   // with).
   //
-  includeHtmlTags: {[tag: string]: HTMLTagData<N<DOM>, T<DOM>, D<DOM>>};
+  includeHtmlTags: { [tag: string]: HTMLTagData<DOM> };
   //
   // The class name of elements whose contents should NOT be processed
   // by tex2jax.  Note that this is used as a regular expression, so
   // be sure to quote any regexp special characters.
   //
-  ignoreHtmlClass: string,
+  ignoreHtmlClass: string;
   //
   // The class name of elements whose contents SHOULD be processed
   // when they appear inside ones that are ignored.  Note that this is
   // used as a regular expression, so be sure to quote any regexp
   // special characters.
   //
-  processHtmlClass: string,
+  processHtmlClass: string;
 };
 
 const options: HTMLDOMSTRINGS_OPTIONS<DOM> = {
-  skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code',
-                 'math', 'select', 'option', 'mjx-container'],
-  includeHtmlTags: expandable({br: '\n', wbr: '', '#comment': ''}),
+  skipHtmlTags: [
+    'script',
+    'noscript',
+    'style',
+    'textarea',
+    'pre',
+    'code',
+    'math',
+    'select',
+    'option',
+    'mjx-container',
+  ],
+  includeHtmlTags: expandable({ br: '\n', wbr: '', '#comment': '' }),
   ignoreHtmlClass: 'mathjax_ignore',
   processHtmlClass: 'mathjax_process',
 };
@@ -92,11 +97,9 @@ const options: HTMLDOMSTRINGS_OPTIONS<DOM> = {
  *
  *  A class for extracting the text from DOM trees
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class HTMLDomStrings<N, T, D> {
+export class HTMLDomStrings<DOM extends DOM_TYPES> {
   /**
    * The default options for string processing
    */
@@ -120,18 +123,18 @@ export class HTMLDomStrings<N, T, D> {
   /**
    * The list of nodes and lengths for the string being constructed
    */
-  protected snodes: HTMLNodeList<N, T>;
+  protected snodes: HTMLNodeList<DOM>;
 
   /**
    * The list of node lists corresponding to the strings in this.strings
    */
-  protected nodes: HTMLNodeList<N, T>[];
+  protected nodes: HTMLNodeList<DOM>[];
 
   /**
    * The container nodes that are currently being traversed, and whether their
    *  contents are being ignored or not
    */
-  protected stack: [N | T, boolean][];
+  protected stack: [NT<DOM>, boolean][];
 
   /**
    * Regular expression for the tags to be skipped
@@ -150,11 +153,10 @@ export class HTMLDomStrings<N, T, D> {
   /**
    * The DOM Adaptor to managing HTML elements
    */
-  public adaptor: DOMAdaptor<N, T, D>;
+  public adaptor: DOMAdaptor<DOM>;
 
   /**
    * @param {OptionList} options  The user-supplied options
-   * @class
    */
   constructor(options: OptionList = null) {
     const CLASS = this.constructor as typeof HTMLDomStrings;
@@ -204,12 +206,12 @@ export class HTMLDomStrings<N, T, D> {
    * Add more text to the current string, and record the
    * node and its position in the string.
    *
-   * @param {N|T} node        The node to be pushed
+   * @param {N|T} node      The node to be pushed
    * @param {string} text   The text to be added (it may not be the actual text
    *                         of the node, if it is one of the nodes that gets
    *                         translated to text, like <br> to a newline).
    */
-  protected extendString(node: N | T, text: string) {
+  protected extendString(node: NT<DOM>, text: string) {
     this.snodes.push([node, text.length]);
     this.string += text;
   }
@@ -217,11 +219,11 @@ export class HTMLDomStrings<N, T, D> {
   /**
    * Handle a #text node (add its text to the current string)
    *
-   * @param {T} node          The Text node to process
-   * @param {boolean} ignore  Whether we are currently ignoring content
-   * @returns {N | T}          The next element to process
+   * @param {T} node           The Text node to process
+   * @param {boolean} ignore   Whether we are currently ignoring content
+   * @returns {NT<DOM>}        The next element to process
    */
-  protected handleText(node: T, ignore: boolean): N | T {
+  protected handleText(node: T<DOM>, ignore: boolean): NT<DOM> {
     if (!ignore) {
       this.extendString(node, this.adaptor.value(node));
     }
@@ -231,11 +233,11 @@ export class HTMLDomStrings<N, T, D> {
   /**
    * Handle a BR, WBR, or #comment element (or others in the includeHtmlTags object).
    *
-   * @param {N} node          The node to process
-   * @param {boolean} ignore  Whether we are currently ignoring content
-   * @returns {N | T}          The next element to process
+   * @param {N} node           The node to process
+   * @param {boolean} ignore   Whether we are currently ignoring content
+   * @returns {NT<DOM>}        The next element to process
    */
-  protected handleTag(node: N, ignore: boolean): N | T {
+  protected handleTag(node: N<DOM>, ignore: boolean): NT<DOM> {
     if (!ignore) {
       const text = this.options['includeHtmlTags'][this.adaptor.kind(node)];
       if (text instanceof Function) {
@@ -261,9 +263,9 @@ export class HTMLDomStrings<N, T, D> {
    *
    * @param {N} node               The node to process
    * @param {boolean} ignore       Whether we are currently ignoring content
-   * @returns {[N|T, boolean]}      The next element to process and whether to ignore its content
+   * @returns {[N|T, boolean]}     The next element to process and whether to ignore its content
    */
-  protected handleContainer(node: N, ignore: boolean): [N | T, boolean] {
+  protected handleContainer(node: N<DOM>, ignore: boolean): [NT<DOM>, boolean] {
     this.pushString();
     const cname = this.adaptor.getAttribute(node, 'class') || '';
     const tname = this.adaptor.kind(node) || '';
@@ -290,9 +292,9 @@ export class HTMLDomStrings<N, T, D> {
    *
    * @param {N} node           The node to process
    * @param {boolean} _ignore  Whether we are currently ignoring content
-   * @returns {N|T}             The next element to process
+   * @returns {N|T}            The next element to process
    */
-  protected handleOther(node: N, _ignore: boolean): N | T {
+  protected handleOther(node: N<DOM>, _ignore: boolean): NT<DOM> {
     this.pushString();
     return this.adaptor.next(node);
   }
@@ -312,10 +314,10 @@ export class HTMLDomStrings<N, T, D> {
    *   Clear the internal values (so the memory can be freed)
    *   Return the strings and node lists
    *
-   * @param {N} node                       The node to search
+   * @param {N|T} node                      The node to search
    * @returns {[string[], HTMLNodeList[]]}  The array of strings and their associated lists of nodes
    */
-  public find(node: N | T): [string[], HTMLNodeList<N, T>[]] {
+  public find(node: NT<DOM>): [string[], HTMLNodeList<DOM>[]] {
     this.init();
     const stop = this.adaptor.next(node);
     let ignore = false;
@@ -324,13 +326,13 @@ export class HTMLDomStrings<N, T, D> {
     while (node && node !== stop) {
       const kind = this.adaptor.kind(node);
       if (kind === '#text') {
-        node = this.handleText(node as T, ignore);
+        node = this.handleText(node as T<DOM>, ignore);
       } else if (Object.hasOwn(include, kind)) {
-        node = this.handleTag(node as N, ignore);
+        node = this.handleTag(node as N<DOM>, ignore);
       } else if (kind) {
-        [node, ignore] = this.handleContainer(node as N, ignore);
+        [node, ignore] = this.handleContainer(node as N<DOM>, ignore);
       } else {
-        node = this.handleOther(node as N, ignore);
+        node = this.handleOther(node as N<DOM>, ignore);
       }
       if (!node && this.stack.length) {
         this.pushString();
@@ -341,7 +343,7 @@ export class HTMLDomStrings<N, T, D> {
     this.pushString();
     const result = [this.strings, this.nodes] as [
       string[],
-      HTMLNodeList<N, T>[],
+      HTMLNodeList<DOM>[],
     ];
     this.init(); // free up memory
     return result;

--- a/ts/handlers/html/HTMLHandler.ts
+++ b/ts/handlers/html/HTMLHandler.ts
@@ -24,26 +24,29 @@
 import { AbstractHandler } from '../../core/Handler.js';
 import { MinHTMLAdaptor } from '../../adaptors/HTMLAdaptor.js';
 import { HTMLDocument } from './HTMLDocument.js';
+import { MathDocumentConstructor } from '../../core/MathDocument.js';
 import { OptionList } from '../../util/Options.js';
+import { DOM_TYPES, N } from '../../types/Types.js';
 
 /*****************************************************************/
 /**
  *  Implements the HTMLHandler class (extends AbstractHandler)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class HTMLHandler<N, T, D> extends AbstractHandler<N, T, D> {
+export class HTMLHandler<DOM extends DOM_TYPES> extends AbstractHandler<DOM> {
   /**
    * The DOMAdaptor for the document being handled
    */
-  public adaptor: MinHTMLAdaptor<N, T, D>; // declare a more specific adaptor type
+  public adaptor: MinHTMLAdaptor<DOM>; // declare a more specific adaptor type
 
   /**
    * @override
    */
-  public documentClass = HTMLDocument;
+  public documentClass = HTMLDocument<DOM> as any as MathDocumentConstructor<
+    HTMLDocument<DOM>,
+    DOM
+  >;
 
   /**
    * @override
@@ -81,10 +84,10 @@ export class HTMLHandler<N, T, D> extends AbstractHandler<N, T, D> {
       document instanceof adaptor.window.HTMLElement ||
       document instanceof adaptor.window.DocumentFragment
     ) {
-      const child = document as N;
+      const child = document as N<DOM>;
       document = adaptor.parse('', 'text/html');
       adaptor.append(adaptor.body(document), child);
     }
-    return super.create(document, options) as HTMLDocument<N, T, D>;
+    return super.create(document, options) as HTMLDocument<DOM>;
   }
 }

--- a/ts/handlers/html/HTMLMathItem.ts
+++ b/ts/handlers/html/HTMLMathItem.ts
@@ -25,20 +25,19 @@ import { AbstractMathItem, Location, STATE } from '../../core/MathItem.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { InputJax } from '../../core/InputJax.js';
 import { HTMLDocument } from './HTMLDocument.js';
+import { DOM_TYPES, NT, T } from '../../types/Types.js';
 
 /*****************************************************************/
 /**
  *  Implements the HTMLMathItem class (extends AbstractMathItem)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   the DOM node types
  */
-export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
+export class HTMLMathItem<DOM extends DOM_TYPES> extends AbstractMathItem<DOM> {
   /**
-   * @returns {DOMAdaptor<N, T, D>} Easy access to DOM adaptor
+   * @returns {DOMAdaptor<DOM>} Easy access to DOM adaptor
    */
-  get adaptor(): DOMAdaptor<N, T, D> {
+  get adaptor(): DOMAdaptor<DOM> {
     return this.inputJax.adaptor;
   }
 
@@ -47,10 +46,10 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
    */
   constructor(
     math: string,
-    jax: InputJax<N, T, D>,
+    jax: InputJax<DOM>,
     display: boolean = true,
-    start: Location<N, T> = { node: null, n: 0, delim: '' },
-    end: Location<N, T> = { node: null, n: 0, delim: '' }
+    start: Location<DOM> = { node: null, n: 0, delim: '' },
+    end: Location<DOM> = { node: null, n: 0, delim: '' }
   ) {
     super(math, jax, display, start, end);
   }
@@ -69,10 +68,10 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
    *
    * @override
    */
-  public updateDocument(_html: HTMLDocument<N, T, D>) {
+  public updateDocument(_html: HTMLDocument<DOM>) {
     if (this.state() < STATE.INSERTED) {
       if (this.inputJax.processStrings) {
-        let node = this.start.node as T;
+        let node = this.start.node as T<DOM>;
         if (node === this.end.node) {
           if (
             this.end.n &&
@@ -81,7 +80,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
             this.adaptor.split(this.end.node, this.end.n);
           }
           if (this.start.n) {
-            node = this.adaptor.split(this.start.node as T, this.start.n);
+            node = this.adaptor.split(this.start.node as T<DOM>, this.start.n);
           }
           if (this.adaptor.parent(node)) {
             this.adaptor.replace(this.typesetRoot, node);
@@ -91,7 +90,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
             node = this.adaptor.split(node, this.start.n);
           }
           while (node !== this.end.node) {
-            const next = this.adaptor.next(node) as T;
+            const next = this.adaptor.next(node) as T<DOM>;
             this.adaptor.remove(node);
             node = next;
           }
@@ -115,7 +114,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
    *
    * @param {HTMLDocument} document   The document whose styles are to be updated
    */
-  public updateStyleSheet(document: HTMLDocument<N, T, D>) {
+  public updateStyleSheet(document: HTMLDocument<DOM>) {
     document.addStyleSheet();
   }
 
@@ -130,7 +129,7 @@ export class HTMLMathItem<N, T, D> extends AbstractMathItem<N, T, D> {
     if (this.state() >= STATE.TYPESET) {
       const adaptor = this.adaptor;
       const node = this.start.node;
-      let math: N | T = adaptor.text('');
+      let math: NT<DOM> = adaptor.text('');
       if (restore) {
         const text = this.start.delim + this.math + this.end.delim;
         if (this.inputJax.processStrings) {

--- a/ts/handlers/html/HTMLMathList.ts
+++ b/ts/handlers/html/HTMLMathList.ts
@@ -22,13 +22,14 @@
  */
 
 import { AbstractMathList } from '../../core/MathList.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /*****************************************************************/
 /**
  *  Implement the HTMLMathList class (extends AbstractMathList)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class HTMLMathList<N, T, D> extends AbstractMathList<N, T, D> {}
+export class HTMLMathList<
+  DOM extends DOM_TYPES,
+> extends AbstractMathList<DOM> {}

--- a/ts/input/asciimath.ts
+++ b/ts/input/asciimath.ts
@@ -26,7 +26,7 @@ import { LegacyAsciiMath } from './asciimath/legacy.js';
 import { separateOptions, OptionList } from '../util/Options.js';
 import { MathDocument } from '../core/MathDocument.js';
 import { MathItem } from '../core/MathItem.js';
-import { DOM, DOM_TYPES, N, T, D } from '../types/Types.js';
+import { DOM, DOM_TYPES } from '../types/Types.js';
 
 import { FindAsciiMath } from './asciimath/FindAsciiMath.js';
 
@@ -38,7 +38,7 @@ import { FindAsciiMath } from './asciimath/FindAsciiMath.js';
 export interface ASCIIMATH_OPTIONS<
   DOM extends DOM_TYPES,
 > extends INPUTJAX_OPTIONS<DOM, null> {
-  FindAsciiMath: FindAsciiMath<N<DOM>, T<DOM>, D<DOM>>;
+  FindAsciiMath: FindAsciiMath<DOM>;
 }
 
 /**
@@ -53,11 +53,9 @@ const options: ASCIIMATH_OPTIONS<DOM> = {
 /**
  *  Implements the AsciiMath class (extends AbstractInputJax)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
+export class AsciiMath<DOM extends DOM_TYPES> extends AbstractInputJax<DOM> {
   /**
    * The name of the input jax
    */
@@ -71,7 +69,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
   /**
    * The FindMath object used to search for AsciiMath in the document
    */
-  protected findAsciiMath: FindAsciiMath<N, T, D>;
+  protected findAsciiMath: FindAsciiMath<DOM>;
 
   /**
    * @override
@@ -91,7 +89,7 @@ export class AsciiMath<N, T, D> extends AbstractInputJax<N, T, D> {
    *
    * @override
    */
-  public compile(math: MathItem<N, T, D>, _document: MathDocument<N, T, D>) {
+  public compile(math: MathItem<DOM>, _document: MathDocument<DOM>) {
     return LegacyAsciiMath.Compile(math.math, math.display);
   }
 

--- a/ts/input/asciimath/FindAsciiMath.ts
+++ b/ts/input/asciimath/FindAsciiMath.ts
@@ -25,6 +25,7 @@ import { AbstractFindMath } from '../../core/FindMath.js';
 import { OptionList } from '../../util/Options.js';
 import { quotePattern } from '../../util/string.js';
 import { ProtoItem, protoItem } from '../../core/MathItem.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /**
  * Shorthand types for data about end delimiters and delimiter pairs
@@ -54,11 +55,11 @@ const options: FINDASCIIMATH_OPTIONS = {
  *
  *  Locates AsciiMath expressions within strings
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
+export class FindAsciiMath<
+  DOM extends DOM_TYPES,
+> extends AbstractFindMath<DOM> {
   /**
    * @override
    */
@@ -129,13 +130,13 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
     n: number,
     start: RegExpExecArray,
     end: EndItem
-  ): ProtoItem<N, T> {
+  ): ProtoItem<DOM> {
     const [, display, pattern] = end;
     const i = (pattern.lastIndex = start.index + start[0].length);
     const match = pattern.exec(text);
     return !match
       ? null
-      : protoItem<N, T>(
+      : protoItem<DOM>(
           start[0],
           match.index < i ? '' : text.substring(i, match.index),
           match[0],
@@ -153,7 +154,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
    * @param {number} n          The index of the string being searched
    * @param {string} text       The string being searched
    */
-  protected findMathInString(math: ProtoItem<N, T>[], n: number, text: string) {
+  protected findMathInString(math: ProtoItem<DOM>[], n: number, text: string) {
     let start, match;
     this.start.lastIndex = 0;
     while ((start = this.start.exec(text))) {
@@ -171,7 +172,7 @@ export class FindAsciiMath<N, T, D> extends AbstractFindMath<N, T, D> {
    * @override
    */
   public findMath(strings: string[]) {
-    const math: ProtoItem<N, T>[] = [];
+    const math: ProtoItem<DOM>[] = [];
     if (this.hasPatterns) {
       for (let i = 0, m = strings.length; i < m; i++) {
         this.findMathInString(math, i, strings[i]);

--- a/ts/input/mathml.ts
+++ b/ts/input/mathml.ts
@@ -29,7 +29,7 @@ import { MathItem } from '../core/MathItem.js';
 import { DOMAdaptor } from '../core/DOMAdaptor.js';
 import { MmlFactory } from '../core/MmlTree/MmlFactory.js';
 import { MmlNode } from '../core/MmlTree/MmlNode.js';
-import { DOM, DOM_TYPES, N, T, D } from '../types/Types.js';
+import { DOM, DOM_TYPES, N, D, NT } from '../types/Types.js';
 import {
   FilterFunctions,
   FilterFunctionList,
@@ -51,9 +51,9 @@ export interface MATHML_OPTIONS<DOM extends DOM_TYPES> extends INPUTJAX_OPTIONS<
 > {
   parseAs: 'html' | 'xml';
   forceReparse: boolean;
-  mmlFilters: FilterFunctionList<N<DOM> | T<DOM>, DOM>;
-  FindMathML: FindMathML<N<DOM>, T<DOM>, D<DOM>>;
-  MathMLCompile: MathMLCompile<N<DOM>, T<DOM>, D<DOM>>;
+  mmlFilters: FilterFunctionList<NT<DOM>, DOM>;
+  FindMathML: FindMathML<DOM>;
+  MathMLCompile: MathMLCompile<DOM>;
   parseError: (node: Node) => void;
 }
 
@@ -76,14 +76,10 @@ const options: MATHML_OPTIONS<DOM> = {
 /**
  *  Implements the MathML class (extends AbstractInputJax)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class MathML<N, T, D> extends AbstractInputJax<
-  N,
-  T,
-  D,
+export class MathML<DOM extends DOM_TYPES> extends AbstractInputJax<
+  DOM,
   string,
   MmlNode
 > {
@@ -100,22 +96,22 @@ export class MathML<N, T, D> extends AbstractInputJax<
   /**
    * The FindMathML instance used to locate MathML in the document
    */
-  protected findMathML: FindMathML<N, T, D>;
+  protected findMathML: FindMathML<DOM>;
 
   /**
    * The MathMLCompile instance used to convert the MathML tree to internal format
    */
-  protected mathml: MathMLCompile<N, T, D>;
+  protected mathml: MathMLCompile<DOM>;
 
   /**
    * A list of functions to call on the parsed MathML DOM before conversion to internal structure
    */
-  public mmlFilters: FilterFunctions<N | T, DOM<N, T, D>>;
+  public mmlFilters: FilterFunctions<NT<DOM>, DOM>;
 
   /**
    * @override
    */
-  public options: MATHML_OPTIONS<DOM<N, T, D>>;
+  public options: MATHML_OPTIONS<DOM>;
 
   /**
    * @override
@@ -127,9 +123,8 @@ export class MathML<N, T, D> extends AbstractInputJax<
       MathMLCompile.OPTIONS
     );
     super(mml);
-    this.findMathML = this.options.FindMathML || new FindMathML<N, T, D>(find);
-    this.mathml =
-      this.options.MathMLCompile || new MathMLCompile<N, T, D>(compile);
+    this.findMathML = this.options.FindMathML || new FindMathML<DOM>(find);
+    this.mathml = this.options.MathMLCompile || new MathMLCompile<DOM>(compile);
     this.mmlFilters = new FunctionList(this.options.mmlFilters);
   }
 
@@ -138,7 +133,7 @@ export class MathML<N, T, D> extends AbstractInputJax<
    *
    * @override
    */
-  public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
+  public setAdaptor(adaptor: DOMAdaptor<DOM>) {
     super.setAdaptor(adaptor);
     this.findMathML.adaptor = adaptor;
     this.mathml.adaptor = adaptor;
@@ -177,7 +172,7 @@ export class MathML<N, T, D> extends AbstractInputJax<
    *
    * @override
    */
-  public compile(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
+  public compile(math: MathItem<DOM>, document: MathDocument<DOM>) {
     let mml = math.start.node;
     if (
       !mml ||
@@ -201,15 +196,15 @@ export class MathML<N, T, D> extends AbstractInputJax<
       if (this.adaptor.childNodes(body).length !== 1) {
         this.error(localize('SingleNode'));
       }
-      mml = this.adaptor.remove(this.adaptor.firstChild(body)) as N;
+      mml = this.adaptor.remove(this.adaptor.firstChild(body)) as N<DOM>;
       if (this.adaptor.kind(mml).replace(/^[a-z]+:/, '') !== 'math') {
         this.error(
           localize('MathNode', '<math>', `<${this.adaptor.kind(mml)}>`)
         );
       }
     }
-    mml = this.executeFilters<N | T>(this.mmlFilters, math, document, mml);
-    let root = this.mathml.compile(mml as N);
+    mml = this.executeFilters<NT<DOM>>(this.mmlFilters, math, document, mml);
+    let root = this.mathml.compile(mml as N<DOM>);
     root = this.executeFilters(this.postFilters, math, document, root);
     math.display = root.attributes.get('display') === 'block';
     return root;
@@ -221,7 +216,7 @@ export class MathML<N, T, D> extends AbstractInputJax<
    * @param {D} doc  The document returns from the DOMParser
    * @returns {D}    The document
    */
-  protected checkForErrors(doc: D): D {
+  protected checkForErrors(doc: D<DOM>): D<DOM> {
     const err = this.adaptor.tags(this.adaptor.body(doc), 'parsererror')[0];
     if (err) {
       if (this.adaptor.textContent(err) === '') {
@@ -244,7 +239,7 @@ export class MathML<N, T, D> extends AbstractInputJax<
   /**
    * @override
    */
-  public findMath(node: N) {
+  public findMath(node: N<DOM>) {
     return this.findMathML.findMath(node);
   }
 }

--- a/ts/input/mathml/FindMathML.ts
+++ b/ts/input/mathml/FindMathML.ts
@@ -25,6 +25,7 @@ import { AbstractFindMath } from '../../core/FindMath.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { OptionList } from '../../util/Options.js';
 import { ProtoItem } from '../../core/MathItem.js';
+import { DOM_TYPES, N } from '../../types/Types.js';
 
 /**
  * The MathML namespace
@@ -35,11 +36,9 @@ const NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
 /**
  *  Implements the FindMathML object (extends AbstractFindMath)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
+export class FindMathML<DOM extends DOM_TYPES> extends AbstractFindMath<DOM> {
   /**
    * @override
    */
@@ -48,7 +47,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
   /**
    * The DOMAdaptor for the document being processed
    */
-  public adaptor: DOMAdaptor<N, T, D>;
+  public adaptor: DOMAdaptor<DOM>;
 
   /**
    * Locates math nodes, possibly with namespace prefixes.
@@ -57,8 +56,8 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
    *
    * @override
    */
-  public findMath(node: N) {
-    const set = new Set<N>();
+  public findMath(node: N<DOM>) {
+    const set = new Set<N<DOM>>();
     this.findMathNodes(node, set);
     this.findMathPrefixed(node, set);
     const html = this.adaptor.root(this.adaptor.document);
@@ -74,7 +73,7 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
    * @param {N} node       The container to seaerch for math
    * @param {Set<N>} set   The set in which to store the math nodes
    */
-  protected findMathNodes(node: N, set: Set<N>) {
+  protected findMathNodes(node: N<DOM>, set: Set<N<DOM>>) {
     for (const math of this.adaptor.tags(node, 'math')) {
       set.add(math);
     }
@@ -83,10 +82,10 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
   /**
    * Find <m:math> tags (or whatever prefixes there are)
    *
-   * @param {N} node  The container to seaerch for math
-   * @param {Set} set   The set in which to store the math nodes
+   * @param {N} node       The container to seaerch for math
+   * @param {Set<N>} set   The set in which to store the math nodes
    */
-  protected findMathPrefixed(node: N, set: Set<N>) {
+  protected findMathPrefixed(node: N<DOM>, set: Set<N<DOM>>) {
     const html = this.adaptor.root(this.adaptor.document);
     for (const attr of this.adaptor.allAttributes(html)) {
       if (attr.name.substring(0, 6) === 'xmlns:' && attr.value === NAMESPACE) {
@@ -101,10 +100,10 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
   /**
    * Find namespaced math in XHTML documents (is this really needed?)
    *
-   * @param {N} node  The container to search for math
-   * @param {Set} set   The set in which to store the math nodes
+   * @param {N} node       The container to search for math
+   * @param {Set<N>} set   The set in which to store the math nodes
    */
-  protected findMathNS(node: N, set: Set<N>) {
+  protected findMathNS(node: N<DOM>, set: Set<N<DOM>>) {
     for (const math of this.adaptor.tags(node, 'math', NAMESPACE)) {
       set.add(math);
     }
@@ -113,12 +112,12 @@ export class FindMathML<N, T, D> extends AbstractFindMath<N, T, D> {
   /**
    *  Produce the array of proto math items from the node set
    *
-   * @param {Set<N>} set The original node set
-   * @returns {ProtoItem<N, T>[]} The set of proto math items
+   * @param {Set<N>} set      The original node set
+   * @returns {ProtoItem[]}   The set of proto math items
    */
-  protected processMath(set: Set<N>): ProtoItem<N, T>[] {
+  protected processMath(set: Set<N<DOM>>): ProtoItem<DOM>[] {
     const adaptor = this.adaptor;
-    const math: ProtoItem<N, T>[] = [];
+    const math: ProtoItem<DOM>[] = [];
     for (const mml of set.values()) {
       if (adaptor.kind(adaptor.parent(mml)) === 'mjx-assistive-mml') continue;
       const display =

--- a/ts/input/mathml/MathMLCompile.ts
+++ b/ts/input/mathml/MathMLCompile.ts
@@ -36,6 +36,7 @@ import * as Entities from '../../util/Entities.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { Locale } from '../../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
+import { DOM_TYPES, N } from '../../types/Types.js';
 
 /********************************************************************/
 
@@ -49,7 +50,7 @@ export type MATHMLCOMPILE_OPTIONS = {
   allowHtmlInTokenNodes: boolean; //    True if HTML is allowed in token nodes
   fixMisplacedChildren: boolean; //     True if we want to use heuristics to try to fix
   //                                      problems with the tree based on HTML not handling
-  //                                       self-closing tags properly
+  //                                      self-closing tags properly
   verify: VERIFY_OPTIONS; //            Options to pass to verifyTree() controlling MathML verification
   translateEntities: boolean; //        True means translate entities in text nodes
 };
@@ -72,11 +73,9 @@ const options: MATHMLCOMPILE_OPTIONS = {
  *  The class for performing the MathML DOM node to
  *  internal MmlNode conversion.
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class MathMLCompile<N, T, D> {
+export class MathMLCompile<DOM extends DOM_TYPES> {
   /**
    *  The default options for this object
    */
@@ -85,7 +84,7 @@ export class MathMLCompile<N, T, D> {
   /**
    * The DOMAdaptor for the document being processed
    */
-  public adaptor: DOMAdaptor<N, T, D>;
+  public adaptor: DOMAdaptor<DOM>;
 
   /**
    *  The instance of the MmlFactory object and
@@ -117,10 +116,10 @@ export class MathMLCompile<N, T, D> {
   /**
    * Convert a MathML DOM tree to internal MmlNodes
    *
-   * @param {N} node     The <math> node to convert to MmlNodes
+   * @param {N} node      The <math> node to convert to MmlNodes
    * @returns {MmlNode}   The MmlNode at the root of the converted tree
    */
-  public compile(node: N): MmlNode {
+  public compile(node: N<DOM>): MmlNode {
     const mml = this.makeNode(node);
     mml.verifyTree(this.options['verify']);
     mml.setInheritedAttributes({}, false, 0, false);
@@ -134,10 +133,10 @@ export class MathMLCompile<N, T, D> {
    *
    *  FIXME: we should use data-* attributes rather than classes for these
    *
-   * @param {N} node     The node to convert to an MmlNode
+   * @param {N} node      The node to convert to an MmlNode
    * @returns {MmlNode}   The converted MmlNode
    */
-  public makeNode(node: N): MmlNode {
+  public makeNode(node: N<DOM>): MmlNode {
     const adaptor = this.adaptor;
     let limits = false;
     const kind = adaptor.kind(node).replace(/^.*:/, '');
@@ -163,15 +162,15 @@ export class MathMLCompile<N, T, D> {
   /**
    * Create an actual MmlNode tree from a given DOM node.
    *
-   * @param {string} type      The type of MmlNode to create
-   * @param {N} node           The original DOM node that is being transcribed
-   * @param {string} texClass  The texClass specified on the node, if any
-   * @param {boolean} limits   True if fixed limits are to be used
+   * @param {string} type       The type of MmlNode to create
+   * @param {N} node            The original DOM node that is being transcribed
+   * @param {string} texClass   The texClass specified on the node, if any
+   * @param {boolean} limits    True if fixed limits are to be used
    * @returns {MmlNode}         The final MmlNode tree
    */
   protected createMml(
     type: string,
-    node: N,
+    node: N<DOM>,
     texClass: string,
     limits: boolean
   ): MmlNode {
@@ -195,14 +194,14 @@ export class MathMLCompile<N, T, D> {
    *
    * @param {string} type   The type of node being requested
    * @param {N} node        The HTML node used to create it.
-   * @returns {MmlNode}      The HtmlNode holding the node (or null)
+   * @returns {MmlNode}     The HtmlNode holding the node (or null)
    */
-  protected unknownNode(type: string, node: N): MmlNode {
+  protected unknownNode(type: string, node: N<DOM>): MmlNode {
     if (
       this.factory.getNodeClass('html') &&
       this.options.allowHtmlInTokenNodes
     ) {
-      return (this.factory.create('html') as HtmlNode<N>).setHTML(
+      return (this.factory.create('html') as HtmlNode<N<DOM>>).setHTML(
         node,
         this.adaptor
       );
@@ -215,9 +214,9 @@ export class MathMLCompile<N, T, D> {
    * Copy the attributes from a MathML node to an MmlNode.
    *
    * @param {MmlNode} mml       The MmlNode to which attributes will be added
-   * @param {N} node  The MathML node whose attributes to copy
+   * @param {N} node            The MathML node whose attributes to copy
    */
-  protected addAttributes(mml: MmlNode, node: N) {
+  protected addAttributes(mml: MmlNode, node: N<DOM>) {
     let ignoreVariant = false;
     for (const attr of this.adaptor.allAttributes(node)) {
       const name = attr.name;
@@ -269,9 +268,9 @@ export class MathMLCompile<N, T, D> {
   /**
    * Provide a hook for the Safe extension to filter attribute values.
    *
-   * @param {string} _name  The name of an attribute to filter
-   * @param {string} value  The value to filter
-   * @returns {string} The filtered value.
+   * @param {string} _name   The name of an attribute to filter
+   * @param {string} value   The value to filter
+   * @returns {string}       The filtered value.
    */
   protected filterAttribute(_name: string, value: string): string {
     return value;
@@ -293,12 +292,12 @@ export class MathMLCompile<N, T, D> {
    * @param {MmlNode} mml  The MmlNode to which children will be added
    * @param {N} node       The MathML node whose children are to be copied
    */
-  protected addChildren(mml: MmlNode, node: N) {
+  protected addChildren(mml: MmlNode, node: N<DOM>) {
     if (mml.arity === 0) {
       return;
     }
     const adaptor = this.adaptor;
-    for (const child of adaptor.childNodes(node) as N[]) {
+    for (const child of adaptor.childNodes(node) as N<DOM>[]) {
       const name = adaptor.kind(child);
       if (name === '#comment') {
         continue;
@@ -340,7 +339,7 @@ export class MathMLCompile<N, T, D> {
    * @param {MmlNode} mml  The MmlNode to which text will be added
    * @param {N} child      The text node whose contents is to be copied
    */
-  protected addText(mml: MmlNode, child: N) {
+  protected addText(mml: MmlNode, child: N<DOM>) {
     let text = this.adaptor.value(child);
     if ((mml.isToken || mml.getProperty('isChars')) && mml.arity) {
       if (mml.isToken) {
@@ -357,9 +356,9 @@ export class MathMLCompile<N, T, D> {
    * Check for special MJX values in the class and process them
    *
    * @param {MmlNode} mml       The MmlNode to be modified according to the class markers
-   * @param {N} node  The MathML node whose class is to be processed
+   * @param {N} node            The MathML node whose class is to be processed
    */
-  protected checkClass(mml: MmlNode, node: N) {
+  protected checkClass(mml: MmlNode, node: N<DOM>) {
     const classList = [];
     for (const name of this.filterClassList(this.adaptor.allClasses(node))) {
       if (name.substring(0, 4) === 'MJX-') {
@@ -383,7 +382,7 @@ export class MathMLCompile<N, T, D> {
   /**
    * Fix the old incorrect spelling of calligraphic.
    *
-   * @param {string} variant  The mathvariant name
+   * @param {string} variant   The mathvariant name
    * @returns {string}         The corrected variant
    */
   protected fixCalligraphic(variant: string): string {
@@ -393,7 +392,7 @@ export class MathMLCompile<N, T, D> {
   /**
    * Check to see if an mrow has delimiters at both ends (so looks like an mfenced structure).
    *
-   * @param {MmlNode} mml  The node to check for mfenced structure
+   * @param {MmlNode} mml   The node to check for mfenced structure
    */
   protected markMrows(mml: MmlNode) {
     if (mml.isKind('mrow') && !mml.isInferred && mml.childNodes.length >= 2) {
@@ -418,7 +417,7 @@ export class MathMLCompile<N, T, D> {
   }
 
   /**
-   * @param {string} text  The text to have spacing normalized
+   * @param {string} text   The text to have spacing normalized
    * @returns {string}      The trimmed text
    */
   protected normalizeSpace(text: string): string {
@@ -442,8 +441,8 @@ export class MathMLCompile<N, T, D> {
     }
   }
   /**
-   * @param {string} message  The error message to produce
-   * @param {string[]} args   The substitution arguments
+   * @param {string} message   The error message to produce
+   * @param {string[]} args    The substitution arguments
    */
   protected error(message: string, ...args: string[]) {
     Locale.throw(COMPONENT, message, ...args);

--- a/ts/input/mathml/mml3/mml3-node.ts
+++ b/ts/input/mathml/mml3/mml3-node.ts
@@ -26,21 +26,20 @@ import { MathDocument } from '../../../core/MathDocument.js';
 import { mjxRoot } from '#root/root.js';
 import { Locale } from '../../../util/Locale.js';
 import { COMPONENT } from '../__locales__/Component.js';
+import { DOM_TYPES, N } from '../../../types/Types.js';
 
 /**
  * Create the transform function that uses Saxon-js to perform the
  *   xslt transformation.
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM element types
  *
- * @returns {(node: N, doc: MathDocument<N,T,D>) => N}   The transformation function
+ * @returns {(node: N, doc: MathDocument<DOM>) => N}   The transformation function
  */
-export function createTransform<N, T, D>(): (
-  node: N,
-  doc: MathDocument<N, T, D>
-) => N {
+export function createTransform<DOM extends DOM_TYPES>(): (
+  node: N<DOM>,
+  doc: MathDocument<DOM>
+) => N<DOM> {
   // get the actual require from node.
   const nodeRequire = eval('require');
   try {
@@ -64,7 +63,7 @@ export function createTransform<N, T, D>(): (
   const xslt = nodeRequire(
     path.resolve(mjxRoot(), 'input', 'mml', 'extensions', 'mml3.sef.json')
   );
-  return (node: N, doc: MathDocument<N, T, D>) => {
+  return (node: N<DOM>, doc: MathDocument<DOM>) => {
     const adaptor = doc.adaptor;
     let mml = adaptor.outerHTML(node);
     //
@@ -91,7 +90,7 @@ export function createTransform<N, T, D>(): (
             }).principalResult
           )
         )
-      ) as N;
+      ) as N<DOM>;
     } catch (_err) {
       result = node;
     }

--- a/ts/input/mathml/mml3/mml3.ts
+++ b/ts/input/mathml/mml3/mml3.ts
@@ -27,6 +27,7 @@ import { MathDocument } from '../../../core/MathDocument.js';
 import { Handler } from '../../../core/Handler.js';
 import { createTransform } from './mml3-node.js';
 import { MathML } from '../../mathml.js';
+import { DOM_TYPES, N } from '../../../types/Types.js';
 
 /**
  * The mml/mml3 option types.
@@ -45,20 +46,20 @@ const options: MML3_OPTIONS = {
 /**
  * The data for a MathML prefilter.
  *
- * @template N  The HTMLElement node class
+ * @template DOM   The DOM node types
  * @template T  The Text node class
  * @template D  The Document class
  */
-export type FILTERDATA<N, T, D> = {
-  math: MathItem<N, T, D>;
-  document: MathDocument<N, T, D> & { options: MML3_OPTIONS };
-  data: N;
+export type FILTERDATA<DOM extends DOM_TYPES> = {
+  math: MathItem<DOM>;
+  document: MathDocument<DOM> & { options: MML3_OPTIONS };
+  data: N<DOM>;
 };
 
 /**
  * Class that handles XSLT transform for MathML3 elementary math tags.
  */
-export class Mml3<N, T, D> {
+export class Mml3<DOM extends DOM_TYPES> {
   /**
    * The XSLT transform as a string;
    */
@@ -68,13 +69,13 @@ export class Mml3<N, T, D> {
    * The function to convert serialized MathML using the XSLT.
    * (Different for browser and node environments.)
    */
-  protected transform: (node: N, doc: MathDocument<N, T, D>) => N;
+  protected transform: (node: N<DOM>, doc: MathDocument<DOM>) => N<DOM>;
 
   /**
    * @param {MathDocument} document   The MathDocument for the transformation
    * @class
    */
-  constructor(document: MathDocument<N, T, D>) {
+  constructor(document: MathDocument<DOM>) {
     if (typeof XSLTProcessor === 'undefined') {
       //
       // For Node, get the trasnform from the external module
@@ -90,13 +91,13 @@ export class Mml3<N, T, D> {
         'text/xml'
       ) as any as Node;
       processor.importStylesheet(parsed);
-      this.transform = (node: N) => {
+      this.transform = (node: N<DOM>) => {
         const adaptor = document.adaptor;
         const div = adaptor.node('div', {}, [adaptor.clone(node)]);
         const dom = adaptor.parse(adaptor.serializeXML(div), 'text/xml');
         const mml = processor.transformToDocument(
           dom as any as Node
-        ) as any as N;
+        ) as any as N<DOM>;
         return mml ? adaptor.tags(mml, 'math')[0] : node;
       };
     }
@@ -107,7 +108,7 @@ export class Mml3<N, T, D> {
    *
    * @param {FILTERDATA} args  The data from the pre-filter chain.
    */
-  public mmlFilter(args: FILTERDATA<N, T, D>) {
+  public mmlFilter(args: FILTERDATA<DOM>) {
     if (args.document.options.enableMml3) {
       args.data = this.transform(args.data, args.document);
     }
@@ -119,10 +120,12 @@ export class Mml3<N, T, D> {
  *
  * @param {Handler} handler The current handler.
  * @returns {Handler} The provided handler for pipelining.
+ *
+ * @template DOM   THe DOM node types
  */
-export function Mml3Handler<N, T, D>(
-  handler: Handler<N, T, D>
-): Handler<N, T, D> {
+export function Mml3Handler<DOM extends DOM_TYPES>(
+  handler: Handler<DOM>
+): Handler<DOM> {
   handler.documentClass = class extends handler.documentClass {
     /**
      * @override
@@ -145,7 +148,7 @@ export function Mml3Handler<N, T, D>(
           if (!jax.options._mml3) {
             // prevent filter being added twice (e.g., when a11y tools load)
             const mml3 = new Mml3(this);
-            (jax as MathML<N, T, D>).mmlFilters.add(mml3.mmlFilter.bind(mml3));
+            (jax as MathML<DOM>).mmlFilters.add(mml3.mmlFilter.bind(mml3));
             jax.options._mml3 = true;
           }
           break;

--- a/ts/input/tex.ts
+++ b/ts/input/tex.ts
@@ -27,7 +27,7 @@ import { MathDocument } from '../core/MathDocument.js';
 import { MathItem } from '../core/MathItem.js';
 import { MmlNode } from '../core/MmlTree/MmlNode.js';
 import { MmlFactory } from '../core/MmlTree/MmlFactory.js';
-import { DOM, DOM_TYPES, N, T, D } from '../types/Types.js';
+import { DOM, DOM_TYPES } from '../types/Types.js';
 
 import { FindTeX } from './tex/FindTeX.js';
 
@@ -51,7 +51,7 @@ export interface TEX_OPTIONS<DOM extends DOM_TYPES> extends INPUTJAX_OPTIONS<
   DOM,
   ParseOptions
 > {
-  FindTeX: FindTeX<N<DOM>, T<DOM>, D<DOM>>;
+  FindTeX: FindTeX<DOM>;
   packages: string[];
   // Maximum size of TeX string to process.
   maxBuffer: number;
@@ -59,7 +59,7 @@ export interface TEX_OPTIONS<DOM extends DOM_TYPES> extends INPUTJAX_OPTIONS<
   maxTemplateSubtitutions: number;
   // math-style to use for Latin and Greek letters
   mathStyle: 'TeX' | 'ISO' | 'French' | 'upright';
-  formatError: (jax: TeX<N<DOM>, T<DOM>, D<DOM>>, err: TexError) => MmlNode;
+  formatError: (jax: TeX<DOM>, err: TexError) => MmlNode;
 }
 
 /**
@@ -72,21 +72,24 @@ const options: TEX_OPTIONS<DOM> = {
   maxBuffer: 5 * 1024,
   maxTemplateSubtitutions: 10000,
   mathStyle: 'TeX',
-  formatError: (jax: TeX<N<DOM>, T<DOM>, D<DOM>>, err: TexError) =>
-    jax.formatError(err),
+  formatError: (jax: TeX<DOM>, err: TexError) => jax.formatError(err),
 };
+
+/**
+ * A generic TeX input jax.
+ */
+export type TEX = TeX<DOM>;
 
 /*****************************************************************/
 /*
  *  Implements the TeX class (extends AbstractInputJax)
+ *
+ * @template DOM   The DOM node types
  */
-
-/**
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- */
-export class TeX<N, T, D> extends AbstractInputJax<N, T, D, ParseOptions> {
+export class TeX<DOM extends DOM_TYPES> extends AbstractInputJax<
+  DOM,
+  ParseOptions
+> {
   /**
    * Name of input jax.
    */
@@ -100,7 +103,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D, ParseOptions> {
   /**
    * The FindTeX instance used for locating TeX in strings
    */
-  protected findTeX: FindTeX<N, T, D>;
+  protected findTeX: FindTeX<DOM>;
 
   /**
    * The configuration of the TeX jax.
@@ -130,7 +133,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D, ParseOptions> {
   ): ParserConfiguration {
     const configuration = new ParserConfiguration(packages, ['tex']);
     configuration.init();
-    return configuration;
+    return configuration as ParserConfiguration;
   }
 
   /**
@@ -153,7 +156,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D, ParseOptions> {
   /**
    * @override
    */
-  public options: TEX_OPTIONS<DOM<N, T, D>>;
+  public options: TEX_OPTIONS<DOM>;
 
   /**
    * @override
@@ -213,10 +216,7 @@ export class TeX<N, T, D> extends AbstractInputJax<N, T, D, ParseOptions> {
   /**
    * @override
    */
-  public compile(
-    math: MathItem<N, T, D>,
-    document: MathDocument<N, T, D>
-  ): MmlNode {
+  public compile(math: MathItem<DOM>, document: MathDocument<DOM>): MmlNode {
     this.parseOptions.clear();
     this.parseOptions.mathItem = math;
     this.executeFilters(this.preFilters, math, document, this.parseOptions);

--- a/ts/input/tex/ColumnParser.ts
+++ b/ts/input/tex/ColumnParser.ts
@@ -35,22 +35,21 @@ import { COMPONENT } from './__locales__/Component.js';
 /**
  * The state of the columns analyzed so far.
  */
-/* prettier-ignore */
 export type ColumnState = {
-  parser: TexParser,                    // the current TexParser
-  template: string;                     // the template string for the columns
-  i: number;                            // the current location in the template
-  c: string;                            // the current column identifier
-  j: number;                            // the current column number
-  calign: string[];                     // the column alignments
-  cwidth: string[];                     // the explicit column widths
-  cspace: string[];                     // the column spacing
-  clines: string[];                     // the column lines
-  cstart: string[];                     // the '>' declarations
-  cend:   string[];                     // the '<' declarations
-  cextra: boolean[];                    // the extra columns from '@' and '!' declarations
-  ralign: [string, string, string][];   // the row alignment and column width/align when specified
-}
+  parser: TexParser; //                    The current TexParser
+  template: string; //                     The template string for the columns
+  i: number; //                            The current location in the template
+  c: string; //                            The current column identifier
+  j: number; //                            The current column number
+  calign: string[]; //                     The column alignments
+  cwidth: string[]; //                     The explicit column widths
+  cspace: string[]; //                     The column spacing
+  clines: string[]; //                     The column lines
+  cstart: string[]; //                     The '>' declarations
+  cend: string[]; //                       The '<' declarations
+  cextra: boolean[]; //                    The extra columns from '@' and '!' declarations
+  ralign: [string, string, string][]; //   The row alignment and column width/align when specified
+};
 
 /**
  * A function to handle a column declaration

--- a/ts/input/tex/Configuration.ts
+++ b/ts/input/tex/Configuration.ts
@@ -28,7 +28,7 @@ import { TagsClass } from './Tags.js';
 import { userOptions, defaultOptions, OptionList } from '../../util/Options.js';
 import { SubHandlers } from './MapHandler.js';
 import { FunctionList } from '../../util/FunctionList.js';
-import { TeX } from '../tex.js';
+import { TEX } from '../tex.js';
 import { PrioritizedList } from '../../util/PrioritizedList.js';
 import { TagsFactory } from './Tags.js';
 import { Locale } from '../../util/Locale.js';
@@ -41,10 +41,7 @@ export type Processor<T> = [T, number];
 export type ProtoProcessor<T> = Processor<T> | T;
 type ProcessorMethod = (data: any) => void;
 export type ProcessorList = Processor<ProcessorMethod>[];
-export type ConfigMethod = (
-  c: ParserConfiguration,
-  j: TeX<any, any, any>
-) => void;
+export type ConfigMethod = (c: ParserConfiguration, j: TEX) => void;
 export type InitMethod = (c: ParserConfiguration) => void;
 
 export class Configuration {
@@ -379,9 +376,9 @@ export class ParserConfiguration {
   /**
    * Init method for when the jax is ready
    *
-   * @param {TeX} jax The TeX jax for this configuration
+   * @param {TEX} jax The TeX jax for this configuration
    */
-  public config(jax: TeX<any, any, any>) {
+  public config(jax: TEX) {
     this.configMethod.execute(this, jax);
     for (const config of this.configurations) {
       this.addFilters(jax, config.item);
@@ -409,10 +406,10 @@ export class ParserConfiguration {
    * Sets items, nodes and runs configuration method explicitly.
    *
    * @param {string} name            The name of the package to add
-   * @param {TeX} jax                The TeX jax where it is being registered
+   * @param {TEX} jax                The TeX jax where it is being registered
    * @param {OptionList=} options    The options for the configuration.
    */
-  public add(name: string, jax: TeX<any, any, any>, options: OptionList = {}) {
+  public add(name: string, jax: TEX, options: OptionList = {}) {
     const config = this.getPackage(name);
     this.append(config);
     this.configurations.add(config, config.priority);
@@ -472,10 +469,10 @@ export class ParserConfiguration {
   /**
    * Adds pre- and postprocessor as filters to the jax.
    *
-   * @param {TeX} jax The TeX Jax.
+   * @param {TEX} jax The TeX Jax.
    * @param {Configuration} config The configuration whose processors are added.
    */
-  private addFilters(jax: TeX<any, any, any>, config: Configuration) {
+  private addFilters(jax: TEX, config: Configuration) {
     for (const [pre, priority] of config.preprocessors) {
       jax.preFilters.add(pre, priority);
     }

--- a/ts/input/tex/FindTeX.ts
+++ b/ts/input/tex/FindTeX.ts
@@ -25,6 +25,7 @@ import { AbstractFindMath } from '../../core/FindMath.js';
 import { OptionList } from '../../util/Options.js';
 import { sortLength, quotePattern } from '../../util/string.js';
 import { ProtoItem, protoItem } from '../../core/MathItem.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /**
  * Shorthand types for data about end delimiters and delimiter pairs
@@ -67,11 +68,9 @@ const options: FINDTEX_OPTIONS = {
  */
 
 /**
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
+export class FindTeX<DOM extends DOM_TYPES> extends AbstractFindMath<DOM> {
   /**
    * the default options
    */
@@ -186,21 +185,21 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
    * @param {number} n               The index of the string being searched
    * @param {RegExpExecArray} start  The result array from the start-delimiter search
    * @param {EndItem} end            The end-delimiter data corresponding to the start delimiter
-   * @returns {ProtoItem<N,T>}        The proto math item for the math, if found
+   * @returns {ProtoItem<DOM>}       The proto math item for the math, if found
    */
   protected findEnd(
     text: string,
     n: number,
     start: RegExpExecArray,
     end: EndItem
-  ): ProtoItem<N, T> {
+  ): ProtoItem<DOM> {
     const [close, display, pattern] = end;
     const i = (pattern.lastIndex = start.index + start[0].length);
     let match: RegExpExecArray,
       braces: number = 0;
     while ((match = pattern.exec(text))) {
       if ((match[1] || match[0]) === close && braces === 0) {
-        return protoItem<N, T>(
+        return protoItem<DOM>(
           start[0],
           text.substring(i, match.index),
           match[0],
@@ -226,7 +225,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
    * @param {number} n          The index of the string being searched
    * @param {string} text       The string being searched
    */
-  protected findMathInString(math: ProtoItem<N, T>[], n: number, text: string) {
+  protected findMathInString(math: ProtoItem<DOM>[], n: number, text: string) {
     let start, match;
     this.start.lastIndex = 0;
     while ((start = this.start.exec(text))) {
@@ -245,7 +244,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
         const math = start[this.sub];
         const end = start.index + start[this.sub].length;
         if (math.length === 2) {
-          match = protoItem<N, T>(
+          match = protoItem<DOM>(
             '\\',
             math.substring(1),
             '',
@@ -254,7 +253,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
             end
           );
         } else {
-          match = protoItem<N, T>('', math, '', n, start.index, end, false);
+          match = protoItem<DOM>('', math, '', n, start.index, end, false);
         }
       } else {
         match = this.findEnd(text, n, start, this.end[start[0]]);
@@ -272,7 +271,7 @@ export class FindTeX<N, T, D> extends AbstractFindMath<N, T, D> {
    * @override
    */
   public findMath(strings: string[]) {
-    const math: ProtoItem<N, T>[] = [];
+    const math: ProtoItem<DOM>[] = [];
     if (this.hasPatterns) {
       for (let i = 0, m = strings.length; i < m; i++) {
         this.findMathInString(math, i, strings[i]);

--- a/ts/input/tex/ParseOptions.ts
+++ b/ts/input/tex/ParseOptions.ts
@@ -33,6 +33,7 @@ import { TexConstant } from './TexConstants.js';
 import { defaultOptions, OptionList } from '../../util/Options.js';
 import { ParserConfiguration } from './Configuration.js';
 import { ColumnParser } from './ColumnParser.js';
+import { DOM } from '../../types/Types.js';
 
 const MATHVARIANT = TexConstant.Variant;
 
@@ -128,7 +129,7 @@ export default class ParseOptions {
   /**
    * The current MathItem
    */
-  public mathItem: MathItem<any, any, any>;
+  public mathItem: MathItem<DOM>;
 
   /**
    * The current root node.

--- a/ts/input/tex/Tags.ts
+++ b/ts/input/tex/Tags.ts
@@ -30,6 +30,7 @@ import NodeUtil from './NodeUtil.js';
 import { TexConstant } from './TexConstants.js';
 import { Locale } from '../../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
+import { DOM } from '../../types/Types.js';
 
 /**
  *  Simple class for label objects.
@@ -207,13 +208,13 @@ export interface Tags {
    *
    * @param {MathItem} math   The MathItem for the current equation
    */
-  startEquation(math: MathItem<any, any, any>): void;
+  startEquation(math: MathItem<DOM>): void;
 
   /**
    * Move equation-specific labels and ids to global ones,
    * save the counter, and mark the MathItem for redos
    */
-  finishEquation(math: MathItem<any, any, any>): void;
+  finishEquation(math: MathItem<DOM>): void;
 
   /**
    * Finalizes tag creation.
@@ -487,7 +488,7 @@ export class AbstractTags implements Tags {
   /**
    * @override
    */
-  public startEquation(math: MathItem<any, any, any>) {
+  public startEquation(math: MathItem<DOM>) {
     this.history = [];
     this.stack = [];
     this.clearTag();
@@ -506,7 +507,7 @@ export class AbstractTags implements Tags {
   /**
    * @override
    */
-  public finishEquation(math: MathItem<any, any, any>) {
+  public finishEquation(math: MathItem<DOM>) {
     if (this.redo) {
       math.inputData.recompile = {
         state: math.state(),

--- a/ts/input/tex/autoload/AutoloadConfiguration.ts
+++ b/ts/input/tex/autoload/AutoloadConfiguration.ts
@@ -26,7 +26,7 @@ import { Configuration, ParserConfiguration } from '../Configuration.js';
 import TexParser from '../TexParser.js';
 import { CommandMap } from '../TokenMap.js';
 import { Macro } from '../Token.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 
 import {
   RequireLoad,
@@ -99,9 +99,9 @@ function initAutoload(config: ParserConfiguration) {
  * (except for \color, which is overridden if present)
  *
  * @param {ParserConfiguration} config The parser configuration.
- * @param {TeX} jax The current tex input jax.
+ * @param {TEX} jax The current tex input jax.
  */
-function configAutoload(config: ParserConfiguration, jax: TeX<any, any, any>) {
+function configAutoload(config: ParserConfiguration, jax: TEX) {
   const parser = jax.parseOptions;
   const macros = parser.handlers.get(HandlerType.MACRO);
   const environments = parser.handlers.get(HandlerType.ENVIRONMENT);

--- a/ts/input/tex/bussproofs/BussproofsUtil.ts
+++ b/ts/input/tex/bussproofs/BussproofsUtil.ts
@@ -33,8 +33,10 @@ import { MathDocument } from '../../../core/MathDocument.js';
 import { Locale } from '../../../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
 
-type MATHITEM = MathItem<any, any, any>;
-type MATHDOCUMENT = MathDocument<any, any, any>;
+import { DOM } from '../../../types/Types.js';
+
+type MATHITEM = MathItem<DOM>;
+type MATHDOCUMENT = MathDocument<DOM>;
 
 type FilterData = {
   math: MATHITEM;

--- a/ts/input/tex/color/ColorConfiguration.ts
+++ b/ts/input/tex/color/ColorConfiguration.ts
@@ -26,7 +26,7 @@ import { CommandMap } from '../TokenMap.js';
 import { Configuration, ParserConfiguration } from '../Configuration.js';
 import { ColorMethods } from './ColorMethods.js';
 import { ColorModel } from './ColorUtil.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 export { COMPONENT } from './__locales__/Component.js';
 
 /**
@@ -44,12 +44,9 @@ new CommandMap('color', {
  * Config method for Color package.
  *
  * @param {Configuration} _config  The current configuration.
- * @param {TeX} jax                The TeX jax having that configuration
+ * @param {TEX} jax                The TeX jax having that configuration
  */
-const config = function (
-  _config: ParserConfiguration,
-  jax: TeX<any, any, any>
-) {
+const config = function (_config: ParserConfiguration, jax: TEX) {
   jax.parseOptions.packageData.set('color', { model: new ColorModel() });
 };
 

--- a/ts/input/tex/colortbl/ColortblConfiguration.ts
+++ b/ts/input/tex/colortbl/ColortblConfiguration.ts
@@ -32,7 +32,7 @@ import { CommandMap } from '../TokenMap.js';
 import TexParser from '../TexParser.js';
 import { texError } from '../TexError.js';
 
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import { COMPONENT } from './__locales__/Component.js';
 export { COMPONENT };
 
@@ -202,9 +202,9 @@ new CommandMap('colortbl', {
  * The configuration function for colortbl.
  *
  * @param {ParserConfiguration} config   The configuration being used.
- * @param {TeX} jax                      The TeX jax using this configuration.
+ * @param {TEX} jax                      The TeX jax using this configuration.
  */
-const config = function (config: ParserConfiguration, jax: TeX<any, any, any>) {
+const config = function (config: ParserConfiguration, jax: TEX) {
   //
   //  Make sure color is configured.  (It doesn't have to be included in tex.packages)
   //

--- a/ts/input/tex/configmacros/ConfigMacrosConfiguration.ts
+++ b/ts/input/tex/configmacros/ConfigMacrosConfiguration.ts
@@ -29,9 +29,7 @@ import ParseMethods from '../ParseMethods.js';
 import { Macro } from '../Token.js';
 import NewcommandMethods from '../newcommand/NewcommandMethods.js';
 import { BeginEnvItem } from '../newcommand/NewcommandItems.js';
-import { TeX } from '../../tex.js';
-
-type TEX = TeX<any, any, any>;
+import { TEX } from '../../tex.js';
 
 /**
  * The name to use for the macros map
@@ -73,7 +71,7 @@ function configmacrosInit(config: ParserConfiguration) {
  * Create the user-defined macros and environments from their options
  *
  * @param {Configuration} _config  The configuration object for the input jax
- * @param {TeX} jax                The TeX input jax
+ * @param {TEX} jax                The TeX input jax
  */
 function configmacrosConfig(_config: ParserConfiguration, jax: TEX) {
   configActives(jax);
@@ -107,7 +105,7 @@ function setMacros(name: string, map: string, jax: TEX) {
 /**
  * Create user-defined active characters from the active option
  *
- * @param {TeX} jax   The TeX input jax
+ * @param {TEX} jax   The TeX input jax
  */
 function configActives(jax: TEX) {
   setMacros('active', ACTIVEMAP, jax);
@@ -116,7 +114,7 @@ function configActives(jax: TEX) {
 /**
  * Create user-defined macros from the macros option
  *
- * @param {TeX} jax   The TeX input jax
+ * @param {TEX} jax   The TeX input jax
  */
 function configMacros(jax: TEX) {
   setMacros('macros', MACROSMAP, jax);
@@ -125,7 +123,7 @@ function configMacros(jax: TEX) {
 /**
  * Create user-defined environments from the environments option
  *
- * @param {TeX} jax   The TeX input jax
+ * @param {TEX} jax   The TeX input jax
  */
 function configEnvironments(jax: TEX) {
   const handler = jax.parseOptions.handlers.retrieve(

--- a/ts/input/tex/mathtools/MathtoolsConfiguration.ts
+++ b/ts/input/tex/mathtools/MathtoolsConfiguration.ts
@@ -28,7 +28,7 @@ import { CommandMap } from '../TokenMap.js';
 import NodeUtil from '../NodeUtil.js';
 import { expandable, EXPANDABLE_LIST_OF } from '../../../util/Options.js';
 import { ParserConfiguration } from '../Configuration.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import ParseOptions from '../ParseOptions.js';
 import { NewcommandConfig } from '../newcommand/NewcommandConfiguration.js';
 import { NewcommandTables } from '../newcommand/NewcommandUtil.js';
@@ -48,9 +48,9 @@ export { COMPONENT } from './__locales__/Component.js';
  * Add any pre-defined paired delimiters, and subclass the configured tag format.
  *
  * @param {ParserConfiguration} config   The current configuration.
- * @param {TeX} jax                      The TeX input jax
+ * @param {TEX} jax                      The TeX input jax
  */
-function configMathtools(config: ParserConfiguration, jax: TeX<any, any, any>) {
+function configMathtools(config: ParserConfiguration, jax: TEX) {
   NewcommandConfig(config, jax);
   const parser = jax.parseOptions;
   const pairedDelims = parser.options.mathtools.pairedDelimiters;

--- a/ts/input/tex/mathtools/MathtoolsTags.ts
+++ b/ts/input/tex/mathtools/MathtoolsTags.ts
@@ -22,7 +22,7 @@
 
 import { texError } from '../TexError.js';
 import { ParserConfiguration } from '../Configuration.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import { AbstractTags, TagsFactory } from '../Tags.js';
 
 import { COMPONENT } from './__locales__/Component.js';
@@ -30,10 +30,9 @@ import { COMPONENT } from './__locales__/Component.js';
 /**
  * The type for the Mathtools tags (including their data).
  */
-/* prettier-ignore */
 export type MathtoolsTags = AbstractTags & {
-  mtFormats: Map<string, [string, string, string]>;  // name -> [left, right, format]
-  mtCurrent: [string, string, string];               // [left, right, format]
+  mtFormats: Map<string, [string, string, string]>; //  name -> [left, right, format]
+  mtCurrent: [string, string, string]; //               [left, right, format]
 };
 
 /**
@@ -46,12 +45,9 @@ let tagID = 0;
  * that handles the formats created by the \newtagform macro.
  *
  * @param {ParserConfiguration} config   The current configuration.
- * @param {TeX} jax                      The TeX input jax
+ * @param {TEX} jax                      The TeX input jax
  */
-export function MathtoolsTagFormat(
-  config: ParserConfiguration,
-  jax: TeX<any, any, any>
-) {
+export function MathtoolsTagFormat(config: ParserConfiguration, jax: TEX) {
   /**
    * If the tag format is being added by one of the other extensions,
    *   as is done for the 'ams' tags, make sure it is defined so we can create it.

--- a/ts/input/tex/newcommand/NewcommandConfiguration.ts
+++ b/ts/input/tex/newcommand/NewcommandConfiguration.ts
@@ -21,7 +21,7 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import { HandlerType, ConfigurationType } from '../HandlerTypes.js';
 import { Configuration, ParserConfiguration } from '../Configuration.js';
 import { BeginEnvItem } from './NewcommandItems.js';
@@ -36,12 +36,9 @@ export { COMPONENT } from './__locales__/Component.js';
  * if they aren't already in place.
  *
  * @param {ParserConfiguration} _config  The parser configuration (ignored)
- * @param {TeX} jax                      The TeX input jax
+ * @param {TEX} jax                      The TeX input jax
  */
-export function NewcommandConfig(
-  _config: ParserConfiguration,
-  jax: TeX<any, any, any>
-) {
+export function NewcommandConfig(_config: ParserConfiguration, jax: TEX) {
   //
   //  Check if we are already initialzied (since other packages call this)
   //

--- a/ts/input/tex/require/RequireConfiguration.ts
+++ b/ts/input/tex/require/RequireConfiguration.ts
@@ -39,6 +39,7 @@ import { Loader, CONFIG as LOADERCONFIG } from '../../../components/loader.js';
 import { mathjax } from '../../../mathjax.js';
 import { expandable, EXPANDABLE_LIST_OF } from '../../../util/Options.js';
 import { MenuMathDocument } from '../../../ui/menu/MenuHandler.js';
+import { DOM } from '../../../types/Types.js';
 
 import { Locale } from '../../../util/Locale.js';
 import { COMPONENT } from './__locales__/Component.js';
@@ -55,7 +56,7 @@ const MJCONFIG = MathJax.config;
  * @param {TeX} jax       The TeX jax whose configuration is to be modified
  * @param {string} name   The name of the extension being added (e.g., '[tex]/amscd')
  */
-function RegisterExtension(jax: TeX<any, any, any>, name: string) {
+function RegisterExtension(jax: TeX<DOM>, name: string) {
   const require = jax.parseOptions.options.require;
   const required = jax.parseOptions.packageData.get('require')
     .required as string[];
@@ -90,11 +91,7 @@ function RegisterExtension(jax: TeX<any, any, any>, name: string) {
  * @param {string} name   The name of the extension being added (e.g., '[tex]/amscd')
  * @param {string} extension The name of the configuration handler for the extension.
  */
-function ProcessExtension(
-  jax: TeX<any, any, any>,
-  name: string,
-  extension: string
-) {
+function ProcessExtension(jax: TeX<DOM>, name: string, extension: string) {
   //
   //  If the required file loaded an extension...
   //
@@ -138,7 +135,7 @@ function ProcessExtension(
  *                             are complete (or null if no retries)
  */
 function RegisterDependencies(
-  jax: TeX<any, any, any>,
+  jax: TeX<DOM>,
   names: string[] = []
 ): Promise<any> {
   const prefix = jax.parseOptions.options.require.prefix;
@@ -182,7 +179,7 @@ export function RequireLoad(parser: TexParser, name: string) {
     texError(COMPONENT, 'RequireFail', name);
   }
   const require = LOADERCONFIG[extension]?.rendererExtensions;
-  const menu = (MathJax.startup.document as MenuMathDocument)?.menu;
+  const menu = (MathJax.startup.document as unknown as MenuMathDocument)?.menu;
   if (require && menu) {
     menu.addRequiredExtensions(require);
   }
@@ -198,12 +195,11 @@ export function RequireLoad(parser: TexParser, name: string) {
  * @param {ParserConfiguration} _config The parser configuration.
  * @param {TeX} jax The current TeX jax.
  */
-function config(_config: ParserConfiguration, jax: TeX<any, any, any>) {
-  /* prettier-ignore */
+function config(_config: ParserConfiguration, jax: TeX<DOM>) {
   jax.parseOptions.packageData.set('require', {
-    jax: jax,                             // \require needs access to this
-    required: [...jax.options.packages],  // stores the names of the packages that have been added
-    configured: new Map()                 // stores the packages that have been configured
+    jax: jax, //                             \require needs access to this
+    required: [...jax.options.packages], //  stores the names of the packages that have been added
+    configured: new Map(), //                stores the packages that have been configured
   });
   const options = jax.parseOptions.options.require;
   const prefix = options.prefix;

--- a/ts/input/tex/setoptions/SetOptionsConfiguration.ts
+++ b/ts/input/tex/setoptions/SetOptionsConfiguration.ts
@@ -27,7 +27,7 @@ import {
   ConfigurationHandler,
   ParserConfiguration,
 } from '../Configuration.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import TexParser from '../TexParser.js';
 import { CommandMap } from '../TokenMap.js';
 import { texError } from '../TexError.js';
@@ -149,12 +149,9 @@ function SetOptions(parser: TexParser, name: string) {
  *   its options, if any.
  *
  * @param {ParserConfiguration} _config The current configuration.
- * @param {TeX} jax                     The active tex input jax.
+ * @param {TEX} jax                     The active tex input jax.
  */
-function setoptionsConfig(
-  _config: ParserConfiguration,
-  jax: TeX<any, any, any>
-) {
+function setoptionsConfig(_config: ParserConfiguration, jax: TEX) {
   const setOptionsMap = new CommandMap('setoptions', {
     setOptions: SetOptions,
   });

--- a/ts/input/tex/tagformat/TagFormatConfiguration.ts
+++ b/ts/input/tex/tagformat/TagFormatConfiguration.ts
@@ -23,7 +23,7 @@
 
 import { ConfigurationType } from '../HandlerTypes.js';
 import { Configuration, ParserConfiguration } from '../Configuration.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import { AbstractTags as _AbstractTags, TagsFactory } from '../Tags.js';
 
 /**
@@ -37,12 +37,9 @@ let tagID = 0;
  * to control the formatting of the tags
  *
  * @param {Configuration} config   The configuration for the input jax
- * @param {TeX} jax                The TeX input jax
+ * @param {TEX} jax                The TeX input jax
  */
-export function tagformatConfig(
-  config: ParserConfiguration,
-  jax: TeX<any, any, any>
-) {
+export function tagformatConfig(config: ParserConfiguration, jax: TEX) {
   /**
    * If the tag format is being added by one of the other extensions,
    *   as is done for the 'ams' tags, make sure it is defined so we can create it.

--- a/ts/input/tex/texhtml/TexHtmlConfiguration.ts
+++ b/ts/input/tex/texhtml/TexHtmlConfiguration.ts
@@ -33,6 +33,7 @@ import { HtmlNode } from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
 import { HTMLDomStrings } from '../../../handlers/html/HTMLDomStrings.js';
 import { DOMAdaptor } from '../../../core/DOMAdaptor.js';
 import { COMPONENT } from '../__locales__/Component.js';
+import { DOM } from '../../../types/Types.js';
 
 export const HtmlNodeMethods: { [key: string]: ParseMethod } = {
   /**
@@ -114,10 +115,7 @@ export const TexHtmlConfiguration = Configuration.create('texhtml', {
       //
       const include = HTMLDomStrings.OPTIONS.includeHtmlTags;
       if (!include['tex-html']) {
-        include['tex-html'] = (
-          node: any,
-          adaptor: DOMAdaptor<any, any, any>
-        ) => {
+        include['tex-html'] = (node: any, adaptor: DOMAdaptor<DOM>) => {
           //
           // Use the node's serialized contents, and check if there are
           //   nested <tex-html> nodes; if so, mark the one that we are using
@@ -136,7 +134,7 @@ export const TexHtmlConfiguration = Configuration.create('texhtml', {
     }
   },
   [ConfigurationType.PREPROCESSORS]: [
-    (data: { document: HTMLDocument<any, any, any>; data: ParseOptions }) => {
+    (data: { document: HTMLDocument<DOM>; data: ParseOptions }) => {
       data.data.packageData.set('texhtml', { adaptor: data.document.adaptor }); // save the DOMadaptor
     },
   ],

--- a/ts/input/tex/textmacros/TextMacrosConfiguration.ts
+++ b/ts/input/tex/textmacros/TextMacrosConfiguration.ts
@@ -22,7 +22,7 @@
  */
 
 import { HandlerType, ConfigurationType } from '../HandlerTypes.js';
-import { TeX } from '../../tex.js';
+import { TEX } from '../../tex.js';
 import TexParser from '../TexParser.js';
 import { Configuration, ParserConfiguration } from '../Configuration.js';
 import ParseOptions from '../ParseOptions.js';
@@ -132,12 +132,9 @@ export const TextMacrosConfiguration = Configuration.create('textmacros', {
   [ConfigurationType.PRIORITY]: 1,
   /**
    * @param {ParserConfiguration} _config  The configuration object we are being configured within
-   * @param {TeX<any,any,any>} jax         The TeX input jax in which we are running
+   * @param {TEX} jax                      The TeX input jax in which we are running
    */
-  [ConfigurationType.CONFIG]: (
-    _config: ParserConfiguration,
-    jax: TeX<any, any, any>
-  ) => {
+  [ConfigurationType.CONFIG]: (_config: ParserConfiguration, jax: TEX) => {
     //
     //  Create the configuration and parseOptions objects for the
     //    internal TextParser and add the textBase configuration.

--- a/ts/mathjax.ts
+++ b/ts/mathjax.ts
@@ -28,6 +28,7 @@ import { OptionList } from './util/Options.js';
 import { MathDocument } from './core/MathDocument.js';
 import { context } from './util/context.js';
 import { json } from '#root/json.js';
+import { DOM } from './types/Types.js';
 
 /*****************************************************************/
 /**
@@ -47,7 +48,7 @@ export const mathjax = {
   /**
    *  The list of registers document handlers
    */
-  handlers: new HandlerList<any, any, any>(),
+  handlers: new HandlerList<DOM>(),
 
   /**
    * Creates a MathDocument using a registered handler that knows how to handl it
@@ -56,10 +57,7 @@ export const mathjax = {
    * @param {OptionList} options   The options to use for the document (e.g., input and output jax)
    * @returns {MathDocument}       The MathDocument to handle the document
    */
-  document: function (
-    document: any,
-    options: OptionList
-  ): MathDocument<any, any, any> {
+  document: function (document: any, options: OptionList): MathDocument<DOM> {
     return mathjax.handlers.document(document, options);
   },
 

--- a/ts/output/chtml.ts
+++ b/ts/output/chtml.ts
@@ -42,33 +42,48 @@ import { Usage } from './chtml/Usage.js';
 import * as LENGTHS from '../util/lengths.js';
 import { unicodeChars } from '../util/string.js';
 import { DefaultFont } from './chtml/DefaultFont.js';
-import { DOM, DOM_TYPES, N, T, D } from '../types/Types.js';
+import { DOM_TYPES, N } from '../types/Types.js';
 
 /*****************************************************************/
 
 /**
+ * The CHTML font types.
+ */
+export type CHTML_FONT = {
+  CC: ChtmlCharOptions;
+  VV: ChtmlVariantData;
+  DD: ChtmlDelimiterData;
+  FD: ChtmlFontData;
+  FC: ChtmlFontDataClass;
+};
+
+/**
  * The CHTML option types.
  */
-export interface CHTML_OPTIONS<DOM extends DOM_TYPES> extends COMMON_OPTIONS<
-  DOM,
-  ChtmlWrapper<N<DOM>, T<DOM>, D<DOM>>,
-  ChtmlWrapperFactory<N<DOM>, T<DOM>, D<DOM>>,
-  ChtmlWrapperClass<N<DOM>, T<DOM>, D<DOM>>,
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass
-> {
+export type OPTIONS = {
   adaptiveCSS: boolean; //       true means only produce CSS that is used in the processed equations
   matchFontHeight: boolean; //   true to match ex-height of surrounding font
-}
+};
+
+/**
+ * The CHTML OutputJax option types.
+ */
+export interface CHTML_OPTIONS<DOM extends DOM_TYPES>
+  extends
+    OPTIONS,
+    COMMON_OPTIONS<
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
+    > {}
 
 /**
  * The CHTML option defaults.
  */
-const options: CHTML_OPTIONS<DOM> = {
-  ...CommonOutputJax.OPTIONS,
+const options: OPTIONS = {
   adaptiveCSS: true,
   matchFontHeight: true,
 };
@@ -77,32 +92,15 @@ const options: CHTML_OPTIONS<DOM> = {
 /**
  *  Implements the CHTML class (extends AbstractOutputJax)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class CHTML<N, T, D> extends CommonOutputJax<
-  //
-  // The HTMLElement, TextNode, and Document classes (for the DOM implementation in use)
-  //
-  N,
-  T,
-  D,
-  //
-  // The Wrapper type and its Factory and Class (these need to know N, T, and D)
-  //
-  ChtmlWrapper<N, T, D>,
-  ChtmlWrapperFactory<N, T, D>,
-  ChtmlWrapperClass<N, T, D>,
-  //
-  // These are font-related objects that depend on the output jax; e,g. the character options
-  //   for CHTML and SVG output differ (CHTML contains font information, while SVG has path data)
-  //
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass
+export class CHTML<DOM extends DOM_TYPES> extends CommonOutputJax<
+  DOM,
+  CHTML_FONT,
+  CHTML<DOM>,
+  ChtmlWrapper<DOM>,
+  ChtmlWrapperFactory<DOM>,
+  ChtmlWrapperClass<DOM>
 > {
   /**
    * The name of this output jax
@@ -112,12 +110,15 @@ export class CHTML<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  public options: CHTML_OPTIONS<DOM<N, T, D>>;
+  public options: CHTML_OPTIONS<DOM>;
 
   /**
    * @override
    */
-  public static OPTIONS = options;
+  public static OPTIONS = {
+    ...CommonOutputJax.OPTIONS,
+    ...options,
+  };
 
   /**
    *  The default styles for CommonHTML
@@ -234,7 +235,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
   /**
    * The CHTML stylesheet, once it is constructed
    */
-  public chtmlStyles: N = null;
+  public chtmlStyles: N<DOM> = null;
 
   /**
    * @override
@@ -263,7 +264,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  public escaped(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
+  public escaped(math: MathItem<DOM>, html: MathDocument<DOM>) {
     this.setDocument(html);
     return this.html('span', {}, [this.text(math.math)]);
   }
@@ -271,7 +272,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  public styleSheet(html: MathDocument<N, T, D>) {
+  public styleSheet(html: MathDocument<DOM>) {
     if (this.chtmlStyles) {
       const styles = new StyleJsonSheet();
       if (this.options.adaptiveCSS) {
@@ -352,7 +353,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
    * @param {ChtmlWrapper} wrapper   The MML node wrapper whose HTML is to be produced
    * @param {N} parent     The HTML node to contain the HTML
    */
-  public processMath(wrapper: ChtmlWrapper<N, T, D>, parent: N) {
+  public processMath(wrapper: ChtmlWrapper<DOM>, parent: N<DOM>) {
     wrapper.toCHTML([parent]);
   }
 
@@ -413,7 +414,7 @@ export class CHTML<N, T, D> extends CommonOutputJax<
    * @override
    */
 
-  public measureTextNode(textNode: N) {
+  public measureTextNode(textNode: N<DOM>) {
     const adaptor = this.adaptor;
     const text = adaptor.clone(textNode);
     //

--- a/ts/output/chtml/FontData.ts
+++ b/ts/output/chtml/FontData.ts
@@ -49,12 +49,11 @@ export * from '../common/FontData.js';
 /**
  * Add the extra data needed for CharOptions in CHTML
  */
-/* prettier-ignore */
 export interface ChtmlCharOptions extends CharOptions {
-  c?: string;                   // the content value (for css)
-  f?: string;                   // the font postfix (for css)
-  ff?: string;                  // the full font css class (for extensions)
-  cmb?: boolean;                // true if this is a combining character
+  c?: string; //                   The content value (for css)
+  f?: string; //                   The font postfix (for css)
+  ff?: string; //                  The full font css class (for extensions)
+  cmb?: boolean; //                True if this is a combining character
 }
 
 /**

--- a/ts/output/chtml/Notation.ts
+++ b/ts/output/chtml/Notation.ts
@@ -22,14 +22,21 @@
  */
 
 import { ChtmlMencloseNTD } from './Wrappers/menclose.js';
+import { DOM_TYPES, N } from '../../types/Types.js';
 import * as Notation from '../common/Notation.js';
 export * from '../common/Notation.js';
 
 /*
  * Shorthands for common types
  */
-export type RENDERER<N, T, D> = Notation.Renderer<ChtmlMencloseNTD<N, T, D>, N>;
-export type DEFPAIR<N, T, D> = Notation.DefPair<ChtmlMencloseNTD<N, T, D>, N>;
+export type RENDERER<DOM extends DOM_TYPES> = Notation.Renderer<
+  ChtmlMencloseNTD<DOM>,
+  N<DOM>
+>;
+export type DEFPAIR<DOM extends DOM_TYPES> = Notation.DefPair<
+  ChtmlMencloseNTD<DOM>,
+  N<DOM>
+>;
 
 /**
  * Create a named element (handled by CSS), and adjust it if thickness is non-standard
@@ -38,10 +45,10 @@ export type DEFPAIR<N, T, D> = Notation.DefPair<ChtmlMencloseNTD<N, T, D>, N>;
  * @param {string} offset  The offset direction to adjust if thickness is non-standard
  * @returns {RENDERER}      The renderer function for the given element name
  */
-export const RenderElement = function <N, T, D>(
+export const RenderElement = function <DOM extends DOM_TYPES>(
   name: string,
   offset: string = ''
-): RENDERER<N, T, D> {
+): RENDERER<DOM> {
   return ((node, _child) => {
     const shape = node.adjustBorder(node.html('mjx-' + name));
     if (offset) {
@@ -52,17 +59,17 @@ export const RenderElement = function <N, T, D>(
       }
     }
     node.adaptor.append(node.dom[0], shape);
-  }) as Notation.Renderer<ChtmlMencloseNTD<N, T, D>, N>;
+  }) as Notation.Renderer<ChtmlMencloseNTD<DOM>, N<DOM>>;
 };
 
 /**
  * @param {Notation.Side} side   The side on which a border should appear
  * @returns {DEFPAIR}      The notation definition for the notation having a line on the given side
  */
-export const Border = function <N, T, D>(
+export const Border = function <DOM extends DOM_TYPES>(
   side: Notation.Side
-): DEFPAIR<N, T, D> {
-  return Notation.CommonBorder<ChtmlMencloseNTD<N, T, D>, N>((node, child) => {
+): DEFPAIR<DOM> {
+  return Notation.CommonBorder<ChtmlMencloseNTD<DOM>, N<DOM>>((node, child) => {
     node.adaptor.setStyle(
       child,
       'border-' + side,
@@ -77,16 +84,18 @@ export const Border = function <N, T, D>(
  * @param {Notation.Side} side2   The second side to get a border
  * @returns {DEFPAIR}       The notation definition for the notation having lines on two sides
  */
-export const Border2 = function <N, T, D>(
+export const Border2 = function <DOM extends DOM_TYPES>(
   name: string,
   side1: Notation.Side,
   side2: Notation.Side
-): DEFPAIR<N, T, D> {
-  return Notation.CommonBorder2<ChtmlMencloseNTD<N, T, D>, N>((node, child) => {
-    const border = node.Em(node.thickness) + ' solid';
-    node.adaptor.setStyle(child, 'border-' + side1, border);
-    node.adaptor.setStyle(child, 'border-' + side2, border);
-  })(name, side1, side2);
+): DEFPAIR<DOM> {
+  return Notation.CommonBorder2<ChtmlMencloseNTD<DOM>, N<DOM>>(
+    (node, child) => {
+      const border = node.Em(node.thickness) + ' solid';
+      node.adaptor.setStyle(child, 'border-' + side1, border);
+      node.adaptor.setStyle(child, 'border-' + side2, border);
+    }
+  )(name, side1, side2);
 };
 
 /**
@@ -94,11 +103,11 @@ export const Border2 = function <N, T, D>(
  * @param {number} neg   1 or -1 to use with the angle
  * @returns {DEFPAIR}     The notation definition for the diagonal strike
  */
-export const DiagonalStrike = function <N, T, D>(
+export const DiagonalStrike = function <DOM extends DOM_TYPES>(
   name: string,
   neg: number
-): DEFPAIR<N, T, D> {
-  return Notation.CommonDiagonalStrike<ChtmlMencloseNTD<N, T, D>, N>(
+): DEFPAIR<DOM> {
+  return Notation.CommonDiagonalStrike<ChtmlMencloseNTD<DOM>, N<DOM>>(
     (cname: string) => (node, _child) => {
       const { w, h, d } = node.getBBox();
       const [a, W] = node.getArgMod(w, h + d);
@@ -121,10 +130,10 @@ export const DiagonalStrike = function <N, T, D>(
  * @param {string} name   The name of the diagonal arrow to define
  * @returns {DEFPAIR}      The notation definition for the diagonal arrow
  */
-export const DiagonalArrow = function <N, T, D>(
+export const DiagonalArrow = function <DOM extends DOM_TYPES>(
   name: string
-): DEFPAIR<N, T, D> {
-  return Notation.CommonDiagonalArrow<ChtmlMencloseNTD<N, T, D>, N>(
+): DEFPAIR<DOM> {
+  return Notation.CommonDiagonalArrow<ChtmlMencloseNTD<DOM>, N<DOM>>(
     (node, arrow) => {
       node.adaptor.append(node.dom[0], arrow);
     }
@@ -135,8 +144,10 @@ export const DiagonalArrow = function <N, T, D>(
  * @param {string} name   The name of the horizontal or vertical arrow to define
  * @returns {DEFPAIR}      The notation definition for the arrow
  */
-export const Arrow = function <N, T, D>(name: string): DEFPAIR<N, T, D> {
-  return Notation.CommonArrow<ChtmlMencloseNTD<N, T, D>, N>((node, arrow) => {
+export const Arrow = function <DOM extends DOM_TYPES>(
+  name: string
+): DEFPAIR<DOM> {
+  return Notation.CommonArrow<ChtmlMencloseNTD<DOM>, N<DOM>>((node, arrow) => {
     node.adaptor.append(node.dom[0], arrow);
   })(name);
 };

--- a/ts/output/chtml/Wrapper.ts
+++ b/ts/output/chtml/Wrapper.ts
@@ -28,17 +28,10 @@ import {
   StringMap,
   SPACE,
 } from '../common/Wrapper.js';
-import { CHTML } from '../chtml.js';
+import { CHTML, CHTML_FONT } from '../chtml.js';
 import { ChtmlWrapperFactory } from './WrapperFactory.js';
 import { BBox } from '../../util/BBox.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from './FontData.js';
-import { Constructor } from '../../types/Types.js';
+import { DOM_TYPES, N, T, Constructor } from '../../types/Types.js';
 
 export { Constructor } from '../../types/Types.js';
 export { StringMap } from '../common/Wrapper.js';
@@ -66,35 +59,23 @@ export const FONTSIZE: StringMap = {
 /**
  * Shorthand for making a ChtmlWrapper constructor
  */
-export type ChtmlConstructor<N, T, D> = Constructor<ChtmlWrapper<N, T, D>>;
+export type ChtmlConstructor<DOM extends DOM_TYPES> = Constructor<
+  ChtmlWrapper<DOM>
+>;
 
 /*****************************************************************/
 /**
  *  The type of the ChtmlWrapper class (used when creating the wrapper factory for this class)
  */
-export interface ChtmlWrapperClass<N, T, D> extends CommonWrapperClass<
-  //
-  // The HTMLElement, TextNode, and Document classes (for the DOM implementation in use)
-  //
-  N,
-  T,
-  D,
-  //
-  // The Wrapper type and its Factory and Class (these need to know N, T, and D)
-  //
-  CHTML<N, T, D>,
-  ChtmlWrapper<N, T, D>,
-  ChtmlWrapperFactory<N, T, D>,
-  ChtmlWrapperClass<N, T, D>,
-  //
-  // These are font-related objects that depend on the output jax; e,g. the character options
-  //   for CHTML and SVG output differ (CHTML contains font information, while SVG has path data)
-  //
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass
+export interface ChtmlWrapperClass<
+  DOM extends DOM_TYPES,
+> extends CommonWrapperClass<
+  DOM,
+  CHTML_FONT,
+  CHTML<DOM>,
+  ChtmlWrapper<DOM>,
+  ChtmlWrapperFactory<DOM>,
+  ChtmlWrapperClass<DOM>
 > {
   /**
    * If true, this causes a style for the node type to be generated automatically
@@ -107,23 +88,15 @@ export interface ChtmlWrapperClass<N, T, D> extends CommonWrapperClass<
 /**
  *  The base ChtmlWrapper class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export class ChtmlWrapper<N, T, D> extends CommonWrapper<
-  N,
-  T,
-  D,
-  CHTML<N, T, D>,
-  ChtmlWrapper<N, T, D>,
-  ChtmlWrapperFactory<N, T, D>,
-  ChtmlWrapperClass<N, T, D>,
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass
+export class ChtmlWrapper<DOM extends DOM_TYPES> extends CommonWrapper<
+  DOM,
+  CHTML_FONT,
+  CHTML<DOM>,
+  ChtmlWrapper<DOM>,
+  ChtmlWrapperFactory<DOM>,
+  ChtmlWrapperClass<DOM>
 > {
   /**
    * @override
@@ -143,7 +116,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    *
    * @param {N[]} parents  The HTML nodes where the output is to be added
    */
-  public toCHTML(parents: N[]) {
+  public toCHTML(parents: N<DOM>[]) {
     if (this.toEmbellishedCHTML(parents)) return;
     this.addChildren(this.standardChtmlNodes(parents));
   }
@@ -154,7 +127,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {N[]} parents  The HTML nodes where the output is to be added
    * @returns {boolean}     True when embellished output is produced, false if not
    */
-  public toEmbellishedCHTML(parents: N[]): boolean {
+  public toEmbellishedCHTML(parents: N<DOM>[]): boolean {
     if (parents.length <= 1 || !this.node.isEmbellished) return false;
     const adaptor = this.adaptor;
     parents.forEach((dom) => adaptor.append(dom, this.html('mjx-linestrut')));
@@ -168,7 +141,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
     for (const [parent, STYLE] of [
       [parents[0], 'before'],
       [parents[1], 'after'],
-    ] as [N, string][]) {
+    ] as [N<DOM>, string][]) {
       if (style !== STYLE) {
         this.toCHTML([parent]);
         dom.push(this.dom[0]);
@@ -186,7 +159,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
   /**
    * @param {N[]} parents  The HTML nodes where the children are to be added
    */
-  public addChildren(parents: N[]) {
+  public addChildren(parents: N<DOM>[]) {
     for (const child of this.childNodes) {
       child.toCHTML(parents);
     }
@@ -200,7 +173,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {N[]} parents  The HTML elements in which the node is to be created
    * @returns {N[]}  The roots of the HTML tree for the wrapped node's output
    */
-  protected standardChtmlNodes(parents: N[]): N[] {
+  protected standardChtmlNodes(parents: N<DOM>[]): N<DOM>[] {
     this.markUsed();
     const chtml = this.createChtmlNodes(parents);
     this.handleStyles();
@@ -224,7 +197,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {N[]} parents  The HTML elements in which the node is to be created
    * @returns {N[]}  The roots of the HTML tree for the wrapped node's output
    */
-  protected createChtmlNodes(parents: N[]): N[] {
+  protected createChtmlNodes(parents: N<DOM>[]): N<DOM>[] {
     this.dom = parents.map((_parent) => this.html('mjx-' + this.node.kind)); // FIXME: add segment id
     parents = this.handleHref(parents);
     for (const i of parents.keys()) {
@@ -239,12 +212,12 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {N[]} parents   The HTML nodes in which the output is to be placed
    * @returns {N[]}          The roots of the HTML tree for the node's output
    */
-  protected handleHref(parents: N[]): N[] {
+  protected handleHref(parents: N<DOM>[]): N<DOM>[] {
     const href = this.node.attributes.get('href');
     if (!href) return parents;
     return parents.map(
       (parent) =>
-        this.adaptor.append(parent, this.html('a', { href: href })) as N
+        this.adaptor.append(parent, this.html('a', { href: href })) as N<DOM>
     );
   }
 
@@ -282,7 +255,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {number} rscale      The relatie scale to apply
    * @returns {N}       The HTML node (for chaining)
    */
-  protected setScale(chtml: N, rscale: number): N {
+  protected setScale(chtml: N<DOM>, rscale: number): N<DOM> {
     const scale = Math.abs(rscale - 1) < 0.001 ? 1 : rscale;
     if (chtml && scale !== 1) {
       const size = this.percent(scale);
@@ -440,7 +413,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {string} align  The alignment for the node
    * @param {number} shift  The indent (positive or negative) for the node
    */
-  protected setIndent(chtml: N, align: string, shift: number) {
+  protected setIndent(chtml: N<DOM>, align: string, shift: number) {
     const adaptor = this.adaptor;
     if (align === 'center' || align === 'left') {
       const L = this.getBBox().L;
@@ -488,7 +461,7 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
             'background-color': 'green',
           },
         }),
-      ] as N[]
+      ] as N<DOM>[]
     );
     const node = this.dom[0] || this.parent.dom[0];
     const size = this.adaptor.getAttribute(node, 'size');
@@ -514,7 +487,11 @@ export class ChtmlWrapper<N, T, D> extends CommonWrapper<
    * @param {(N|T)[]} content  The child nodes for the created HTML node
    * @returns {N}               The generated HTML tree
    */
-  public html(type: string, def: OptionList = {}, content: (N | T)[] = []): N {
+  public html(
+    type: string,
+    def: OptionList = {},
+    content: (N<DOM> | T<DOM>)[] = []
+  ): N<DOM> {
     return this.jax.html(type, def, content);
   }
 

--- a/ts/output/chtml/WrapperFactory.ts
+++ b/ts/output/chtml/WrapperFactory.ts
@@ -21,49 +21,27 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../chtml.js';
+import { CHTML, CHTML_FONT } from '../chtml.js';
 import { CommonWrapperFactory } from '../common/WrapperFactory.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from './Wrapper.js';
 import { ChtmlWrappers } from './Wrappers.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from './FontData.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /*****************************************************************/
 /**
  *  The ChtmlWrapperFactory class for creating ChtmlWrapper nodes
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export class ChtmlWrapperFactory<N, T, D> extends CommonWrapperFactory<
-  //
-  // The HTMLElement, TextNode, and Document classes (for the DOM implementation in use)
-  //
-  N,
-  T,
-  D,
-  //
-  // The Wrapper type and its Factory and Class (these need to know N, T, and D)
-  //
-  CHTML<N, T, D>,
-  ChtmlWrapper<N, T, D>,
-  ChtmlWrapperFactory<N, T, D>,
-  ChtmlWrapperClass<N, T, D>,
-  //
-  // These are font-related objects that depend on the output jax; e,g. the character options
-  //   for CHTML and SVG output differ (CHTML contains font information, while SVG has path data)
-  //
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass
+export class ChtmlWrapperFactory<
+  DOM extends DOM_TYPES,
+> extends CommonWrapperFactory<
+  DOM,
+  CHTML_FONT,
+  CHTML<DOM>,
+  ChtmlWrapper<DOM>,
+  ChtmlWrapperFactory<DOM>,
+  ChtmlWrapperClass<DOM>
 > {
   /**
    * The default list of wrapper nodes this factory can create

--- a/ts/output/chtml/Wrappers.ts
+++ b/ts/output/chtml/Wrappers.ts
@@ -21,6 +21,7 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
+import { DOM } from '../../types/Types.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from './Wrapper.js';
 import { ChtmlMath } from './Wrappers/math.js';
 import { ChtmlMi } from './Wrappers/mi.js';
@@ -59,7 +60,7 @@ import { ChtmlTextNode } from './Wrappers/TextNode.js';
 import { ChtmlHtmlNode } from './Wrappers/HtmlNode.js';
 
 export const ChtmlWrappers: {
-  [kind: string]: ChtmlWrapperClass<any, any, any>;
+  [kind: string]: ChtmlWrapperClass<DOM>;
 } = {
   [ChtmlMath.kind]: ChtmlMath,
   [ChtmlMrow.kind]: ChtmlMrow,

--- a/ts/output/chtml/Wrappers/HtmlNode.ts
+++ b/ts/output/chtml/Wrappers/HtmlNode.ts
@@ -62,13 +62,13 @@ export interface ChtmlHtmlNodeClass<
 /**
  * The ChtmlHtmlNode wrapper class for the MmlHtmlNode class
  */
-export class ChtmlHtmlNode
+export const ChtmlHtmlNode = (function (): ChtmlHtmlNodeClass<DOM> {
   // @ts-expect-error Avoid message about base constructors not having the same type
-  extends ChtmlXmlNode
-  implements ChtmlHtmlNodeNTD<DOM>
-{
-  /**
-   * @override
-   */
-  public static kind = HtmlNode.prototype.kind;
-}
+  return class ChtmlHtmlNode extends ChtmlXmlNode implements ChtmlHtmlNodeNTD<DOM>
+  {
+    /**
+     * @override
+     */
+    public static kind = HtmlNode.prototype.kind;
+  }
+})();

--- a/ts/output/chtml/Wrappers/HtmlNode.ts
+++ b/ts/output/chtml/Wrappers/HtmlNode.ts
@@ -30,34 +30,31 @@ import {
 } from './semantics.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { HtmlNode } from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlHtmlNode interface for the CHTML HtmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlHtmlNodeNTD<N, T, D> extends ChtmlXmlNodeNTD<N, T, D> {}
+export interface ChtmlHtmlNodeNTD<
+  DOM extends DOM_TYPES,
+> extends ChtmlXmlNodeNTD<DOM> {}
 
 /**
  * The ChtmlHtmlNodeClass interface for the CHTML HtmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlHtmlNodeClass<N, T, D> extends ChtmlXmlNodeClass<
-  N,
-  T,
-  D
-> {
+export interface ChtmlHtmlNodeClass<
+  DOM extends DOM_TYPES,
+> extends ChtmlXmlNodeClass<DOM> {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlHtmlNodeNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlHtmlNodeNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -65,21 +62,13 @@ export interface ChtmlHtmlNodeClass<N, T, D> extends ChtmlXmlNodeClass<
 /**
  * The ChtmlHtmlNode wrapper class for the MmlHtmlNode class
  */
-export const ChtmlHtmlNode = (function <N, T, D>(): ChtmlHtmlNodeClass<
-  N,
-  T,
-  D
-> {
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlHtmlNode
-    extends ChtmlXmlNode
-    implements ChtmlHtmlNodeNTD<N, T, D>
-  {
-    /**
-     * @override
-     */
-    public static kind = HtmlNode.prototype.kind;
-  };
-})<any, any, any>();
+export class ChtmlHtmlNode
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  extends ChtmlXmlNode
+  implements ChtmlHtmlNodeNTD<DOM>
+{
+  /**
+   * @override
+   */
+  public static kind = HtmlNode.prototype.kind;
+}

--- a/ts/output/chtml/Wrappers/TeXAtom.ts
+++ b/ts/output/chtml/Wrappers/TeXAtom.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonTeXAtom,
   CommonTeXAtomClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/TeXAtom.js';
 import { TeXAtom } from '../../../core/MmlTree/MmlNodes/TeXAtom.js';
 import { MmlNode, TEXCLASSNAMES } from '../../../core/MmlTree/MmlNode.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlTeXAtom interface for the CHTML TeXAtom wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlTeXAtomNTD<N, T, D>
+export interface ChtmlTeXAtomNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonTeXAtom<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlTeXAtomClass interface for the CHTML TeXAtom wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlTeXAtomClass<N, T, D>
+export interface ChtmlTeXAtomClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonTeXAtomClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlTeXAtomNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlTeXAtomNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,26 +79,18 @@ export interface ChtmlTeXAtomClass<N, T, D>
 /**
  * The ChtmlTeXAtom wrapper class for the MmlTeXAtom class
  */
-export const ChtmlTeXAtom = (function <N, T, D>(): ChtmlTeXAtomClass<N, T, D> {
+export const ChtmlTeXAtom = (function (): ChtmlTeXAtomClass<DOM> {
   const Base = CommonTeXAtomMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlTeXAtomClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlTeXAtomClass<DOM>
   >(ChtmlWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlTeXAtom extends Base implements ChtmlTeXAtomNTD<N, T, D> {
+  return class ChtmlTeXAtom extends Base implements ChtmlTeXAtomNTD<DOM> {
     /**
      * @override
      */
@@ -129,7 +99,7 @@ export const ChtmlTeXAtom = (function <N, T, D>(): ChtmlTeXAtomClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       super.toCHTML(parents);
       this.dom.forEach((dom) =>
         this.adaptor.setAttribute(
@@ -140,4 +110,4 @@ export const ChtmlTeXAtom = (function <N, T, D>(): ChtmlTeXAtomClass<N, T, D> {
       );
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/TextNode.ts
+++ b/ts/output/chtml/Wrappers/TextNode.ts
@@ -21,17 +21,10 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlCharData,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
+import { ChtmlCharData } from '../FontData.js';
 import {
   CommonTextNode,
   CommonTextNodeClass,
@@ -40,98 +33,67 @@ import {
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlTextNode interface for the CHTML TextNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlTextNodeNTD<N, T, D>
+export interface ChtmlTextNodeNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonTextNode<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlTextNodeClass interface for the CHTML TextNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlTextNodeClass<N, T, D>
+export interface ChtmlTextNodeClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonTextNodeClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlTextNodeNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlTextNodeNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The ChtmlTextNode wrapper class for the MmlTextNode class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlTextNode = (function (): ChtmlTextNodeClass<DOM> {
   const Base = CommonTextNodeMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlTextNodeClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlTextNodeClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlTextNode extends Base implements ChtmlTextNodeNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlTextNode extends Base implements ChtmlTextNodeNTD<DOM> {
     /**
      * The TextNode wrapper
      */
@@ -160,7 +122,7 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       this.markUsed();
       const parent = parents[0];
       const adaptor = this.adaptor;
@@ -193,7 +155,7 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<
               )
             );
             if (i < m - 1 || bbox.oc) {
-              adaptor.setAttribute(node as N, 'noic', 'true');
+              adaptor.setAttribute(node as N<DOM>, 'noic', 'true');
             }
             if (H) {
               //
@@ -202,7 +164,7 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<
               //  the parent element).  Only fixes the issue within a given
               //  MathML node, but that is useful for \text{} in particular.
               //
-              adaptor.setStyle(node as N, 'padding-top', H);
+              adaptor.setStyle(node as N<DOM>, 'padding-top', H);
             }
             this.font.charUsage.add([variant, n]);
           }
@@ -219,11 +181,11 @@ export const ChtmlTextNode = (function <N, T, D>(): ChtmlTextNodeClass<
      * @param {N} parent         The parent node where the text is being added
      * @returns {string}          The new value for utext
      */
-    protected addUtext(utext: string, variant: string, parent: N): string {
+    protected addUtext(utext: string, variant: string, parent: N<DOM>): string {
       if (utext) {
         this.adaptor.append(parent, this.jax.unknownText(utext, variant));
       }
       return '';
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/maction.ts
+++ b/ts/output/chtml/Wrappers/maction.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMaction,
   CommonMactionClass,
@@ -43,62 +36,47 @@ import { TooltipData } from '../../common/Wrappers/maction.js';
 import { TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { MACTION } from '../../../a11y/semantic-enrich/maction.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMaction interface for the CHTML Maction wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMactionNTD<N, T, D>
+export interface ChtmlMactionNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMaction<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMactionClass interface for the CHTML Maction wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMactionClass<N, T, D>
+export interface ChtmlMactionClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMactionClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMactionNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMactionNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -106,27 +84,19 @@ export interface ChtmlMactionClass<N, T, D>
 /**
  * The ChtmlMaction wrapper class for the MmlMaction class
  */
-export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
+export const ChtmlMaction = (function (): ChtmlMactionClass<DOM> {
   const Base = CommonMactionMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMactionClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMactionClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMaction extends Base implements ChtmlMactionNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMaction extends Base implements ChtmlMactionNTD<DOM> {
     /**
      * @override
      */
@@ -230,8 +200,8 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
                     },
                     [node.html('mjx-tip')]
                   )
-                ) as N;
-                tip.toCHTML([adaptor.firstChild(tool) as N]);
+                ) as N<DOM>;
+                tip.toCHTML([adaptor.firstChild(tool) as N<DOM>]);
                 //
                 // Set up the event handlers to display and remove the tooltip
                 //
@@ -268,19 +238,13 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
         ],
       ],
     ] as ActionDef<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass,
-      ChtmlMactionNTD<N, T, D>
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>,
+      ChtmlMactionNTD<DOM>
     >[]);
 
     /*************************************************************/
@@ -288,7 +252,7 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       const chtml = this.standardChtmlNodes(parents);
       const child = this.selected;
@@ -296,4 +260,4 @@ export const ChtmlMaction = (function <N, T, D>(): ChtmlMactionClass<N, T, D> {
       this.action(this, this.data);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/math.ts
+++ b/ts/output/chtml/Wrappers/math.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMath,
   CommonMathClass,
@@ -40,62 +33,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMath } from '../../../core/MmlTree/MmlNodes/math.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMath interface for the CHTML Math wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlMathNTD<N, T, D>
+export interface ChtmlMathNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMath<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMathClass interface for the CHTML Math wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlMathClass<N, T, D>
+export interface ChtmlMathClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMathClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMathNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMathNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -103,30 +81,20 @@ export interface ChtmlMathClass<N, T, D>
 /**
  * The ChtmlMath wrapper class for the MmlMath class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
+export const ChtmlMath = (function (): ChtmlMathClass<DOM> {
   const Base = CommonMathMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMathClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMathClass<DOM>
   >(ChtmlWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlMath extends Base implements ChtmlMathNTD<N, T, D> {
+  return class ChtmlMath extends Base implements ChtmlMathNTD<DOM> {
     /**
      * @override
      */
@@ -191,7 +159,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
      *
      * @param {N} parent     The HTML node to contain the HTML
      */
-    protected handleDisplay(parent: N) {
+    protected handleDisplay(parent: N<DOM>) {
       const adaptor = this.adaptor;
       const [align, shift] = this.getAlignShift();
       if (align !== 'center') {
@@ -222,7 +190,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
      *
      * @param {N} parent     The HTML node to contain the HTML
      */
-    protected handleInline(parent: N) {
+    protected handleInline(parent: N<DOM>) {
       //
       // Transfer right margin to container (for things like $x\hskip -2em y$)
       //
@@ -240,7 +208,7 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       super.toCHTML(parents);
       const adaptor = this.adaptor;
       const display = this.node.attributes.get('display') === 'block';
@@ -278,4 +246,4 @@ export const ChtmlMath = (function <N, T, D>(): ChtmlMathClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/menclose.ts
+++ b/ts/output/chtml/Wrappers/menclose.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMenclose,
   CommonMencloseClass,
@@ -43,6 +36,7 @@ import * as Notation from '../Notation.js';
 import { OptionList } from '../../../util/Options.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { em } from '../../../util/lengths.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 
@@ -65,41 +59,33 @@ const ANGLE = Angle(Notation.ARROWDX, Notation.ARROWY);
 /**
  * The ChtmlMenclose interface for the CHTML Menclose wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlMencloseNTD<N, T, D>
+export interface ChtmlMencloseNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMenclose<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass,
-      ChtmlMsqrtNTD<N, T, D>
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>,
+      ChtmlMsqrtNTD<DOM>
     > {
   /**
    * @param {N} node   The HTML element whose border width must be
    *                   adjusted if the thickness isn't the default
    * @returns {N}       The adjusted element
    */
-  adjustBorder(node: N): N;
+  adjustBorder(node: N<DOM>): N<DOM>;
 
   /**
    * @param {N} shape   The svg element whose stroke-thickness must be
    *                    adjusted if the thickness isn't the default
    * @returns {N}        The adjusted element
    */
-  adjustThickness(shape: N): N;
+  adjustThickness(shape: N<DOM>): N<DOM>;
 
   /**
    * @param {number} m    A number to be shown with a fixed number of digits
@@ -120,32 +106,24 @@ export interface ChtmlMencloseNTD<N, T, D>
 /**
  * The ChtmlMencloseClass interface for the CHTML Menclose wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlMencloseClass<N, T, D>
+export interface ChtmlMencloseClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMencloseClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMencloseNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMencloseNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -153,36 +131,22 @@ export interface ChtmlMencloseClass<N, T, D>
 /**
  * The ChtmlMenclose wrapper class for the MmlMenclose class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlMenclose = (function (): ChtmlMencloseClass<DOM> {
   const Base = CommonMencloseMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMsqrtNTD<N, T, D>,
-    ChtmlMencloseClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMsqrtNTD<DOM>,
+    ChtmlMencloseClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMenclose extends Base implements ChtmlMencloseNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMenclose extends Base implements ChtmlMencloseNTD<DOM> {
     /**
      * @override
      */
@@ -358,7 +322,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
     /**
      *  @override
      */
-    public static notations: Notation.DefList<ChtmlMencloseNTD<N, T, D>, N> =
+    public static notations: Notation.DefList<ChtmlMencloseNTD<DOM>, N<DOM>> =
       new Map([
         Notation.Border('top'),
         Notation.Border('right'),
@@ -487,11 +451,11 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
               const arc1 = adaptor.append(
                 node.dom[0],
                 node.html('mjx-dbox-top')
-              ) as N;
+              ) as N<DOM>;
               const arc2 = adaptor.append(
                 node.dom[0],
                 node.html('mjx-dbox-bot')
-              ) as N;
+              ) as N<DOM>;
               const t = node.thickness;
               const p = node.padding;
               if (t !== Notation.THICKNESS) {
@@ -543,7 +507,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
             renderChild: true,
           },
         ],
-      ] as Notation.DefPair<ChtmlMencloseNTD<N, T, D>, N>[]);
+      ] as Notation.DefPair<ChtmlMencloseNTD<DOM>, N<DOM>>[]);
 
     /********************************************************/
 
@@ -551,7 +515,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
      * @param {N} arrow          The arrow whose thickness and arrow head is to be adjusted
      * @param {boolean} double   True if the arrow is double-headed
      */
-    protected adjustArrow(arrow: N, double: boolean) {
+    protected adjustArrow(arrow: N<DOM>, double: boolean) {
       const t = this.thickness;
       const head = this.arrowhead;
       if (
@@ -565,7 +529,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       const a = Angle(head.dx, head.y);
       const [line, rthead, rbhead, lthead, lbhead] = this.adaptor.childNodes(
         arrow
-      ) as N[];
+      ) as N<DOM>[];
       this.adjustHead(rthead, [y, '0', '1px', x], a);
       this.adjustHead(rbhead, ['1px', '0', y, x], '-' + a);
       this.adjustHead(lthead, [y, x, '1px', '0'], '-' + a);
@@ -578,7 +542,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
      * @param {string[]} border   The border sizes [T, R, B, L]
      * @param {string} a          The skew angle for the piece
      */
-    protected adjustHead(head: N, border: string[], a: string) {
+    protected adjustHead(head: N<DOM>, border: string[], a: string) {
       if (head) {
         this.adaptor.setStyle(head, 'border-width', border.join(' '));
         this.adaptor.setStyle(head, 'transform', 'skewX(' + a + 'rad)');
@@ -591,7 +555,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
      * @param {number} x         The arrow head x size
      * @param {boolean} double   True if the arrow is double-headed
      */
-    protected adjustLine(line: N, t: number, x: number, double: boolean) {
+    protected adjustLine(line: N<DOM>, t: number, x: number, double: boolean) {
       this.adaptor.setStyle(line, 'borderTop', this.em(t) + ' solid');
       this.adaptor.setStyle(line, 'top', this.em(-t / 2));
       this.adaptor.setStyle(line, 'right', this.em(t * (x - 1)));
@@ -605,7 +569,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
      * @param {string} offset  The direction to move the arrow
      * @param {number} d       The distance to translate in that direction
      */
-    protected moveArrow(arrow: N, offset: string, d: number) {
+    protected moveArrow(arrow: N<DOM>, offset: string, d: number) {
       if (!d) return;
       const transform = this.adaptor.getStyle(arrow, 'transform');
       this.adaptor.setStyle(
@@ -620,7 +584,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
     /**
      * @override
      */
-    public adjustBorder(node: N): N {
+    public adjustBorder(node: N<DOM>): N<DOM> {
       if (this.thickness !== Notation.THICKNESS) {
         this.adaptor.setStyle(node, 'borderWidth', this.em(this.thickness));
       }
@@ -630,7 +594,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
     /**
      * @override
      */
-    public adjustThickness(shape: N): N {
+    public adjustThickness(shape: N<DOM>): N<DOM> {
       if (this.thickness !== Notation.THICKNESS) {
         this.adaptor.setStyle(shape, 'strokeWidth', this.fixed(this.thickness));
       }
@@ -662,14 +626,14 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       const adaptor = this.adaptor;
       const chtml = this.standardChtmlNodes(parents);
       //
       //  Create a box for the child (that can have padding and borders added by the notations)
       //    and add the child HTML into it
       //
-      const block = adaptor.append(chtml[0], this.html('mjx-box')) as N;
+      const block = adaptor.append(chtml[0], this.html('mjx-box')) as N<DOM>;
       if (this.renderChild) {
         this.renderChild(this, block);
       } else {
@@ -705,7 +669,7 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       double: boolean,
       offset: string = '',
       dist: number = 0
-    ): N {
+    ): N<DOM> {
       const W = this.getBBox().w;
       const style = { width: this.em(w) } as OptionList;
       if (W !== w) {
@@ -729,4 +693,4 @@ export const ChtmlMenclose = (function <N, T, D>(): ChtmlMencloseClass<
       return arrow;
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mfenced.ts
+++ b/ts/output/chtml/Wrappers/mfenced.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMfenced,
   CommonMfencedClass,
@@ -39,62 +32,47 @@ import {
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMfenced } from '../../../core/MmlTree/MmlNodes/mfenced.js';
 import { ChtmlInferredMrowNTD } from './mrow.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMfenced interface for the CHTML Mfenced wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMfencedNTD<N, T, D>
+export interface ChtmlMfencedNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMfenced<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMfencedClass interface for the CHTML Mfenced wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMfencedClass<N, T, D>
+export interface ChtmlMfencedClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMfencedClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMfencedNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMfencedNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -102,27 +80,19 @@ export interface ChtmlMfencedClass<N, T, D>
 /**
  * The ChtmlMfenced wrapper class for the MmlMfenced class
  */
-export const ChtmlMfenced = (function <N, T, D>(): ChtmlMfencedClass<N, T, D> {
+export const ChtmlMfenced = (function (): ChtmlMfencedClass<DOM> {
   const Base = CommonMfencedMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMfencedClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMfencedClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class ChtmlMfenced extends Base implements ChtmlMfencedNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMfenced extends Base implements ChtmlMfencedNTD<DOM> {
     /**
      * @override
      */
@@ -131,9 +101,9 @@ export const ChtmlMfenced = (function <N, T, D>(): ChtmlMfencedClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       const chtml = this.standardChtmlNodes(parents);
-      (this.mrow as ChtmlInferredMrowNTD<N, T, D>).toCHTML(chtml);
+      (this.mrow as ChtmlInferredMrowNTD<DOM>).toCHTML(chtml);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mfrac.ts
+++ b/ts/output/chtml/Wrappers/mfrac.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMfrac,
   CommonMfracClass,
@@ -41,62 +34,47 @@ import { MmlMfrac } from '../../../core/MmlTree/MmlNodes/mfrac.js';
 import { ChtmlMoNTD } from './mo.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { OptionList } from '../../../util/Options.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMfrac interface for the CHTML Mfrac wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  THe DOM node types
  */
-export interface ChtmlMfracNTD<N, T, D>
+export interface ChtmlMfracNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMfrac<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMfracClass interface for the CHTML Mfrac wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  THe DOM node types
  */
-export interface ChtmlMfracClass<N, T, D>
+export interface ChtmlMfracClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMfracClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMfracNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMfracNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -104,27 +82,19 @@ export interface ChtmlMfracClass<N, T, D>
 /**
  * The ChtmlMfrac wrapper class for the MmlMfrac class
  */
-export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
+export const ChtmlMfrac = (function (): ChtmlMfracClass<DOM> {
   const Base = CommonMfracMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMfracClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMfracClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMfrac extends Base implements ChtmlMfracNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMfrac extends Base implements ChtmlMfracNTD<DOM> {
     /**
      * @override
      */
@@ -133,103 +103,101 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
     /**
      * @override
      */
-    /* prettier-ignore */
     public static styles: StyleJson = {
       'mjx-frac': {
         display: 'inline-block',
-        'vertical-align': '0.17em',  // axis_height - 1.5 * rule_thickness
-        padding: '0 .22em'           // nulldelimiterspace + .1 (for line's -.1em margin)
+        'vertical-align': '0.17em', //   axis_height - 1.5 * rule_thickness
+        padding: '0 .22em', //           nulldelimiterspace + .1 (for line's -.1em margin)
       },
       'mjx-frac[type="d"]': {
-        'vertical-align': '.04em'    // axis_height - 3.5 * rule_thickness
+        'vertical-align': '.04em', //    axis_height - 3.5 * rule_thickness
       },
       'mjx-frac[delims]': {
-        padding: '0 .1em'            // .1 (for line's -.1em margin)
+        padding: '0 .1em', //            .1 (for line's -.1em margin)
       },
       'mjx-frac[atop]': {
-        padding: '0 .12em'           // nulldelimiterspace
+        padding: '0 .12em', //           nulldelimiterspace
       },
       'mjx-frac[atop][delims]': {
-        padding: '0'
+        padding: '0',
       },
       'mjx-dtable': {
         display: 'inline-table',
-        width: '100%'
+        width: '100%',
       },
       'mjx-dtable > mjx-line, mjx-dtable > mjx-row': {
-        'font-size': '2000%'
+        'font-size': '2000%',
       },
       'mjx-dbox': {
         display: 'block',
-        'font-size': '5%'
+        'font-size': '5%',
       },
       'mjx-num': {
         display: 'block',
-        'text-align': 'center'
+        'text-align': 'center',
       },
       'mjx-den': {
         display: 'block',
-        'text-align': 'center'
+        'text-align': 'center',
       },
       'mjx-mfrac[bevelled] > mjx-num': {
-        display: 'inline-block'
+        display: 'inline-block',
       },
       'mjx-mfrac[bevelled] > mjx-den': {
-        display: 'inline-block'
+        display: 'inline-block',
       },
 
       'mjx-den[align="right"], mjx-num[align="right"]': {
-        'text-align': 'right'
+        'text-align': 'right',
       },
       'mjx-den[align="left"], mjx-num[align="left"]': {
-        'text-align': 'left'
+        'text-align': 'left',
       },
 
       'mjx-nstrut': {
         display: 'inline-block',
-        height: '.054em',              // num2 - a - 1.5t
+        height: '.054em', //               num2 - a - 1.5t
         width: 0,
-        'vertical-align': '-.054em'    // ditto
+        'vertical-align': '-.054em', //    Ditto
       },
       'mjx-nstrut[type="d"]': {
-        height: '.217em',              // num1 - a - 3.5t
-        'vertical-align': '-.217em',   // ditto
+        height: '.217em', //               num1 - a - 3.5t
+        'vertical-align': '-.217em', //    Ditto
       },
       'mjx-dstrut': {
         display: 'inline-block',
-        height: '.505em',              // denom2 + a - 1.5t
-        width: 0
+        height: '.505em', //               denom2 + a - 1.5t
+        width: 0,
       },
       'mjx-dstrut[type="d"]': {
-        height: '.726em',              // denom1 + a - 3.5t
+        height: '.726em', //               denom1 + a - 3.5t
       },
 
       'mjx-line': {
         display: 'block',
         'box-sizing': 'border-box',
         'min-height': '1px',
-        height: '.06em',               // t = rule_thickness
-        'border-top': '.075em solid',  // t * rule_factor (extra thickness as borders tend to be thin)
-        margin: '.06em -.1em',         // t
-        overflow: 'hidden'
+        height: '.06em', //                t = rule_thickness
+        'border-top': '.075em solid', //   t * rule_factor (extra thickness as borders tend to be thin)
+        margin: '.06em -.1em', //          t
+        overflow: 'hidden',
       },
       'mjx-line[type="d"]': {
-        margin: '.18em -.1em'          // 3t
-      }
-
+        margin: '.18em -.1em', //          3t
+      },
     };
 
     /**
      * An mo element to use for bevelled fractions
      */
-    protected bevel: ChtmlMoNTD<N, T, D>;
+    protected bevel: ChtmlMoNTD<DOM>;
 
     /************************************************/
 
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       this.standardChtmlNodes(parents);
       const { linethickness, bevelled } = this.node.attributes.getList(
@@ -380,10 +348,10 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
       //  Create HTML tree
       //
       adaptor.setAttribute(this.dom[0], 'bevelled', 'ture');
-      const num = adaptor.append(this.dom[0], this.html('mjx-num')) as N;
+      const num = adaptor.append(this.dom[0], this.html('mjx-num')) as N<DOM>;
       this.childNodes[0].toCHTML([num]);
       this.bevel.toCHTML(this.dom);
-      const den = adaptor.append(this.dom[0], this.html('mjx-den')) as N;
+      const den = adaptor.append(this.dom[0], this.html('mjx-den')) as N<DOM>;
       this.childNodes[1].toCHTML([den]);
       //
       //  Place the parts
@@ -400,4 +368,4 @@ export const ChtmlMfrac = (function <N, T, D>(): ChtmlMfracClass<N, T, D> {
       adaptor.setStyle(this.bevel.dom[0], 'marginRight', dx);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mglyph.ts
+++ b/ts/output/chtml/Wrappers/mglyph.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMglyph,
   CommonMglyphClass,
@@ -40,62 +33,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMglyph } from '../../../core/MmlTree/MmlNodes/mglyph.js';
 import { ChtmlTextNodeNTD } from './TextNode.js';
 import { StyleJson, StyleJsonData } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMglyph interface for the CHTML Mglyph wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM nod types
  */
-export interface ChtmlMglyphNTD<N, T, D>
+export interface ChtmlMglyphNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMglyph<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMglyphClass interface for the CHTML Mglyph wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM nod types
  */
-export interface ChtmlMglyphClass<N, T, D>
+export interface ChtmlMglyphClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMglyphClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMglyphNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMglyphNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -103,27 +81,19 @@ export interface ChtmlMglyphClass<N, T, D>
 /**
  * The ChtmlMglyph wrapper class for the MmlMglyph class
  */
-export const ChtmlMglyph = (function <N, T, D>(): ChtmlMglyphClass<N, T, D> {
+export const ChtmlMglyph = (function (): ChtmlMglyphClass<DOM> {
   const Base = CommonMglyphMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMglyphClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMglyphClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMglyph extends Base implements ChtmlMglyphNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMglyph extends Base implements ChtmlMglyphNTD<DOM> {
     /**
      * @override
      */
@@ -143,10 +113,10 @@ export const ChtmlMglyph = (function <N, T, D>(): ChtmlMglyphClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       const chtml = this.standardChtmlNodes(parents);
       if (this.charWrapper) {
-        (this.charWrapper as ChtmlTextNodeNTD<N, T, D>).toCHTML(chtml);
+        (this.charWrapper as ChtmlTextNodeNTD<DOM>).toCHTML(chtml);
         return;
       }
       const { src, alt } = this.node.attributes.getList('src', 'alt');
@@ -166,4 +136,4 @@ export const ChtmlMglyph = (function <N, T, D>(): ChtmlMglyphClass<N, T, D> {
       this.adaptor.append(chtml[0], img);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mi.ts
+++ b/ts/output/chtml/Wrappers/mi.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMi,
   CommonMiClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mi.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMi } from '../../../core/MmlTree/MmlNodes/mi.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMi interface for the CHTML Mi wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMiNTD<N, T, D>
+export interface ChtmlMiNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMi<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMiClass interface for the CHTML Mi wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMiClass<N, T, D>
+export interface ChtmlMiClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMiClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMiNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMiNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,29 +79,21 @@ export interface ChtmlMiClass<N, T, D>
 /**
  * The ChtmlMi wrapper class for the MmlMi class
  */
-export const ChtmlMi = (function <N, T, D>(): ChtmlMiClass<N, T, D> {
+export const ChtmlMi = (function (): ChtmlMiClass<DOM> {
   const Base = CommonMiMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMiClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMiClass<DOM>
   >(ChtmlWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlMi extends Base implements ChtmlMiNTD<N, T, D> {
+  return class ChtmlMi extends Base implements ChtmlMiNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMi.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mmultiscripts.ts
+++ b/ts/output/chtml/Wrappers/mmultiscripts.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMmultiscripts,
   CommonMmultiscriptsClass,
@@ -42,100 +35,69 @@ import { MmlMmultiscripts } from '../../../core/MmlTree/MmlNodes/mmultiscripts.j
 import { BBox } from '../../../util/BBox.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { split } from '../../../util/string.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMmultiscripts interface for the CHTML Mmultiscripts wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM types
  */
-export interface ChtmlMmultiscriptsNTD<N, T, D>
+export interface ChtmlMmultiscriptsNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMsubsupNTD<N, T, D>,
+    ChtmlMsubsupNTD<DOM>,
     CommonMmultiscripts<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMmultiscriptsClass interface for the CHTML Mmultiscripts wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM types
  */
-export interface ChtmlMmultiscriptsClass<N, T, D>
+export interface ChtmlMmultiscriptsClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMsubsupClass<N, T, D>,
+    ChtmlMsubsupClass<DOM>,
     CommonMmultiscriptsClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMmultiscriptsNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMmultiscriptsNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The ChtmlMmultiscripts wrapper class for the MmlMmultiscripts class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const ChtmlMmultiscripts = (function <
-  N,
-  T,
-  D,
->(): ChtmlMmultiscriptsClass<N, T, D> {
+export const ChtmlMmultiscripts = (function (): ChtmlMmultiscriptsClass<DOM> {
   const Base = CommonMmultiscriptsMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMmultiscriptsClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMmultiscriptsClass<DOM>
   >(ChtmlMsubsup);
 
   return class ChtmlMmultiscripts
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be ChtmlWrapper<N, T, D>, but are thought of
-    // as different by typescript)
+    // @ts-expect-error Avoid message about base constructors not having the same type
     extends Base
-    implements ChtmlMmultiscriptsNTD<N, T, D>
+    implements ChtmlMmultiscriptsNTD<DOM>
   {
     /**
      * @override
@@ -180,7 +142,7 @@ export const ChtmlMmultiscripts = (function <
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       const chtml = this.standardChtmlNodes(parents);
       const data = this.scriptData;
@@ -244,7 +206,7 @@ export const ChtmlMmultiscripts = (function <
      * @returns {N}             The script table for these scripts
      */
     protected addScripts(
-      dom: N,
+      dom: N<DOM>,
       u: number,
       v: number,
       isPre: boolean,
@@ -252,7 +214,7 @@ export const ChtmlMmultiscripts = (function <
       sup: BBox,
       i: number,
       n: number
-    ): N {
+    ): N<DOM> {
       const adaptor = this.adaptor;
       const q = u - sup.d + (v - sub.h); // separation of scripts
       const U = u < 0 && v === 0 ? sub.h + u : u; // vertical offset of table
@@ -265,16 +227,16 @@ export const ChtmlMmultiscripts = (function <
       const m = i + 2 * n;
       while (i < m) {
         this.childNodes[i++].toCHTML([
-          adaptor.append(subRow, this.html('mjx-cell')) as N,
+          adaptor.append(subRow, this.html('mjx-cell')) as N<DOM>,
         ]);
         this.childNodes[i++].toCHTML([
-          adaptor.append(supRow, this.html('mjx-cell')) as N,
+          adaptor.append(supRow, this.html('mjx-cell')) as N<DOM>,
         ]);
       }
       return adaptor.append(
         dom,
         this.html(name, tabledef, [supRow, sepRow, subRow])
-      ) as N;
+      ) as N<DOM>;
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mn.ts
+++ b/ts/output/chtml/Wrappers/mn.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMn,
   CommonMnClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mn.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMn } from '../../../core/MmlTree/MmlNodes/mn.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMn interface for the CHTML Mn wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMnNTD<N, T, D>
+export interface ChtmlMnNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMn<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMnClass interface for the CHTML Mn wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMnClass<N, T, D>
+export interface ChtmlMnClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMnClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMnNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMnNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,29 +79,21 @@ export interface ChtmlMnClass<N, T, D>
 /**
  * The ChtmlMn wrapper class for the MmlMn class
  */
-export const ChtmlMn = (function <N, T, D>(): ChtmlMnClass<N, T, D> {
+export const ChtmlMn = (function (): ChtmlMnClass<DOM> {
   const Base = CommonMnMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMnClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMnClass<DOM>
   >(ChtmlWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlMn extends Base implements ChtmlMnNTD<N, T, D> {
+  return class ChtmlMn extends Base implements ChtmlMnNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMn.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mo.ts
+++ b/ts/output/chtml/Wrappers/mo.ts
@@ -21,18 +21,10 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass, StringMap } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-  VFUZZ,
-  HFUZZ,
-} from '../FontData.js';
+import { ChtmlCharOptions, VFUZZ, HFUZZ } from '../FontData.js';
 import { CharDataArray } from '../../common/FontData.js';
 import {
   CommonMo,
@@ -43,62 +35,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMo } from '../../../core/MmlTree/MmlNodes/mo.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { DIRECTION } from '../FontData.js';
+import { DOM, DOM_TYPES, N, NT } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMo interface for the CHTML Mo wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMoNTD<N, T, D>
+export interface ChtmlMoNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMo<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMoClass interface for the CHTML Mo wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMoClass<N, T, D>
+export interface ChtmlMoClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMoClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMoNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMoNTD<DOM>;
 }
 
 export type PartData = CharDataArray<ChtmlCharOptions>;
@@ -107,32 +84,20 @@ export type PartData = CharDataArray<ChtmlCharOptions>;
 
 /**
  * The ChtmlMo wrapper class for the MmlMo class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
+export const ChtmlMo = (function (): ChtmlMoClass<DOM> {
   const Base = CommonMoMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMoClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMoClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMo extends Base implements ChtmlMoNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMo extends Base implements ChtmlMoNTD<DOM> {
     /**
      * @override
      */
@@ -191,7 +156,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       const adaptor = this.adaptor;
       const attributes = this.node.attributes;
       const symmetric =
@@ -247,14 +212,14 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
      *
      * @param {N} chtml  The parent element in which to put the delimiter
      */
-    protected stretchHTML(chtml: N[]) {
+    protected stretchHTML(chtml: N<DOM>[]) {
       const c = this.getText().codePointAt(0);
       this.font.delimUsage.add(c);
       this.childNodes[0].markUsed();
       const delim = this.stretch;
       const stretch = delim.stretch;
       const stretchv = this.font.getStretchVariants(c);
-      const dom: N[] = [];
+      const dom: N<DOM>[] = [];
 
       //
       //  Look up the characters to use
@@ -317,7 +282,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       parts: PartData[],
       sn: number[],
       sv: string[],
-      dom: N[],
+      dom: N<DOM>[],
       wh: number,
       ext: number,
       nl: string = ''
@@ -372,7 +337,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       data: PartData,
       n: number,
       v: string,
-      dom: N[],
+      dom: N<DOM>[],
       W: number = 0,
       Wx: number = 0,
       nl: string = '',
@@ -386,7 +351,7 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
         const font =
           options.ff || (letter ? `${this.font.cssFontPrefix}-${letter}` : '');
         const c = options.c || String.fromCodePoint(n);
-        let nodes = [] as (N | T)[];
+        let nodes = [] as NT<DOM>[];
         if (part === 'mjx-ext' && (Wx || options.dx)) {
           //
           // If the top and bottom must overlap, adjust the border sizes and remove the clipping
@@ -431,4 +396,4 @@ export const ChtmlMo = (function <N, T, D>(): ChtmlMoClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mpadded.ts
+++ b/ts/output/chtml/Wrappers/mpadded.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass, StringMap } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMpadded,
   CommonMpaddedClass,
@@ -39,62 +32,47 @@ import {
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMpadded } from '../../../core/MmlTree/MmlNodes/mpadded.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMpadded interface for the CHTML Mpadded wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface ChtmlMpaddedNTD<N, T, D>
+export interface ChtmlMpaddedNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMpadded<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMpaddedClass interface for the CHTML Mpadded wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface ChtmlMpaddedClass<N, T, D>
+export interface ChtmlMpaddedClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMpaddedClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMpaddedNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMpaddedNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -102,27 +80,19 @@ export interface ChtmlMpaddedClass<N, T, D>
 /**
  * The ChtmlMpadded wrapper class for the MmlMpadded class
  */
-export const ChtmlMpadded = (function <N, T, D>(): ChtmlMpaddedClass<N, T, D> {
+export const ChtmlMpadded = (function (): ChtmlMpaddedClass<DOM> {
   const Base = CommonMpaddedMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMpaddedClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMpaddedClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class ChtmlMpadded extends Base implements ChtmlMpaddedNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMpadded extends Base implements ChtmlMpaddedNTD<DOM> {
     /**
      * @override
      */
@@ -144,10 +114,10 @@ export const ChtmlMpadded = (function <N, T, D>(): ChtmlMpaddedClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       let chtml = this.standardChtmlNodes(parents);
-      const content: N[] = [];
+      const content: N<DOM>[] = [];
       const style: StringMap = {};
       const [, , W, dh, dd, dw, x, y, dx] = this.getDimens();
       //
@@ -188,7 +158,7 @@ export const ChtmlMpadded = (function <N, T, D>(): ChtmlMpaddedClass<N, T, D> {
         this.adaptor.append(
           chtml[0],
           this.html('mjx-block', { style: style }, content)
-        ) as N,
+        ) as N<DOM>,
       ];
       if (this.childNodes[0].childNodes.length) {
         this.childNodes[0].toCHTML([content[0] || chtml[0]]);
@@ -198,4 +168,4 @@ export const ChtmlMpadded = (function <N, T, D>(): ChtmlMpaddedClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mroot.ts
+++ b/ts/output/chtml/Wrappers/mroot.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMroot,
   CommonMrootClass,
@@ -40,62 +33,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { ChtmlMsqrt, ChtmlMsqrtClass, ChtmlMsqrtNTD } from './msqrt.js';
 import { BBox } from '../../../util/BBox.js';
 import { MmlMroot } from '../../../core/MmlTree/MmlNodes/mroot.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMroot interface for the CHTML Mroot wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMrootNTD<N, T, D>
+export interface ChtmlMrootNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMsqrtNTD<N, T, D>,
+    ChtmlMsqrtNTD<DOM>,
     CommonMroot<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMrootClass interface for the CHTML Mroot wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMrootClass<N, T, D>
+export interface ChtmlMrootClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMsqrtClass<N, T, D>,
+    ChtmlMsqrtClass<DOM>,
     CommonMrootClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMrootNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMrootNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -103,27 +81,19 @@ export interface ChtmlMrootClass<N, T, D>
 /**
  * The ChtmlMroot wrapper class for the MmlMroot class
  */
-export const ChtmlMroot = (function <N, T, D>(): ChtmlMrootClass<N, T, D> {
+export const ChtmlMroot = (function (): ChtmlMrootClass<DOM> {
   const Base = CommonMrootMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMrootClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMrootClass<DOM>
   >(ChtmlMsqrt);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMroot extends Base implements ChtmlMrootNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMroot extends Base implements ChtmlMrootNTD<DOM> {
     /**
      * @override
      */
@@ -133,8 +103,8 @@ export const ChtmlMroot = (function <N, T, D>(): ChtmlMrootClass<N, T, D> {
      * @override
      */
     protected addRoot(
-      ROOT: N,
-      root: ChtmlWrapper<N, T, D>,
+      ROOT: N<DOM>,
+      root: ChtmlWrapper<DOM>,
       sbox: BBox,
       H: number
     ) {
@@ -145,11 +115,11 @@ export const ChtmlMroot = (function <N, T, D>(): ChtmlMrootClass<N, T, D> {
       adaptor.setStyle(ROOT, 'width', this.em(x));
       if (dx) {
         adaptor.setStyle(
-          adaptor.firstChild(ROOT) as N,
+          adaptor.firstChild(ROOT) as N<DOM>,
           'paddingLeft',
           this.em(dx)
         );
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mrow.ts
+++ b/ts/output/chtml/Wrappers/mrow.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMrow,
   CommonMrowClass,
@@ -47,94 +40,67 @@ import {
   MmlInferredMrow,
 } from '../../../core/MmlTree/MmlNodes/mrow.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMrow interface for the CHTML Mrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMrowNTD<N, T, D>
+export interface ChtmlMrowNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMrow<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMrowClass interface for the CHTML Mrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMrowClass<N, T, D>
+export interface ChtmlMrowClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMrowClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMrowNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMrowNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The ChtmlMrow wrapper class for the MmlMrow class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
+export const ChtmlMrow = (function (): ChtmlMrowClass<DOM> {
   const Base = CommonMrowMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMrowClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMrowClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMrow extends Base implements ChtmlMrowNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMrow extends Base implements ChtmlMrowNTD<DOM> {
     /**
      * @override
      */
@@ -210,7 +176,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       const n = (this.linebreakCount = this.isStack ? 0 : this.breakCount);
       if (n || !this.node.isInferred) {
         parents = this.standardChtmlNodes(parents);
@@ -230,7 +196,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
      * @param {N[]} parents  The HTML nodes in which to place the lines
      * @param {number} n     The number of lines
      */
-    protected placeLines(parents: N[], n: number) {
+    protected placeLines(parents: N<DOM>[], n: number) {
       this.getBBox(); // make sure we have linebreak information
       const lines = this.lineBBox;
       const adaptor = this.adaptor;
@@ -267,7 +233,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
     /**
      * @param {N} dom  The HTML element for the mrow
      */
-    protected handleVerticalAlign(dom: N) {
+    protected handleVerticalAlign(dom: N<DOM>) {
       if (this.dh) {
         this.adaptor.setStyle(
           this.adaptor.parent(dom),
@@ -280,7 +246,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
     /**
      * @param {N} dom  The HTML element for the mrow
      */
-    protected handleNegativeWidth(dom: N) {
+    protected handleNegativeWidth(dom: N<DOM>) {
       const { w } = this.getBBox();
       if (w < 0) {
         this.adaptor.setStyle(dom, 'width', this.em(Math.max(0, w)));
@@ -291,7 +257,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
     /**
      * @override
      */
-    protected createChtmlNodes(parents: N[]): N[] {
+    protected createChtmlNodes(parents: N<DOM>[]): N<DOM>[] {
       const n = this.linebreakCount;
       if (!n) return super.createChtmlNodes(parents);
       //
@@ -301,7 +267,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       const kind = this.node.isInferred
         ? 'mjx-linestack'
         : 'mjx-' + this.node.kind;
-      this.dom = [adaptor.append(parents[0], this.html(kind)) as N];
+      this.dom = [adaptor.append(parents[0], this.html(kind)) as N<DOM>];
       if (kind === 'mjx-mrow' && !this.isStack) {
         adaptor.setAttribute(this.dom[0], 'break-top', 'true');
       }
@@ -320,17 +286,17 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       // Add an href anchor, if needed, and insert the linestack/mrow
       //
       this.dom = [
-        adaptor.append(this.handleHref(parents)[0], this.dom[0]) as N,
+        adaptor.append(this.handleHref(parents)[0], this.dom[0]) as N<DOM>,
       ];
       //
       //  Add the line boxes
       //
-      const chtml = Array(n) as N[];
+      const chtml = Array(n) as N<DOM>[];
       for (let i = 0; i <= n; i++) {
         chtml[i] = adaptor.append(
           this.dom[0],
           this.html('mjx-linebox', { lineno: i })
-        ) as N;
+        ) as N<DOM>;
       }
       //
       //  Return the line boxes as the parent nodes for their contents
@@ -341,7 +307,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
     /**
      * @override
      */
-    public addChildren(parents: N[]) {
+    public addChildren(parents: N<DOM>[]) {
       let i = 0;
       for (const child of this.childNodes) {
         const n = child.breakCount;
@@ -350,7 +316,7 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -358,57 +324,41 @@ export const ChtmlMrow = (function <N, T, D>(): ChtmlMrowClass<N, T, D> {
 /**
  * The ChtmlInferredMrow interface for the CHTML InferredMrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface ChtmlInferredMrowNTD<N, T, D>
+export interface ChtmlInferredMrowNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMrowNTD<N, T, D>,
+    ChtmlMrowNTD<DOM>,
     CommonInferredMrow<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlInferredMrowClass interface for the CHTML InferredMrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface ChtmlInferredMrowClass<N, T, D>
+export interface ChtmlInferredMrowClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMrowClass<N, T, D>,
+    ChtmlMrowClass<DOM>,
     CommonInferredMrowClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlInferredMrowNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlInferredMrowNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -416,37 +366,25 @@ export interface ChtmlInferredMrowClass<N, T, D>
 /**
  * The ChtmlInferredMrow wrapper class for the MmlInferredMrow class
  */
-export const ChtmlInferredMrow = (function <N, T, D>(): ChtmlInferredMrowClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlInferredMrow = (function (): ChtmlInferredMrowClass<DOM> {
   const Base = CommonInferredMrowMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlInferredMrowClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlInferredMrowClass<DOM>
   >(ChtmlMrow);
 
   return class ChtmlInferredMrow
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be ChtmlWrapper<N, T, D>, but are thought of
-    // as different by typescript)
+    // @ts-expect-error Avoid message about base constructors not having the same type
     extends Base
-    implements ChtmlInferredMrowNTD<N, T, D>
+    implements ChtmlInferredMrowNTD<DOM>
   {
     /**
      * @override
      */
     public static kind = MmlInferredMrow.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/ms.ts
+++ b/ts/output/chtml/Wrappers/ms.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMs,
   CommonMsClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/ms.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMs } from '../../../core/MmlTree/MmlNodes/ms.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMs interface for the CHTML Ms wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface ChtmlMsNTD<N, T, D>
+export interface ChtmlMsNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMs<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMsClass interface for the CHTML Ms wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   THe DOM node types
  */
-export interface ChtmlMsClass<N, T, D>
+export interface ChtmlMsClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMsClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMsNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMsNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,30 +79,22 @@ export interface ChtmlMsClass<N, T, D>
 /**
  * The ChtmlMs wrapper class for the MmlMs class
  */
-export const ChtmlMs = (function <N, T, D>(): ChtmlMsClass<N, T, D> {
+export const ChtmlMs = (function (): ChtmlMsClass<DOM> {
   const Base = CommonMsMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMsClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMsClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMs extends Base implements ChtmlMsNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMs extends Base implements ChtmlMsNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMs.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mspace.ts
+++ b/ts/output/chtml/Wrappers/mspace.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMspace,
   CommonMspaceClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mspace.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMspace } from '../../../core/MmlTree/MmlNodes/mspace.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMspace interface for the CHTML Mspace wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMspaceNTD<N, T, D>
+export interface ChtmlMspaceNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMspace<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMspaceClass interface for the CHTML Mspace wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMspaceClass<N, T, D>
+export interface ChtmlMspaceClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMspaceClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMspaceNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMspaceNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,27 +79,19 @@ export interface ChtmlMspaceClass<N, T, D>
 /**
  * The ChtmlMspace wrapper class for the MmlMspace class
  */
-export const ChtmlMspace = (function <N, T, D>(): ChtmlMspaceClass<N, T, D> {
+export const ChtmlMspace = (function (): ChtmlMspaceClass<DOM> {
   const Base = CommonMspaceMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMspaceClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMspaceClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMspace extends Base implements ChtmlMspaceNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMspace extends Base implements ChtmlMspaceNTD<DOM> {
     /**
      * @override
      */
@@ -130,7 +100,7 @@ export const ChtmlMspace = (function <N, T, D>(): ChtmlMspaceClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (parents.length > 1) {
         parents.forEach((dom) =>
           this.adaptor.append(dom, this.html('mjx-linestrut'))
@@ -154,4 +124,4 @@ export const ChtmlMspace = (function <N, T, D>(): ChtmlMspaceClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/msqrt.ts
+++ b/ts/output/chtml/Wrappers/msqrt.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMsqrt,
   CommonMsqrtClass,
@@ -41,62 +34,47 @@ import { ChtmlMoNTD } from './mo.js';
 import { BBox } from '../../../util/BBox.js';
 import { MmlMsqrt } from '../../../core/MmlTree/MmlNodes/msqrt.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMsqrt interface for the CHTML Msqrt wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsqrtNTD<N, T, D>
+export interface ChtmlMsqrtNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMsqrt<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMsqrtClass interface for the CHTML Msqrt wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsqrtClass<N, T, D>
+export interface ChtmlMsqrtClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMsqrtClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMsqrtNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMsqrtNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -104,31 +82,21 @@ export interface ChtmlMsqrtClass<N, T, D>
 /**
  * The ChtmlMsqrt wrapper class for the MmlMsqrt class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
+export const ChtmlMsqrt = (function (): ChtmlMsqrtClass<DOM> {
   const Base = CommonMsqrtMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMsqrtClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMsqrtClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMsqrt extends Base implements ChtmlMsqrtNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMsqrt extends Base implements ChtmlMsqrtNTD<DOM> {
     /**
      * @override
      */
@@ -164,8 +132,8 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
-      const surd = this.surd as ChtmlMoNTD<N, T, D>;
+    public toCHTML(parents: N<DOM>[]) {
+      const surd = this.surd as ChtmlMoNTD<DOM>;
       const base = this.childNodes[this.base];
       //
       //  Get the parameters for the spacing of the parts
@@ -182,7 +150,7 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
       const CHTML = this.standardChtmlNodes(parents);
       let SURD, BASE, ROOT, root;
       if (this.root != null) {
-        ROOT = adaptor.append(CHTML[0], this.html('mjx-root')) as N;
+        ROOT = adaptor.append(CHTML[0], this.html('mjx-root')) as N<DOM>;
         root = this.childNodes[this.root];
       }
       const SQRT = adaptor.append(
@@ -191,7 +159,7 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
           (SURD = this.html('mjx-surd')),
           (BASE = this.html('mjx-box', { style: { paddingTop: this.em(q) } })),
         ])
-      ) as N;
+      ) as N<DOM>;
       if (t !== 0.06) {
         adaptor.setStyle(
           BASE,
@@ -224,10 +192,10 @@ export const ChtmlMsqrt = (function <N, T, D>(): ChtmlMsqrtClass<N, T, D> {
      * @param {number} _H           The height of the root as a whole
      */
     protected addRoot(
-      _ROOT: N,
-      _root: ChtmlWrapper<N, T, D>,
+      _ROOT: N<DOM>,
+      _root: ChtmlWrapper<DOM>,
       _sbox: BBox,
       _H: number
     ) {}
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/msubsup.ts
+++ b/ts/output/chtml/Wrappers/msubsup.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMsub,
   CommonMsubClass,
@@ -55,62 +48,47 @@ import {
   MmlMsup,
 } from '../../../core/MmlTree/MmlNodes/msubsup.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMsub interface for the CHTML Msub wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsubNTD<N, T, D>
+export interface ChtmlMsubNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlScriptbaseNTD<N, T, D>,
+    ChtmlScriptbaseNTD<DOM>,
     CommonMsub<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMsubClass interface for the CHTML Msub wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsubClass<N, T, D>
+export interface ChtmlMsubClass<DOM extends DOM_TYPES>
   extends
-    ChtmlScriptbaseClass<N, T, D>,
+    ChtmlScriptbaseClass<DOM>,
     CommonMsubClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMsubNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMsubNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -118,33 +96,25 @@ export interface ChtmlMsubClass<N, T, D>
 /**
  * The ChtmlMsub wrapper class for the MmlMsub class
  */
-export const ChtmlMsub = (function <N, T, D>(): ChtmlMsubClass<N, T, D> {
+export const ChtmlMsub = (function (): ChtmlMsubClass<DOM> {
   const Base = CommonMsubMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMsubClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMsubClass<DOM>
   >(ChtmlScriptbase);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMsub extends Base implements ChtmlMsubNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMsub extends Base implements ChtmlMsubNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMsub.prototype.kind;
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -152,57 +122,41 @@ export const ChtmlMsub = (function <N, T, D>(): ChtmlMsubClass<N, T, D> {
 /**
  * The ChtmlMsup interface for the CHTML Msup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsupNTD<N, T, D>
+export interface ChtmlMsupNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlScriptbaseNTD<N, T, D>,
+    ChtmlScriptbaseNTD<DOM>,
     CommonMsup<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMsupClass interface for the CHTML Msup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsupClass<N, T, D>
+export interface ChtmlMsupClass<DOM extends DOM_TYPES>
   extends
-    ChtmlScriptbaseClass<N, T, D>,
+    ChtmlScriptbaseClass<DOM>,
     CommonMsupClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMsupNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMsupNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -210,33 +164,25 @@ export interface ChtmlMsupClass<N, T, D>
 /**
  * The ChtmlMsup wrapper class for the MmlMsup class
  */
-export const ChtmlMsup = (function <N, T, D>(): ChtmlMsupClass<N, T, D> {
+export const ChtmlMsup = (function (): ChtmlMsupClass<DOM> {
   const Base = CommonMsupMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMsupClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMsupClass<DOM>
   >(ChtmlScriptbase);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMsup extends Base implements ChtmlMsupNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMsup extends Base implements ChtmlMsupNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMsup.prototype.kind;
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -244,57 +190,41 @@ export const ChtmlMsup = (function <N, T, D>(): ChtmlMsupClass<N, T, D> {
 /**
  * The ChtmlMsubsup interface for the CHTML Msubsup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsubsupNTD<N, T, D>
+export interface ChtmlMsubsupNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlScriptbaseNTD<N, T, D>,
+    ChtmlScriptbaseNTD<DOM>,
     CommonMsubsup<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMsubsupClass interface for the CHTML Msubsup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMsubsupClass<N, T, D>
+export interface ChtmlMsubsupClass<DOM extends DOM_TYPES>
   extends
-    ChtmlScriptbaseClass<N, T, D>,
+    ChtmlScriptbaseClass<DOM>,
     CommonMsubsupClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMsubsupNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMsubsupNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -302,27 +232,19 @@ export interface ChtmlMsubsupClass<N, T, D>
 /**
  * The ChtmlMsubsup wrapper class for the MmlMsubsup class
  */
-export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
+export const ChtmlMsubsup = (function (): ChtmlMsubsupClass<DOM> {
   const Base = CommonMsubsupMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMsubsupClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMsubsupClass<DOM>
   >(ChtmlScriptbase);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMsubsup extends Base implements ChtmlMsubsupNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMsubsup extends Base implements ChtmlMsubsupNTD<DOM> {
     /**
      * @override
      */
@@ -345,7 +267,7 @@ export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       const adaptor = this.adaptor;
       const chtml = this.standardChtmlNodes(parents);
@@ -356,7 +278,7 @@ export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
       const stack = adaptor.append(
         chtml[chtml.length - 1],
         this.html('mjx-script', { style })
-      ) as N;
+      ) as N<DOM>;
       sup.toCHTML([stack]);
       adaptor.append(
         stack,
@@ -383,4 +305,4 @@ export const ChtmlMsubsup = (function <N, T, D>(): ChtmlMsubsupClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mtable.ts
+++ b/ts/output/chtml/Wrappers/mtable.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtable,
   CommonMtableClass,
@@ -42,73 +35,58 @@ import { ChtmlMtrNTD } from './mtr.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { isPercent } from '../../../util/string.js';
 import { OptionList } from '../../../util/Options.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMtable interface for the CHTML Mtable wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtableNTD<N, T, D>
+export interface ChtmlMtableNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMtable<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass,
-      ChtmlMtrNTD<N, T, D>
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>,
+      ChtmlMtrNTD<DOM>
     > {
   /**
    * The column for labels
    */
-  labels: N;
+  labels: N<DOM>;
 
   /**
    * The inner table DOM node
    */
-  itable: N;
+  itable: N<DOM>;
 }
 
 /**
  * The ChtmlMtableClass interface for the CHTML Mtable wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtableClass<N, T, D>
+export interface ChtmlMtableClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMtableClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMtableNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMtableNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -116,28 +94,20 @@ export interface ChtmlMtableClass<N, T, D>
 /**
  * The ChtmlMtable wrapper class for the MmlMtable class
  */
-export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
+export const ChtmlMtable = (function (): ChtmlMtableClass<DOM> {
   const Base = CommonMtableMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMtrNTD<N, T, D>,
-    ChtmlMtableClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMtrNTD<DOM>,
+    ChtmlMtableClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMtable extends Base implements ChtmlMtableNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMtable extends Base implements ChtmlMtableNTD<DOM> {
     /**
      * @override
      */
@@ -212,12 +182,12 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     /**
      * @override
      */
-    public labels: N;
+    public labels: N<DOM>;
 
     /**
      * @override
      */
-    public itable: N;
+    public itable: N<DOM>;
 
     /******************************************************************/
 
@@ -225,9 +195,9 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
      * @override
      */
     constructor(
-      factory: ChtmlWrapperFactory<N, T, D>,
+      factory: ChtmlWrapperFactory<DOM>,
       node: MmlNode,
-      parent: ChtmlWrapper<N, T, D> = null
+      parent: ChtmlWrapper<DOM> = null
     ) {
       super(factory, node, parent);
       this.itable = this.html('mjx-itable');
@@ -248,7 +218,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       //
       //  Create the rows inside an mjx-itable (which will be used to center the table on the math axis)
       //
@@ -297,7 +267,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
      */
     protected padRows() {
       const adaptor = this.adaptor;
-      for (const row of adaptor.childNodes(this.itable) as N[]) {
+      for (const row of adaptor.childNodes(this.itable) as N<DOM>[]) {
         while (adaptor.childNodes(row).length < this.numCols) {
           adaptor.append(row, this.html('mjx-mtd', { extra: true }));
         }
@@ -339,7 +309,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
           //
           const styleNode = cell
             ? cell.dom[0]
-            : (this.adaptor.childNodes(row.dom[0])[i] as N);
+            : (this.adaptor.childNodes(row.dom[0])[i] as N<DOM>);
           if ((i > 1 && lspace !== '0.4em') || (lspace !== '0' && i === 1)) {
             this.adaptor.setStyle(styleNode, 'paddingLeft', lspace);
           }
@@ -361,7 +331,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       const lines = this.getColumnAttributes('columnlines');
       for (const row of this.childNodes) {
         let i = 0;
-        const cells = this.adaptor.childNodes(row.dom[0]).slice(1) as N[];
+        const cells = this.adaptor.childNodes(row.dom[0]).slice(1) as N<DOM>[];
         for (const cell of cells) {
           const line = lines[i++];
           if (line === 'none') continue;
@@ -376,7 +346,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
     protected handleColumnWidths() {
       for (const row of this.childNodes) {
         let i = 0;
-        for (const cell of this.adaptor.childNodes(row.dom[0]) as N[]) {
+        for (const cell of this.adaptor.childNodes(row.dom[0]) as N<DOM>[]) {
           const w = this.cWidths[i++];
           if (w !== null) {
             const width = typeof w === 'number' ? this.em(w) : w;
@@ -445,7 +415,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       for (const row of this.childNodes.slice(1)) {
         const line = lines[i++];
         if (line === 'none') continue;
-        for (const cell of this.adaptor.childNodes(row.dom[0]) as N[]) {
+        for (const cell of this.adaptor.childNodes(row.dom[0]) as N<DOM>[]) {
           this.adaptor.setStyle(cell, 'borderTop', '.07em ' + line);
         }
       }
@@ -484,7 +454,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
      * @param {ChtmlWrapper} row   The row whose height is to be set
      * @param {number} HD          The height to be set for the row
      */
-    protected setRowHeight(row: ChtmlWrapper<N, T, D>, HD: number) {
+    protected setRowHeight(row: ChtmlWrapper<DOM>, HD: number) {
       this.adaptor.setStyle(row.dom[0], 'height', this.em(HD));
     }
 
@@ -496,11 +466,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
      * @param {number} HD          The total height+depth for the row
      * @param {number} D           The new depth for the row
      */
-    protected setRowBaseline(
-      row: ChtmlWrapper<N, T, D>,
-      HD: number,
-      D: number
-    ) {
+    protected setRowBaseline(row: ChtmlWrapper<DOM>, HD: number, D: number) {
       const ralign = row.node.attributes.get('rowalign') as string;
       //
       //  Loop through the cells and set the strut height and depth.
@@ -521,7 +487,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
      * @returns {boolean}           True if no other cells in this row need to be processed
      */
     protected setCellBaseline(
-      cell: ChtmlWrapper<N, T, D>,
+      cell: ChtmlWrapper<DOM>,
       ralign: string,
       HD: number,
       D: number
@@ -529,7 +495,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       const calign = cell.node.attributes.get('rowalign');
       if (calign === 'baseline' || calign === 'axis') {
         const adaptor = this.adaptor;
-        const child = adaptor.lastChild(cell.dom[0]) as N;
+        const child = adaptor.lastChild(cell.dom[0]) as N<DOM>;
         adaptor.setStyle(child, 'height', this.em(HD));
         adaptor.setStyle(child, 'verticalAlign', this.em(-D));
         const row = cell.parent;
@@ -573,7 +539,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
         if (W === 'auto') return;
         W = this.em(this.length2em(W) + 2 * this.fLine);
       }
-      const table = adaptor.firstChild(dom) as N;
+      const table = adaptor.firstChild(dom) as N<DOM>;
       adaptor.setStyle(table, 'width', W);
       adaptor.setStyle(table, 'minWidth', this.em(w));
       if (L || R) {
@@ -646,7 +612,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       //  Handle indentation
       //
       if (shift) {
-        const table = adaptor.firstChild(this.dom[0]) as N;
+        const table = adaptor.firstChild(this.dom[0]) as N<DOM>;
         this.setIndent(table, align, shift);
       }
       //
@@ -717,7 +683,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       //    and line thickness for each non-labeled row.
       //
       let h = this.fLine;
-      let current = adaptor.firstChild(this.labels) as N;
+      let current = adaptor.firstChild(this.labels) as N<DOM>;
       for (let i = 0; i < this.numRows; i++) {
         const row = this.childNodes[i];
         if (row.node.isKind('mlabeledtr')) {
@@ -732,7 +698,7 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
             'height',
             this.em((equal ? HD : H[i] + D[i]) + space[i] + space[i + 1])
           );
-          current = adaptor.next(current) as N;
+          current = adaptor.next(current) as N<DOM>;
           h = this.rLines[i];
         } else {
           h +=
@@ -744,4 +710,4 @@ export const ChtmlMtable = (function <N, T, D>(): ChtmlMtableClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mtd.ts
+++ b/ts/output/chtml/Wrappers/mtd.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtd,
   CommonMtdClass,
@@ -39,62 +32,47 @@ import {
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtd } from '../../../core/MmlTree/MmlNodes/mtd.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMtd interface for the CHTML Mtd wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtdNTD<N, T, D>
+export interface ChtmlMtdNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMtd<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMtdClass interface for the CHTML Mtd wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtdClass<N, T, D>
+export interface ChtmlMtdClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMtdClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMtdNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMtdNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -102,26 +80,18 @@ export interface ChtmlMtdClass<N, T, D>
 /**
  * The ChtmlMtd wrapper class for the MmlMtd class
  */
-export const ChtmlMtd = (function <N, T, D>(): ChtmlMtdClass<N, T, D> {
+export const ChtmlMtd = (function (): ChtmlMtdClass<DOM> {
   const Base = CommonMtdMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMtdClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMtdClass<DOM>
   >(ChtmlWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlMtd extends Base implements ChtmlMtdNTD<N, T, D> {
+  return class ChtmlMtd extends Base implements ChtmlMtdNTD<DOM> {
     /**
      * @override
      */
@@ -187,7 +157,7 @@ export const ChtmlMtd = (function <N, T, D>(): ChtmlMtdClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       super.toCHTML(parents);
       const ralign = this.node.attributes.get('rowalign') as string;
       const calign = this.node.attributes.get('columnalign') as string;
@@ -212,4 +182,4 @@ export const ChtmlMtd = (function <N, T, D>(): ChtmlMtdClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mtext.ts
+++ b/ts/output/chtml/Wrappers/mtext.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtext,
   CommonMtextClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mtext.js';
 import { MmlNode, TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtext } from '../../../core/MmlTree/MmlNodes/mtext.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMtext interface for the CHTML Mtext wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtextNTD<N, T, D>
+export interface ChtmlMtextNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMtext<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMtextClass interface for the CHTML Mtext wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtextClass<N, T, D>
+export interface ChtmlMtextClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMtextClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMtextNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMtextNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,27 +79,19 @@ export interface ChtmlMtextClass<N, T, D>
 /**
  * The ChtmlMtext wrapper class for the MmlMtext class
  */
-export const ChtmlMtext = (function <N, T, D>(): ChtmlMtextClass<N, T, D> {
+export const ChtmlMtext = (function (): ChtmlMtextClass<DOM> {
   const Base = CommonMtextMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMtextClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMtextClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMtext extends Base implements ChtmlMtextNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMtext extends Base implements ChtmlMtextNTD<DOM> {
     /**
      * @override
      */
@@ -130,7 +100,7 @@ export const ChtmlMtext = (function <N, T, D>(): ChtmlMtextClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       //
       // If no breakpoints, do the usual thing
       //
@@ -184,4 +154,4 @@ export const ChtmlMtext = (function <N, T, D>(): ChtmlMtextClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/mtr.ts
+++ b/ts/output/chtml/Wrappers/mtr.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtr,
   CommonMtrClass,
@@ -44,62 +37,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtr, MmlMlabeledtr } from '../../../core/MmlTree/MmlNodes/mtr.js';
 import { ChtmlMtableNTD } from './mtable.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMtr interface for the CHTML Mtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtrNTD<N, T, D>
+export interface ChtmlMtrNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonMtr<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMtrClass interface for the CHTML Mtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMtrClass<N, T, D>
+export interface ChtmlMtrClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonMtrClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMtrNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMtrNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -107,27 +85,19 @@ export interface ChtmlMtrClass<N, T, D>
 /**
  * The ChtmlMtr wrapper class for the MmlMtr class
  */
-export const ChtmlMtr = (function <N, T, D>(): ChtmlMtrClass<N, T, D> {
+export const ChtmlMtr = (function (): ChtmlMtrClass<DOM> {
   const Base = CommonMtrMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMtrClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMtrClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMtr extends Base implements ChtmlMtrNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMtr extends Base implements ChtmlMtrNTD<DOM> {
     /**
      * @override
      */
@@ -160,7 +130,7 @@ export const ChtmlMtr = (function <N, T, D>(): ChtmlMtrClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       super.toCHTML(parents);
       const align = this.node.attributes.get('rowalign') as string;
       if (align !== 'baseline') {
@@ -170,63 +140,47 @@ export const ChtmlMtr = (function <N, T, D>(): ChtmlMtrClass<N, T, D> {
       this.adaptor.setStyle(this.dom[0], 'height', this.em(h + d));
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /**
  * The ChtmlMlabeledtr interface for the CHTML Mlabeledtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMlabeledtrNTD<N, T, D>
+export interface ChtmlMlabeledtrNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMtrNTD<N, T, D>,
+    ChtmlMtrNTD<DOM>,
     CommonMlabeledtr<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMlabeledtrClass interface for the CHTML Mlabeledtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMlabeledtrClass<N, T, D>
+export interface ChtmlMlabeledtrClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMtrClass<N, T, D>,
+    ChtmlMtrClass<DOM>,
     CommonMlabeledtrClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMlabeledtrNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMlabeledtrNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -234,36 +188,19 @@ export interface ChtmlMlabeledtrClass<N, T, D>
 /**
  * The ChtmlMlabeledtr wrapper class for the MmlMlabeledtr class
  */
-export const ChtmlMlabeledtr = (function <N, T, D>(): ChtmlMlabeledtrClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlMlabeledtr = (function (): ChtmlMlabeledtrClass<DOM> {
   const Base = CommonMlabeledtrMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMlabeledtrClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMlabeledtrClass<DOM>
   >(ChtmlMtr);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlMlabeledtr
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be ChtmlWrapper<N, T, D>, but are thought of
-    // as different by typescript)
-    extends Base
-    implements ChtmlMlabeledtrNTD<N, T, D>
-  {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMlabeledtr extends Base implements ChtmlMlabeledtrNTD<DOM> {
     /**
      * @override
      */
@@ -296,9 +233,9 @@ export const ChtmlMlabeledtr = (function <N, T, D>(): ChtmlMlabeledtrClass<
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       super.toCHTML(parents);
-      const child = this.adaptor.firstChild(this.dom[0]) as N;
+      const child = this.adaptor.firstChild(this.dom[0]) as N<DOM>;
       if (child) {
         //
         // Remove label and put it into the labels box inside a row
@@ -308,10 +245,7 @@ export const ChtmlMlabeledtr = (function <N, T, D>(): ChtmlMlabeledtrClass<
         const attr =
           align !== 'baseline' && align !== 'axis' ? { rowalign: align } : {};
         const row = this.html('mjx-mtr', attr, [child]);
-        this.adaptor.append(
-          (this.parent as ChtmlMtableNTD<N, T, D>).labels,
-          row
-        );
+        this.adaptor.append((this.parent as ChtmlMtableNTD<DOM>).labels, row);
       }
     }
 
@@ -323,4 +257,4 @@ export const ChtmlMlabeledtr = (function <N, T, D>(): ChtmlMlabeledtrClass<
       this.jax.wrapperUsage.add(ChtmlMtr.kind);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/munderover.ts
+++ b/ts/output/chtml/Wrappers/munderover.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonMunder,
   CommonMunderClass,
@@ -61,62 +54,47 @@ import {
   ChtmlMsubsupNTD,
 } from './msubsup.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlMunder interface for the CHTML Munder wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMunderNTD<N, T, D>
+export interface ChtmlMunderNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMsubNTD<N, T, D>,
+    ChtmlMsubNTD<DOM>,
     CommonMunder<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMunderClass interface for the CHTML Munder wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMunderClass<N, T, D>
+export interface ChtmlMunderClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMsubClass<N, T, D>,
+    ChtmlMsubClass<DOM>,
     CommonMunderClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMunderNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMunderNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -124,27 +102,19 @@ export interface ChtmlMunderClass<N, T, D>
 /**
  * The ChtmlMunder wrapper class for the MmlMunder class
  */
-export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
+export const ChtmlMunder = (function (): ChtmlMunderClass<DOM> {
   const Base = CommonMunderMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMunderClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMunderClass<DOM>
   >(ChtmlMsub);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMunder extends Base implements ChtmlMunderNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMunder extends Base implements ChtmlMunderNTD<DOM> {
     /**
      * @override
      */
@@ -171,7 +141,7 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       if (this.hasMovableLimits()) {
         super.toCHTML(parents);
@@ -180,13 +150,13 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
       }
       this.dom = this.standardChtmlNodes(parents);
       const base = this.adaptor.append(
-        this.adaptor.append(this.dom[0], this.html('mjx-row')) as N,
+        this.adaptor.append(this.dom[0], this.html('mjx-row')) as N<DOM>,
         this.html('mjx-base')
-      ) as N;
+      ) as N<DOM>;
       const under = this.adaptor.append(
-        this.adaptor.append(this.dom[0], this.html('mjx-row')) as N,
+        this.adaptor.append(this.dom[0], this.html('mjx-row')) as N<DOM>,
         this.html('mjx-under')
-      ) as N;
+      ) as N<DOM>;
       this.baseChild.toCHTML([base]);
       this.scriptChild.toCHTML([under]);
       const basebox = this.baseChild.getOuterBBox();
@@ -203,7 +173,7 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
       this.adjustUnderDepth(under, underbox);
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -211,57 +181,41 @@ export const ChtmlMunder = (function <N, T, D>(): ChtmlMunderClass<N, T, D> {
 /**
  * The ChtmlMover interface for the CHTML Mover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMoverNTD<N, T, D>
+export interface ChtmlMoverNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMsupNTD<N, T, D>,
+    ChtmlMsupNTD<DOM>,
     CommonMover<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMoverClass interface for the CHTML Mover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMoverClass<N, T, D>
+export interface ChtmlMoverClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMsupClass<N, T, D>,
+    ChtmlMsupClass<DOM>,
     CommonMoverClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMoverNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMoverNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -269,27 +223,19 @@ export interface ChtmlMoverClass<N, T, D>
 /**
  * The ChtmlMover wrapper class for the MmlMover class
  */
-export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
+export const ChtmlMover = (function (): ChtmlMoverClass<DOM> {
   const Base = CommonMoverMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMoverClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMoverClass<DOM>
   >(ChtmlMsup);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlMover extends Base implements ChtmlMoverNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMover extends Base implements ChtmlMoverNTD<DOM> {
     /**
      * @override
      */
@@ -313,7 +259,7 @@ export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       if (this.hasMovableLimits()) {
         super.toCHTML(parents);
@@ -321,8 +267,14 @@ export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
         return;
       }
       this.dom = this.standardChtmlNodes(parents);
-      const over = this.adaptor.append(this.dom[0], this.html('mjx-over')) as N;
-      const base = this.adaptor.append(this.dom[0], this.html('mjx-base')) as N;
+      const over = this.adaptor.append(
+        this.dom[0],
+        this.html('mjx-over')
+      ) as N<DOM>;
+      const base = this.adaptor.append(
+        this.dom[0],
+        this.html('mjx-base')
+      ) as N<DOM>;
       this.scriptChild.toCHTML([over]);
       this.baseChild.toCHTML([base]);
       const overbox = this.scriptChild.getOuterBBox();
@@ -338,7 +290,7 @@ export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
       this.adjustOverDepth(over, overbox);
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -346,57 +298,41 @@ export const ChtmlMover = (function <N, T, D>(): ChtmlMoverClass<N, T, D> {
 /**
  * The ChtmlMunderover interface for the CHTML Munderover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMunderoverNTD<N, T, D>
+export interface ChtmlMunderoverNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlMsubsupNTD<N, T, D>,
+    ChtmlMsubsupNTD<DOM>,
     CommonMunderover<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlMunderoverClass interface for the CHTML Munderover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlMunderoverClass<N, T, D>
+export interface ChtmlMunderoverClass<DOM extends DOM_TYPES>
   extends
-    ChtmlMsubsupClass<N, T, D>,
+    ChtmlMsubsupClass<DOM>,
     CommonMunderoverClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlMunderoverNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlMunderoverNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -404,34 +340,19 @@ export interface ChtmlMunderoverClass<N, T, D>
 /**
  * The ChtmlMunderover wrapper class for the MmlMunderover class
  */
-export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlMunderover = (function (): ChtmlMunderoverClass<DOM> {
   const Base = CommonMunderoverMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlMunderoverClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlMunderoverClass<DOM>
   >(ChtmlMsubsup);
 
-  return class ChtmlMunderover
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be ChtmlWrapper<N, T, D>, but are thought of
-    // as different by typescript)
-    extends Base
-    implements ChtmlMunderoverNTD<N, T, D>
-  {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlMunderover extends Base implements ChtmlMunderoverNTD<DOM> {
     /**
      * @override
      */
@@ -454,7 +375,7 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       if (this.hasMovableLimits()) {
         super.toCHTML(parents);
@@ -462,19 +383,22 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<
         return;
       }
       this.dom = this.standardChtmlNodes(parents);
-      const over = this.adaptor.append(this.dom[0], this.html('mjx-over')) as N;
+      const over = this.adaptor.append(
+        this.dom[0],
+        this.html('mjx-over')
+      ) as N<DOM>;
       const table = this.adaptor.append(
-        this.adaptor.append(this.dom[0], this.html('mjx-box')) as N,
+        this.adaptor.append(this.dom[0], this.html('mjx-box')) as N<DOM>,
         this.html('mjx-munder')
-      ) as N;
+      ) as N<DOM>;
       const base = this.adaptor.append(
-        this.adaptor.append(table, this.html('mjx-row')) as N,
+        this.adaptor.append(table, this.html('mjx-row')) as N<DOM>,
         this.html('mjx-base')
-      ) as N;
+      ) as N<DOM>;
       const under = this.adaptor.append(
-        this.adaptor.append(table, this.html('mjx-row')) as N,
+        this.adaptor.append(table, this.html('mjx-row')) as N<DOM>,
         this.html('mjx-under')
-      ) as N;
+      ) as N<DOM>;
       this.overChild.toCHTML([over]);
       this.baseChild.toCHTML([base]);
       this.underChild.toCHTML([under]);
@@ -499,4 +423,4 @@ export const ChtmlMunderover = (function <N, T, D>(): ChtmlMunderoverClass<
       this.adjustUnderDepth(under, underbox);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/scriptbase.ts
+++ b/ts/output/chtml/Wrappers/scriptbase.ts
@@ -24,16 +24,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonScriptbase,
   CommonScriptbaseClass,
@@ -43,125 +36,91 @@ import { ChtmlMsubsup } from './msubsup.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
 import { StyleJsonData } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The ChtmlScriptbase interface for the CHTML Scriptbase wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlScriptbaseNTD<N, T, D>
+export interface ChtmlScriptbaseNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonScriptbase<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   /**
    * @param {N[]} nodes    The HTML elements to be centered in a stack
    * @param {number[]} dx  The x offsets needed to center the elements
    */
-  setDeltaW(nodes: N[], dx: number[]): void;
+  setDeltaW(nodes: N<DOM>[], dx: number[]): void;
 
   /**
    * @param {N} over        The HTML element for the overscript
    * @param {BBox} overbox  The bbox for the overscript
    */
-  adjustOverDepth(over: N, overbox: BBox): void;
+  adjustOverDepth(over: N<DOM>, overbox: BBox): void;
 
   /**
    * @param {N} under        The HTML element for the underscript
    * @param {BBox} underbox  The bbox for the underscript
    */
-  adjustUnderDepth(under: N, underbox: BBox): void;
+  adjustUnderDepth(under: N<DOM>, underbox: BBox): void;
 
   /**
    * @param {N} base        The HTML element for the base
    * @param {BBox} basebox  The bbox for the base
    */
-  adjustBaseHeight(base: N, basebox: BBox): void;
+  adjustBaseHeight(base: N<DOM>, basebox: BBox): void;
 }
 
 /**
  * The ChtmlScriptbaseClass interface for the CHTML Scriptbase wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface ChtmlScriptbaseClass<N, T, D>
+export interface ChtmlScriptbaseClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonScriptbaseClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlScriptbaseNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlScriptbaseNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The ChtmlScriptbase wrapper class for the MmlScriptbase class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlScriptbase = (function (): ChtmlScriptbaseClass<DOM> {
   const Base = CommonScriptbaseMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlScriptbaseClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlScriptbaseClass<DOM>
   >(ChtmlWrapper);
 
-  return class ChtmlScriptbase
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be ChtmlWrapper<N, T, D>, but are thought of
-    // as different by typescript)
-    extends Base
-    implements ChtmlScriptbaseNTD<N, T, D>
-  {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlScriptbase extends Base implements ChtmlScriptbaseNTD<DOM> {
     /**
      * @override
      */
@@ -173,7 +132,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
      *
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       this.dom = this.standardChtmlNodes(parents);
       const [x, v] = this.getOffset();
@@ -185,7 +144,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
       this.baseChild.toCHTML(this.dom);
       const dom = this.dom[this.dom.length - 1];
       this.scriptChild.toCHTML([
-        this.adaptor.append(dom, this.html('mjx-script', { style })) as N,
+        this.adaptor.append(dom, this.html('mjx-script', { style })) as N<DOM>,
       ]);
     }
 
@@ -203,7 +162,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
      * @param {N[]} nodes    The HTML elements to be centered in a stack
      * @param {number[]} dx  The x offsets needed to center the elements
      */
-    public setDeltaW(nodes: N[], dx: number[]) {
+    public setDeltaW(nodes: N<DOM>[], dx: number[]) {
       for (let i = 0; i < dx.length; i++) {
         if (dx[i]) {
           this.adaptor.setStyle(nodes[i], 'paddingLeft', this.em(dx[i]));
@@ -215,7 +174,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
      * @param {N} over        The HTML element for the overscript
      * @param {BBox} overbox  The bbox for the overscript
      */
-    public adjustOverDepth(over: N, overbox: BBox) {
+    public adjustOverDepth(over: N<DOM>, overbox: BBox) {
       if (overbox.d >= 0) return;
       this.adaptor.setStyle(
         over,
@@ -228,7 +187,7 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
      * @param {N} under        The HTML element for the underscript
      * @param {BBox} underbox  The bbox for the underscript
      */
-    public adjustUnderDepth(under: N, underbox: BBox) {
+    public adjustUnderDepth(under: N<DOM>, underbox: BBox) {
       if (underbox.d >= 0) return;
       const adaptor = this.adaptor;
       const v = this.em(underbox.d);
@@ -236,18 +195,18 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
         style: { 'margin-bottom': v, 'vertical-align': v },
       });
       for (const child of adaptor.childNodes(
-        adaptor.firstChild(under) as N
-      ) as N[]) {
+        adaptor.firstChild(under) as N<DOM>
+      ) as N<DOM>[]) {
         adaptor.append(box, child);
       }
-      adaptor.append(adaptor.firstChild(under) as N, box);
+      adaptor.append(adaptor.firstChild(under) as N<DOM>, box);
     }
 
     /**
      * @param {N} base        The HTML element for the base
      * @param {BBox} basebox  The bbox for the base
      */
-    public adjustBaseHeight(base: N, basebox: BBox) {
+    public adjustBaseHeight(base: N<DOM>, basebox: BBox) {
       if (this.node.attributes.get('accent')) {
         const minH = this.font.params.x_height * this.baseScale;
         if (basebox.h < minH) {
@@ -257,4 +216,4 @@ export const ChtmlScriptbase = (function <N, T, D>(): ChtmlScriptbaseClass<
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/chtml/Wrappers/semantics.ts
+++ b/ts/output/chtml/Wrappers/semantics.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CHTML } from '../../chtml.js';
+import { CHTML, CHTML_FONT } from '../../chtml.js';
 import { ChtmlWrapper, ChtmlWrapperClass } from '../Wrapper.js';
 import { ChtmlWrapperFactory } from '../WrapperFactory.js';
-import {
-  ChtmlCharOptions,
-  ChtmlVariantData,
-  ChtmlDelimiterData,
-  ChtmlFontData,
-  ChtmlFontDataClass,
-} from '../FontData.js';
 import {
   CommonSemantics,
   CommonSemanticsClass,
@@ -51,6 +44,7 @@ import {
 import { XMLNode } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { StyleList } from '../../../util/Styles.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 export type FontStyles = {
   'font-family': string;
@@ -61,57 +55,41 @@ export type FontStyles = {
 /**
  * The ChtmlSemantics interface for the CHTML Semantics wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlSemanticsNTD<N, T, D>
+export interface ChtmlSemanticsNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonSemantics<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {}
 
 /**
  * The ChtmlSemanticsClass interface for the CHTML Semantics wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlSemanticsClass<N, T, D>
+export interface ChtmlSemanticsClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonSemanticsClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlSemanticsNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlSemanticsNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -119,33 +97,18 @@ export interface ChtmlSemanticsClass<N, T, D>
 /**
  * The ChtmlSemantics wrapper class for the MmlSemantics class
  */
-export const ChtmlSemantics = (function <N, T, D>(): ChtmlSemanticsClass<
-  N,
-  T,
-  D
-> {
+export const ChtmlSemantics = (function (): ChtmlSemanticsClass<DOM> {
   const Base = CommonSemanticsMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlSemanticsClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlSemanticsClass<DOM>
   >(ChtmlWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be ChtmlWrapper<N, T, D>, but are thought of as different by typescript)
-  return class ChtmlSemantics
-    extends Base
-    implements ChtmlSemanticsNTD<N, T, D>
-  {
+  return class ChtmlSemantics extends Base implements ChtmlSemanticsNTD<DOM> {
     /**
      * @override
      */
@@ -154,7 +117,7 @@ export const ChtmlSemantics = (function <N, T, D>(): ChtmlSemanticsClass<
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       if (this.toEmbellishedCHTML(parents)) return;
       const chtml = this.standardChtmlNodes(parents);
       if (this.childNodes.length) {
@@ -162,92 +125,72 @@ export const ChtmlSemantics = (function <N, T, D>(): ChtmlSemanticsClass<
       }
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /**
  * The ChtmlAnnotation wrapper for the MmlAnnotation class
  */
-export const ChtmlAnnotation = (function <N, T, D>(): ChtmlWrapperClass<
-  N,
-  T,
-  D
-> {
-  return class ChtmlAnnotation extends ChtmlWrapper<N, T, D> {
-    /**
-     * @override
-     */
-    public static kind = MmlAnnotation.prototype.kind;
+export class ChtmlAnnotation extends ChtmlWrapper<DOM> {
+  /**
+   * @override
+   */
+  public static kind = MmlAnnotation.prototype.kind;
 
-    /**
-     * @override
-     */
-    public toCHTML(parents: N[]) {
-      // FIXME:  output as plain text
-      super.toCHTML(parents);
-    }
+  /**
+   * @override
+   */
+  public toCHTML(parents: N<DOM>[]) {
+    // FIXME:  output as plain text
+    super.toCHTML(parents);
+  }
 
-    /**
-     * @override
-     */
-    public computeBBox() {
-      // FIXME:  compute using the DOM, if possible
-      return this.bbox;
-    }
-  };
-})<any, any, any>();
+  /**
+   * @override
+   */
+  public computeBBox() {
+    // FIXME:  compute using the DOM, if possible
+    return this.bbox;
+  }
+}
 
 /*****************************************************************/
 /**
  * The ChtmlAnnotationXML wrapper for the MmlAnnotationXML class
  */
-export const ChtmlAnnotationXML = (function <N, T, D>(): ChtmlWrapperClass<
-  N,
-  T,
-  D
-> {
-  return class ChtmlAnnotationXML extends ChtmlWrapper<N, T, D> {
-    /**
-     * @override
-     */
-    public static kind = MmlAnnotationXML.prototype.kind;
+export class ChtmlAnnotationXML extends ChtmlWrapper<DOM> {
+  /**
+   * @override
+   */
+  public static kind = MmlAnnotationXML.prototype.kind;
 
-    /**
-     * @override
-     */
-    public static styles: StyleJson = {
-      'mjx-annotation-xml': {
-        'font-family': 'initial',
-        'line-height': 'normal',
-      },
-    };
+  /**
+   * @override
+   */
+  public static styles: StyleJson = {
+    'mjx-annotation-xml': {
+      'font-family': 'initial',
+      'line-height': 'normal',
+    },
   };
-})<any, any, any>();
+}
 
 /*****************************************************************/
 /**
  * The ChtmlXmlNode interface for the CHTML XmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlXmlNodeNTD<N, T, D>
+export interface ChtmlXmlNodeNTD<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapper<N, T, D>,
+    ChtmlWrapper<DOM>,
     CommonXmlNode<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   /**
    * @returns {FontStyles}  the font family and size data
@@ -258,58 +201,42 @@ export interface ChtmlXmlNodeNTD<N, T, D>
 /**
  * The ChtmlXmlNodeClass interface for the CHTML XmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM  The DOM node types
  */
-export interface ChtmlXmlNodeClass<N, T, D>
+export interface ChtmlXmlNodeClass<DOM extends DOM_TYPES>
   extends
-    ChtmlWrapperClass<N, T, D>,
+    ChtmlWrapperClass<DOM>,
     CommonXmlNodeClass<
-      N,
-      T,
-      D,
-      CHTML<N, T, D>,
-      ChtmlWrapper<N, T, D>,
-      ChtmlWrapperFactory<N, T, D>,
-      ChtmlWrapperClass<N, T, D>,
-      ChtmlCharOptions,
-      ChtmlVariantData,
-      ChtmlDelimiterData,
-      ChtmlFontData,
-      ChtmlFontDataClass
+      DOM,
+      CHTML_FONT,
+      CHTML<DOM>,
+      ChtmlWrapper<DOM>,
+      ChtmlWrapperFactory<DOM>,
+      ChtmlWrapperClass<DOM>
     > {
   new (
-    factory: ChtmlWrapperFactory<N, T, D>,
+    factory: ChtmlWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: ChtmlWrapper<N, T, D>
-  ): ChtmlXmlNodeNTD<N, T, D>;
+    parent?: ChtmlWrapper<DOM>
+  ): ChtmlXmlNodeNTD<DOM>;
 }
 
 /**
  * The ChtmlXmlNode wrapper for the XMLNode class
  */
-export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
+export const ChtmlXmlNode = (function (): ChtmlXmlNodeClass<DOM> {
   const Base = CommonXmlNodeMixin<
-    N,
-    T,
-    D,
-    CHTML<N, T, D>,
-    ChtmlWrapper<N, T, D>,
-    ChtmlWrapperFactory<N, T, D>,
-    ChtmlWrapperClass<N, T, D>,
-    ChtmlCharOptions,
-    ChtmlVariantData,
-    ChtmlDelimiterData,
-    ChtmlFontData,
-    ChtmlFontDataClass,
-    ChtmlXmlNodeClass<N, T, D>
+    DOM,
+    CHTML_FONT,
+    CHTML<DOM>,
+    ChtmlWrapper<DOM>,
+    ChtmlWrapperFactory<DOM>,
+    ChtmlWrapperClass<DOM>,
+    ChtmlXmlNodeClass<DOM>
   >(ChtmlWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be ChtmlWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class ChtmlXmlNode extends Base implements ChtmlXmlNodeNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class ChtmlXmlNode extends Base implements ChtmlXmlNodeNTD<DOM> {
     /**
      * @override
      */
@@ -318,9 +245,9 @@ export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
     /**
      * @override
      */
-    public toCHTML(parents: N[]) {
+    public toCHTML(parents: N<DOM>[]) {
       this.markUsed();
-      this.dom = [this.adaptor.append(parents[0], this.getHTML()) as N];
+      this.dom = [this.adaptor.append(parents[0], this.getHTML()) as N<DOM>];
     }
 
     /**
@@ -335,7 +262,7 @@ export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
     /**
      * @override
      */
-    public addHDW(html: N, styles: StyleList): N {
+    public addHDW(html: N<DOM>, styles: StyleList): N<DOM> {
       const scale = this.jax.options.scale;
       const { h, d, w } = this.bbox;
       const rscale = scale * this.metrics.scale;
@@ -355,4 +282,4 @@ export const ChtmlXmlNode = (function <N, T, D>(): ChtmlWrapperClass<N, T, D> {
       );
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/common.ts
+++ b/ts/output/common.ts
@@ -46,7 +46,7 @@ import { StyleList, Styles } from '../util/Styles.js';
 import { StyleJson, StyleJsonSheet } from '../util/StyleJson.js';
 import { BBox } from '../util/BBox.js';
 import { SEM } from '../a11y/semantic-enrich/strings.js';
-import { DOM, DOM_TYPES, N, T, D, EMPTY } from '../types/Types.js';
+import { DOM, DOM_TYPES, N, T, EMPTY } from '../types/Types.js';
 
 /*****************************************************************/
 
@@ -58,8 +58,8 @@ export interface ExtendedMetrics extends Metrics {
  * Maps linking a node to the test node it contains,
  *  and a map linking a node to the metrics within that node.
  */
-export type MetricMap<N> = Map<N, ExtendedMetrics>;
-type MetricDomMap<N> = Map<N, N>;
+export type MetricMap<DOM extends DOM_TYPES> = Map<N<DOM>, ExtendedMetrics>;
+type MetricDomMap<DOM extends DOM_TYPES> = Map<N<DOM>, N<DOM>>;
 
 /**
  * Maps for unknown characters
@@ -73,79 +73,70 @@ export const FONTPATH = '@mathjax/%%FONT%%-font';
 /*****************************************************************/
 
 /**
+ * The font data for the common classes.
+ */
+export type COMMON_FONT = {
+  CC: CharOptions;
+  VV: VariantData<COMMON_FONT['CC']>;
+  DD: DelimiterData;
+  FD: FontData<COMMON_FONT['CC'], COMMON_FONT['VV'], COMMON_FONT['DD']>;
+  FC: FontDataClass<COMMON_FONT['CC'], COMMON_FONT['VV'], COMMON_FONT['DD']>;
+};
+
+/*****************************************************************/
+
+/**
  * The option types for linebreaking.
  */
-/* prettier-ignore */
 export type LINEBREAKS = {
-  inline: boolean;             // true for browser-based breaking of inline equations
-  width: string;               // a fixed size or a percentage of the container width
-  lineleading: number;         // the default lineleading in em units
-  LinebreakVisitor:            // The LinebreakVisitor to use
-  typeof LinebreakVisitor;
+  inline: boolean; //             true for browser-based breaking of inline equations
+  width: string; //               a fixed size or a percentage of the container width
+  lineleading: number; //         the default lineleading in em units
+  LinebreakVisitor: typeof LinebreakVisitor; // The LinebreakVisitor to use
 };
 
 /**
  * The option types for the common output jax.
  */
-/* prettier-ignore */
 export interface COMMON_OPTIONS<
   DOM extends DOM_TYPES,
-  WW extends CommonWrapper<
-    N<DOM>, T<DOM>, D<DOM>,
-    CommonOutputJax<N<DOM>, T<DOM>, D<DOM>, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >,
-  WF extends CommonWrapperFactory<
-    N<DOM>, T<DOM>, D<DOM>,
-    CommonOutputJax<N<DOM>, T<DOM>, D<DOM>, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >,
-  WC extends CommonWrapperClass<
-    N<DOM>, T<DOM>, D<DOM>,
-    CommonOutputJax<N<DOM>, T<DOM>, D<DOM>, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
 > extends OUTPUTJAX_OPTIONS {
-  scale: number;                 // global scaling factor for all expressions
-  minScale: number;              // smallest scaling factor to use
-  mtextInheritFont: boolean;     // true to make mtext elements use surrounding font
-  merrorInheritFont: boolean;    // true to make merror text use surrounding font
-  mtextFont: string;             // font to use for mtext, if not inheriting (empty means use MathJax fonts)
-  merrorFont: string;            // font to use for merror, if not inheriting (empty means use MathJax fonts)
-  mathmlSpacing: boolean;        // true for MathML spacing rules, false for TeX rules
-  skipAttributes: EMPTY;         // RFDa and other attributes NOT to copy to the output
-  exFactor: number;              // default size of ex in em units
-  displayAlign:                  // default for indentalign when set to 'auto'
-    'left' | 'center' | 'right' | 'auto';
-  displayIndent: string;         // default for indentshift when set to 'auto'
-  displayOverflow:               // default for how to handle wide expressions
+  scale: number; //                 Global scaling factor for all expressions
+  minScale: number; //              Smallest scaling factor to use
+  mtextInheritFont: boolean; //     True to make mtext elements use surrounding font
+  merrorInheritFont: boolean; //    True to make merror text use surrounding font
+  mtextFont: string; //             Font to use for mtext, if not inheriting (empty means use MathJax fonts)
+  merrorFont: string; //            Font to use for merror, if not inheriting (empty means use MathJax fonts)
+  mathmlSpacing: boolean; //        True for MathML spacing rules, false for TeX rules
+  skipAttributes: EMPTY; //         RFDa and other attributes NOT to copy to the output
+  exFactor: number; //              Default size of ex in em units
+  //                                Default for indentalign when set to 'auto'
+  displayAlign: 'left' | 'center' | 'right' | 'auto';
+  displayIndent: string; //         Default for indentshift when set to 'auto'
+  //                                Default for how to handle wide expressions
+  displayOverflow:
     'overflow' | 'scroll' | 'scale' | 'truncate' | 'elide' | 'linebreak';
-  linebreaks: LINEBREAKS;        // the line-breaking options
-  font: string;                  // the font component to load
-  fontExtensions: string[];      // the font extensions to load
-  htmlHDW:                       // How to handle data-mjx-hdw attributes
-    'auto' | 'use' | 'force' | 'ignore';
-  wrapperFactory:                // The wrapper factory to use
-    CommonWrapperFactory<
-      N<DOM>, T<DOM>, D<DOM>,
-      CommonOutputJax<N<DOM>, T<DOM>, D<DOM>, WW, WF, WC, CC, VV, DD, FD, FC>,
-      WW, WF, WC, CC, VV, DD, FD, FC
-    >,
-  fontData:                      // The FontData object to use
-    FontData<CC, VV, DD> | typeof FontData;
-  fontPath: string;              // The path to the font definitions
-  styleJson: StyleJsonSheet;     // The StyleJsonSheet object to use
+  linebreaks: LINEBREAKS; //        The line-breaking options
+  font: string; //                  The font component to load
+  fontExtensions: string[]; //      The font extensions to load
+  //                                How to handle data-mjx-hdw attributes
+  htmlHDW: 'auto' | 'use' | 'force' | 'ignore';
+  wrapperFactory: WF; //            The wrapper factory to use
+  //                                The FontData object to use
+  fontData: FONT['FC'] | typeof FontData;
+  fontPath: string; //              The path to the font definitions
+  styleJson: StyleJsonSheet; //     The StyleJsonSheet object to use
 }
 
 /**
  * The default options.
  */
-const options: COMMON_OPTIONS<any, any, any, any, any, any, any, any, any> = {
+const options: COMMON_OPTIONS<DOM, COMMON_FONT, any, any, any, any> = {
   ...AbstractOutputJax.OPTIONS,
   scale: 1,
   minScale: 0.5,
@@ -179,47 +170,16 @@ const options: COMMON_OPTIONS<any, any, any, any, any, any, any, any, any> = {
 /**
  *  The CommonOutputJax class on which the CHTML and SVG jax are built
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM ...
  */
 export abstract class CommonOutputJax<
-  N,
-  T,
-  D,
-  /* prettier-ignore */
-  WW extends CommonWrapper<
-    N, T, D,
-    CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >,
-  /* prettier-ignore */
-  WF extends CommonWrapperFactory<
-    N, T, D,
-    CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >,
-  /* prettier-ignore */
-  WC extends CommonWrapperClass<
-    N, T, D,
-    CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends AbstractOutputJax<N, T, D> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends AbstractOutputJax<DOM> {
   /**
    * The name of this output jax
    */
@@ -265,11 +225,7 @@ export abstract class CommonOutputJax<
   /**
    * The font to use for generic extensions
    */
-  public static genericFont: FontDataClass<
-    CharOptions,
-    VariantData<CharOptions>,
-    DelimiterData
-  >;
+  public static genericFont: COMMON_FONT['FC'];
 
   /**
    * Used for collecting styles needed for the output jax
@@ -279,17 +235,17 @@ export abstract class CommonOutputJax<
   /**
    * The MathDocument for the math we find
    */
-  public document: MathDocument<N, T, D>;
+  public document: MathDocument<DOM>;
 
   /**
    * the MathItem currently being processed
    */
-  public math: MathItem<N, T, D>;
+  public math: MathItem<DOM>;
 
   /**
    * The container element for the math
    */
-  public container: N;
+  public container: N<DOM>;
 
   /**
    * The top-level table, if any
@@ -304,7 +260,7 @@ export abstract class CommonOutputJax<
   /**
    * The data for the font in use
    */
-  public font: FD;
+  public font: FONT['FD'];
 
   /**
    * The wrapper factory for the MathML nodes
@@ -314,12 +270,7 @@ export abstract class CommonOutputJax<
   /**
    * The linebreak visitor to use for automatic linebreaks
    */
-  /* prettier-ignore */
-  public linebreaks: Linebreaks<
-    N, T, D,
-    CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  >;
+  public linebreaks: Linebreaks<DOM, FONT, JX, WW, WF, WC>;
 
   /**
    * @returns {boolean} True when in-line breaks need to be forced (e.g., for
@@ -344,12 +295,12 @@ export abstract class CommonOutputJax<
   /**
    * Node used to test for in-line metric data
    */
-  public testInline: N;
+  public testInline: N<DOM>;
 
   /**
    * Node used to test for display metric data
    */
-  public testDisplay: N;
+  public testDisplay: N<DOM>;
 
   /**
    * Cache of unknonw character bounding boxes for this element
@@ -359,7 +310,7 @@ export abstract class CommonOutputJax<
   /**
    * @override
    */
-  public options: COMMON_OPTIONS<DOM<N, T, D>, WW, WF, WC, CC, VV, DD, FD, FC>;
+  public options: COMMON_OPTIONS<DOM, FONT, JX, WW, WF, WC>;
 
   /*****************************************************************/
 
@@ -369,13 +320,13 @@ export abstract class CommonOutputJax<
    *
    * @param {OptionList} options                   The configuration options
    * @param {CommonWrapperFactory} defaultFactory  The default wrapper factory class
-   * @param {FC} defaultFont                       The default FontData constructor
+   * @param {FONT['FC']} defaultFont               The default FontData constructor
    * @class
    */
   constructor(
     options: OptionList = {},
     defaultFactory: typeof CommonWrapperFactory = null,
-    defaultFont: FC = null
+    defaultFont: FONT['FC'] = null
   ) {
     const [fontClass, font] =
       options.fontData instanceof FontData
@@ -388,18 +339,14 @@ export abstract class CommonOutputJax<
     super(jaxOptions);
     this.factory =
       (this.options.wrapperFactory as any) ||
-      /* prettier-ignore */
-      new defaultFactory<
-        N, T, D,
-        CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-        WW, WF, WC, CC, VV, DD, FD, FC
-      >();
-    this.factory.jax = this;
+      new defaultFactory<DOM, FONT, JX, WW, WF, WC>();
+    this.factory.jax = this as any as JX;
     this.styleJson = this.options.styleJson || new StyleJsonSheet();
     this.font = font || new fontClass(fontOptions);
     this.font.setOptions({ mathmlSpacing: this.options.mathmlSpacing });
-    /* prettier-ignore */
-    (this.constructor as typeof CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>).genericFont = fontClass;
+    (
+      this.constructor as typeof CommonOutputJax<DOM, FONT, JX, WW, WF, WC>
+    ).genericFont = fontClass;
     this.unknownCache = new Map();
     const linebreaks = (this.options.linebreaks.LinebreakVisitor ||
       LinebreakVisitor) as typeof Linebreaks;
@@ -409,7 +356,7 @@ export abstract class CommonOutputJax<
   /**
    * @override
    */
-  public setAdaptor(adaptor: DOMAdaptor<N, T, D>) {
+  public setAdaptor(adaptor: DOMAdaptor<DOM>) {
     super.setAdaptor(adaptor);
     //
     //  Set the htmlHDW option based on the adaptor's ability to measure nodes
@@ -427,7 +374,7 @@ export abstract class CommonOutputJax<
    * @returns {string[]}                New CSS rules needed for the font
    */
   public addExtension(
-    font: FontExtensionData<CC, DD>,
+    font: FontExtensionData<FONT['CC'], FONT['DD']>,
     prefix: string = ''
   ): string[] {
     return this.font.addExtension(font, prefix);
@@ -443,11 +390,11 @@ export abstract class CommonOutputJax<
    *
    * @override
    */
-  public typeset(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
+  public typeset(math: MathItem<DOM>, html: MathDocument<DOM>) {
     /* prettier-ignore */
-    const CLASS = (this.constructor as typeof CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>);
+    const CLASS = this.constructor as typeof CommonOutputJax<DOM, FONT, JX, WW, WF, WC>;
     const generic = CLASS.genericFont;
-    CLASS.genericFont = this.font.constructor as FontDataClass<CC, VV, DD>;
+    CLASS.genericFont = this.font.constructor as FONT['FC'];
     this.setDocument(html);
     const node = this.createNode();
     try {
@@ -459,9 +406,9 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @returns {N}  The container DOM node for the typeset math
+   * @returns {N<DOM>}  The container DOM node for the typeset math
    */
-  protected createNode(): N {
+  protected createNode(): N<DOM> {
     const jax = (this.constructor as typeof CommonOutputJax).NAME;
     return this.html('mjx-container', {
       class: 'MathJax',
@@ -471,10 +418,10 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @param {N} node         The container whose scale is to be set
+   * @param {N<DOM>} node    The container whose scale is to be set
    * @param {WW} wrapper     The wrapper for the math element being scaled
    */
-  protected setScale(node: N, wrapper: WW) {
+  protected setScale(node: N<DOM>, wrapper: WW) {
     let scale = this.getInitialScale() * this.options.scale;
     if (
       wrapper.node.attributes.get('overflow') === 'scale' &&
@@ -510,13 +457,13 @@ export abstract class CommonOutputJax<
    * Execute the post-filters
    *
    * @param {MathItem} math      The math item to convert
-   * @param {N} node             The contaier to place the result into
+   * @param {N<DOM>} node        The contaier to place the result into
    * @param {MathDocument} html  The document containing the math
    */
   public toDOM(
-    math: MathItem<N, T, D>,
-    node: N,
-    html: MathDocument<N, T, D> = null
+    math: MathItem<DOM>,
+    node: N<DOM>,
+    html: MathDocument<DOM> = null
   ) {
     this.setDocument(html);
     this.math = math;
@@ -564,9 +511,9 @@ export abstract class CommonOutputJax<
    * This is the actual typesetting function supplied by the subclass
    *
    * @param {WW} wrapper   The wrapped intenral MathML node of the root math element to process
-   * @param {N} node       The container node where the math is to be typeset
+   * @param {N<DOM>} node  The container node where the math is to be typeset
    */
-  public abstract processMath(wrapper: WW, node: N): void;
+  public abstract processMath(wrapper: WW, node: N<DOM>): void;
 
   /*****************************************************************/
 
@@ -575,7 +522,7 @@ export abstract class CommonOutputJax<
    * @param {MathDocument} html  The MathDocument for the math
    * @returns {BBox}             The bounding box
    */
-  public getBBox(math: MathItem<N, T, D>, html: MathDocument<N, T, D>): BBox {
+  public getBBox(math: MathItem<DOM>, html: MathDocument<DOM>): BBox {
     this.setDocument(html);
     this.math = math;
     math.root.setTeXclass(null);
@@ -693,7 +640,7 @@ export abstract class CommonOutputJax<
    * @param {MmlNode} node        The parent node to mark
    * @param {MmlNode} child       The child node to mark
    * @param {MmlNode} mo          The core mo to mark
-   * @returns {boolean}            The modified marked variable
+   * @returns {boolean}           The modified marked variable
    */
   protected markInlineBreak(
     marked: boolean,
@@ -744,7 +691,7 @@ export abstract class CommonOutputJax<
   /**
    * @override
    */
-  public getMetrics(html: MathDocument<N, T, D>) {
+  public getMetrics(html: MathDocument<DOM>) {
     this.setDocument(html);
     const adaptor = this.adaptor;
     const maps = this.getMetricMaps(html);
@@ -766,11 +713,11 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @param {N} node            The container node whose metrics are to be measured
+   * @param {N<DOM>} node       The container node whose metrics are to be measured
    * @param {boolean} display   True if the metrics are for displayed math
-   * @returns {Metrics}          Object containing em, ex, containerWidth, etc.
+   * @returns {Metrics}         Object containing em, ex, containerWidth, etc.
    */
-  public getMetricsFor(node: N, display: boolean): ExtendedMetrics {
+  public getMetricsFor(node: N<DOM>, display: boolean): ExtendedMetrics {
     const getFamily =
       this.options.mtextInheritFont || this.options.merrorInheritFont;
     const test = this.getTestElement(node, display);
@@ -783,13 +730,13 @@ export abstract class CommonOutputJax<
    * Get a MetricMap for the math list
    *
    * @param {MathDocument} html  The math document whose math list is to be processed.
-   * @returns {MetricMap[]}       The node-to-metrics maps for all the containers that have math
+   * @returns {MetricMap[]}      The node-to-metrics maps for all the containers that have math
    */
-  protected getMetricMaps(html: MathDocument<N, T, D>): MetricMap<N>[] {
+  protected getMetricMaps(html: MathDocument<DOM>): MetricMap<DOM>[] {
     const adaptor = this.adaptor;
     const domMaps = [
-      new Map() as MetricDomMap<N>,
-      new Map() as MetricDomMap<N>,
+      new Map() as MetricDomMap<DOM>,
+      new Map() as MetricDomMap<DOM>,
     ];
     //
     // Add the test elements all at once (so only one reflow)
@@ -812,7 +759,7 @@ export abstract class CommonOutputJax<
     //
     const getFamily =
       this.options.mtextInheritFont || this.options.merrorInheritFont;
-    const maps = [new Map() as MetricMap<N>, new Map() as MetricMap<N>];
+    const maps = [new Map() as MetricMap<DOM>, new Map() as MetricMap<DOM>];
     for (const i of maps.keys()) {
       for (const node of domMaps[i].keys()) {
         maps[i].set(node, this.measureMetrics(domMaps[i].get(node), getFamily));
@@ -830,11 +777,11 @@ export abstract class CommonOutputJax<
   }
 
   /**
-   * @param {N} node    The math element to be measured
-   * @param {boolean} display Is the element in display math?
-   * @returns {N}        The test elements that were added
+   * @param {N<DOM>} node       The math element to be measured
+   * @param {boolean} display   Is the element in display math?
+   * @returns {N<DOM>}          The test elements that were added
    */
-  protected getTestElement(node: N, display: boolean): N {
+  protected getTestElement(node: N<DOM>, display: boolean): N<DOM> {
     const adaptor = this.adaptor;
     if (!this.testInline) {
       this.testInline = this.html(
@@ -885,38 +832,38 @@ export abstract class CommonOutputJax<
       adaptor.setStyle(this.testDisplay, 'display', 'table');
       adaptor.setStyle(this.testDisplay, 'margin-right', '');
       adaptor.setStyle(
-        adaptor.firstChild(this.testDisplay) as N,
+        adaptor.firstChild(this.testDisplay) as N<DOM>,
         'display',
         'none'
       );
-      const right = adaptor.lastChild(this.testDisplay) as N;
+      const right = adaptor.lastChild(this.testDisplay) as N<DOM>;
       adaptor.setStyle(right, 'display', 'table-cell');
       adaptor.setStyle(right, 'width', '10000em');
       adaptor.setStyle(right, 'float', '');
     }
     return adaptor.append(
       node,
-      adaptor.clone(display ? this.testDisplay : this.testInline) as N
-    ) as N;
+      adaptor.clone(display ? this.testDisplay : this.testInline) as N<DOM>
+    ) as N<DOM>;
   }
 
   /**
-   * @param {N} node              The test node to measure
+   * @param {N<DOM>} node         The test node to measure
    * @param {boolean} getFamily   True if font family of surroundings is to be determined
-   * @returns {ExtendedMetrics}    The metric data for the given node
+   * @returns {ExtendedMetrics}   The metric data for the given node
    */
-  protected measureMetrics(node: N, getFamily: boolean): ExtendedMetrics {
+  protected measureMetrics(node: N<DOM>, getFamily: boolean): ExtendedMetrics {
     const adaptor = this.adaptor;
     const family = getFamily ? adaptor.fontFamily(node) : '';
     const em = adaptor.fontSize(node);
-    const [w, h] = adaptor.nodeSize(adaptor.childNode(node, 1) as N);
+    const [w, h] = adaptor.nodeSize(adaptor.childNode(node, 1) as N<DOM>);
     const ex = w ? h / 60 : em * this.options.exFactor;
     const containerWidth = !w
       ? 1000000
       : adaptor.getStyle(node, 'display') === 'table'
-        ? adaptor.nodeSize(adaptor.lastChild(node) as N)[0] - 1
-        : adaptor.nodeBBox(adaptor.lastChild(node) as N).left -
-          adaptor.nodeBBox(adaptor.firstChild(node) as N).left -
+        ? adaptor.nodeSize(adaptor.lastChild(node) as N<DOM>)[0] - 1
+        : adaptor.nodeBBox(adaptor.lastChild(node) as N<DOM>).left -
+          adaptor.nodeBBox(adaptor.firstChild(node) as N<DOM>).left -
           2;
     const scale = Math.max(
       this.options.minScale,
@@ -932,7 +879,7 @@ export abstract class CommonOutputJax<
   /**
    * @override
    */
-  public styleSheet(html: MathDocument<N, T, D>) {
+  public styleSheet(html: MathDocument<DOM>) {
     this.setDocument(html);
     //
     // Start with the common styles
@@ -960,7 +907,7 @@ export abstract class CommonOutputJax<
     const sheet = this.html('style', { id: 'MJX-styles' }, [
       this.text('\n' + this.styleJson.cssText + '\n'),
     ]);
-    return sheet as N;
+    return sheet as N<DOM>;
   }
 
   /**
@@ -987,10 +934,7 @@ export abstract class CommonOutputJax<
     CLASS: typeof CommonWrapper,
     styles: StyleJsonSheet
   ) {
-    CLASS.addStyles<CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>>(
-      styles,
-      this
-    );
+    CLASS.addStyles<CommonOutputJax<DOM, FONT, JX, WW, WF, WC>>(styles, this);
   }
 
   /**
@@ -1005,7 +949,7 @@ export abstract class CommonOutputJax<
   /**
    * @param {MathDocument} html  The document to be used
    */
-  protected setDocument(html: MathDocument<N, T, D>) {
+  protected setDocument(html: MathDocument<DOM>) {
     if (html) {
       this.document = html;
       this.adaptor.document = html.document;
@@ -1017,30 +961,30 @@ export abstract class CommonOutputJax<
    * @param {OptionList} def   The properties to set on the HTML node
    * @param {(N|T)[]} content  Array of child nodes to set for the HTML node
    * @param {string} ns        The namespace for the element
-   * @returns {N}               The newly created DOM tree
+   * @returns {N<DOM>}         The newly created DOM tree
    */
   public html(
     type: string,
     def: OptionList = {},
-    content: (N | T)[] = [],
+    content: (N<DOM> | T<DOM>)[] = [],
     ns?: string
-  ): N {
+  ): N<DOM> {
     return this.adaptor.node(type, def, content, ns);
   }
 
   /**
    * @param {string} text  The text string for which to make a text node
    *
-   * @returns {T}  A text node with the given text
+   * @returns {T<DOM>}  A text node with the given text
    */
-  public text(text: string): T {
+  public text(text: string): T<DOM> {
     return this.adaptor.text(text);
   }
 
   /**
    * @param {number} m    A number to be shown with a fixed number of digits
    * @param {number=} n   The number of digits to use
-   * @returns {string}     The formatted number
+   * @returns {string}    The formatted number
    */
   public fixed(m: number, n: number = 3): string {
     if (Math.abs(m) < 0.0006) {
@@ -1060,9 +1004,9 @@ export abstract class CommonOutputJax<
    *
    * @param {string} text        The text to be displayed
    * @param {string} variant     The name of the variant for the text
-   * @returns {N}                 The text element containing the text
+   * @returns {N<DOM>}           The text element containing the text
    */
-  public abstract unknownText(text: string, variant: string): N;
+  public abstract unknownText(text: string, variant: string): N<DOM>;
 
   /**
    * Measure text from a specific font, or that isn't in the MathJax font
@@ -1070,7 +1014,7 @@ export abstract class CommonOutputJax<
    * @param {string} text        The text to measure
    * @param {string} variant     The variant for the text
    * @param {CssFontData} font   The family, italic, and bold data for explicit fonts
-   * @returns {UnknownBBox}       The width, height, and depth of the text (in ems)
+   * @returns {UnknownBBox}      The width, height, and depth of the text (in ems)
    */
   public measureText(
     text: string,
@@ -1089,14 +1033,14 @@ export abstract class CommonOutputJax<
    * Get the size of a text node, caching the result, and using
    *   a cached result, if there is one.
    *
-   * @param {N} text             The text element to measure
+   * @param {N<DOM>} text        The text element to measure
    * @param {string} chars       The string contained in the text node
    * @param {string} variant     The variant for the text
    * @param {CssFontData} font   The family, italic, and bold data for explicit fonts
-   * @returns {UnknownBBox}       The width, height and depth for the text
+   * @returns {UnknownBBox}      The width, height and depth for the text
    */
   public measureTextNodeWithCache(
-    text: N,
+    text: N<DOM>,
     chars: string,
     variant: string,
     font: CssFontData = ['', false, false]
@@ -1121,15 +1065,15 @@ export abstract class CommonOutputJax<
    * Measure the width of a text element by placing it in the page
    *  and looking up its size (fake the height and depth, since we can't measure that)
    *
-   * @param {N} text            The text element to measure
-   * @returns {UnknownBBox}      The width, height and depth for the text (in ems)
+   * @param {N<DOM>} text     The text element to measure
+   * @returns {UnknownBBox}   The width, height and depth for the text (in ems)
    */
-  public abstract measureTextNode(text: N): UnknownBBox;
+  public abstract measureTextNode(text: N<DOM>): UnknownBBox;
 
   /**
    * @param {CssFontData} font   The family, style, and weight for the given font
    * @param {StyleList} styles   The style object to add the font data to
-   * @returns {StyleList}         The modified (or initialized) style object
+   * @returns {StyleList}        The modified (or initialized) style object
    */
   public cssFontStyles(font: CssFontData, styles: StyleList = {}): StyleList {
     const [family, italic, bold] = font;
@@ -1141,7 +1085,7 @@ export abstract class CommonOutputJax<
 
   /**
    * @param {Styles} styles   The style object to query
-   * @returns {CssFontData}    The family, italic, and boolean values
+   * @returns {CssFontData}   The family, italic, and boolean values
    */
   public getFontData(styles: Styles): CssFontData {
     if (!styles) {

--- a/ts/output/common/FontData.ts
+++ b/ts/output/common/FontData.ts
@@ -41,15 +41,14 @@ export const HFUZZ = 0.07; // overlap for horizontal stretchy glyphs
 /**
  * The extra options allowed in a CharData array
  */
-/* prettier-ignore */
 export interface CharOptions {
-  ic?: number;                  // italic correction value
-  oc?: number;                  // original ic for -tex-mit font
-  sk?: number;                  // skew value
-  dx?: number;                  // offset for combining characters
-  unknown?: boolean;            // true if not found in the given variant
-  smp?: number;                 // Math Alphanumeric codepoint this char is mapped to
-  hd?: [number, number];        // the original height and depth for an extender
+  ic?: number; //                  Italic correction value
+  oc?: number; //                  Original ic for -tex-mit font
+  sk?: number; //                  Skew value
+  dx?: number; //                  Offset for combining characters
+  unknown?: boolean; //            True if not found in the given variant
+  smp?: number; //                 Math Alphanumeric codepoint this char is mapped to
+  hd?: [number, number]; //        The original height and depth for an extender
 }
 
 /****************************************************************************/
@@ -135,22 +134,21 @@ export type CssFontMap = {
 /**
  * Data needed for stretchy vertical and horizontal characters
  */
-/* prettier-ignore */
 export type DelimiterData = {
-  dir: string;          // vertical or horizontal direction
-  sizes?: number[];     // Array of fixed sizes for this character
-  variants?: number[];  // The variants in which the different sizes can be found (if not the default)
-  schar?: number[];     // The character number to use for each size (if different from the default)
-  stretch?: number[];   // The unicode code points for the parts of multi-character versions [beg, ext, end, mid?]
-  stretchv?: number[];  // the variants to use for the stretchy characters (index into variant name array)
-  HDW?: number[];       // [h, d, w] (for vertical, h and d are the normal size, w is the multi-character width,
-                        //            for horizontal, h and d are the multi-character ones, w is for the normal size).
-  hd?: number[];        // The extender's original [h, d] values
-  ext?: number;         // The extenders left- plus right-bearing
-  min?: number;         // The minimum size a multi-character version can be
-  c?: number;           // The character number (for aliased delimiters)
-  fullExt?: [number, number]  // When present, extenders must be full sized, and the first number is
-                              //   the size of the extender, while the second is the total size of the ends
+  dir: string; //          Vertical or horizontal direction
+  sizes?: number[]; //     Array of fixed sizes for this character
+  variants?: number[]; //  The variants in which the different sizes can be found (if not the default)
+  schar?: number[]; //     The character number to use for each size (if different from the default)
+  stretch?: number[]; //   The unicode code points for the parts of multi-character versions [beg, ext, end, mid?]
+  stretchv?: number[]; //  The variants to use for the stretchy characters (index into variant name array)
+  HDW?: number[]; //       [h, d, w] (for vertical, h and d are the normal size, w is the multi-character width,
+  //                                  For horizontal, h and d are the multi-character ones, w is for the normal size).
+  hd?: number[]; //        The extender's original [h, d] values
+  ext?: number; //         The extenders left- plus right-bearing
+  min?: number; //         The minimum size a multi-character version can be
+  c?: number; //           The character number (for aliased delimiters)
+  fullExt?: [number, number]; //  When present, extenders must be full sized, and the first number is
+  //                              The size of the extender, while the second is the total size of the ends
 };
 
 /**
@@ -286,15 +284,14 @@ export type DynamicFileDef = [string, DynamicVariants, DynamicRanges?];
 /**
  * Data stored about a dynamic font
  */
-/* prettier-ignore */
 export type DynamicFile = {
-  extension: string;              // name of the extension for this file (or blank)
-  file: string;                   // file containing the character data
-  variants: DynamicVariants;      // characters in each variant in the file
-  delimiters: DynamicRanges;      // delimiters in the file
-  setup: DynamicSetup;            // setup function to call to add the characters to the font
-  promise: Promise<void>;         // promise for when the file is loaded
-  failed: boolean;                // true when loading has failed
+  extension: string; //              Name of the extension for this file (or blank)
+  file: string; //                   File containing the character data
+  variants: DynamicVariants; //      Characters in each variant in the file
+  delimiters: DynamicRanges; //      Delimiters in the file
+  setup: DynamicSetup; //            Setup function to call to add the characters to the font
+  promise: Promise<void>; //         Promise for when the file is loaded
+  failed: boolean; //                True when loading has failed
 };
 
 /**
@@ -514,88 +511,83 @@ export class FontData<
   /**
    * Character ranges to remap into Math Alphanumerics
    */
-  /* prettier-ignore */
   public static SmpRanges = [
-    [0, 0x41, 0x5A],   // Upper-case alpha
-    [1, 0x61, 0x7A],   // Lower-case alpha
-    [2, 0x391, 0x3A9], // Upper-case Greek
-    [3, 0x3B1, 0x3C9], // Lower-case Greek
-    [4, 0x30, 0x39]    // Numbers
+    [0, 0x41, 0x5a], //   Upper-case alpha
+    [1, 0x61, 0x7a], //   Lower-case alpha
+    [2, 0x391, 0x3a9], // Upper-case Greek
+    [3, 0x3b1, 0x3c9], // Lower-case Greek
+    [4, 0x30, 0x39], //   Numbers
   ];
 
   /**
    * Characters to map back to other Unicode positions
    * (holes in the Math Alphanumeric ranges)
    */
-  /* prettier-ignore */
   public static SmpRemap: SmpMap = {
-    0x1D455: 0x210E,   // PLANCK CONSTANT
-    0x1D49D: 0x212C,   // SCRIPT CAPITAL B
-    0x1D4A0: 0x2130,   // SCRIPT CAPITAL E
-    0x1D4A1: 0x2131,   // SCRIPT CAPITAL F
-    0x1D4A3: 0x210B,   // SCRIPT CAPITAL H
-    0x1D4A4: 0x2110,   // SCRIPT CAPITAL I
-    0x1D4A7: 0x2112,   // SCRIPT CAPITAL L
-    0x1D4A8: 0x2133,   // SCRIPT CAPITAL M
-    0x1D4AD: 0x211B,   // SCRIPT CAPITAL R
-    0x1D4BA: 0x212F,   // SCRIPT SMALL E
-    0x1D4BC: 0x210A,   // SCRIPT SMALL G
-    0x1D4C4: 0x2134,   // SCRIPT SMALL O
-    0x1D506: 0x212D,   // BLACK-LETTER CAPITAL C
-    0x1D50B: 0x210C,   // BLACK-LETTER CAPITAL H
-    0x1D50C: 0x2111,   // BLACK-LETTER CAPITAL I
-    0x1D515: 0x211C,   // BLACK-LETTER CAPITAL R
-    0x1D51D: 0x2128,   // BLACK-LETTER CAPITAL Z
-    0x1D53A: 0x2102,   // DOUBLE-STRUCK CAPITAL C
-    0x1D53F: 0x210D,   // DOUBLE-STRUCK CAPITAL H
-    0x1D545: 0x2115,   // DOUBLE-STRUCK CAPITAL N
-    0x1D547: 0x2119,   // DOUBLE-STRUCK CAPITAL P
-    0x1D548: 0x211A,   // DOUBLE-STRUCK CAPITAL Q
-    0x1D549: 0x211D,   // DOUBLE-STRUCK CAPITAL R
-    0x1D551: 0x2124,   // DOUBLE-STRUCK CAPITAL Z
+    0x1d455: 0x210e, //   Planck CONSTANT
+    0x1d49d: 0x212c, //   Script CAPITAL B
+    0x1d4a0: 0x2130, //   Script CAPITAL E
+    0x1d4a1: 0x2131, //   Script CAPITAL F
+    0x1d4a3: 0x210b, //   Script CAPITAL H
+    0x1d4a4: 0x2110, //   Script CAPITAL I
+    0x1d4a7: 0x2112, //   Script CAPITAL L
+    0x1d4a8: 0x2133, //   Script CAPITAL M
+    0x1d4ad: 0x211b, //   Script CAPITAL R
+    0x1d4ba: 0x212f, //   Script SMALL E
+    0x1d4bc: 0x210a, //   Script SMALL G
+    0x1d4c4: 0x2134, //   Script SMALL O
+    0x1d506: 0x212d, //   Black-LETTER CAPITAL C
+    0x1d50b: 0x210c, //   Black-LETTER CAPITAL H
+    0x1d50c: 0x2111, //   Black-LETTER CAPITAL I
+    0x1d515: 0x211c, //   Black-LETTER CAPITAL R
+    0x1d51d: 0x2128, //   Black-LETTER CAPITAL Z
+    0x1d53a: 0x2102, //   Double-STRUCK CAPITAL C
+    0x1d53f: 0x210d, //   Double-STRUCK CAPITAL H
+    0x1d545: 0x2115, //   Double-STRUCK CAPITAL N
+    0x1d547: 0x2119, //   Double-STRUCK CAPITAL P
+    0x1d548: 0x211a, //   Double-STRUCK CAPITAL Q
+    0x1d549: 0x211d, //   Double-STRUCK CAPITAL R
+    0x1d551: 0x2124, //   Double-STRUCK CAPITAL Z
   };
 
   /**
    * Greek upper-case variants
    */
-  /* prettier-ignore */
   public static SmpRemapGreekU: SmpMap = {
-    0x2207: 0x19,  // nabla
-    0x03F4: 0x11   // theta symbol
+    0x2207: 0x19, //  Nabla
+    0x03f4: 0x11, //   Theta symbol
   };
 
   /**
    * Greek lower-case variants
    */
-  /* prettier-ignore */
   public static SmpRemapGreekL: SmpMap = {
-    0x3D1: 0x1B,  // theta symbol
-    0x3D5: 0x1D,  // phi symbol
-    0x3D6: 0x1F,  // omega symbol
-    0x3F0: 0x1C,  // kappa symbol
-    0x3F1: 0x1E,  // rho symbol
-    0x3F5: 0x1A,  // lunate epsilon symbol
-    0x2202: 0x19  // partial differential
+    0x3d1: 0x1b, //   theta symbol
+    0x3d5: 0x1d, //   phi symbol
+    0x3d6: 0x1f, //   omega symbol
+    0x3f0: 0x1c, //   kappa symbol
+    0x3f1: 0x1e, //   rho symbol
+    0x3f5: 0x1a, //   lunate epsilon symbol
+    0x2202: 0x19, //  partial differential
   };
 
   /**
    *  The default remappings
    */
-  /* prettier-ignore */
   public static defaultAccentMap: RemapMap = {
-    0x005E: '\u02C6',  // hat
-    0x007E: '\u02DC',  // tilde
-    0x0300: '\u02CB',  // grave accent
-    0x0301: '\u02CA',  // acute accent
-    0x0302: '\u02C6',  // curcumflex
-    0x0303: '\u02DC',  // tilde accent
-    0x0304: '\u02C9',  // macron
-    0x0306: '\u02D8',  // breve
-    0x0307: '\u02D9',  // dot
-    0x0308: '\u00A8',  // diaresis
-    0x030A: '\u02DA',  // ring above
-    0x030C: '\u02C7',  // caron
-    0x2192: '\u20D7'
+    0x005e: '\u02C6', //  Hat
+    0x007e: '\u02DC', //  Tilde
+    0x0300: '\u02CB', //  Grave accent
+    0x0301: '\u02CA', //  Acute accent
+    0x0302: '\u02C6', //  Curcumflex
+    0x0303: '\u02DC', //  Tilde accent
+    0x0304: '\u02C9', //  Macron
+    0x0306: '\u02D8', //  Breve
+    0x0307: '\u02D9', //  Dot
+    0x0308: '\u00A8', //  Diaresis
+    0x030a: '\u02DA', //  Ring above
+    0x030c: '\u02C7', //  Caron
+    0x2192: '\u20D7', //  Vector
   };
 
   /**
@@ -648,11 +640,11 @@ export class FontData<
     delimiterfactor:     901,
     delimitershortfall:   .3,
 
-    rule_factor:         1.25,     // multiply surd_height and rule_thickness by this for CHTML
-    min_rule_thickness:  1.25,     // in pixels
-    separation_factor:   1.75,     // expansion factor for spacing e.g. between accents and base
-    extra_ic:            .033,     // extra spacing for scripts (compensate for not having actual ic values)
-    extender_factor:     .333      // factor to adjust between full stretchy height/depth and extender height/depth
+    rule_factor:         1.25, //     Multiply surd_height and rule_thickness by this for CHTML
+    min_rule_thickness:  1.25, //     In pixels
+    separation_factor:   1.75, //     Expansion factor for spacing e.g. between accents and base
+    extra_ic:            .033, //     Extra spacing for scripts (compensate for not having actual ic values)
+    extender_factor:     .333, //     Factor to adjust between full stretchy height/depth and extender height/depth
   };
 
   /**
@@ -753,8 +745,8 @@ export class FontData<
   }
 
   /**
-   * @param {CharMap} font   The font to check
-   * @param {number} n       The character to get options for
+   * @param {CharMap} font    The font to check
+   * @param {number} n        The character to get options for
    * @returns {CharOptions}   The options for the character
    */
   public static charOptions(
@@ -778,8 +770,8 @@ export class FontData<
   /**
    * Define the dynamic file information.
    *
-   * @param {DynamicFileDef[]} dynamicFiles   The definitions to make
-   * @param {string} extension                The name of the extension for this file (or empty)
+   * @param {DynamicFileDef[]} dynamicFiles    The definitions to make
+   * @param {string} extension                 The name of the extension for this file (or empty)
    * @returns {DynamicFileList}                The object of dynamic file data
    */
   public static defineDynamicFiles(
@@ -806,11 +798,12 @@ export class FontData<
   /**
    * Create the setup function for a given dynamically loaded file
    *
-   * @param {string} extension      The name of the font extension for this file
-   * @param {string} file           The file being loaded
-   * @param {CharMapMap} variants   The character data to be added
-   * @param {DelimiterMap} delimiters The delimiter data to be added
-   * @param {string[]} fonts        The fonts to add CSS to
+   * @param {string} extension          The name of the font extension for this file
+   * @param {string} file               The file being loaded
+   * @param {CharMapMap} variants       The character data to be added
+   * @param {DelimiterMap} delimiters   The delimiter data to be added
+   * @param {string[]} fonts            The fonts to add CSS to
+   *
    * @template C  The CharOptions type
    * @template D  The DelimiterData type
    */
@@ -968,7 +961,7 @@ export class FontData<
    *
    * @param {FontExtensionData} data    The data for the font extension to merge into this font.
    * @param {string} prefix             The [prefix] to add to all component names
-   * @returns {string[]}                 The new CSS rules needed for this extension
+   * @returns {string[]}                The new CSS rules needed for this extension
    */
   public addExtension(
     data: FontExtensionData<C, D>,
@@ -1063,7 +1056,7 @@ export class FontData<
    * @param {string} name     The new variant to create
    * @param {string} inherit  The variant to use if a character is not in this one
    * @param {string} link     A variant to search before the inherit one (but only
-   *                           its top-level object).
+   *                          its top-level object).
    */
   public createVariant(
     name: string,
@@ -1089,8 +1082,8 @@ export class FontData<
    * Create the mapping from Basic Latin and Greek blocks to
    * the Math Alphanumeric block for a given variant.
    *
-   * @param {CharMap<C>} chars The character mapping to fill.
-   * @param {string} name The new variant name.
+   * @param {CharMap<C>} chars   The character mapping to fill.
+   * @param {string} name        The new variant name.
    */
   protected remapSmpChars(chars: CharMap<C>, name: string) {
     const CLASS = this.CLASS;
@@ -1122,7 +1115,7 @@ export class FontData<
   }
 
   /**
-   * @param {number} n           Math Alphanumerics position for this remapping
+   * @param {number} n            Math Alphanumerics position for this remapping
    * @returns {CharDataArray<C>}  The character data for the remapping
    */
   protected smpChar(n: number): CharDataArray<C> {
@@ -1133,7 +1126,7 @@ export class FontData<
    * Create a collection of variants
    *
    * @param {string[][]} variants  Array of [name, inherit?, link?] values for
-   *                              the variants to define
+   *                               the variants to define
    */
   public createVariants(variants: string[][]) {
     for (const variant of variants) {
@@ -1219,7 +1212,7 @@ export class FontData<
    *
    * @param {DynamicRanges} ranges   The ranges to be flattened
    * @param {DynamicFile} dynamic    The DynamicFile to tie to the ranges
-   * @returns {DynamicCharMap}        The map from character positions to dynamic file
+   * @returns {DynamicCharMap}       The map from character positions to dynamic file
    */
   protected flattenRanges(
     ranges: DynamicRanges,
@@ -1240,7 +1233,7 @@ export class FontData<
 
   /**
    * @param {DynamicFile} dynamic    The data for the dynamic file
-   * @returns {string}                The prefixed name for the file
+   * @returns {string}               The prefixed name for the file
    */
   protected dynamicFileName(dynamic: DynamicFile): string {
     const prefix = !dynamic.extension
@@ -1256,7 +1249,7 @@ export class FontData<
    *   and do any associated setup that needs access to the FontData instance.
    *
    * @param {DynamicFile} dynamic   The data for the file to load
-   * @returns {Promise<void>}        The promise that is resolved when the file is loaded
+   * @returns {Promise<void>}       The promise that is resolved when the file is loaded
    */
   public async loadDynamicFile(dynamic: DynamicFile): Promise<void> {
     if (dynamic.failed) {
@@ -1352,8 +1345,8 @@ export class FontData<
   public addDynamicFontCss(_fonts: string[], _root?: string) {}
 
   /**
-   * @param {number} n  The delimiter character number whose data is desired
-   * @returns {DelimiterData}  The data for that delimiter (or undefined)
+   * @param {number} n          The delimiter character number whose data is desired
+   * @returns {DelimiterData}   The data for that delimiter (or undefined)
    */
   public getDelimiter(n: number): DelimiterData {
     const delim = this.delimiters[n];
@@ -1370,8 +1363,8 @@ export class FontData<
   }
 
   /**
-   * @param {number} n  The delimiter character number whose variant is needed
-   * @param {number} i  The index in the size array of the size whose variant is needed
+   * @param {number} n   The delimiter character number whose variant is needed
+   * @param {number} i   The index in the size array of the size whose variant is needed
    * @returns {string}   The variant of the i-th size for delimiter n
    */
   public getSizeVariant(n: number, i: number): string {
@@ -1383,8 +1376,8 @@ export class FontData<
   }
 
   /**
-   * @param {number} n  The delimiter character number whose variant is needed
-   * @param {number} i  The index in the stretch array of the part whose variant is needed
+   * @param {number} n   The delimiter character number whose variant is needed
+   * @param {number} i   The index in the stretch array of the part whose variant is needed
    * @returns {string}   The variant of the i-th part for delimiter n
    */
   public getStretchVariant(n: number, i: number): string {
@@ -1393,7 +1386,7 @@ export class FontData<
   }
 
   /**
-   * @param {number} n   The delimiter character number whose variants are needed
+   * @param {number} n    The delimiter character number whose variants are needed
    * @returns {string[]}  The variants for the parts of the delimiter
    */
   public getStretchVariants(n: number): string[] {
@@ -1403,7 +1396,7 @@ export class FontData<
   /**
    * @param {string} name       The variant whose character data is being querried
    * @param {number} n          The unicode number for the character to be found
-   * @returns {CharDataArray}    The data for the given character (or undefined)
+   * @returns {CharDataArray}   The data for the given character (or undefined)
    */
   public getChar(name: string, n: number): CharDataArray<C> {
     const char = this.variant[name].chars[n];
@@ -1437,7 +1430,7 @@ export class FontData<
 
   /**
    * @param {string} name   The name of the variant whose data is to be obtained
-   * @returns {V}            The data for the requested variant (or undefined)
+   * @returns {V}           The data for the requested variant (or undefined)
    */
   public getVariant(name: string): V {
     return this.variant[name];
@@ -1445,7 +1438,7 @@ export class FontData<
 
   /**
    * @param {string} variant   The name of the variant whose data is to be obtained
-   * @returns {CssFontData}     The CSS data for the requested variant
+   * @returns {CssFontData}    The CSS data for the requested variant
    */
   public getCssFont(variant: string): CssFontData {
     return this.cssFontMap[variant] || ['serif', false, false];
@@ -1453,7 +1446,7 @@ export class FontData<
 
   /**
    * @param {string} family   The font camily to use
-   * @returns {string}         The family with the css prefix
+   * @returns {string}        The family with the css prefix
    */
   public getFamily(family: string): string {
     return this.cssFamilyPrefix ? this.cssFamilyPrefix + ', ' + family : family;
@@ -1462,7 +1455,7 @@ export class FontData<
   /**
    * @param {string} name   The name of the map to query
    * @param {number} c      The character to remap
-   * @returns {string}       The remapped character (or the original)
+   * @returns {string}      The remapped character (or the original)
    */
   public getRemappedChar(name: string, c: number): string {
     const map = this.remapChars[name] || ({} as RemapMap);

--- a/ts/output/common/LinebreakVisitor.ts
+++ b/ts/output/common/LinebreakVisitor.ts
@@ -22,15 +22,8 @@
  */
 
 import { AbstractVisitor } from '../../core/Tree/Visitor.js';
-import { CommonOutputJax } from '../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../common.js';
 import { CommonWrapperFactory } from './WrapperFactory.js';
-import {
-  FontData,
-  FontDataClass,
-  DelimiterData,
-  VariantData,
-  CharOptions,
-} from './FontData.js';
 import { CommonWrapper, CommonWrapperClass } from './Wrapper.js';
 import { CommonMo } from './Wrappers/mo.js';
 import { CommonMspace } from './Wrappers/mspace.js';
@@ -46,6 +39,7 @@ import { LineBBox } from './LineBBox.js';
 import { TEXCLASS } from '../../core/MmlTree/MmlNode.js';
 import { OPTABLE } from '../../core/MmlTree/OperatorDictionary.js';
 import { MmlNode, TextNode } from '../../core/MmlTree/MmlNode.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /************************************************************************************/
 
@@ -69,17 +63,16 @@ export type BreakData<WW> = [[WW, IndexData], number, number, number, number];
 /**
  * The data used for a line-breaking operation
  */
-/* prettier-ignore */
 export interface StateData<WW> {
-  breaks: Set<[WW, IndexData]>;  // The breakpoints to use and the break index (for mtext)
-  potential: BreakData<WW>[];    // The list of best breakpoints so far
-  width: number;                 // The maximum width for the lines
-  w: number;                     // The accumulated width since the last best breakpoint
-  prevWidth: number;             // The width of the previous line
-  prevBreak: BreakData<WW>;      // The most recent breakpoint used
-  depth: number;                 // The nesting depth of the active node
-  mathWidth: number;             // The full width of the unbroken math
-  mathLeft: number;              // The amount of width left after the most recent break
+  breaks: Set<[WW, IndexData]>; //  The breakpoints to use and the break index (for mtext)
+  potential: BreakData<WW>[]; //    The list of best breakpoints so far
+  width: number; //                 The maximum width for the lines
+  w: number; //                     The accumulated width since the last best breakpoint
+  prevWidth: number; //             The width of the previous line
+  prevBreak: BreakData<WW>; //      The most recent breakpoint used
+  depth: number; //                 The nesting depth of the active node
+  mathWidth: number; //             The full width of the unbroken math
+  mathLeft: number; //              The amount of width left after the most recent break
 }
 
 /************************************************************************************/
@@ -87,32 +80,19 @@ export interface StateData<WW> {
 /**
  * A do-nothing linebreaker for use when automatic linebreaks are not requested
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export class Linebreaks<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
 > extends AbstractVisitor<WW> {
   /**
    * Break a line to the given width
@@ -129,33 +109,20 @@ export class Linebreaks<
  */
 
 /**
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export class LinebreakVisitor<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends Linebreaks<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends Linebreaks<DOM, FONT, JX, WW, WF, WC> {
   /**
    * Penalty functions for the various linebreak values
    */
@@ -173,7 +140,7 @@ export class LinebreakVisitor<
   protected FACTORS: {
     [key: string]: (
       p: number,
-      mo?: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+      mo?: CommonMo<DOM, FONT, JX, WW, WF, WC>
     ) => number;
   } = {
     //
@@ -249,10 +216,7 @@ export class LinebreakVisitor<
     // Adjust for mspace width
     //
     space: (p, node) => {
-      /* prettier-ignore */
-      const mspace = node as any as CommonMspace<
-        N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-      >;
+      const mspace = node as any as CommonMspace<DOM, FONT, JX, WW, WF, WC>;
       if (!mspace.canBreak) return NOBREAK;
       const w = mspace.getBBox().w;
       return w < 0 ? NOBREAK : w < 1 ? p : p - 100 * (w + 4);
@@ -528,10 +492,7 @@ export class LinebreakVisitor<
    * @param {number} _i    The line within that node to break
    */
   public visitMoNode(wrapper: WW, _i: number) {
-    /* prettier-ignore */
-    const mo = wrapper as any as CommonMo<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const mo = wrapper as any as CommonMo<DOM, FONT, JX, WW, WF, WC>;
     const bbox = LineBBox.from(
       mo.getOuterBBox(),
       mo.linebreakOptions.lineleading
@@ -567,9 +528,7 @@ export class LinebreakVisitor<
    * @param {CommonMo} mo    The mo whose penalty is to be computed
    * @returns {number}        The computed penalty
    */
-  protected moPenalty(
-    mo: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-  ): number {
+  protected moPenalty(mo: CommonMo<DOM, FONT, JX, WW, WF, WC>): number {
     const { linebreak, fence, form } = mo.node.attributes.getList(
       'linebreak',
       'fence',
@@ -600,7 +559,7 @@ export class LinebreakVisitor<
    * @returns {MmlNode | null} The core mo if it exists
    */
   protected getPrevious(
-    mo: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    mo: CommonMo<DOM, FONT, JX, WW, WF, WC>
   ): MmlNode | null {
     let child = mo.node;
     let parent = child.parent;
@@ -623,10 +582,7 @@ export class LinebreakVisitor<
    */
   public visitMspaceNode(wrapper: WW, i: number) {
     const bbox = wrapper.getLineBBox(i);
-    /* prettier-ignore */
-    const mspace = wrapper as any as CommonMspace<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const mspace = wrapper as any as CommonMspace<DOM, FONT, JX, WW, WF, WC>;
     if (mspace.canBreak) {
       const penalty = this.mspacePenalty(mspace);
       bbox.getIndentData(wrapper.node);
@@ -647,7 +603,7 @@ export class LinebreakVisitor<
    * @returns {number}               The computed penalty
    */
   protected mspacePenalty(
-    mspace: CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    mspace: CommonMspace<DOM, FONT, JX, WW, WF, WC>
   ): number {
     const linebreak = mspace.node.attributes.get('linebreak');
     const FACTORS = this.FACTORS;
@@ -671,10 +627,7 @@ export class LinebreakVisitor<
       this.visitDefault(wrapper, i);
       return;
     }
-    /* prettier-ignore */
-    const mtext = wrapper as any as CommonMtext<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const mtext = wrapper as any as CommonMtext<DOM, FONT, JX, WW, WF, WC>;
     mtext.clearBreakPoints();
     const space = mtext.textWidth(' ');
     const bbox = wrapper.getBBox();
@@ -755,10 +708,7 @@ export class LinebreakVisitor<
    * @param {number} i     The line within that node to break
    */
   public visitMfracNode(wrapper: WW, i: number) {
-    /* prettier-ignore */
-    const mfrac = wrapper as any as CommonMfrac<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const mfrac = wrapper as any as CommonMfrac<DOM, FONT, JX, WW, WF, WC>;
     if (
       !mfrac.node.attributes.get('bevelled') &&
       mfrac.getOuterBBox().w > this.state.width
@@ -777,10 +727,7 @@ export class LinebreakVisitor<
    */
   public visitMsqrtNode(wrapper: WW, i: number) {
     if (wrapper.getOuterBBox().w > this.state.width) {
-      /* prettier-ignore */
-      const msqrt = wrapper as any as CommonMsqrt<
-        N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-      >;
+      const msqrt = wrapper as any as CommonMsqrt<DOM, FONT, JX, WW, WF, WC>;
       const base = msqrt.childNodes[msqrt.base];
       this.breakToWidth(base, this.state.width - msqrt.rootWidth());
       msqrt.getStretchedSurd();
@@ -804,10 +751,7 @@ export class LinebreakVisitor<
    */
   public visitMsubNode(wrapper: WW, i: number) {
     this.visitDefault(wrapper, i);
-    /* prettier-ignore */
-    const msub = wrapper as any as CommonMsub<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const msub = wrapper as any as CommonMsub<DOM, FONT, JX, WW, WF, WC>;
     const x = msub.getOffset()[0];
     const sbox = msub.scriptChild.getOuterBBox();
     const [L, R] = this.getBorderLR(wrapper);
@@ -823,10 +767,7 @@ export class LinebreakVisitor<
    */
   public visitMsupNode(wrapper: WW, i: number) {
     this.visitDefault(wrapper, i);
-    /* prettier-ignore */
-    const msup = wrapper as any as CommonMsup<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const msup = wrapper as any as CommonMsup<DOM, FONT, JX, WW, WF, WC>;
     const x = msup.getOffset()[0];
     const sbox = msup.scriptChild.getOuterBBox();
     const [L, R] = this.getBorderLR(wrapper);
@@ -842,10 +783,7 @@ export class LinebreakVisitor<
    */
   public visitMsubsupNode(wrapper: WW, i: number) {
     this.visitDefault(wrapper, i);
-    /* prettier-ignore */
-    const msubsup = wrapper as any as CommonMsubsup<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const msubsup = wrapper as any as CommonMsubsup<DOM, FONT, JX, WW, WF, WC>;
     const subbox = msubsup.subChild.getOuterBBox();
     const supbox = msubsup.supChild.getOuterBBox();
     const x = msubsup.getAdjustedIc();
@@ -862,9 +800,7 @@ export class LinebreakVisitor<
    */
   public visitMmultiscriptsNode(wrapper: WW, i: number) {
     /* prettier-ignore */
-    const mmultiscripts = wrapper as any as CommonMmultiscripts<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const mmultiscripts = wrapper as any as CommonMmultiscripts< DOM, FONT, JX, WW, WF, WC>;
     const data = mmultiscripts.scriptData;
     if (data.numPrescripts) {
       const w = Math.max(
@@ -896,10 +832,7 @@ export class LinebreakVisitor<
    * @param {number} i     The line within that node to break
    */
   public visitMfencedNode(wrapper: WW, i: number) {
-    /* prettier-ignore */
-    const mfenced = wrapper as any as CommonMfenced<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const mfenced = wrapper as any as CommonMfenced<DOM, FONT, JX, WW, WF, WC>;
     const bbox = wrapper.getLineBBox(i);
     const [L, R] = this.getBorderLR(wrapper);
     if (i === 0) {
@@ -918,10 +851,7 @@ export class LinebreakVisitor<
    * @param {number} i     The line within that node to break
    */
   public visitMactionNode(wrapper: WW, i: number) {
-    /* prettier-ignore */
-    const maction = wrapper as any as CommonMaction<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    const maction = wrapper as any as CommonMaction<DOM, FONT, JX, WW, WF, WC>;
     const bbox = wrapper.getLineBBox(i);
     const [L, R] = this.getBorderLR(wrapper);
     if (i === 0) {

--- a/ts/output/common/Notation.ts
+++ b/ts/output/common/Notation.ts
@@ -23,6 +23,8 @@
 
 import { CommonWrapper } from './Wrapper.js';
 import { CommonMenclose } from './Wrappers/menclose.js';
+import { DOM } from '../../types/Types.js';
+import { COMMON_FONT as FONT } from '../common.js';
 
 /*****************************************************************/
 
@@ -41,15 +43,12 @@ export const SOLID = THICKNESS + 'em solid'; // a solid border
  * Shorthand for CommonMenclose
  */
 /* prettier-ignore */
-export type Menclose =
-  CommonMenclose<any, any, any, any, any, any, any, any, any, any, any, any, any>;
+export type Menclose = CommonMenclose<DOM, FONT, any, any, any, any, any>;
 
 /**
  * Shorthand for CommonWrapper
  */
-/* prettier-ignore */
-export type AnyWrapper =
-  CommonWrapper<any, any, any, any, any, any, any, any, any, any, any, any>;
+export type AnyWrapper = CommonWrapper<DOM, FONT, any, any, any, any>;
 
 /**
  * Top, right, bottom, left padding data
@@ -59,7 +58,8 @@ export type PaddingData = [number, number, number, number];
 /**
  * The functions used for notation definitions
  *
- * @template N  The DOM node class
+ * @template W   The menclose wrapper class
+ * @template N   The DOM node class
  */
 export type Renderer<W extends AnyWrapper, N> = (node: W, child: N) => void;
 export type BBoxExtender<W extends AnyWrapper> = (node: W) => PaddingData;
@@ -72,14 +72,13 @@ export type Initializer<W extends AnyWrapper> = (node: W) => void;
  * @template W  The menclose wrapper class
  * @template N  The DOM node class
  */
-/* prettier-ignore */
 export type NotationDef<W extends AnyWrapper, N> = {
-  renderer: Renderer<W, N>;  // renders the DOM nodes for the notation
-  bbox: BBoxExtender<W>;     // gives the offsets to the child bounding box: [top, right, bottom, left]
-  border?: BBoxBorder<W>;    // gives the amount of the bbox offset that is due to borders on the child
-  renderChild?: boolean;     // true if the notation is used to render the child directly (e.g., radical)
-  init?: Initializer<W>;     // function to be called during wrapper construction
-  remove?: string;           // list of notations that are suppressed by this one
+  renderer: Renderer<W, N>; //   Renders the DOM nodes for the notation
+  bbox: BBoxExtender<W>; //      Gives the offsets to the child bounding box: [top, right, bottom, left]
+  border?: BBoxBorder<W>; //     Gives the amount of the bbox offset that is due to borders on the child
+  renderChild?: boolean; //      True if the notation is used to render the child directly (e.g., radical)
+  init?: Initializer<W>; //      Function to be called during wrapper construction
+  remove?: string; //            List of notations that are suppressed by this one
 };
 
 /**
@@ -147,7 +146,7 @@ export const arrowHead = (node: Menclose): number => {
  * @param {PaddingData} TRBL The arrow head data
  * @returns {PaddingData} The adjusted arrow head
  */
-export const arrowBBoxHD = (node: Menclose, TRBL: PaddingData) => {
+export const arrowBBoxHD = (node: Menclose, TRBL: PaddingData): PaddingData => {
   if (node.childNodes[0]) {
     const { h, d } = node.childNodes[0].getBBox();
     TRBL[0] = TRBL[2] = Math.max(
@@ -165,7 +164,7 @@ export const arrowBBoxHD = (node: Menclose, TRBL: PaddingData) => {
  * @param {PaddingData} TRBL The arrow head data
  * @returns {PaddingData} The adjusted arrow head
  */
-export const arrowBBoxW = (node: Menclose, TRBL: PaddingData) => {
+export const arrowBBoxW = (node: Menclose, TRBL: PaddingData): PaddingData => {
   if (node.childNodes[0]) {
     const { w } = node.childNodes[0].getBBox();
     TRBL[1] = TRBL[3] = Math.max(0, node.thickness * node.arrowhead.y - w / 2);

--- a/ts/output/common/Wrapper.ts
+++ b/ts/output/common/Wrapper.ts
@@ -38,7 +38,7 @@ import * as LENGTHS from '../../util/lengths.js';
 import { Styles } from '../../util/Styles.js';
 import { StyleJson, StyleJsonSheet } from '../../util/StyleJson.js';
 import { OptionList, lookup } from '../../util/Options.js';
-import { CommonOutputJax } from '../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../common.js';
 import { CommonWrapperFactory } from './WrapperFactory.js';
 import { CommonMo } from './Wrappers/mo.js';
 import { CommonMrow } from './Wrappers/mrow.js';
@@ -46,16 +46,8 @@ import { BBox } from '../../util/BBox.js';
 import { LineBBox } from './LineBBox.js';
 import { Linebreaks } from './LinebreakVisitor.js';
 import { LINEBREAKS as LINEBREAK_OPTIONS } from '../common.js';
-import {
-  FontData,
-  FontDataClass,
-  DelimiterData,
-  VariantData,
-  CharOptions,
-  CharDataArray,
-  DIRECTION,
-  NOSTRETCH,
-} from './FontData.js';
+import { CharDataArray, DIRECTION, NOSTRETCH } from './FontData.js';
+import { DOM_TYPES, N, T, NT } from '../../types/Types.js';
 import { Locale } from '../../util/Locale.js';
 import { COMPONENT } from '../../core/__locales__/Component.js';
 
@@ -123,68 +115,43 @@ export type StyleData = {
 /**
  * Generic CommonWrapper constructor
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export type CommonWrapperConstructor<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
   /* prettier-ignore */
-  CW extends CommonWrapper<
-    N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-  > = CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  CW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>
+    = CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
 > = new (factory: WF, node: MmlNode, parent?: WW) => CW;
 
 /*********************************************************/
 /**
  *  The CommonWrapper class interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonWrapperClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
 > extends WrapperClass<MmlNode, MmlNodeClass, WW> {
   /**
    * The wrapper kind
@@ -240,32 +207,20 @@ export interface CommonWrapperClass<
 /**
  * The base CommonWrapper class
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export class CommonWrapper<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
 > extends AbstractWrapper<MmlNode, MmlNodeClass, WW> {
   /**
    * The wrapper kind
@@ -375,7 +330,7 @@ export class CommonWrapper<
   /**
    * The DOM tree generated for this wrapper
    */
-  public dom: N[] = null;
+  public dom: N<DOM>[] = null;
 
   /**
    * Styles that must be handled directly by the wrappers (mostly having to do with fonts)
@@ -419,12 +374,12 @@ export class CommonWrapper<
   /**
    * Delimiter data for stretching this node (NOSTRETCH means not yet determined)
    */
-  public stretch: DD = NOSTRETCH as DD;
+  public stretch: FONT['DD'] = NOSTRETCH;
 
   /**
    * Easy access to the font parameters
    */
-  public font: FD = null;
+  public font: FONT['FD'] = null;
 
   /**
    * Easy access to the output jax for this node
@@ -440,7 +395,7 @@ export class CommonWrapper<
    *
    * @returns {DOMAdaptor} The DOMAdaptor object
    */
-  get adaptor(): DOMAdaptor<N, T, D> {
+  get adaptor(): DOMAdaptor<DOM> {
     return this.factory.jax.adaptor;
   }
 
@@ -467,12 +422,7 @@ export class CommonWrapper<
    *
    * @returns {Linebreaks} The linebreak visitor
    */
-  /* prettier-ignore */
-  get linebreaks(): Linebreaks<
-    N, T, D,
-    CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-    WW, WF, WC, CC, VV, DD, FD, FC
-  > {
+  get linebreaks(): Linebreaks<DOM, FONT, JX, WW, WF, WC> {
     return this.jax.linebreaks;
   }
 
@@ -503,9 +453,7 @@ export class CommonWrapper<
         ? this.coreMO().embellishedBreakCount
         : node.arity < 0 &&
             !node.linebreakContainer &&
-            /* prettier-ignore */
-            (this.childNodes[0] as any as
-              CommonMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>)
+            (this.childNodes[0] as any as CommonMrow<DOM, FONT, JX, WW, WF, WC>)
               .isStack
           ? this.childNodes[0].breakCount
           : 0;
@@ -1143,11 +1091,10 @@ export class CommonWrapper<
   /**
    * @returns {CommonMo}   The wrapper for this node's core <mo> node
    */
-  public coreMO(): CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  public coreMO(): CommonMo<DOM, FONT, JX, WW, WF, WC> {
     /* prettier-ignore */
-    return this.jax.nodeMap.get(this.node.coreMO()) as any as CommonMo<
-      N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-    >;
+    return this.jax.nodeMap.get(this.node.coreMO()) as
+      any as CommonMo<DOM, FONT, JX, WW, WF, WC>;
   }
 
   /**
@@ -1196,7 +1143,7 @@ export class CommonWrapper<
    * @returns {boolean}         Whether the node can stretch in that direction
    */
   public canStretch(direction: string): boolean {
-    this.stretch = NOSTRETCH as DD;
+    this.stretch = NOSTRETCH;
     if (this.node.isEmbellished) {
       const core = this.core();
       if (core && core.node !== this.node) {
@@ -1393,7 +1340,9 @@ export class CommonWrapper<
       //    the Math Alphabet mapping for this character.
       //  Otherwise use the original code point, n.
       //
-      chars = chars.map((n) => (map[n] as CharDataArray<CC>)?.[3]?.smp || n);
+      chars = chars.map(
+        (n) => (map[n] as CharDataArray<FONT['CC']>)?.[3]?.smp || n
+      );
     }
     return chars;
   }
@@ -1441,9 +1390,7 @@ export class CommonWrapper<
    * @param {string} text   The text for the wrapped element
    * @returns {CommonMo}    The wrapped MmlMo node
    */
-  protected createMo(
-    text: string
-  ): CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  protected createMo(text: string): CommonMo<DOM, FONT, JX, WW, WF, WC> {
     const mmlFactory = (this.node as AbstractMmlNode).factory;
     const textNode = (mmlFactory.create('text') as TextNode).setText(text);
     const mml = mmlFactory.create('mo', { stretchy: true }, [textNode]);
@@ -1451,7 +1398,7 @@ export class CommonWrapper<
     mml.parent = this.node.parent;
     const node = this.wrap(mml);
     node.parent = this as any as WW;
-    return node as any as CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+    return node as any as CommonMo<DOM, FONT, JX, WW, WF, WC>;
   }
 
   /**
@@ -1459,12 +1406,15 @@ export class CommonWrapper<
    * @param {number} n         The number of the character to look up
    * @returns {CharDataArray}  The full CharData object, with CharOptions guaranteed to be defined
    */
-  protected getVariantChar(variant: string, n: number): CharDataArray<CC> {
+  protected getVariantChar(
+    variant: string,
+    n: number
+  ): CharDataArray<FONT['CC']> {
     const char = this.font.getChar(variant, n) || [0, 0, 0, { unknown: true }];
     if (char.length === 3) {
       (char as any)[3] = {};
     }
-    return char as [number, number, number, CC];
+    return char as [number, number, number, FONT['CC']];
   }
 
   /*******************************************************************/
@@ -1478,7 +1428,11 @@ export class CommonWrapper<
    * @param {(N|T)[]} content  The child nodes for the created HTML node
    * @returns {N}              The generated HTML tree
    */
-  public html(type: string, def: OptionList = {}, content: (N | T)[] = []): N {
+  public html(
+    type: string,
+    def: OptionList = {},
+    content: NT<DOM>[] = []
+  ): N<DOM> {
     return this.jax.html(type, def, content);
   }
 
@@ -1486,7 +1440,7 @@ export class CommonWrapper<
    * @param {string} text  The text from which to create an HTML text node
    * @returns {T}          The generated text node with the given text
    */
-  public text(text: string): T {
+  public text(text: string): T<DOM> {
     return this.jax.text(text);
   }
 }

--- a/ts/output/common/WrapperFactory.ts
+++ b/ts/output/common/WrapperFactory.ts
@@ -21,57 +21,39 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { CommonOutputJax } from '../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../common.js';
 import { AbstractWrapperFactory } from '../../core/Tree/WrapperFactory.js';
 import { CommonWrapper, CommonWrapperClass } from './Wrapper.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from './FontData.js';
 import { MmlNode, MmlNodeClass } from '../../core/MmlTree/MmlNode.js';
+import { DOM as ANY_DOM, DOM_TYPES } from '../../types/Types.js';
 
 /*****************************************************************/
 
 /**
  *  The OutputWrapperFactory class for creating OutputWrapper nodes
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export class CommonWrapperFactory<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, any, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
 > extends AbstractWrapperFactory<MmlNode, MmlNodeClass, WW, WC> {
   /**
    * The default list of wrapper nodes this factory can create
    *   (filled in by subclasses)
    */
-  /* prettier-ignore */
   public static defaultNodes: {
-    [kind: string]: CommonWrapperClass<any, any, any, any, any, any, any, any, any, any, any, any>;
+    /* prettier-ignore */
+    [kind: string]: CommonWrapperClass<ANY_DOM, COMMON_FONT, any, any, any, any>;
   } = {};
 
   /**

--- a/ts/output/common/Wrappers/TeXAtom.ts
+++ b/ts/output/common/Wrappers/TeXAtom.ts
@@ -27,78 +27,48 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonTeXAtom interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonTeXAtom<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonTeXAtomClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonTeXAtomClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -106,41 +76,28 @@ export interface CommonTeXAtomClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The Mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The Mixin interface to create
  */
 export function CommonTeXAtomMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonTeXAtomMixin
     extends Base
-    implements CommonTeXAtom<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonTeXAtom<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/TextNode.ts
+++ b/ts/output/common/Wrappers/TextNode.ts
@@ -27,49 +27,31 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
 import { TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMo } from '../../../core/MmlTree/MmlNodes/mo.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonTextNode interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonTextNode<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * @param {string} text     The text to remap
    * @param {string} variant  The variant for the character
@@ -81,33 +63,21 @@ export interface CommonTextNode<
 /**
  * The CommonTextNodeClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonTextNodeClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -115,41 +85,28 @@ export interface CommonTextNodeClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonTextNodeMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonTextNodeMixin
     extends Base
-    implements CommonTextNode<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonTextNode<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/XmlNode.ts
+++ b/ts/output/common/Wrappers/XmlNode.ts
@@ -28,50 +28,37 @@ import {
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
 import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax, ExtendedMetrics, UnknownBBox } from '../../common.js';
+  CommonOutputJax,
+  ExtendedMetrics,
+  UnknownBBox,
+  COMMON_FONT,
+} from '../../common.js';
 import { MmlNode, XMLNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
 import { StyleList } from '../../../util/Styles.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { split } from '../../../util/string.js';
+import { DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonXmlNode interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonXmlNode<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The relative scaling from the root to this node
    */
@@ -80,13 +67,13 @@ export interface CommonXmlNode<
   /**
    * @returns {N}  The HTML for the node
    */
-  getHTML(): N;
+  getHTML(): N<DOM>;
 
   /**
    * @param {N} html            The html to adjust if using or forcing HDW
    * @param {StyleList} styles  The styles object to add to, as needed
    */
-  addHDW(html: N, styles: StyleList): N;
+  addHDW(html: N<DOM>, styles: StyleList): N<DOM>;
 
   /**
    * @param {N} xml          The XML tree to check
@@ -94,7 +81,7 @@ export interface CommonXmlNode<
    * @param {string} force   The second (optional) xmlHDW value to check
    * @returns {string}       The data-mjx-hdw value, if the options are met
    */
-  getHDW(xml: N, use: string, force?: string): string;
+  getHDW(xml: N<DOM>, use: string, force?: string): string;
 
   /**
    * @param {string} hdw     The data-mjx-hdw string to split
@@ -106,33 +93,21 @@ export interface CommonXmlNode<
 /**
  * The CommonXmlNodeClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonXmlNodeClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -140,41 +115,28 @@ export interface CommonXmlNodeClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The Mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The Mixin interface to create
  */
 export function CommonXmlNodeMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   abstract class CommonXmlNodeMixin
     extends Base
-    implements CommonXmlNode<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonXmlNode<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * Don't set up inline-block styles for this
@@ -226,7 +188,7 @@ export function CommonXmlNodeMixin<
      * @override
      */
     public computeBBox(bbox: BBox, _recompute: boolean = false) {
-      const xml = (this.node as XMLNode).getXML() as N;
+      const xml = (this.node as XMLNode).getXML() as N<DOM>;
       const hdw = this.getHDW(xml, 'use', 'force');
       const { h, d, w } = hdw ? this.splitHDW(hdw) : this.measureXmlNode(xml);
       bbox.w = w;
@@ -237,9 +199,9 @@ export function CommonXmlNodeMixin<
     /**
      * @override
      */
-    public getHTML(): N {
+    public getHTML(): N<DOM> {
       const adaptor = this.adaptor;
-      let html = adaptor.clone((this.node as XMLNode).getXML() as N);
+      let html = adaptor.clone((this.node as XMLNode).getXML() as N<DOM>);
       const styles = this.getFontStyles();
       const hdw = this.getHDW(html, 'force');
       if (hdw || this.jax.options.scale !== 1) {
@@ -255,12 +217,12 @@ export function CommonXmlNodeMixin<
     /**
      * @override
      */
-    abstract addHDW(html: N, _styles: StyleList): N;
+    abstract addHDW(html: N<DOM>, _styles: StyleList): N<DOM>;
 
     /**
      * @override
      */
-    public getHDW(xml: N, use: string, force: string = use): string {
+    public getHDW(xml: N<DOM>, use: string, force: string = use): string {
       const option = this.jax.options.htmlHDW;
       const hdw = this.adaptor.getAttribute(xml, 'data-mjx-hdw') as string;
       return hdw && (option === use || option === force) ? hdw : null;
@@ -299,7 +261,7 @@ export function CommonXmlNodeMixin<
      * @param {N} xml          The xml content node to be measured
      * @returns {UnknownBBox}  The width, height, and depth of the content
      */
-    public measureXmlNode(xml: N): UnknownBBox {
+    public measureXmlNode(xml: N<DOM>): UnknownBBox {
       const adaptor = this.adaptor;
       const content = this.html(
         'mjx-xml-block',

--- a/ts/output/common/Wrappers/maction.ts
+++ b/ts/output/common/Wrappers/maction.ts
@@ -27,14 +27,7 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMaction } from '../../../core/MmlTree/MmlNodes/maction.js';
 import { TextNode } from '../../../core/MmlTree/MmlNode.js';
@@ -42,113 +35,77 @@ import { STATE } from '../../../core/MathItem.js';
 import { mathjax } from '../../../mathjax.js';
 import { BBox } from '../../../util/BBox.js';
 import { split } from '../../../util/string.js';
+import { DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The types needed to define the actiontypes
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The Font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  *
  * @template MA  The Maction type
  */
 export type ActionData = { [name: string]: any };
 
 export type ActionHandler<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  MA extends CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  MA extends CommonMaction<DOM, FONT, JX, WW, WF, WC>,
 > = (node: MA, data?: ActionData) => void;
 
 export type ActionPair<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  MA extends CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-> = [
-  ActionHandler<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC, MA>,
-  ActionData,
-];
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  MA extends CommonMaction<DOM, FONT, JX, WW, WF, WC>,
+> = [ActionHandler<DOM, FONT, JX, WW, WF, WC, MA>, ActionData];
 
 export type ActionMap<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  MA extends CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-> = Map<string, ActionPair<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC, MA>>;
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  MA extends CommonMaction<DOM, FONT, JX, WW, WF, WC>,
+> = Map<string, ActionPair<DOM, FONT, JX, WW, WF, WC, MA>>;
 
 export type ActionDef<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  MA extends CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-> = [
-  string,
-  [ActionHandler<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC, MA>, ActionData],
-];
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  MA extends CommonMaction<DOM, FONT, JX, WW, WF, WC>,
+> = [string, [ActionHandler<DOM, FONT, JX, WW, WF, WC, MA>, ActionData]];
 
 export type EventHandler = (event: Event) => void;
 
 /**
  * Data used for tooltip actions
  */
-/* prettier-ignore */
 export const TooltipData = {
-  dx: '.2em',          // x-offset of tooltip from right side of maction bbox
-  dy: '.1em',          // y-offset of tooltip from bottom of maction bbox
+  dx: '.2em', //          x-offset of tooltip from right side of maction bbox
+  dy: '.1em', //          y-offset of tooltip from bottom of maction bbox
 
-  postDelay: 600,      // milliseconds before tooltip posts
-  clearDelay: 100,     // milliseconds before tooltip is removed
+  postDelay: 600, //      milliseconds before tooltip posts
+  clearDelay: 100, //     milliseconds before tooltip is removed
 
-  hoverTimer: new Map<any, number>(),    // timers for posting tooltips
-  clearTimer: new Map<any, number>(),    // timers for removing tooltips
+  hoverTimer: new Map<any, number>(), //    timers for posting tooltips
+  clearTimer: new Map<any, number>(), //    timers for removing tooltips
 
   /*
    * clear the timers if any are active
@@ -162,48 +119,35 @@ export const TooltipData = {
       clearTimeout(data.hoverTimer.get(node));
       data.hoverTimer.delete(node);
     }
-  }
-
+  },
 };
 
 /*****************************************************************/
 /**
  * The CommonMaction interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMaction<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The handler for the specified actiontype
    */
   /* prettier-ignore */
   action: ActionHandler<
-    N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
-    CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    DOM, FONT, JX, WW, WF, WC,
+    CommonMaction<DOM, FONT, JX, WW, WF, WC>
   >;
   /**
    * The data for the specified actiontype
@@ -242,7 +186,7 @@ export interface CommonMaction<
    * @param {N=} dom The DOM node. If not provided goes over all elements of
    *the dom tree of this wrapper.
    */
-  setEventHandler(type: string, handler: EventHandler, dom?: N): void;
+  setEventHandler(type: string, handler: EventHandler, dom?: N<DOM>): void;
 
   /**
    * Public access to em method (for use in notation functions)
@@ -262,39 +206,27 @@ export interface CommonMaction<
 /**
  * The CommonMaction class interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font node types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMactionClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The valid action types and their handlers
    */
   /* prettier-ignore */
-  actions: ActionMap<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
-    CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+  actions: ActionMap<DOM, FONT, JX, WW, WF, WC,
+    CommonMaction<DOM, FONT, JX, WW, WF, WC>
   >;
 }
 
@@ -304,46 +236,32 @@ export interface CommonMactionClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMactionMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMactionMixin
     extends Base
-    implements CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMaction<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
      */
-    /* prettier-ignore */
     public static actions = new Map([
       [
         'toggle',
@@ -404,7 +322,7 @@ export function CommonMactionMixin<
 
       [
         'tooltip',
-        [(_node, _data) => {}, {}] // overriden in by subclasses
+        [(_node, _data) => {}, {}], // overriden in by subclasses
       ],
 
       [
@@ -446,16 +364,22 @@ export function CommonMactionMixin<
           },
         ],
       ],
-    ]) as ActionMap<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD,
-      FC, CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    ]) as ActionMap<
+      DOM,
+      FONT,
+      JX,
+      WW,
+      WF,
+      WC,
+      CommonMaction<DOM, FONT, JX, WW, WF, WC>
     >;
 
     /**
      * @override
      */
     /* prettier-ignore */
-    public action: ActionHandler<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
-      CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    public action: ActionHandler<DOM, FONT, JX, WW, WF, WC,
+      CommonMaction<DOM, FONT, JX, WW, WF, WC>
     >;
 
     /**
@@ -507,18 +431,16 @@ export function CommonMactionMixin<
      */
     constructor(factory: WF, node: MmlNode, parent: WW = null) {
       super(factory, node, parent);
-      const actions =
-        /* prettier-ignore */
-        (this.constructor as
-         CommonMactionClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>)
-        .actions;
+      const actions = (
+        this.constructor as CommonMactionClass<DOM, FONT, JX, WW, WF, WC>
+      ).actions;
       const action = this.node.attributes.get('actiontype') as string;
       const [handler, data] =
         /* prettier-ignore */
         actions.get(action) || [
           ((_node, _data) => {}) as ActionHandler<
-            N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
-            CommonMaction<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+            DOM, FONT, JX, WW, WF, WC,
+            CommonMaction<DOM, FONT, JX, WW, WF, WC>
           >,
           {},
         ];
@@ -554,7 +476,11 @@ export function CommonMactionMixin<
     /**
      * @override
      */
-    public setEventHandler(type: string, handler: EventHandler, dom: N = null) {
+    public setEventHandler(
+      type: string,
+      handler: EventHandler,
+      dom: N<DOM> = null
+    ) {
       (dom ? [dom] : this.dom).forEach((node) =>
         (node as any).addEventListener(type, handler)
       );

--- a/ts/output/common/Wrappers/math.ts
+++ b/ts/output/common/Wrappers/math.ts
@@ -27,120 +27,74 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMath interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMath<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMathClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMathClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
  *  The CommonMath wrapper mixin for the MmlMath object
  *
- * @param {CommonWrapperConstructor} Base The constructor class to extend
- * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @param {CommonWrapperConstructor} Base   The constructor class to extend
+ * @returns {B}                             The mixin constructor
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMathMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMathMixin
     extends Base
-    implements CommonMath<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMath<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/menclose.ts
+++ b/ts/output/common/Wrappers/menclose.ts
@@ -27,62 +27,44 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMsqrt } from './msqrt.js';
 import * as Notation from '../Notation.js';
 import { BBox } from '../../../util/BBox.js';
 import { MmlNode, AbstractMmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { split } from '../../../util/string.js';
+import { DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMenclose interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  *
  * @template S   The msqrt wrapper type
  */
 export interface CommonMenclose<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  S extends CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  S extends CommonMsqrt<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The notations active on this menclose, if any
    */
-  notations: Notation.List<WW, N>;
+  notations: Notation.List<WW, N<DOM>>;
   /**
    * The notation to use for the child, if any
    */
-  renderChild: Notation.Renderer<WW, N>;
+  renderChild: Notation.Renderer<WW, N<DOM>>;
 
   /**
    * A fake msqrt for radial notation (if used)
@@ -177,7 +159,7 @@ export interface CommonMenclose<
     double: boolean,
     offset?: string,
     trans?: number
-  ): N;
+  ): N<DOM>;
 
   /**
    * Get the angle and width of a diagonal arrow, plus the x and y extension
@@ -214,37 +196,25 @@ export interface CommonMenclose<
 /**
  * The CommonMenclose class interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMencloseClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {
   /**
    *  The definitions of the various notations
    */
-  notations: Notation.DefList<WW, N>;
+  notations: Notation.DefList<WW, N<DOM>>;
 }
 
 /*****************************************************************/
@@ -253,53 +223,40 @@ export interface CommonMencloseClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template S   The msqrt wrapper class
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template S     The msqrt wrapper class
+ * @template B     The mixin interface to create
  */
 export function CommonMencloseMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  S extends CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  S extends CommonMsqrt<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMencloseMixin
     extends Base
-    implements CommonMenclose<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC, S>
+    implements CommonMenclose<DOM, FONT, JX, WW, WF, WC, S>
   {
     /**
      * @override
      */
-    public notations: Notation.List<WW, N> = {};
+    public notations: Notation.List<WW, N<DOM>> = {};
 
     /**
      * @override
      */
-    public renderChild: Notation.Renderer<WW, N> = null;
+    public renderChild: Notation.Renderer<WW, N<DOM>> = null;
 
     /**
      * @override
@@ -356,11 +313,8 @@ export function CommonMencloseMixin<
      * @override
      */
     public getNotations() {
-      /* prettier-ignore */
       const Notations = (
-        this.constructor as CommonMencloseClass<
-          N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-        >
+        this.constructor as CommonMencloseClass<DOM, FONT, JX, WW, WF, WC>
       ).notations;
       for (const name of split(
         this.node.attributes.get('notation') as string
@@ -468,8 +422,8 @@ export function CommonMencloseMixin<
       _double: boolean,
       _offset: string = '',
       _dist: number = 0
-    ): N {
-      return null as N;
+    ): N<DOM> {
+      return null as N<DOM>;
     }
 
     /**

--- a/ts/output/common/Wrappers/mfenced.ts
+++ b/ts/output/common/Wrappers/mfenced.ts
@@ -27,54 +27,36 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonInferredMrow } from './mrow.js';
 import { MmlNode, AbstractMmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMfenced } from '../../../core/MmlTree/MmlNodes/mfenced.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMfenced interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMfenced<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * An mrow to use for the layout of the mfenced
    */
-  mrow: CommonInferredMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+  mrow: CommonInferredMrow<DOM, FONT, JX, WW, WF, WC>;
 
   /**
    * Creates the mrow wrapper to use for the layout
@@ -99,33 +81,21 @@ export interface CommonMfenced<
 /**
  * The CommonMfencedClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMfencedClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -133,48 +103,33 @@ export interface CommonMfencedClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMfencedMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMfencedMixin
     extends Base
-    implements CommonMfenced<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMfenced<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
      */
-    /* prettier-ignore */
-    public mrow:
-      CommonInferredMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> = null;
+    public mrow: CommonInferredMrow<DOM, FONT, JX, WW, WF, WC> = null;
 
     /**
      * @override

--- a/ts/output/common/Wrappers/mfrac.ts
+++ b/ts/output/common/Wrappers/mfrac.ts
@@ -27,54 +27,36 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMo } from './mo.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
 import { DIRECTION } from '../FontData.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMfrac interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMfrac<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * Wrapper for <mo> to use for bevelled fraction
    */
-  bevel: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+  bevel: CommonMo<DOM, FONT, JX, WW, WF, WC>;
 
   /**
    * Padding around fractions
@@ -146,33 +128,21 @@ export interface CommonMfrac<
 /**
  * The CommonMfracClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMfracClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -180,46 +150,33 @@ export interface CommonMfracClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMfracMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMfracMixin
     extends Base
-    implements CommonMfrac<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMfrac<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
      */
-    public bevel: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> = null;
+    public bevel: CommonMo<DOM, FONT, JX, WW, WF, WC> = null;
 
     /**
      * @override

--- a/ts/output/common/Wrappers/mglyph.ts
+++ b/ts/output/common/Wrappers/mglyph.ts
@@ -27,49 +27,31 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonTextNode } from './TextNode.js';
 import { MmlNode, TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMglyph interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMglyph<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The image's width converted to em's
    */
@@ -86,7 +68,7 @@ export interface CommonMglyph<
   /**
    * TextNode used for deprecated fontfamily/index use case
    */
-  charWrapper: CommonTextNode<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+  charWrapper: CommonTextNode<DOM, FONT, JX, WW, WF, WC>;
 
   /**
    * Obtain the width, height, and valign.
@@ -101,33 +83,21 @@ export interface CommonMglyph<
 /**
  * The CommonMglyphClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMglyphClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -135,41 +105,28 @@ export interface CommonMglyphClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMglyphMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMglyphMixin
     extends Base
-    implements CommonMglyph<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMglyph<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -187,9 +144,7 @@ export function CommonMglyphMixin<
     /**
      * @override
      */
-    /* prettier-ignore */
-    public charWrapper:
-      CommonTextNode<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+    public charWrapper: CommonTextNode<DOM, FONT, JX, WW, WF, WC>;
 
     /**
      * @override

--- a/ts/output/common/Wrappers/mi.ts
+++ b/ts/output/common/Wrappers/mi.ts
@@ -27,78 +27,48 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMi interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMi<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMiClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMiClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -106,41 +76,28 @@ export interface CommonMiClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMiMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMiMixin
     extends Base
-    implements CommonMi<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMi<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/mmultiscripts.ts
+++ b/ts/output/common/Wrappers/mmultiscripts.ts
@@ -23,30 +23,23 @@
 
 import { CommonWrapper, CommonWrapperClass, Constructor } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMsubsup, CommonMsubsupClass } from './msubsup.js';
 import { BBox } from '../../../util/BBox.js';
 import { LineBBox } from '../LineBBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 
 /**
  * The data about the scripts and base
  */
-/* prettier-ignore */
 export type ScriptData = {
   base: BBox;
-  sub: BBox;   // combined bbox for all subscripts
-  sup: BBox;   // combined bbox for all superscripts
-  psub: BBox;  // combined bbox for all presubscripts
-  psup: BBox;  // combined bbox for all presuperscripts
+  sub: BBox; //   Combined bbox for all subscripts
+  sup: BBox; //   Combined bbox for all superscripts
+  psub: BBox; //  Combined bbox for all presubscripts
+  psup: BBox; //  Combined bbox for all presuperscripts
   numPrescripts: number;
   numScripts: number;
 };
@@ -84,33 +77,21 @@ export const ScriptNames = ['sup', 'sup', 'psup', 'psub'] as ScriptDataName[];
 /**
  * The CommonMmultiscripts interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMmultiscripts<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMsubsup<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMsubsup<DOM, FONT, JX, WW, WF, WC> {
   /**
    *  The cached data for the various bounding boxes
    */
@@ -181,33 +162,21 @@ export interface CommonMmultiscripts<
 /**
  * The CommonMmlultisciptsClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMmultiscriptsClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMsubsupClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMsubsupClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -215,41 +184,28 @@ export interface CommonMmultiscriptsClass<
  *
  * @param {Constructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMmultiscriptsMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonMsubsupClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: Constructor<CommonMsubsup<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonMsubsupClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: Constructor<CommonMsubsup<DOM, FONT, JX, WW, WF, WC>>): B {
   return class CommonMmultiscriptsMixin
     extends Base
-    implements CommonMmultiscripts<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMmultiscripts<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/mn.ts
+++ b/ts/output/common/Wrappers/mn.ts
@@ -27,77 +27,47 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMn interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMn<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMnClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMnClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -105,41 +75,28 @@ export interface CommonMnClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMnMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMnMixin
     extends Base
-    implements CommonMn<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMn<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/mo.ts
+++ b/ts/output/common/Wrappers/mo.ts
@@ -27,52 +27,35 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { DelimiterData } from '../FontData.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { MmlNode, TEXCLASS } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMo } from '../../../core/MmlTree/MmlNodes/mo.js';
 import { BBox } from '../../../util/BBox.js';
 import { LineBBox } from '../LineBBox.js';
 import { unicodeChars } from '../../../util/string.js';
 import { DIRECTION, NOSTRETCH } from '../FontData.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMo interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMo<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The font size that a stretched operator uses.
    * If -1, then stretch arbitrarily, and bbox gives the actual height, depth, width
@@ -92,7 +75,7 @@ export interface CommonMo<
   /**
    * The linebreakmultchar used for breaking an invisible times
    */
-  multChar: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+  multChar: CommonMo<DOM, FONT, JX, WW, WF, WC>;
 
   /**
    * Value is 1 if this embellished mo is a breakpoint, 0 otherwise
@@ -198,33 +181,21 @@ export interface CommonMo<
 /**
  * The CommonMoClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMoClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -232,41 +203,28 @@ export interface CommonMoClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMoMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMoMixin
     extends Base
-    implements CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMo<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -286,7 +244,7 @@ export function CommonMoMixin<
     /**
      * The linebreakmultchar used for breaking an invisible times
      */
-    public multChar: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+    public multChar: CommonMo<DOM, FONT, JX, WW, WF, WC>;
 
     /**
      * @override
@@ -387,7 +345,7 @@ export function CommonMoMixin<
       const C = this.getText().codePointAt(0);
       let delim = this.stretch;
       if (this.size) {
-        this.stretch = delim = this.font.getDelimiter(C) as DD;
+        this.stretch = delim = this.font.getDelimiter(C) as FONT['DD'];
         this.size = null;
       }
       const c = delim.c || C;
@@ -671,7 +629,7 @@ export function CommonMoMixin<
       const delim = this.font.getDelimiter(c.codePointAt(0));
       this.stretch = (
         delim && delim.dir === direction ? delim : NOSTRETCH
-      ) as DD;
+      ) as FONT['DD'];
       return this.stretch.dir !== DIRECTION.None;
     }
 

--- a/ts/output/common/Wrappers/mpadded.ts
+++ b/ts/output/common/Wrappers/mpadded.ts
@@ -27,48 +27,30 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
 import { Property } from '../../../core/Tree/Node.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMpadded interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMpadded<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * Get the content bounding box, and the change in size and offsets
    *   as specified by the parameters
@@ -101,33 +83,21 @@ export interface CommonMpadded<
 /**
  * The CommonMpaddedClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMpaddedClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -135,41 +105,28 @@ export interface CommonMpaddedClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMpaddedMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMpaddedMixin
     extends Base
-    implements CommonMpadded<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMpadded<DOM, FONT, JX, WW, WF, WC>
   {
     get containerWidth(): number {
       const attributes = this.node.attributes;

--- a/ts/output/common/Wrappers/mroot.ts
+++ b/ts/output/common/Wrappers/mroot.ts
@@ -23,79 +23,49 @@
 
 import { CommonWrapper, CommonWrapperClass, Constructor } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMsqrt, CommonMsqrtClass } from './msqrt.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMroot interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMroot<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMsqrt<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMrootClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMrootClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMsqrtClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMsqrtClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -103,41 +73,28 @@ export interface CommonMrootClass<
  *
  * @param {Constructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMrootMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonMsqrtClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: Constructor<CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonMsqrtClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: Constructor<CommonMsqrt<DOM, FONT, JX, WW, WF, WC>>): B {
   return class CommonMrootMixin
     extends Base
-    implements CommonMroot<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMroot<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/mrow.ts
+++ b/ts/output/common/Wrappers/mrow.ts
@@ -27,50 +27,32 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
 import { LineBBox } from '../LineBBox.js';
 import { DIRECTION } from '../FontData.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMrow interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMrow<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * True if this mrow is not the top-level linebreak mrow
    */
@@ -91,33 +73,21 @@ export interface CommonMrow<
 /**
  * The CommonMrowClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMrowClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -125,41 +95,28 @@ export interface CommonMrowClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMrowMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMrowMixin
     extends Base
-    implements CommonMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMrow<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -456,64 +413,40 @@ export function CommonMrowMixin<
 /**
  * The CommonInferredMrow interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonInferredMrow<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMrow<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonInferredMrowClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonInferredMrowClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMrowClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMrowClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -521,45 +454,34 @@ export interface CommonInferredMrowClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonInferredMrowMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonMrowClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonMrowClass<DOM, FONT, JX, WW, WF, WC>,
 >(
   /* prettier-ignore */
   Base: CommonWrapperConstructor<
-    N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
-    CommonMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    DOM, FONT, JX, WW, WF, WC,
+    CommonMrow<DOM, FONT, JX, WW, WF, WC>
   >
 ): B {
   return class CommonInferredMrowMixin
     extends Base
-    implements CommonInferredMrow<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonInferredMrow<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * Since inferred rows don't produce a container node, we can't

--- a/ts/output/common/Wrappers/ms.ts
+++ b/ts/output/common/Wrappers/ms.ts
@@ -27,47 +27,29 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMs interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMs<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * Create a text wrapper with the given text;
    *
@@ -80,33 +62,21 @@ export interface CommonMs<
 /**
  * The CommonMsClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -114,41 +84,28 @@ export interface CommonMsClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMsMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMsMixin
     extends Base
-    implements CommonMs<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMs<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * Create a text wrapper with the given text;

--- a/ts/output/common/Wrappers/mspace.ts
+++ b/ts/output/common/Wrappers/mspace.ts
@@ -27,50 +27,32 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMspace } from '../../../core/MmlTree/MmlNodes/mspace.js';
 import { BBox } from '../../../util/BBox.js';
 import { LineBBox } from '../LineBBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMspance interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMspace<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * True when mspace is allowed to break
    */
@@ -92,33 +74,21 @@ export interface CommonMspace<
 /**
  * The CommonMspaceClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMspaceClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -126,41 +96,28 @@ export interface CommonMspaceClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMspaceMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMspaceMixin
     extends Base
-    implements CommonMspace<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMspace<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/msqrt.ts
+++ b/ts/output/common/Wrappers/msqrt.ts
@@ -27,50 +27,32 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMo } from './mo.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
 import { DIRECTION } from '../FontData.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMsqrt interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsqrt<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The index of the base of the root in childNodes
    */
@@ -84,7 +66,7 @@ export interface CommonMsqrt<
   /**
    * The surd node
    */
-  surd: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+  surd: CommonMo<DOM, FONT, JX, WW, WF, WC>;
 
   /**
    * The requested height of the stretched surd character
@@ -127,33 +109,21 @@ export interface CommonMsqrt<
 /**
  * The CommonMsqrtClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsqrtClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -161,41 +131,28 @@ export interface CommonMsqrtClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMsqrtMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMsqrtMixin
     extends Base
-    implements CommonMsqrt<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMsqrt<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -214,7 +171,7 @@ export function CommonMsqrtMixin<
     /**
      * @override
      */
-    public surd: CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+    public surd: CommonMo<DOM, FONT, JX, WW, WF, WC>;
 
     /**
      * @override

--- a/ts/output/common/Wrappers/msubsup.ts
+++ b/ts/output/common/Wrappers/msubsup.ts
@@ -24,14 +24,7 @@
 
 import { CommonWrapper, CommonWrapperClass } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import {
   CommonScriptbase,
   CommonScriptbaseClass,
@@ -43,111 +36,75 @@ import {
   MmlMsub,
   MmlMsup,
 } from '../../../core/MmlTree/MmlNodes/msubsup.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMsub interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsub<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbase<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMsubClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsubClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
  * The CommonMsub wrapper mixin for the MmlMsub object
  *
- * @param {CommonScriptbaseConstructor} Base The constructor class to extend
- * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @param {CommonScriptbaseConstructor} Base   The constructor class to extend
+ * @returns {B}                                The mixin constructor
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMsubMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonScriptbaseConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMsubMixin
     extends Base
-    implements CommonMsub<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMsub<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * Do not include italic correction
@@ -177,106 +134,69 @@ export function CommonMsubMixin<
 /**
  * The CommonMsup interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsup<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbase<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMsupClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsupClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
  * The CommonMsup wrapper mixin for the MmlMsup object
  *
- * @param {CommonScriptbaseConstructor} Base The constructor class to extend
- * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @param {CommonScriptbaseConstructor} Base   The constructor class to extend
+ * @returns {B}                                The mixin constructor
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMsupMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonScriptbaseConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMsupMixin
     extends Base
-    implements CommonMsup<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMsup<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -301,33 +221,21 @@ export function CommonMsupMixin<
 /**
  * The CommonMsubsup interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsubsup<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbase<DOM, FONT, JX, WW, WF, WC> {
   /**
    *  Cached values for the script offsets and separation (so if they are
    *  computed in computeBBox(), they don't have to be recomputed during output)
@@ -349,7 +257,7 @@ export interface CommonMsubsup<
    *
    * @param {BBox} subbox     The bounding box of the superscript
    * @param {BBox} supbox     The bounding box of the subscript
-   * @returns {number[]}       The vertical offsets for super and subscripts, and the space between them
+   * @returns {number[]}      The vertical offsets for super and subscripts, and the space between them
    */
   getUVQ(subbox?: BBox, supbox?: BBox): number[];
 }
@@ -357,75 +265,50 @@ export interface CommonMsubsup<
 /**
  * The CommonMsubsupClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMsubsupClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
  * The CommomMsubsup wrapper for the MmlMsubsup object
  *
- * @param {CommonScriptbaseConstructor} Base The constructor class to extend
- * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @param {CommonScriptbaseConstructor} Base   The constructor class to extend
+ * @returns {B}                                The mixin constructor
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMsubsupMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonScriptbaseConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMsubsupMixin
     extends Base
-    implements CommonMsubsup<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMsubsup<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * Do not include italic correction

--- a/ts/output/common/Wrappers/mtable.ts
+++ b/ts/output/common/Wrappers/mtable.ts
@@ -27,14 +27,7 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMtr } from './mtr.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { BBox } from '../../../util/BBox.js';
@@ -42,6 +35,7 @@ import { DIRECTION } from '../FontData.js';
 import { split, isPercent } from '../../../util/string.js';
 import { sum, max } from '../../../util/numeric.js';
 import { Styles, TRBL } from '../../../util/Styles.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
@@ -74,36 +68,24 @@ export const BREAK_BELOW = 0.333;
 /**
  * The CommonMtable interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  *
- * @template R   The class for table rows
+ * @template R     The class for table rows
  */
 export interface CommonMtable<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  R extends CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  R extends CommonMtr<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The number of columns in the table
    */
@@ -447,33 +429,21 @@ export interface CommonMtable<
 /**
  * The CommonMtableClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtableClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -481,43 +451,30 @@ export interface CommonMtableClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template R   The table row class
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template R     The table row class
+ * @template B     The mixin interface to create
  */
 export function CommonMtableMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  R extends CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  R extends CommonMtr<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMtableMixin
     extends Base
-    implements CommonMtable<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC, R>
+    implements CommonMtable<DOM, FONT, JX, WW, WF, WC, R>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/mtd.ts
+++ b/ts/output/common/Wrappers/mtd.ts
@@ -27,79 +27,49 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMtable } from '../../common/Wrappers/mtable.js';
 import { CommonMtr } from '../../common/Wrappers/mtr.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMtd interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtd<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMtdClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtdClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -107,41 +77,28 @@ export interface CommonMtdClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMtdMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMtdMixin
     extends Base
-    implements CommonMtd<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMtd<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -162,14 +119,16 @@ export function CommonMtdMixin<
      * @override
      */
     public getWrapWidth(_j: number) {
-      /* prettier-ignore */
-      const table = this.parent.parent as any as
-        CommonMtable<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC,
-          CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-         >;
-      /* prettier-ignore */
-      const row = this.parent as any as
-        CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+      const table = this.parent.parent as any as CommonMtable<
+        DOM,
+        FONT,
+        JX,
+        WW,
+        WF,
+        WC,
+        CommonMtr<DOM, FONT, JX, WW, WF, WC>
+      >;
+      const row = this.parent as any as CommonMtr<DOM, FONT, JX, WW, WF, WC>;
       const i = this.node.childPosition() - (row.labeled ? 1 : 0);
       return (
         typeof table.cWidths[i] === 'number'

--- a/ts/output/common/Wrappers/mtext.ts
+++ b/ts/output/common/Wrappers/mtext.ts
@@ -27,49 +27,31 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { IndexData } from '../LinebreakVisitor.js';
 import { LineBBox } from '../LineBBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMtext interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtext<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The list of breakpoints within the text
    */
@@ -106,33 +88,21 @@ export interface CommonMtext<
 /**
  * The CommonMtextClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtextClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The font-family, weight, and style to use for the variants when mtextInheritFont
    * is true or mtextFont is specified.  If not in this list, then the font's
@@ -144,45 +114,32 @@ export interface CommonMtextClass<
 
 /*****************************************************************/
 /**
-b *  The CommonMtext wrapper mixin for the MmlMtext object
+ *  The CommonMtext wrapper mixin for the MmlMtext object
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMtextMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMtextMixin
     extends Base
-    implements CommonMtext<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMtext<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/mtr.ts
+++ b/ts/output/common/Wrappers/mtr.ts
@@ -29,48 +29,30 @@ import {
   Constructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
 import { DIRECTION } from '../FontData.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMtr interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtr<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The number of mtd's in the mtr
    */
@@ -111,33 +93,21 @@ export interface CommonMtr<
 /**
  * The CommonMtrClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMtrClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -145,41 +115,28 @@ export interface CommonMtrClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMtrMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMtrMixin
     extends Base
-    implements CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMtr<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -285,64 +242,40 @@ export function CommonMtrMixin<
 /**
  * The CommonMlabeledtr interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMlabeledtr<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMtr<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMlabeledtrClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMlabeledtrClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonMtrClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonMtrClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -350,41 +283,28 @@ export interface CommonMlabeledtrClass<
  *
  * @param {Constructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMlabeledtrMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonMtrClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: Constructor<CommonMtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonMtrClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: Constructor<CommonMtr<DOM, FONT, JX, WW, WF, WC>>): B {
   return class CommonMlabeledtrMixin
     extends Base
-    implements CommonMlabeledtr<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMlabeledtr<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/common/Wrappers/munderover.ts
+++ b/ts/output/common/Wrappers/munderover.ts
@@ -24,14 +24,7 @@
 
 import { CommonWrapper, CommonWrapperClass } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import {
   CommonScriptbase,
   CommonScriptbaseClass,
@@ -43,69 +36,46 @@ import {
   MmlMover,
 } from '../../../core/MmlTree/MmlNodes/munderover.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonMunder interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMunder<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbase<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMunderClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMunderClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -113,41 +83,28 @@ export interface CommonMunderClass<
  *
  * @param {CommonScriptbaseConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMunderMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonScriptbaseConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMunderMixin
     extends Base
-    implements CommonMunder<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMunder<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -194,64 +151,40 @@ export function CommonMunderMixin<
 /**
  * The CommonMover interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMover<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbase<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonMoverClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMoverClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -259,40 +192,28 @@ export interface CommonMoverClass<
  *
  * @param {CommonScriptbaseConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
- * @template B   The mixin interface to create
+ *
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMoverMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonScriptbaseConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMoverMixin
     extends Base
-    implements CommonMover<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMover<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override
@@ -342,33 +263,21 @@ export function CommonMoverMixin<
 /**
  * The CommonMunderover interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMunderover<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbase<DOM, FONT, JX, WW, WF, WC> {
   /*
    * The wrapped under node
    */
@@ -383,33 +292,21 @@ export interface CommonMunderover<
 /**
  * The CommonMunderoverClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonMunderoverClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonScriptbaseClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -417,41 +314,28 @@ export interface CommonMunderoverClass<
  *
  * @param {CommonScriptbaseConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonMunderoverMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonScriptbaseConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonScriptbaseConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonMunderoverMixin
     extends Base
-    implements CommonMunderover<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonMunderover<DOM, FONT, JX, WW, WF, WC>
   {
     /*
      * @override

--- a/ts/output/common/Wrappers/scriptbase.ts
+++ b/ts/output/common/Wrappers/scriptbase.ts
@@ -31,14 +31,7 @@ import {
   Constructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { CommonMunderover } from './munderover.js';
 import { CommonMo } from './mo.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
@@ -48,38 +41,27 @@ import { BBox } from '../../../util/BBox.js';
 import { LineBBox } from '../LineBBox.js';
 import { DIRECTION } from '../FontData.js';
 import { SEM } from '../../../a11y/semantic-enrich/strings.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonScriptbase interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonScriptbase<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {
   /**
    * The core mi or mo of the base (or the base itself if there isn't one)
    */
@@ -163,7 +145,7 @@ export interface CommonScriptbase<
    *
    * @param {WW} fence    The potential fence
    * @param {string} id   The fencepointer id
-   * @returns {WW}         The original fence the scripts belong to
+   * @returns {WW}        The original fence the scripts belong to
    */
   getBaseFence(fence: WW, id: string): WW;
 
@@ -184,7 +166,7 @@ export interface CommonScriptbase<
 
   /**
    * @returns {boolean}  True if the base is an mi, mn, or mo (not a largeop) consisting of
-   *                    a single unstretched character
+   *                     a single unstretched character
    */
   isCharBase(): boolean;
 
@@ -195,7 +177,7 @@ export interface CommonScriptbase<
 
   /**
    * @param {WW} script   The script node to check for being a line
-   * @returns {boolean}    True if the script is U+2015
+   * @returns {boolean}   True if the script is U+2015
    */
   isLineAccent(script: WW): boolean;
 
@@ -251,7 +233,7 @@ export interface CommonScriptbase<
    *
    * @param {BBox} basebox  The bounding box of the base
    * @param {BBox} overbox  The bounding box of the overscript
-   * @returns {number[]}     The separation between their boxes, and the offset of the overscript
+   * @returns {number[]}    The separation between their boxes, and the offset of the overscript
    */
   getOverKU(basebox: BBox, overbox: BBox): number[];
 
@@ -260,21 +242,21 @@ export interface CommonScriptbase<
    *
    * @param {BBox} basebox   The bounding box of the base
    * @param {BBox} underbox  The bounding box of the underscript
-   * @returns {number[]}      The separation between their boxes, and the offset of the underscript
+   * @returns {number[]}     The separation between their boxes, and the offset of the underscript
    */
   getUnderKV(basebox: BBox, underbox: BBox): number[];
 
   /**
    * @param {BBox[]} boxes     The bounding boxes whose offsets are to be computed
    * @param {number[]=} delta  The initial x offsets of the boxes
-   * @returns {number[]}        The actual offsets needed to center the boxes in the stack
+   * @returns {number[]}       The actual offsets needed to center the boxes in the stack
    */
   getDeltaW(boxes: BBox[], delta?: number[]): number[];
 
   /**
    * @param {WW} script         The child that is above or below the base
    * @param {boolean=} noskew   Whether to ignore the skew amount
-   * @returns {number}           The offset for under and over
+   * @returns {number}          The offset for under and over
    */
   getDelta(script: WW, noskew?: boolean): number;
 
@@ -288,7 +270,7 @@ export interface CommonScriptbase<
    * Add the scripts into the given bounding box for msub and msup (overridden by msubsup)
    *
    * @param {BBox} bbox   The bounding box to augment
-   * @returns {BBox}       The modified bounding box
+   * @returns {BBox}      The modified bounding box
    */
   appendScripts(bbox: BBox): BBox;
 }
@@ -296,33 +278,21 @@ export interface CommonScriptbase<
 /**
  * The CommonScriptbaseClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonScriptbaseClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {
   /**
    * Set to true for munderover/munder/mover/msup (Appendix G 13)
    */
@@ -332,35 +302,23 @@ export interface CommonScriptbaseClass<
 /**
  *  Shorthand for the CommonScriptbase constructor
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  *
- * @template B   The mixin interface being created
+ * @template B     The mixin interface being created
  */
 export type CommonScriptbaseConstructor<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> = Constructor<CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>>;
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> = Constructor<CommonScriptbase<DOM, FONT, JX, WW, WF, WC>>;
 
 /*****************************************************************/
 /**
@@ -369,41 +327,28 @@ export type CommonScriptbaseConstructor<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonScriptbaseMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonScriptbaseMixin
     extends Base
-    implements CommonScriptbase<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonScriptbase<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * Set to false for msubsup/msub (Appendix G 13)
@@ -493,11 +438,8 @@ export function CommonScriptbaseMixin<
             node.isKind('mphantom') ||
             node.isKind('semantics'))) ||
           (node.isKind('munderover') &&
-            /* prettier-ignore */
-            (
-              core as any as
-              CommonMunderover<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-            ).isMathAccent))
+            (core as any as CommonMunderover<DOM, FONT, JX, WW, WF, WC>)
+              .isMathAccent))
       ) {
         this.setBaseAccentsFor(core);
         core = core.childNodes[0];
@@ -604,9 +546,7 @@ export function CommonScriptbaseMixin<
       } else if (this.node.isKind('munder')) {
         this.isLineBelow = this.isLineAccent(this.scriptChild);
       } else {
-        /* prettier-ignore */
-        const mml = this as any as CommonMunderover<
-          N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>;
+        const mml = this as any as CommonMunderover<DOM, FONT, JX, WW, WF, WC>;
         this.isLineAbove = this.isLineAccent(mml.overChild);
         this.isLineBelow = this.isLineAccent(mml.underChild);
       }
@@ -651,9 +591,7 @@ export function CommonScriptbaseMixin<
       const largeop = !!this.baseCore.node.attributes.get('largeop');
       const sized = !!(
         this.baseCore.node.isKind('mo') &&
-        /* prettier-ignore */
-        (this.baseCore as any as
-         CommonMo<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>).size
+        (this.baseCore as any as CommonMo<DOM, FONT, JX, WW, WF, WC>).size
       );
       const scale = this.baseScale;
       return this.baseIsChar && !largeop && !sized && scale === 1 ? 0 : n;
@@ -877,13 +815,8 @@ export function CommonScriptbaseMixin<
       this.baseRemoveIc =
         !this.isLineAbove &&
         !this.isLineBelow &&
-        (!(
-          /* prettier-ignore */
-          (this.constructor as CommonScriptbaseClass<
-            N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC
-          >)
-          .useIC
-        ) ||
+        (!(this.constructor as CommonScriptbaseClass<DOM, FONT, JX, WW, WF, WC>)
+          .useIC ||
           this.isMathAccent);
     }
 

--- a/ts/output/common/Wrappers/semantics.ts
+++ b/ts/output/common/Wrappers/semantics.ts
@@ -27,78 +27,48 @@ import {
   CommonWrapperConstructor,
 } from '../Wrapper.js';
 import { CommonWrapperFactory } from '../WrapperFactory.js';
-import {
-  CharOptions,
-  VariantData,
-  DelimiterData,
-  FontData,
-  FontDataClass,
-} from '../FontData.js';
-import { CommonOutputJax } from '../../common.js';
+import { CommonOutputJax, COMMON_FONT } from '../../common.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The CommonSemantics interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonSemantics<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapper<DOM, FONT, JX, WW, WF, WC> {}
 
 /**
  * The CommonSemanticsClass interface
  *
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
  */
 export interface CommonSemanticsClass<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-> extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC> {}
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+> extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC> {}
 
 /*****************************************************************/
 /**
@@ -106,41 +76,28 @@ export interface CommonSemanticsClass<
  *
  * @param {CommonWrapperConstructor} Base The constructor class to extend
  * @returns {B} The mixin constructor
- * @template N   The DOM node type
- * @template T   The DOM text node type
- * @template D   The DOM document type
- * @template JX  The OutputJax type
- * @template WW  The Wrapper type
- * @template WF  The WrapperFactory type
- * @template WC  The WrapperClass type
- * @template CC  The CharOptions type
- * @template VV  The VariantData type
- * @template DD  The DelimiterData type
- * @template FD  The FontData type
- * @template FC  The FontDataClass type
  *
- * @template B   The mixin interface to create
+ * @template DOM   The DOM node types
+ * @template FONT  The font data types
+ * @template JX    The OutputJax type
+ * @template WW    The Wrapper type
+ * @template WF    The WrapperFactory type
+ * @template WC    The WrapperClass type
+ *
+ * @template B     The mixin interface to create
  */
 export function CommonSemanticsMixin<
-  N,
-  T,
-  D,
-  JX extends CommonOutputJax<N, T, D, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WW extends CommonWrapper<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WF extends CommonWrapperFactory<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  WC extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
-  CC extends CharOptions,
-  VV extends VariantData<CC>,
-  DD extends DelimiterData,
-  FD extends FontData<CC, VV, DD>,
-  FC extends FontDataClass<CC, VV, DD>,
-  B extends CommonWrapperClass<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>,
->(
-  Base: CommonWrapperConstructor<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
-): B {
+  DOM extends DOM_TYPES,
+  FONT extends COMMON_FONT,
+  JX extends CommonOutputJax<DOM, FONT, JX, WW, WF, WC>,
+  WW extends CommonWrapper<DOM, FONT, JX, WW, WF, WC>,
+  WF extends CommonWrapperFactory<DOM, FONT, JX, WW, WF, WC>,
+  WC extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+  B extends CommonWrapperClass<DOM, FONT, JX, WW, WF, WC>,
+>(Base: CommonWrapperConstructor<DOM, FONT, JX, WW, WF, WC>): B {
   return class CommonSemanticsMixin
     extends Base
-    implements CommonSemantics<N, T, D, JX, WW, WF, WC, CC, VV, DD, FD, FC>
+    implements CommonSemantics<DOM, FONT, JX, WW, WF, WC>
   {
     /**
      * @override

--- a/ts/output/svg.ts
+++ b/ts/output/svg.ts
@@ -40,7 +40,7 @@ import { unicodeChars } from '../util/string.js';
 import * as LENGTHS from '../util/lengths.js';
 import { SPACE } from './common/Wrapper.js';
 import { DefaultFont } from './svg/DefaultFont.js';
-import { DOM, DOM_TYPES, N, T, D } from '../types/Types.js';
+import { DOM_TYPES, N, NT } from '../types/Types.js';
 
 export const SVGNS = 'http://www.w3.org/2000/svg';
 export const XLINKNS = 'http://www.w3.org/1999/xlink';
@@ -48,30 +48,42 @@ export const XLINKNS = 'http://www.w3.org/1999/xlink';
 /*****************************************************************/
 
 /**
- * The SVG option types.
+ * The CHTML font types.
  */
-export interface SVG_OPTIONS<DOM extends DOM_TYPES> extends COMMON_OPTIONS<
-  DOM,
-  SvgWrapper<N<DOM>, T<DOM>, D<DOM>>,
-  SvgWrapperFactory<N<DOM>, T<DOM>, D<DOM>>,
-  SvgWrapperClass<N<DOM>, T<DOM>, D<DOM>>,
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass
-> {
+export type SVG_FONT = {
+  CC: SvgCharOptions;
+  VV: SvgVariantData;
+  DD: SvgDelimiterData;
+  FD: SvgFontData;
+  FC: SvgFontDataClass;
+};
+
+export type OPTIONS = {
   blacker: number; //                          Stroke-width to use for SVG character paths (in thousands of an em)
   fontCache: 'local' | 'global' | 'none'; //   The type of character cache to use
   localID: string; //                          ID to use for local font cache (for single equation processing)
   useXlink: boolean; //                        true to include xlink namespace for <use> hrefs, false to not
-}
+};
+
+/**
+ * The SVG option types.
+ */
+export interface SVG_OPTIONS<DOM extends DOM_TYPES>
+  extends
+    OPTIONS,
+    COMMON_OPTIONS<
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
+    > {}
 
 /**
  * The svg option defaults.
  */
-const options: SVG_OPTIONS<DOM> = {
-  ...CommonOutputJax.OPTIONS,
+const options: OPTIONS = {
   blacker: 3,
   fontCache: 'local',
   localID: null,
@@ -82,32 +94,15 @@ const options: SVG_OPTIONS<DOM> = {
 /**
  *  Implements the SVG class (extends AbstractOutputJax)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class SVG<N, T, D> extends CommonOutputJax<
-  //
-  // The HTMLElement, TextNode, and Document classes (for the DOM implementation in use)
-  //
-  N,
-  T,
-  D,
-  //
-  // The Wrapper type and its Factory and Class (these need to know N, T, and D)
-  //
-  SvgWrapper<N, T, D>,
-  SvgWrapperFactory<N, T, D>,
-  SvgWrapperClass<N, T, D>,
-  //
-  // These are font-related objects that depend on the output jax; e,g. the character options
-  //   for CHTML and SVG output differ (CHTML contains font information, while SVG has path data)
-  //
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass
+export class SVG<DOM extends DOM_TYPES> extends CommonOutputJax<
+  DOM,
+  SVG_FONT,
+  SVG<DOM>,
+  SvgWrapper<DOM>,
+  SvgWrapperFactory<DOM>,
+  SvgWrapperClass<DOM>
 > {
   /**
    * The name of the output jax
@@ -117,8 +112,10 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  /* prettier-ignore */
-  public static OPTIONS = options;
+  public static OPTIONS = {
+    ...CommonOutputJax.OPTIONS,
+    ...options,
+  };
 
   /**
    *  The default styles for SVG
@@ -178,7 +175,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * Stores the information about the cached character glyphs
    */
-  public fontCache: FontCache<N, T, D>;
+  public fontCache: FontCache<DOM>;
 
   /**
    * Minimum width for tables with labels,
@@ -192,12 +189,12 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * The SVG stylesheet, once it is constructed
    */
-  public svgStyles: N = null;
+  public svgStyles: N<DOM> = null;
 
   /**
    * @override
    */
-  public options: SVG_OPTIONS<DOM<N, T, D>> & { matchFontHeight: boolean };
+  public options: SVG_OPTIONS<DOM> & { matchFontHeight: boolean };
 
   /**
    * @override
@@ -236,7 +233,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  public escaped(math: MathItem<N, T, D>, html: MathDocument<N, T, D>) {
+  public escaped(math: MathItem<DOM>, html: MathDocument<DOM>) {
     this.setDocument(html);
     return this.html('span', {}, [this.text(math.math)]);
   }
@@ -244,7 +241,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  public styleSheet(html: MathDocument<N, T, D>) {
+  public styleSheet(html: MathDocument<DOM>) {
     if (this.svgStyles) {
       return this.svgStyles; // stylesheet is already added to the document
     }
@@ -268,7 +265,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * @override
    */
-  public pageElements(html: MathDocument<N, T, D>) {
+  public pageElements(html: MathDocument<DOM>) {
     if (this.options.fontCache === 'global' && !this.findCache(html)) {
       return this.svg(
         'svg',
@@ -280,7 +277,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
         [this.fontCache.getCache()]
       );
     }
-    return null as N;
+    return null as N<DOM>;
   }
 
   /**
@@ -289,7 +286,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
    * @param {MathDocument} html   The document to search
    * @returns {boolean}            True if a font cache already exists in the page
    */
-  protected findCache(html: MathDocument<N, T, D>): boolean {
+  protected findCache(html: MathDocument<DOM>): boolean {
     const adaptor = this.adaptor;
     const svgs = adaptor.tags(adaptor.body(html.document), 'svg');
     for (let i = svgs.length - 1; i >= 0; i--) {
@@ -308,10 +305,10 @@ export class SVG<N, T, D> extends CommonOutputJax<
   }
 
   /**
-   * @param {SvgWrapper<N, T, D>} wrapper   The MML node wrapper whose SVG is to be produced
-   * @param {N} parent                      The HTML node to contain the SVG
+   * @param {SvgWrapper<DOM>} wrapper   The MML node wrapper whose SVG is to be produced
+   * @param {N} parent                  The HTML node to contain the SVG
    */
-  public processMath(wrapper: SvgWrapper<N, T, D>, parent: N) {
+  public processMath(wrapper: SvgWrapper<DOM>, parent: N<DOM>) {
     //
     // Cache the container (tooltips process into separate containers)
     //
@@ -335,9 +332,9 @@ export class SVG<N, T, D> extends CommonOutputJax<
 
   /**
    * @param {SvgWrapper} wrapper   The wrapped math to process
-   * @returns {[N, N]}              The svg and g nodes for the math
+   * @returns {[N, N]}             The svg and g nodes for the math
    */
-  protected createRoot(wrapper: SvgWrapper<N, T, D>): [N, N] {
+  protected createRoot(wrapper: SvgWrapper<DOM>): [N<DOM>, N<DOM>] {
     const { w, h, d, pwidth } = wrapper.getOuterBBox();
     const [svg, g] = this.createSVG(h, d, w);
     if (pwidth) {
@@ -370,9 +367,9 @@ export class SVG<N, T, D> extends CommonOutputJax<
    * @param {number} h   The height of the SVG to create
    * @param {number} d   The depth of the SVG to create
    * @param {number} w   The width of the SVG to create
-   * @returns {[N, N]}      The svg element and its initial g child
+   * @returns {[N, N]}   The svg element and its initial g child
    */
-  protected createSVG(h: number, d: number, w: number): [N, N] {
+  protected createSVG(h: number, d: number, w: number): [N<DOM>, N<DOM>] {
     const px = this.math.metrics.em / 1000;
     const W = Math.max(w, px); // make sure we are at least one px wide (needed for e.g. \llap)
     const H = Math.max(h + d, px); // make sure we are at least one px tall (needed for e.g., \smash)
@@ -384,7 +381,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
       fill: 'currentColor',
       'stroke-width': 0,
       transform: 'scale(1,-1)',
-    }) as N;
+    }) as N<DOM>;
     //
     //  The svg element with its viewBox, size and alignment
     //
@@ -409,7 +406,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
         },
         [g]
       )
-    ) as N;
+    ) as N<DOM>;
     if (W === 0.001) {
       adaptor.setAttribute(svg, 'preserveAspectRatio', 'xMidYMid slice');
       if (w < 0) {
@@ -430,7 +427,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
    * @param {N} svg                The main svg element for the typeet math
    * @param {N} g                  The group in which the math is typeset
    */
-  protected typesetSvg(wrapper: SvgWrapper<N, T, D>, svg: N, g: N) {
+  protected typesetSvg(wrapper: SvgWrapper<DOM>, svg: N<DOM>, g: N<DOM>) {
     const adaptor = this.adaptor;
     //
     //  Typeset the math and add minWidth (from mtables), or set the alignment and indentation
@@ -458,7 +455,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
    * @param {string} align  The alignment for the node
    * @param {number} shift  The indent (positive or negative) for the node
    */
-  protected setIndent(svg: N, align: string, shift: number) {
+  protected setIndent(svg: N<DOM>, align: string, shift: number) {
     if (align === 'center' || align === 'left') {
       this.adaptor.setStyle(svg, 'margin-left', this.ex(shift));
     }
@@ -468,19 +465,25 @@ export class SVG<N, T, D> extends CommonOutputJax<
   }
 
   /**
-   * @param {SvgWrapper<N,T,D>} wrapper   The MML node wrapper whose SVG gets inline breaks
-   * @param {N} svg                       The SVG node that is breaking
-   * @param {N} g                         The group in which the math is typeset
+   * @param {SvgWrapper<DOM>} wrapper   The MML node wrapper whose SVG gets inline breaks
+   * @param {N} svg                     The SVG node that is breaking
+   * @param {N} g                       The group in which the math is typeset
    */
-  protected handleInlineBreaks(wrapper: SvgWrapper<N, T, D>, svg: N, g: N) {
+  protected handleInlineBreaks(
+    wrapper: SvgWrapper<DOM>,
+    svg: N<DOM>,
+    g: N<DOM>
+  ) {
     const n = wrapper.childNodes[0].breakCount;
     if (!n) return;
     //
     // Find the math element and the lines that it contains
     //
     const adaptor = this.adaptor;
-    const math = adaptor.firstChild(g) as N;
-    const lines = adaptor.childNodes(adaptor.firstChild(math) as N) as N[];
+    const math = adaptor.firstChild(g) as N<DOM>;
+    const lines = adaptor.childNodes(
+      adaptor.firstChild(math) as N<DOM>
+    ) as N<DOM>[];
     const lineBBox = wrapper.childNodes[0].lineBBox;
     //
     // Remove content from original SVG other than <defs>, if any
@@ -495,7 +498,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
       const [mml, mo] = wrapper.childNodes[0].getBreakNode(line);
       const { scale } = mml.getBBox();
       const [nsvg, ng] = this.createSVG(h * scale, d * scale, w * scale);
-      const nmath = adaptor.append(ng, adaptor.clone(math, false)) as N;
+      const nmath = adaptor.append(ng, adaptor.clone(math, false)) as N<DOM>;
       for (const child of adaptor.childNodes(lines[i])) {
         adaptor.append(nmath, child);
       }
@@ -527,7 +530,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
     //
     if (adaptor.childNodes(svg).length) {
       adaptor.append(
-        adaptor.firstChild(adaptor.parent(svg)) as N,
+        adaptor.firstChild(adaptor.parent(svg)) as N<DOM>,
         adaptor.firstChild(svg)
       );
     }
@@ -539,7 +542,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
    * @param {number} dimen     The size of the break
    * @param {boolean} forced   Whether the break is forced or not
    */
-  protected addInlineBreak(nsvg: N, dimen: number, forced: boolean) {
+  protected addInlineBreak(nsvg: N<DOM>, dimen: number, forced: boolean) {
     const adaptor = this.adaptor;
     const space = LENGTHS.em(dimen);
     if (!forced) {
@@ -563,7 +566,7 @@ export class SVG<N, T, D> extends CommonOutputJax<
   }
 
   /**
-   * @param {number} m  A number to be shown in ex
+   * @param {number} m   A number to be shown in ex
    * @returns {string}   The number with units of ex
    */
   public ex(m: number): string {
@@ -576,23 +579,23 @@ export class SVG<N, T, D> extends CommonOutputJax<
   /**
    * @param {string} kind             The kind of node to create
    * @param {OptionList} properties   The properties to set for the element
-   * @param {(N|T)[]} children            The child nodes for this node
-   * @returns {N}                      The newly created node in the SVG namespace
+   * @param {NT[]} children           The child nodes for this node
+   * @returns {N}                     The newly created node in the SVG namespace
    */
   public svg(
     kind: string,
     properties: OptionList = {},
-    children: (N | T)[] = []
-  ): N {
+    children: NT<DOM>[] = []
+  ): N<DOM> {
     return this.html(kind, properties, children, SVGNS);
   }
 
   /**
    * @param {string} text      The text to be displayed
    * @param {string} variant   The name of the variant for the text
-   * @returns {N}               The text element containing the text
+   * @returns {N}              The text element containing the text
    */
-  public unknownText(text: string, variant: string): N {
+  public unknownText(text: string, variant: string): N<DOM> {
     const metrics = this.math.metrics;
     const scale = (this.font.params.x_height / metrics.ex) * metrics.em * 1000;
     const svg = this.svg(
@@ -625,10 +628,10 @@ export class SVG<N, T, D> extends CommonOutputJax<
    * Measure the width of a text element by placing it in the page
    *  and looking up its size (fake the height and depth, since we can't measure that)
    *
-   * @param {N} text         The text element to measure
-   * @returns {object}        The width, height and depth for the text
+   * @param {N} text     The text element to measure
+   * @returns {object}   The width, height and depth for the text
    */
-  public measureTextNode(text: N): UnknownBBox {
+  public measureTextNode(text: N<DOM>): UnknownBBox {
     const adaptor = this.adaptor;
     text = adaptor.clone(text);
     adaptor.removeAttribute(text, 'transform');

--- a/ts/output/svg/FontCache.ts
+++ b/ts/output/svg/FontCache.ts
@@ -22,17 +22,16 @@
  */
 
 import { SVG } from '../svg.js';
+import { DOM_TYPES, N } from '../../types/Types.js';
 
 /**
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class FontCache<N, T, D> {
+export class FontCache<DOM extends DOM_TYPES> {
   /**
    * The SVG jax that owns this cache
    */
-  protected jax: SVG<N, T, D>;
+  protected jax: SVG<DOM>;
 
   /**
    * The cache of font character IDs to their paths
@@ -42,7 +41,7 @@ export class FontCache<N, T, D> {
   /**
    * The SVG <defs> element for storing the cache
    */
-  protected defs: N = null;
+  protected defs: N<DOM> = null;
 
   /**
    * A string to use to make per-equation cache IDs unique
@@ -57,7 +56,7 @@ export class FontCache<N, T, D> {
   /**
    * @param {SVG} jax  The SVG jax owning this font cache
    */
-  constructor(jax: SVG<N, T, D>) {
+  constructor(jax: SVG<DOM>) {
     this.jax = jax;
   }
 
@@ -116,7 +115,7 @@ export class FontCache<N, T, D> {
    *
    * @returns {N} The definitions
    */
-  public getCache(): N {
+  public getCache(): N<DOM> {
     return this.defs;
   }
 }

--- a/ts/output/svg/Notation.ts
+++ b/ts/output/svg/Notation.ts
@@ -22,6 +22,7 @@
  */
 
 import { SvgMencloseNTD } from './Wrappers/menclose.js';
+import { DOM, DOM_TYPES, N } from '../../types/Types.js';
 import * as Notation from '../common/Notation.js';
 export * from '../common/Notation.js';
 
@@ -30,13 +31,19 @@ export * from '../common/Notation.js';
 /**
  * Shorthand for Svgmenclose
  */
-export type Menclose = SvgMencloseNTD<any, any, any>;
+export type Menclose = SvgMencloseNTD<DOM>;
 
 /*
  * Shorthands for common types
  */
-export type RENDERER<N, T, D> = Notation.Renderer<SvgMencloseNTD<N, T, D>, N>;
-export type DEFPAIR<N, T, D> = Notation.DefPair<SvgMencloseNTD<N, T, D>, N>;
+export type RENDERER<DOM extends DOM_TYPES> = Notation.Renderer<
+  SvgMencloseNTD<DOM>,
+  N<DOM>
+>;
+export type DEFPAIR<DOM extends DOM_TYPES> = Notation.DefPair<
+  SvgMencloseNTD<DOM>,
+  N<DOM>
+>;
 
 /**
  * The kinds of lines that can be drawn
@@ -118,10 +125,10 @@ export const lineOffset = function (
  * @param {string} offset  The direction to offset
  * @returns {RENDERER}     The renderer function for the given line
  */
-export const RenderLine = function <N, T, D>(
+export const RenderLine = function <DOM extends DOM_TYPES>(
   line: LineName,
   offset: string = ''
-): RENDERER<N, T, D> {
+): RENDERER<DOM> {
   return (node, _child) => {
     const L = node.line(lineData(node, line, offset));
     node.adaptor.append(node.dom[0], L);
@@ -132,28 +139,28 @@ export const RenderLine = function <N, T, D>(
 
 /**
  * @param {Notation.Side} side   The kind of line (side, diagonal, etc.)
- * @returns {DEFPAIR}      The notation definition for the notation having a line on the given side
+ * @returns {DEFPAIR}            The notation definition for the notation having a line on the given side
  */
-export const Border = function <N, T, D>(
+export const Border = function <DOM extends DOM_TYPES>(
   side: Notation.Side
-): DEFPAIR<N, T, D> {
-  return Notation.CommonBorder<SvgMencloseNTD<N, T, D>, N>((node, _child) => {
+): DEFPAIR<DOM> {
+  return Notation.CommonBorder<SvgMencloseNTD<DOM>, N<DOM>>((node, _child) => {
     node.adaptor.append(node.dom[0], node.line(lineData(node, side)));
   })(side);
 };
 
 /**
- * @param {string} name    The name of the notation to define
+ * @param {string} name           The name of the notation to define
  * @param {Notation.Side} side1   The first side to get a border
  * @param {Notation.Side} side2   The second side to get a border
- * @returns {DEFPAIR}       The notation definition for the notation having lines on two sides
+ * @returns {DEFPAIR}             The notation definition for the notation having lines on two sides
  */
-export const Border2 = function <N, T, D>(
+export const Border2 = function <DOM extends DOM_TYPES>(
   name: string,
   side1: Notation.Side,
   side2: Notation.Side
-): DEFPAIR<N, T, D> {
-  return Notation.CommonBorder2<SvgMencloseNTD<N, T, D>, N>((node, _child) => {
+): DEFPAIR<DOM> {
+  return Notation.CommonBorder2<SvgMencloseNTD<DOM>, N<DOM>>((node, _child) => {
     node.adaptor.append(node.dom[0], node.line(lineData(node, side1)));
     node.adaptor.append(node.dom[0], node.line(lineData(node, side2)));
   })(name, side1, side2);
@@ -165,10 +172,10 @@ export const Border2 = function <N, T, D>(
  * @param {LineName} name  The name of the diagonal strike to define
  * @returns {DEFPAIR}       The notation definition for the diagonal strike
  */
-export const DiagonalStrike = function <N, T, D>(
+export const DiagonalStrike = function <DOM extends DOM_TYPES>(
   name: LineName
-): DEFPAIR<N, T, D> {
-  return Notation.CommonDiagonalStrike<SvgMencloseNTD<N, T, D>, N>(
+): DEFPAIR<DOM> {
+  return Notation.CommonDiagonalStrike<SvgMencloseNTD<DOM>, N<DOM>>(
     (_cname: string) => (node, _child) => {
       node.adaptor.append(node.dom[0], node.line(lineData(node, name)));
     }
@@ -181,10 +188,10 @@ export const DiagonalStrike = function <N, T, D>(
  * @param {string} name   The name of the diagonal arrow to define
  * @returns {DEFPAIR}      The notation definition for the diagonal arrow
  */
-export const DiagonalArrow = function <N, T, D>(
+export const DiagonalArrow = function <DOM extends DOM_TYPES>(
   name: string
-): DEFPAIR<N, T, D> {
-  return Notation.CommonDiagonalArrow<SvgMencloseNTD<N, T, D>, N>(
+): DEFPAIR<DOM> {
+  return Notation.CommonDiagonalArrow<SvgMencloseNTD<DOM>, N<DOM>>(
     (node, arrow) => {
       node.adaptor.append(node.dom[0], arrow);
     }
@@ -195,8 +202,10 @@ export const DiagonalArrow = function <N, T, D>(
  * @param {string} name   The name of the horizontal or vertical arrow to define
  * @returns {DEFPAIR}      The notation definition for the arrow
  */
-export const Arrow = function <N, T, D>(name: string): DEFPAIR<N, T, D> {
-  return Notation.CommonArrow<SvgMencloseNTD<N, T, D>, N>((node, arrow) => {
+export const Arrow = function <DOM extends DOM_TYPES>(
+  name: string
+): DEFPAIR<DOM> {
+  return Notation.CommonArrow<SvgMencloseNTD<DOM>, N<DOM>>((node, arrow) => {
     node.adaptor.append(node.dom[0], arrow);
   })(name);
 };

--- a/ts/output/svg/Wrapper.ts
+++ b/ts/output/svg/Wrapper.ts
@@ -28,15 +28,10 @@ import {
   CommonWrapperClass,
   CommonWrapperConstructor,
 } from '../common/Wrapper.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from './FontData.js';
-import { SVG, XLINKNS } from '../svg.js';
+import { SvgFontData } from './FontData.js';
+import { SVG, SVG_FONT, XLINKNS } from '../svg.js';
 import { SvgWrapperFactory } from './WrapperFactory.js';
+import { DOM_TYPES, N, NT } from '../../types/Types.js';
 
 export { Constructor, StringMap } from '../common/Wrapper.js';
 
@@ -45,71 +40,43 @@ export { Constructor, StringMap } from '../common/Wrapper.js';
 /**
  * Shorthand for makeing an SvgWrapper constructor
  */
-export type SvgConstructor<N, T, D> = CommonWrapperConstructor<
-  //
-  // The HTMLElement, TextNode, and Document classes (for the DOM implementation in use)
-  //
-  N,
-  T,
-  D,
-  //
-  // The Wrapper type and its Factory and Class (these need to know N, T, and D)
-  //
-  SVG<N, T, D>,
-  SvgWrapper<N, T, D>,
-  SvgWrapperFactory<N, T, D>,
-  SvgWrapperClass<N, T, D>,
-  //
-  // These are font-related objects that depend on the output jax; e,g. the character options
-  //   for CHTML and SVG output differ (CHTML contains font information, while SVG has path data)
-  //
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass
+export type SvgConstructor<DOM extends DOM_TYPES> = CommonWrapperConstructor<
+  DOM,
+  SVG_FONT,
+  SVG<DOM>,
+  SvgWrapper<DOM>,
+  SvgWrapperFactory<DOM>,
+  SvgWrapperClass<DOM>
 >;
 
 /*****************************************************************/
 /**
  *  The type of the SvgWrapper class (used when creating the wrapper factory for this class)
  */
-export interface SvgWrapperClass<N, T, D> extends CommonWrapperClass<
-  N,
-  T,
-  D,
-  SVG<N, T, D>,
-  SvgWrapper<N, T, D>,
-  SvgWrapperFactory<N, T, D>,
-  SvgWrapperClass<N, T, D>,
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass
+export interface SvgWrapperClass<
+  DOM extends DOM_TYPES,
+> extends CommonWrapperClass<
+  DOM,
+  SVG_FONT,
+  SVG<DOM>,
+  SvgWrapper<DOM>,
+  SvgWrapperFactory<DOM>,
+  SvgWrapperClass<DOM>
 > {}
 
 /*****************************************************************/
 /**
  *  The base SvgWrapper class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class SvgWrapper<N, T, D> extends CommonWrapper<
-  N,
-  T,
-  D,
-  SVG<N, T, D>,
-  SvgWrapper<N, T, D>,
-  SvgWrapperFactory<N, T, D>,
-  SvgWrapperClass<N, T, D>,
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass
+export class SvgWrapper<DOM extends DOM_TYPES> extends CommonWrapper<
+  DOM,
+  SVG_FONT,
+  SVG<DOM>,
+  SvgWrapper<DOM>,
+  SvgWrapperFactory<DOM>,
+  SvgWrapperClass<DOM>
 > {
   /**
    * The kind of wrapper
@@ -141,9 +108,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   /**
    * Create the HTML for the wrapped node.
    *
-   * @param {N[]} parents  The HTML nodes where the output is to be added
+   * @param {N[]} parents   The HTML nodes where the output is to be added
    */
-  public toSVG(parents: N[]) {
+  public toSVG(parents: N<DOM>[]) {
     if (this.toEmbellishedSVG(parents)) return;
     this.addChildren(this.standardSvgNodes(parents));
   }
@@ -151,10 +118,10 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   /**
    * Create the HTML for an embellished mo, if this is one.
    *
-   * @param {N[]} parents  The HTML nodes where the output is to be added
+   * @param {N[]} parents   The HTML nodes where the output is to be added
    * @returns {boolean}     True when embellished output is produced, false if not
    */
-  public toEmbellishedSVG(parents: N[]): boolean {
+  public toEmbellishedSVG(parents: N<DOM>[]): boolean {
     if (
       parents.length <= 1 ||
       !this.node.isEmbellished ||
@@ -172,7 +139,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     for (const [parent, STYLE] of [
       [parents[0], 'before'],
       [parents[1], 'after'],
-    ] as [N, string][]) {
+    ] as [N<DOM>, string][]) {
       if (style !== STYLE) {
         this.toSVG([parent]);
         dom.push(this.dom[0]);
@@ -186,9 +153,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   }
 
   /**
-   * @param {N[]} parents  The element in which to add the children
+   * @param {N[]} parents   The element in which to add the children
    */
-  public addChildren(parents: N[]) {
+  public addChildren(parents: N<DOM>[]) {
     let x = 0;
     for (const child of this.childNodes) {
       child.toSVG(parents);
@@ -206,9 +173,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * Create the standard SVG element for the given wrapped node.
    *
    * @param {N[]} parents  The HTML elements in which the node is to be created
-   * @returns {N[]}  The roots of the HTML trees for the wrapped node's output
+   * @returns {N[]}        The roots of the HTML trees for the wrapped node's output
    */
-  protected standardSvgNodes(parents: N[]): N[] {
+  protected standardSvgNodes(parents: N<DOM>[]): N<DOM>[] {
     const svg = this.createSvgNodes(parents);
     this.handleStyles();
     this.handleScale();
@@ -220,9 +187,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
 
   /**
    * @param {N[]} parents  The HTML elements in which the node is to be created
-   * @returns {N[]}  The roots of the HTML tree for the wrapped node's output
+   * @returns {N[]}        The roots of the HTML tree for the wrapped node's output
    */
-  protected createSvgNodes(parents: N[]): N[] {
+  protected createSvgNodes(parents: N<DOM>[]): N<DOM>[] {
     this.dom = parents.map((_parent) =>
       this.svg('g', { 'data-mml-node': this.node.kind })
     ); // FIXME: add segment id
@@ -237,15 +204,18 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * Add an anchor for hrefs and insert hot boxes into the DOM containers
    *
    * @param {N[]} parents   The HTML nodes in which the output is to be placed
-   * @returns {N[]}          The roots of the HTML tree for the node's output
+   * @returns {N[]}         The roots of the HTML tree for the node's output
    */
-  protected handleHref(parents: N[]): N[] {
+  protected handleHref(parents: N<DOM>[]): N<DOM>[] {
     const href = this.node.attributes.get('href');
     if (!href) return parents;
     let i = 0;
     const isEmbellished = this.node.isEmbellished && !this.node.isKind('mo');
     return parents.map((parent) => {
-      parent = this.adaptor.append(parent, this.svg('a', { href: href })) as N;
+      parent = this.adaptor.append(
+        parent,
+        this.svg('a', { href: href })
+      ) as N<DOM>;
       const { h, d, w } = isEmbellished
         ? this.getOuterBBox()
         : this.getLineBBox(i);
@@ -380,7 +350,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
         [outerLB, outerRB, innerRB, innerLB],
         [outerLB, outerLT, innerLT, innerLB],
       ];
-      const child = adaptor.firstChild(dom) as N;
+      const child = adaptor.firstChild(dom) as N<DOM>;
       const dx = L * this.dx;
       for (const i of [0, 1, 2, 3]) {
         if (!border.width[i] || (i === 3 && !L) || (i === 1 && !R)) continue;
@@ -414,8 +384,8 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   protected addBorderSolid(
     path: number[][],
     color: string,
-    child: N,
-    parent: N,
+    child: N<DOM>,
+    parent: N<DOM>,
     dx: number
   ) {
     const border = this.svg('polygon', {
@@ -443,7 +413,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * @param {number} t                  The thickness for the border line
    * @param {number} i                  The side being drawn
    * @param {N} parent                  The parent container
-   * @param {number} dx                  The offset of the node
+   * @param {number} dx                 The offset of the node
    */
   protected addBorderBroken(
     path: number[][],
@@ -451,7 +421,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     style: string,
     t: number,
     i: number,
-    parent: N,
+    parent: N<DOM>,
     dx: number
   ) {
     const dot = style === 'dotted';
@@ -533,7 +503,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * @param {number} y   The y-offset for the element
    * @param {N} element  The element to be placed
    */
-  public place(x: number, y: number, element: N = null) {
+  public place(x: number, y: number, element: N<DOM> = null) {
     if (!element) {
       x += this.dx * this.bbox.rscale;
     }
@@ -558,8 +528,8 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    *   a <text> element (e.g., when mtextInheritFont is true), so add a text
    *   element to help Safari get the right location.
    *
-   * @param {number} y     The current offset of the element
-   * @returns {number}      The new offset for the element if it has an id
+   * @param {number} y   The current offset of the element
+   * @returns {number}   The new offset for the element if it has an id
    */
   protected handleId(y: number): number {
     if (!this.node.attributes || !this.node.attributes.get('id')) {
@@ -591,43 +561,43 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   /**
    * Return the first child element, skipping id align boxes and href hit boxes
    *
-   * @param {N} dom The dom element
-   * @returns {N}   The first "real" child element
+   * @param {N} dom   The dom element
+   * @returns {N}     The first "real" child element
    */
-  public firstChild(dom: N = this.dom[0]): N {
+  public firstChild(dom: N<DOM> = this.dom[0]): N<DOM> {
     const adaptor = this.adaptor;
     let child = adaptor.firstChild(dom);
     if (
       child &&
       adaptor.kind(child) === 'text' &&
-      adaptor.getAttribute(child as N, 'data-id-align')
+      adaptor.getAttribute(child as N<DOM>, 'data-id-align')
     ) {
-      child = adaptor.firstChild(adaptor.next(child) as N);
+      child = adaptor.firstChild(adaptor.next(child) as N<DOM>);
     }
     if (
       child &&
       adaptor.kind(child) === 'rect' &&
-      adaptor.getAttribute(child as N, 'data-hitbox')
+      adaptor.getAttribute(child as N<DOM>, 'data-hitbox')
     ) {
       child = adaptor.next(child);
     }
-    return child as N;
+    return child as N<DOM>;
   }
 
   /**
-   * @param {number} n        The character number
-   * @param {number} x        The x-position of the character
-   * @param {number} y        The y-position of the character
-   * @param {N} parent        The container for the character
-   * @param {string} variant  The variant to use for the character
-   * @param {boolean} buffer  True to collect unknown characters into one text element
+   * @param {number} n         The character number
+   * @param {number} x         The x-position of the character
+   * @param {number} y         The y-position of the character
+   * @param {N} parent         The container for the character
+   * @param {string} variant   The variant to use for the character
+   * @param {boolean} buffer   True to collect unknown characters into one text element
    * @returns {number}         The width of the character
    */
   public placeChar(
     n: number,
     x: number,
     y: number,
-    parent: N,
+    parent: N<DOM>,
     variant: string = null,
     buffer: boolean = false
   ): number {
@@ -647,7 +617,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       this.place(
         x,
         y,
-        this.adaptor.append(parent, this.charNode(variant, C, path)) as N
+        this.adaptor.append(parent, this.charNode(variant, C, path)) as N<DOM>
       );
       return w + dx;
     }
@@ -655,7 +625,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
       const g = this.adaptor.append(
         parent,
         this.svg('g', { 'data-c': C })
-      ) as N;
+      ) as N<DOM>;
       this.place(x + dx, y, g);
       x = 0;
       for (const n of this.unicodeChars(data.c, variant)) {
@@ -673,7 +643,12 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * @param {string} variant   The variant to use for the string
    * @returns {number}         The computed width of the text
    */
-  protected addUtext(x: number, y: number, parent: N, variant: string): number {
+  protected addUtext(
+    x: number,
+    y: number,
+    parent: N<DOM>,
+    variant: string
+  ): number {
     const c = this.utext;
     if (!c) {
       return 0;
@@ -682,7 +657,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
     const text = this.adaptor.append(
       parent,
       this.jax.unknownText(c, variant)
-    ) as N;
+    ) as N<DOM>;
     this.place(x, y, text);
     return this.jax.measureTextNodeWithCache(text, c, variant).w;
   }
@@ -691,9 +666,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * @param {string} variant    The name of the variant being used
    * @param {string} C          The hex string for the character code
    * @param {string} path       The data from the character
-   * @returns {N}                The <path> or <use> node for the glyph
+   * @returns {N}               The <path> or <use> node for the glyph
    */
-  protected charNode(variant: string, C: string, path: string): N {
+  protected charNode(variant: string, C: string, path: string): N<DOM> {
     const cache = this.jax.options.fontCache;
     return cache !== 'none'
       ? this.useNode(variant, C, path)
@@ -703,9 +678,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   /**
    * @param {string} C          The hex string for the character code
    * @param {string} path       The data from the character
-   * @returns {N}                The <path> for the glyph
+   * @returns {N}               The <path> for the glyph
    */
-  protected pathNode(C: string, path: string): N {
+  protected pathNode(C: string, path: string): N<DOM> {
     return this.svg('path', { 'data-c': C, d: path });
   }
 
@@ -713,9 +688,9 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
    * @param {string} variant    The name of the variant being used
    * @param {string} C          The hex string for the character code
    * @param {string} path       The data from the character
-   * @returns {N}                The <use> node for the glyph
+   * @returns {N}               The <use> node for the glyph
    */
-  protected useNode(variant: string, C: string, path: string): N {
+  protected useNode(variant: string, C: string, path: string): N<DOM> {
     const use = this.svg('use', { 'data-c': C });
     const id = '#' + this.jax.fontCache.cachePath(variant, C, path);
     this.adaptor.setAttribute(
@@ -751,7 +726,7 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
         width: this.fixed(w),
         y: this.fixed(-d),
       }),
-    ] as N[]);
+    ] as N<DOM>[]);
     const node = this.dom[0] || this.parent.dom[0];
     this.adaptor.append(node, box);
   }
@@ -764,26 +739,34 @@ export class SvgWrapper<N, T, D> extends CommonWrapper<
   /**
    * @param {string} type      The tag name of the HTML node to be created
    * @param {OptionList} def   The properties to set for the created node
-   * @param {(N|T)[]} content  The child nodes for the created HTML node
-   * @returns {N}               The generated HTML tree
+   * @param {(NT)[]} content   The child nodes for the created HTML node
+   * @returns {N}              The generated HTML tree
    */
-  public html(type: string, def: OptionList = {}, content: (N | T)[] = []): N {
+  public html(
+    type: string,
+    def: OptionList = {},
+    content: NT<DOM>[] = []
+  ): N<DOM> {
     return this.jax.html(type, def, content);
   }
 
   /**
    * @param {string} type      The tag name of the svg node to be created
    * @param {OptionList} def   The properties to set for the created node
-   * @param {(N|T)[]} content  The child nodes for the created SVG node
-   * @returns {N}               The generated SVG tree
+   * @param {(NT)[]} content   The child nodes for the created SVG node
+   * @returns {N}              The generated SVG tree
    */
-  public svg(type: string, def: OptionList = {}, content: (N | T)[] = []): N {
+  public svg(
+    type: string,
+    def: OptionList = {},
+    content: NT<DOM>[] = []
+  ): N<DOM> {
     return this.jax.svg(type, def, content);
   }
 
   /**
-   * @param {number} x   The dimension to display
-   * @param {number=} n  The number of digits to display
+   * @param {number} x    The dimension to display
+   * @param {number=} n   The number of digits to display
    * @returns {string}    The dimension with the given number of digits (minus trailing zeros)
    */
   public fixed(x: number, n: number = 1): string {

--- a/ts/output/svg/WrapperFactory.ts
+++ b/ts/output/svg/WrapperFactory.ts
@@ -21,49 +21,27 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../svg.js';
+import { SVG, SVG_FONT } from '../svg.js';
 import { CommonWrapperFactory } from '../common/WrapperFactory.js';
 import { SvgWrapper, SvgWrapperClass } from './Wrapper.js';
 import { SvgWrappers } from './Wrappers.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from './FontData.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /*****************************************************************/
 /*
  *  The SvgWrapperFactory class for creating SvgWrapper nodes
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class SvgWrapperFactory<N, T, D> extends CommonWrapperFactory<
-  //
-  // The HTMLElement, TextNode, and Document classes (for the DOM implementation in use)
-  //
-  N,
-  T,
-  D,
-  //
-  // The Wrapper type and its Factory and Class (these need to know N, T, and D)
-  //
-  SVG<N, T, D>,
-  SvgWrapper<N, T, D>,
-  SvgWrapperFactory<N, T, D>,
-  SvgWrapperClass<N, T, D>,
-  //
-  // These are font-related objects that depend on the output jax; e,g. the character options
-  //   for CHTML and SVG output differ (CHTML contains font information, while SVG has path data)
-  //
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass
+export class SvgWrapperFactory<
+  DOM extends DOM_TYPES,
+> extends CommonWrapperFactory<
+  DOM,
+  SVG_FONT,
+  SVG<DOM>,
+  SvgWrapper<DOM>,
+  SvgWrapperFactory<DOM>,
+  SvgWrapperClass<DOM>
 > {
   /**
    * The default list of wrapper nodes this factory can create

--- a/ts/output/svg/Wrappers.ts
+++ b/ts/output/svg/Wrappers.ts
@@ -57,8 +57,9 @@ import { SvgMglyph } from './Wrappers/mglyph.js';
 import { SvgTeXAtom } from './Wrappers/TeXAtom.js';
 import { SvgTextNode } from './Wrappers/TextNode.js';
 import { SvgHtmlNode } from './Wrappers/HtmlNode.js';
+import { DOM } from '../../types/Types.js';
 
-export const SvgWrappers: { [kind: string]: SvgWrapperClass<any, any, any> } = {
+export const SvgWrappers: { [kind: string]: SvgWrapperClass<DOM> } = {
   [SvgMath.kind]: SvgMath,
   [SvgMrow.kind]: SvgMrow,
   [SvgInferredMrow.kind]: SvgInferredMrow,

--- a/ts/output/svg/Wrappers/HtmlNode.ts
+++ b/ts/output/svg/Wrappers/HtmlNode.ts
@@ -26,30 +26,31 @@ import { SvgWrapperFactory } from '../WrapperFactory.js';
 import { SvgXmlNode, SvgXmlNodeNTD, SvgXmlNodeClass } from './semantics.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { HtmlNode } from '../../../core/MmlTree/MmlNodes/HtmlNode.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgHtmlNode interface for the SVG HtmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgHtmlNodeNTD<N, T, D> extends SvgXmlNodeNTD<N, T, D> {}
+export interface SvgHtmlNodeNTD<
+  DOM extends DOM_TYPES,
+> extends SvgXmlNodeNTD<DOM> {}
 
 /**
  * The SvgHtmlNodeClass interface for the SVG HtmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgHtmlNodeClass<N, T, D> extends SvgXmlNodeClass<N, T, D> {
+export interface SvgHtmlNodeClass<
+  DOM extends DOM_TYPES,
+> extends SvgXmlNodeClass<DOM> {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgHtmlNodeNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgHtmlNodeNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -57,17 +58,10 @@ export interface SvgHtmlNodeClass<N, T, D> extends SvgXmlNodeClass<N, T, D> {
 /**
  * The SvgHtmlNode wrapper class for the MmlHtmlNode class
  */
-export const SvgHtmlNode = (function <N, T, D>(): SvgHtmlNodeClass<N, T, D> {
-  return class SvgHtmlNode
-    // @ts-expect-error Avoid message about SvgXmlNode constructors not having
-    // the same type (they should both be SvgWrapper<N, T, D>, but are thought
-    // of as different by typescript)
-    extends SvgXmlNode
-    implements SvgHtmlNodeNTD<N, T, D>
-  {
-    /**
-     * @override
-     */
-    public static kind = HtmlNode.prototype.kind;
-  };
-})<any, any, any>();
+// @ts-expect-error Avoid message about base constructors not having the same type
+export class SvgHtmlNode extends SvgXmlNode implements SvgHtmlNodeNTD<DOM> {
+  /**
+   * @override
+   */
+  public static kind = HtmlNode.prototype.kind;
+}

--- a/ts/output/svg/Wrappers/HtmlNode.ts
+++ b/ts/output/svg/Wrappers/HtmlNode.ts
@@ -58,10 +58,12 @@ export interface SvgHtmlNodeClass<
 /**
  * The SvgHtmlNode wrapper class for the MmlHtmlNode class
  */
-// @ts-expect-error Avoid message about base constructors not having the same type
-export class SvgHtmlNode extends SvgXmlNode implements SvgHtmlNodeNTD<DOM> {
-  /**
-   * @override
-   */
-  public static kind = HtmlNode.prototype.kind;
-}
+export const SvgHtmlNode = (function (): SvgHtmlNodeClass<DOM> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgHtmlNode extends SvgXmlNode implements SvgHtmlNodeNTD<DOM> {
+    /**
+     * @override
+     */
+    public static kind = HtmlNode.prototype.kind;
+  }
+})();

--- a/ts/output/svg/Wrappers/TeXAtom.ts
+++ b/ts/output/svg/Wrappers/TeXAtom.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonTeXAtom,
   CommonTeXAtomClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/TeXAtom.js';
 import { TeXAtom } from '../../../core/MmlTree/MmlNodes/TeXAtom.js';
 import { MmlNode, TEXCLASSNAMES } from '../../../core/MmlTree/MmlNode.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgTeXAtom interface for the SVG TeXAtom wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgTeXAtomNTD<N, T, D>
+export interface SvgTeXAtomNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonTeXAtom<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgTeXAtomClass interface for the SVG TeXAtom wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgTeXAtomClass<N, T, D>
+export interface SvgTeXAtomClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonTeXAtomClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgTeXAtomNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgTeXAtomNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,26 +79,18 @@ export interface SvgTeXAtomClass<N, T, D>
 /**
  * The SvgTeXAtom wrapper for the MmlTeXAtom class
  */
-export const SvgTeXAtom = (function <N, T, D>(): SvgTeXAtomClass<N, T, D> {
+export const SvgTeXAtom = (function (): SvgTeXAtomClass<DOM> {
   const Base = CommonTeXAtomMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgTeXAtomClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgTeXAtomClass<DOM>
   >(SvgWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be SvgWrapper<N, T, D>, but are thought of as different by typescript)
-  return class SvgTeXAtom extends Base implements SvgTeXAtomNTD<N, T, D> {
+  return class SvgTeXAtom extends Base implements SvgTeXAtomNTD<DOM> {
     /**
      * @override
      */
@@ -129,7 +99,7 @@ export const SvgTeXAtom = (function <N, T, D>(): SvgTeXAtomClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       super.toSVG(parents);
       this.adaptor.setAttribute(
         this.dom[0],
@@ -137,5 +107,5 @@ export const SvgTeXAtom = (function <N, T, D>(): SvgTeXAtomClass<N, T, D> {
         TEXCLASSNAMES[this.node.texClass]
       );
     }
-  } as any as SvgTeXAtomClass<N, T, D>;
-})<any, any, any>();
+  } as any as SvgTeXAtomClass<DOM>;
+})();

--- a/ts/output/svg/Wrappers/TextNode.ts
+++ b/ts/output/svg/Wrappers/TextNode.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonTextNode,
   CommonTextNodeClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/TextNode.js';
 import { MmlNode, TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJsonSheet } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgTextNode interface for the SVG TextNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgTextNodeNTD<N, T, D>
+export interface SvgTextNodeNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonTextNode<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgTextNodeClass interface for the SVG TextNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgTextNodeClass<N, T, D>
+export interface SvgTextNodeClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonTextNodeClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgTextNodeNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgTextNodeNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,27 +79,19 @@ export interface SvgTextNodeClass<N, T, D>
 /**
  * The SvgTextNode wrapper for the MmlTextNode class
  */
-export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
+export const SvgTextNode = (function (): SvgTextNodeClass<DOM> {
   const Base = CommonTextNodeMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgTextNodeClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgTextNodeClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgTextNode extends Base implements SvgTextNodeNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgTextNode extends Base implements SvgTextNodeNTD<DOM> {
     /**
      * @override
      */
@@ -130,7 +100,7 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
     /**
      * @override
      */
-    public static addStyles<JX extends SVG<any, any, any>>(
+    public static addStyles<JX extends SVG<DOM>>(
       styles: StyleJsonSheet,
       jax: JX
     ) {
@@ -145,14 +115,17 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const adaptor = this.adaptor;
       const variant = this.parent.variant;
       const text = (this.node as TextNode).getText();
       if (text.length === 0) return;
       if (variant === '-explicitFont') {
         this.dom = [
-          adaptor.append(parents[0], this.jax.unknownText(text, variant)) as N,
+          adaptor.append(
+            parents[0],
+            this.jax.unknownText(text, variant)
+          ) as N<DOM>,
         ];
       } else {
         const chars = this.remappedText(text, variant);
@@ -161,7 +134,7 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
             adaptor.append(
               parents[0],
               this.svg('g', { 'data-mml-node': 'text' })
-            ) as N,
+            ) as N<DOM>,
           ];
         } else {
           this.dom = parents;
@@ -174,4 +147,4 @@ export const SvgTextNode = (function <N, T, D>(): SvgTextNodeClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/maction.ts
+++ b/ts/output/svg/Wrappers/maction.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMaction,
   CommonMactionClass,
@@ -46,94 +39,67 @@ import {
 } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { MACTION } from '../../../a11y/semantic-enrich/maction.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMaction interface for the SVG maction wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMactionNTD<N, T, D>
+export interface SvgMactionNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMaction<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMactionClass interface for the SVG maction wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMactionClass<N, T, D>
+export interface SvgMactionClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMactionClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMactionNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMactionNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMaction wrapper for the MmlMaction class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
+export const SvgMaction = (function (): SvgMactionClass<DOM> {
   const Base = CommonMactionMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMactionClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMactionClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMaction extends Base implements SvgMactionNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMaction extends Base implements SvgMactionNTD<DOM> {
     /**
      * @override
      */
@@ -244,10 +210,10 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
                   node.svg('foreignObject', { style: { display: 'none' } }, [
                     tool,
                   ])
-                ) as N;
+                ) as N<DOM>;
                 node.jax.processMath(
                   node.jax.factory.wrap(math),
-                  adaptor.firstChild(tool) as N
+                  adaptor.firstChild(tool) as N<DOM>
                 );
                 node.childNodes[1].node.parent = node.node;
                 //
@@ -299,19 +265,13 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
         ],
       ],
     ] as ActionDef<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass,
-      SvgMactionNTD<N, T, D>
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>,
+      SvgMactionNTD<DOM>
     >[]);
 
     /*************************************************************/
@@ -319,7 +279,7 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       const svg = this.standardSvgNodes(parents);
       const child = this.selected;
@@ -346,4 +306,4 @@ export const SvgMaction = (function <N, T, D>(): SvgMactionClass<N, T, D> {
       this.action(this, this.data);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/math.ts
+++ b/ts/output/svg/Wrappers/math.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMath,
   CommonMathClass,
@@ -41,62 +34,47 @@ import { MmlMath } from '../../../core/MmlTree/MmlNodes/math.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { BBox } from '../../../util/BBox.js';
 import { ZeroFontDataUrl } from './zero.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The Svgmath interface for the SVG math wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMathNTD<N, T, D>
+export interface SvgMathNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMath<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgmathClass interface for the SVG math wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMathClass<N, T, D>
+export interface SvgMathClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMathClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMathNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMathNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -104,26 +82,18 @@ export interface SvgMathClass<N, T, D>
 /**
  * The SvgMath wrapper for the MmlMath class
  */
-export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
+export const SvgMath = (function (): SvgMathClass<DOM> {
   const Base = CommonMathMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMathClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMathClass<DOM>
   >(SvgWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be SvgWrapper<N, T, D>, but are thought of as different by typescript)
-  return class SvgMath extends Base implements SvgMathNTD<N, T, D> {
+  return class SvgMath extends Base implements SvgMathNTD<DOM> {
     /**
      * @override
      */
@@ -211,7 +181,7 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       super.toSVG(parents);
       const adaptor = this.adaptor;
       const display = this.node.attributes.get('display') === 'block';
@@ -236,4 +206,4 @@ export const SvgMath = (function <N, T, D>(): SvgMathClass<N, T, D> {
       );
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/menclose.ts
+++ b/ts/output/svg/Wrappers/menclose.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMenclose,
   CommonMencloseClass,
@@ -41,32 +34,25 @@ import { MmlMenclose } from '../../../core/MmlTree/MmlNodes/menclose.js';
 import * as Notation from '../Notation.js';
 import { SvgMsqrtNTD } from './msqrt.js';
 import { OptionList } from '../../../util/Options.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMenclose interface for the SVG menclose wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMencloseNTD<N, T, D>
+export interface SvgMencloseNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMenclose<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass,
-      SvgMsqrtNTD<N, T, D>
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>,
+      SvgMsqrtNTD<DOM>
     > {
   /**
    * Create a line element
@@ -74,7 +60,7 @@ export interface SvgMencloseNTD<N, T, D>
    * @param {number[]} pq   The coordinates of the endpoints, [x1, y1, x2, y2]
    * @returns {N}            The newly created line element
    */
-  line(pq: [number, number, number, number]): N;
+  line(pq: [number, number, number, number]): N<DOM>;
 
   /**
    * Create a rectangle element
@@ -85,7 +71,7 @@ export interface SvgMencloseNTD<N, T, D>
    * @param {number=} r   The corner radius for a rounded rectangle
    * @returns {N}          The newly created line element
    */
-  box(w: number, h: number, d: number, r?: number): N;
+  box(w: number, h: number, d: number, r?: number): N<DOM>;
 
   /**
    * Create an ellipse element
@@ -95,7 +81,7 @@ export interface SvgMencloseNTD<N, T, D>
    * @param {number} d  The depth of the ellipse
    * @returns {N}        The newly created ellipse node
    */
-  ellipse(w: number, h: number, d: number): N;
+  ellipse(w: number, h: number, d: number): N<DOM>;
 
   /**
    * Create a path element from the commands that specify it
@@ -104,7 +90,7 @@ export interface SvgMencloseNTD<N, T, D>
    * @param {(string|number)[]} P   The list of commands and coordinates for the path
    * @returns {N}                    The newly created path
    */
-  path(join: string, ...P: (string | number)[]): N;
+  path(join: string, ...P: (string | number)[]): N<DOM>;
 
   /**
    * Create a filled path element from the commands the specify it
@@ -113,38 +99,30 @@ export interface SvgMencloseNTD<N, T, D>
    * @param {(string|number)[]} P   The list of commands and coordinates for the path
    * @returns {N}                    The newly created path
    */
-  fill(...P: (string | number)[]): N;
+  fill(...P: (string | number)[]): N<DOM>;
 }
 
 /**
  * The SvgMencloseClass interface for the SVG menclose wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMencloseClass<N, T, D>
+export interface SvgMencloseClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMencloseClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMencloseNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMencloseNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -152,28 +130,20 @@ export interface SvgMencloseClass<N, T, D>
 /**
  * The SvgMenclose wrapper for the MmlMenclose class
  */
-export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
+export const SvgMenclose = (function (): SvgMencloseClass<DOM> {
   const Base = CommonMencloseMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMsqrtNTD<N, T, D>,
-    SvgMencloseClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMsqrtNTD<DOM>,
+    SvgMencloseClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMenclose extends Base implements SvgMencloseNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMenclose extends Base implements SvgMencloseNTD<DOM> {
     /**
      * @override
      */
@@ -182,7 +152,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      *  The definitions of the various notations
      */
-    public static notations: Notation.DefList<SvgMenclose, N> = new Map([
+    public static notations: Notation.DefList<SvgMenclose, N<DOM>> = new Map([
       Notation.Border('top'),
       Notation.Border('right'),
       Notation.Border('bottom'),
@@ -346,14 +316,14 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
           renderChild: true,
         },
       ],
-    ] as Notation.DefPair<SvgMenclose, N>[]);
+    ] as Notation.DefPair<SvgMenclose, N<DOM>>[]);
 
     /********************************************************/
 
     /**
      * @override
      */
-    public line(pq: [number, number, number, number]): N {
+    public line(pq: [number, number, number, number]): N<DOM> {
       const [x1, y1, x2, y2] = pq;
       return this.svg('line', {
         x1: this.fixed(x1),
@@ -367,7 +337,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      * @override
      */
-    public box(w: number, h: number, d: number, r: number = 0): N {
+    public box(w: number, h: number, d: number, r: number = 0): N<DOM> {
       const t = this.thickness;
       const def: OptionList = {
         x: this.fixed(t / 2),
@@ -386,7 +356,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      * @override
      */
-    public ellipse(w: number, h: number, d: number): N {
+    public ellipse(w: number, h: number, d: number): N<DOM> {
       const t = this.thickness;
       return this.svg('ellipse', {
         rx: this.fixed((w - t) / 2),
@@ -401,7 +371,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      * @override
      */
-    public path(join: string, ...P: (string | number)[]): N {
+    public path(join: string, ...P: (string | number)[]): N<DOM> {
       return this.svg('path', {
         d: P.map((x) => (typeof x === 'string' ? x : this.fixed(x))).join(' '),
         style: { 'stroke-width': this.fixed(this.thickness) },
@@ -414,7 +384,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      * @override
      */
-    public fill(...P: (string | number)[]): N {
+    public fill(...P: (string | number)[]): N<DOM> {
       return this.svg('path', {
         d: P.map((x) => (typeof x === 'string' ? x : this.fixed(x))).join(' '),
       });
@@ -425,44 +395,97 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      * @override
      */
-    /* prettier-ignore */
-    public arrow(W: number, a: number, double: boolean, offset: string = '', dist: number = 0): N {
-      const {w, h, d} = this.getBBox();
+    public arrow(
+      W: number,
+      a: number,
+      double: boolean,
+      offset: string = '',
+      dist: number = 0
+    ): N<DOM> {
+      const { w, h, d } = this.getBBox();
       const dw = (W - w) / 2;
       const m = (h - d) / 2;
       const t = this.thickness;
       const t2 = t / 2;
-      const [x, y, dx] = [t * this.arrowhead.x, t * this.arrowhead.y, t * this.arrowhead.dx];
-      const arrow =
-        (double ?
-         this.fill(
-           'M', w + dw, m,                            // point of arrow
-           'l', -(x + dx), y,  'l', dx, t2 - y,       // upper right head
-           'L', x - dw, m + t2,                       // upper side of shaft
-           'l', dx, y - t2, 'l', -(x + dx), - y,      // left point
-           'l', x + dx, -y,    'l', -dx, y - t2,      // lower left head
-           'L', w + dw - x, m - t2,                   // lower side of shaft
-           'l', -dx, t2 - y, 'Z'                      // lower head
-         ) :
-         this.fill(
-           'M', w + dw, m,                            // point of arrow
-           'l', -(x + dx), y,  'l', dx, t2 - y,       // upper head
-           'L', -dw, m + t2, 'l', 0, -t,              // upper side of shaft
-           'L', w + dw - x, m - t2,                   // lower side of shaft
-           'l', -dx, t2 - y, 'Z'                      // lower head
-         ));
+      const [x, y, dx] = [
+        t * this.arrowhead.x,
+        t * this.arrowhead.y,
+        t * this.arrowhead.dx,
+      ];
+      const arrow = double
+        ? this.fill(
+            'M',
+            w + dw,
+            m, //                            Point of arrow
+            'l',
+            -(x + dx),
+            y,
+            'l',
+            dx,
+            t2 - y, //       Upper right head
+            'L',
+            x - dw,
+            m + t2, //                       Upper side of shaft
+            'l',
+            dx,
+            y - t2,
+            'l',
+            -(x + dx),
+            -y, //      Left point
+            'l',
+            x + dx,
+            -y,
+            'l',
+            -dx,
+            y - t2, //      Lower left head
+            'L',
+            w + dw - x,
+            m - t2, //                   Lower side of shaft
+            'l',
+            -dx,
+            t2 - y,
+            'Z' //                      Lower head
+          )
+        : this.fill(
+            'M',
+            w + dw,
+            m, //                            Point of arrow
+            'l',
+            -(x + dx),
+            y,
+            'l',
+            dx,
+            t2 - y, //       Upper head
+            'L',
+            -dw,
+            m + t2,
+            'l',
+            0,
+            -t, //              Upper side of shaft
+            'L',
+            w + dw - x,
+            m - t2, //                   Lower side of shaft
+            'l',
+            -dx,
+            t2 - y,
+            'Z' //                      Lower head
+          );
       const transform = [];
       if (dist) {
-        transform.push(offset === 'X' ? `translate(${this.fixed(-dist)} 0)` : `translate(0 ${this.fixed(dist)})`);
+        transform.push(
+          offset === 'X'
+            ? `translate(${this.fixed(-dist)} 0)`
+            : `translate(0 ${this.fixed(dist)})`
+        );
       }
       if (a) {
-        const A = this.jax.fixed(-a * 180 / Math.PI);
+        const A = this.jax.fixed((-a * 180) / Math.PI);
         transform.push(`rotate(${A} ${this.fixed(w / 2)} ${this.fixed(m)})`);
       }
       if (transform.length) {
         this.adaptor.setAttribute(arrow, 'transform', transform.join(' '));
       }
-      return arrow as N;
+      return arrow as N<DOM>;
     }
 
     /********************************************************/
@@ -470,7 +493,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const svg = this.standardSvgNodes(parents);
       //
       //  Create a box at the correct position and add the children
@@ -480,7 +503,7 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
       if (left > 0) {
         def.transform = 'translate(' + this.fixed(left) + ', 0)';
       }
-      const block = this.adaptor.append(svg[0], this.svg('g', def)) as N;
+      const block = this.adaptor.append(svg[0], this.svg('g', def)) as N<DOM>;
       if (this.renderChild) {
         this.renderChild(this, block);
       } else {
@@ -498,4 +521,4 @@ export const SvgMenclose = (function <N, T, D>(): SvgMencloseClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/merror.ts
+++ b/ts/output/svg/Wrappers/merror.ts
@@ -26,30 +26,29 @@ import { SvgWrapperFactory } from '../WrapperFactory.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMerror } from '../../../core/MmlTree/MmlNodes/merror.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMerror interface for the Svg merror wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMerrorNTD<N, T, D> extends SvgWrapper<N, T, D> {}
+export interface SvgMerrorNTD<DOM extends DOM_TYPES> extends SvgWrapper<DOM> {}
 
 /**
  * The SvgMerrorClass interface for the SVG merror wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMerrorClass<N, T, D> extends SvgWrapperClass<N, T, D> {
+export interface SvgMerrorClass<
+  DOM extends DOM_TYPES,
+> extends SvgWrapperClass<DOM> {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMerrorNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMerrorNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -57,53 +56,48 @@ export interface SvgMerrorClass<N, T, D> extends SvgWrapperClass<N, T, D> {
 /**
  * The SvgMerror wrapper class for the MmlMerror class
  */
-export const SvgMerror = (function <N, T, D>(): SvgMerrorClass<N, T, D> {
-  return class SvgMerror
-    extends SvgWrapper<N, T, D>
-    implements SvgMerrorNTD<N, T, D>
-  {
-    /**
-     * @override
-     */
-    public static kind = MmlMerror.prototype.kind;
+export class SvgMerror extends SvgWrapper<DOM> implements SvgMerrorNTD<DOM> {
+  /**
+   * @override
+   */
+  public static kind = MmlMerror.prototype.kind;
 
-    /**
-     * @override
-     */
-    public static styles: StyleJson = {
-      'g[data-mml-node="merror"] > g': {
-        fill: 'red',
-        stroke: 'red',
-      },
-      'g[data-mml-node="merror"] > rect[data-background]': {
-        fill: 'yellow',
-        stroke: 'none',
-      },
-    };
+  /**
+   * @override
+   */
+  public static styles: StyleJson = {
+    'g[data-mml-node="merror"] > g': {
+      fill: 'red',
+      stroke: 'red',
+    },
+    'g[data-mml-node="merror"] > rect[data-background]': {
+      fill: 'yellow',
+      stroke: 'none',
+    },
+  };
 
-    /**
-     * @override
-     */
-    public toSVG(parents: N[]) {
-      const svg = this.standardSvgNodes(parents);
-      const { h, d, w } = this.getBBox();
+  /**
+   * @override
+   */
+  public toSVG(parents: N<DOM>[]) {
+    const svg = this.standardSvgNodes(parents);
+    const { h, d, w } = this.getBBox();
+    this.adaptor.append(
+      this.dom[0],
+      this.svg('rect', {
+        'data-background': true,
+        width: this.fixed(w),
+        height: this.fixed(h + d),
+        y: this.fixed(-d),
+      })
+    );
+    const title = this.node.attributes.get('title') as string;
+    if (title) {
       this.adaptor.append(
         this.dom[0],
-        this.svg('rect', {
-          'data-background': true,
-          width: this.fixed(w),
-          height: this.fixed(h + d),
-          y: this.fixed(-d),
-        })
+        this.svg('title', {}, [this.adaptor.text(title)])
       );
-      const title = this.node.attributes.get('title') as string;
-      if (title) {
-        this.adaptor.append(
-          this.dom[0],
-          this.svg('title', {}, [this.adaptor.text(title)])
-        );
-      }
-      this.addChildren(svg);
     }
-  };
-})<any, any, any>();
+    this.addChildren(svg);
+  }
+}

--- a/ts/output/svg/Wrappers/mfenced.ts
+++ b/ts/output/svg/Wrappers/mfenced.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMfenced,
   CommonMfencedClass,
@@ -39,62 +32,47 @@ import {
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMfenced } from '../../../core/MmlTree/MmlNodes/mfenced.js';
 import { SvgInferredMrowNTD } from './mrow.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMfenced interface for the SVG mfenced wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMfencedNTD<N, T, D>
+export interface SvgMfencedNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMfenced<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMfencedClass interface for the SVG mfenced wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMfencedClass<N, T, D>
+export interface SvgMfencedClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMfencedClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMfencedNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMfencedNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -102,27 +80,19 @@ export interface SvgMfencedClass<N, T, D>
 /**
  * The SvgMfenced wrapper class for the MmlMfenced class
  */
-export const SvgMfenced = (function <N, T, D>(): SvgMfencedClass<N, T, D> {
+export const SvgMfenced = (function (): SvgMfencedClass<DOM> {
   const Base = CommonMfencedMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMfencedClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMfencedClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMfenced extends Base implements SvgMfencedNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMfenced extends Base implements SvgMfencedNTD<DOM> {
     /**
      * @override
      */
@@ -131,12 +101,12 @@ export const SvgMfenced = (function <N, T, D>(): SvgMfencedClass<N, T, D> {
     /**
      * An mrow used to render the result
      */
-    public mrow: SvgInferredMrowNTD<N, T, D>;
+    public mrow: SvgInferredMrowNTD<DOM>;
 
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const svg = this.standardSvgNodes(parents);
       this.setChildrenParent(this.mrow); // temporarily change parents to the mrow
       this.mrow.toSVG(svg);
@@ -146,10 +116,10 @@ export const SvgMfenced = (function <N, T, D>(): SvgMfencedClass<N, T, D> {
     /**
      * @param {SvgWrapper} parent   The parent to use for the fenced children
      */
-    protected setChildrenParent(parent: SvgWrapper<N, T, D>) {
+    protected setChildrenParent(parent: SvgWrapper<DOM>) {
       for (const child of this.childNodes) {
         child.parent = parent;
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mfrac.ts
+++ b/ts/output/svg/Wrappers/mfrac.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMfrac,
   CommonMfracClass,
@@ -39,62 +32,47 @@ import {
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMfrac } from '../../../core/MmlTree/MmlNodes/mfrac.js';
 import { SvgMoNTD } from './mo.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMfrac interface for the SVG Mfrac wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMfracNTD<N, T, D>
+export interface SvgMfracNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMfrac<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMfracClass interface for the SVG Mfrac wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMfracClass<N, T, D>
+export interface SvgMfracClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMfracClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMfracNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMfracNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -102,27 +80,19 @@ export interface SvgMfracClass<N, T, D>
 /**
  * The SvgMfrac wrapper class for the MmlMfrac class
  */
-export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
+export const SvgMfrac = (function (): SvgMfracClass<DOM> {
   const Base = CommonMfracMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMfracClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMfracClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMfrac extends Base implements SvgMfracNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMfrac extends Base implements SvgMfracNTD<DOM> {
     /**
      * @override
      */
@@ -131,14 +101,14 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
     /**
      * An mo element used to render bevelled fractions
      */
-    protected bevel: SvgMoNTD<N, T, D>;
+    protected bevel: SvgMoNTD<DOM>;
 
     /************************************************/
 
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       this.standardSvgNodes(parents);
       const { linethickness, bevelled } = this.node.attributes.getList(
@@ -260,4 +230,4 @@ export const SvgMfrac = (function <N, T, D>(): SvgMfracClass<N, T, D> {
       );
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mglyph.ts
+++ b/ts/output/svg/Wrappers/mglyph.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMglyph,
   CommonMglyphClass,
@@ -40,62 +33,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMglyph } from '../../../core/MmlTree/MmlNodes/mglyph.js';
 import { SvgTextNodeNTD } from './TextNode.js';
 import { OptionList } from '../../../util/Options.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMglyph interface for the SVG Mglyph wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMglyphNTD<N, T, D>
+export interface SvgMglyphNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMglyph<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMglyphClass interface for the SVG Mglyph wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMglyphClass<N, T, D>
+export interface SvgMglyphClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMglyphClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMglyphNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMglyphNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -103,27 +81,19 @@ export interface SvgMglyphClass<N, T, D>
 /**
  * The SvgMglyph wrapper class for the MmlMglyph class
  */
-export const SvgMglyph = (function <N, T, D>(): SvgMglyphClass<N, T, D> {
+export const SvgMglyph = (function (): SvgMglyphClass<DOM> {
   const Base = CommonMglyphMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMglyphClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMglyphClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMglyph extends Base implements SvgMglyphNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMglyph extends Base implements SvgMglyphNTD<DOM> {
     /**
      * @override
      */
@@ -132,10 +102,10 @@ export const SvgMglyph = (function <N, T, D>(): SvgMglyphClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const svg = this.standardSvgNodes(parents);
       if (this.charWrapper) {
-        (this.charWrapper as SvgTextNodeNTD<N, T, D>).toSVG(svg);
+        (this.charWrapper as SvgTextNodeNTD<DOM>).toSVG(svg);
         return;
       }
       const { src, alt } = this.node.attributes.getList('src', 'alt');
@@ -154,4 +124,4 @@ export const SvgMglyph = (function <N, T, D>(): SvgMglyphClass<N, T, D> {
       this.adaptor.append(svg[0], img);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mi.ts
+++ b/ts/output/svg/Wrappers/mi.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMi,
   CommonMiClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mi.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMi } from '../../../core/MmlTree/MmlNodes/mi.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMi interface for the SVG Mi wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMiNTD<N, T, D>
+export interface SvgMiNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMi<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMiClass interface for the SVG Mi wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMiClass<N, T, D>
+export interface SvgMiClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMiClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMiNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMiNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,29 +79,21 @@ export interface SvgMiClass<N, T, D>
 /**
  * The SvgMi wrapper class for the MmlMi class
  */
-export const SvgMi = (function <N, T, D>(): SvgMiClass<N, T, D> {
+export const SvgMi = (function (): SvgMiClass<DOM> {
   const Base = CommonMiMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMiClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMiClass<DOM>
   >(SvgWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be SvgWrapper<N, T, D>, but are thought of as different by typescript)
-  return class SvgMi extends Base implements SvgMiNTD<N, T, D> {
+  return class SvgMi extends Base implements SvgMiNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMi.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mmultiscripts.ts
+++ b/ts/output/svg/Wrappers/mmultiscripts.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMmultiscripts,
   CommonMmultiscriptsClass,
@@ -40,6 +33,7 @@ import { SvgMsubsup, SvgMsubsupNTD, SvgMsubsupClass } from './msubsup.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMmultiscripts } from '../../../core/MmlTree/MmlNodes/mmultiscripts.js';
 import { split } from '../../../util/string.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 
@@ -70,95 +64,63 @@ export function AlignX(align: string): AlignFunction {
 /**
  * The SvgMmultiscripts interface for the SVG Mmultiscripts wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMmultiscriptsNTD<N, T, D>
+export interface SvgMmultiscriptsNTD<DOM extends DOM_TYPES>
   extends
-    SvgMsubsupNTD<N, T, D>,
+    SvgMsubsupNTD<DOM>,
     CommonMmultiscripts<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMmultiscriptsClass interface for the SVG Mmultiscripts wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMmultiscriptsClass<N, T, D>
+export interface SvgMmultiscriptsClass<DOM extends DOM_TYPES>
   extends
-    SvgMsubsupClass<N, T, D>,
+    SvgMsubsupClass<DOM>,
     CommonMmultiscriptsClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMmultiscriptsNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMmultiscriptsNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMmultiscripts wrapper class for the MmlMmultiscripts class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
-  N,
-  T,
-  D
-> {
+export const SvgMmultiscripts = (function (): SvgMmultiscriptsClass<DOM> {
   const Base = CommonMmultiscriptsMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMmultiscriptsClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMmultiscriptsClass<DOM>
   >(SvgMsubsup);
 
   return class SvgMmultiscripts
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be SvgWrapper<N, T, D>, but are thought of as
-    // different by typescript)
+    // @ts-expect-error Avoid message about base constructors not having the same type
     extends Base
-    implements SvgMmultiscriptsNTD<N, T, D>
+    implements SvgMmultiscriptsNTD<DOM>
   {
     /**
      * @override
@@ -168,7 +130,7 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       const svg = this.standardSvgNodes(parents);
       const data = this.scriptData;
@@ -224,7 +186,7 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
      * @returns {number}        The right-hand offset of the scripts
      */
     protected addScripts(
-      svg: N,
+      svg: N<DOM>,
       x: number,
       u: number,
       v: number,
@@ -234,8 +196,8 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
     ): number {
       const adaptor = this.adaptor;
       const alignX = AlignX(align);
-      const supRow = adaptor.append(svg, this.svg('g')) as N;
-      const subRow = adaptor.append(svg, this.svg('g')) as N;
+      const supRow = adaptor.append(svg, this.svg('g')) as N<DOM>;
+      const subRow = adaptor.append(svg, this.svg('g')) as N<DOM>;
       this.place(x, u, supRow);
       this.place(x, v, subRow);
       const m = i + 2 * n;
@@ -254,4 +216,4 @@ export const SvgMmultiscripts = (function <N, T, D>(): SvgMmultiscriptsClass<
       return x + dx;
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mn.ts
+++ b/ts/output/svg/Wrappers/mn.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMn,
   CommonMnClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mn.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMn } from '../../../core/MmlTree/MmlNodes/mn.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMn interface for the SVG Mn wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMnNTD<N, T, D>
+export interface SvgMnNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMn<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMnClass interface for the SVG Mn wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMnClass<N, T, D>
+export interface SvgMnClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMnClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMnNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMnNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,29 +79,21 @@ export interface SvgMnClass<N, T, D>
 /**
  * The SvgMn wrapper class for the MmlMn class
  */
-export const SvgMn = (function <N, T, D>(): SvgMnClass<N, T, D> {
+export const SvgMn = (function (): SvgMnClass<DOM> {
   const Base = CommonMnMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMnClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMnClass<DOM>
   >(SvgWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be SvgWrapper<N, T, D>, but are thought of as different by typescript)
-  return class SvgMn extends Base implements SvgMnNTD<N, T, D> {
+  return class SvgMn extends Base implements SvgMnNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMn.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mo.ts
+++ b/ts/output/svg/Wrappers/mo.ts
@@ -21,18 +21,10 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-  VFUZZ,
-  HFUZZ,
-} from '../FontData.js';
+import { SvgCharOptions, VFUZZ, HFUZZ } from '../FontData.js';
 import {
   CommonMo,
   CommonMoClass,
@@ -42,94 +34,67 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMo } from '../../../core/MmlTree/MmlNodes/mo.js';
 import { BBox } from '../../../util/BBox.js';
 import { DIRECTION, SvgCharData } from '../FontData.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMo interface for the SVG Mo wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMoNTD<N, T, D>
+export interface SvgMoNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMo<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMoClass interface for the SVG Mo wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMoClass<N, T, D>
+export interface SvgMoClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMoClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMoNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMoNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMo wrapper class for the MmlMo class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
+export const SvgMo = (function (): SvgMoClass<DOM> {
   const Base = CommonMoMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMoClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMoClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMo extends Base implements SvgMoNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMo extends Base implements SvgMoNTD<DOM> {
     /**
      * @override
      */
@@ -138,7 +103,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const attributes = this.node.attributes;
       const symmetric =
         (attributes.get('symmetric') as boolean) &&
@@ -207,7 +172,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
      *
      * @returns {string[]} The variants array
      */
-    protected getStretchVariants() {
+    protected getStretchVariants(): string[] {
       const c = this.stretch.c || this.getText().codePointAt(0);
       const variants = [] as string[];
       for (const i of this.stretch.stretch.keys()) {
@@ -291,7 +256,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       variant: string,
       x: number,
       y: number,
-      parent: N = null
+      parent: N<DOM> = null
     ): number {
       if (parent) {
         return this.placeChar(n, x, y, parent, variant);
@@ -360,7 +325,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       this.addGlyph(n, v, 0, 0, svg);
       const glyph = adaptor.lastChild(svg);
       adaptor.setAttribute(
-        glyph as N,
+        glyph as N<DOM>,
         'transform',
         `scale(1,${this.jax.fixed(s)})`
       );
@@ -447,7 +412,7 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       this.addGlyph(n, v, 0, 0, svg);
       const glyph = adaptor.lastChild(svg);
       adaptor.setAttribute(
-        glyph as N,
+        glyph as N<DOM>,
         'transform',
         `scale(${this.jax.fixed(s)},1)`
       );
@@ -484,4 +449,4 @@ export const SvgMo = (function <N, T, D>(): SvgMoClass<N, T, D> {
       return [(W - w) / 2, (W + w) / 2];
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mpadded.ts
+++ b/ts/output/svg/Wrappers/mpadded.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMpadded,
   CommonMpaddedClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mpadded.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMpadded } from '../../../core/MmlTree/MmlNodes/mpadded.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMpadded interface for the SVG Mpadded wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMpaddedNTD<N, T, D>
+export interface SvgMpaddedNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMpadded<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMpaddedClass interface for the SVG Mpadded wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMpaddedClass<N, T, D>
+export interface SvgMpaddedClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMpaddedClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMpaddedNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMpaddedNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,27 +79,19 @@ export interface SvgMpaddedClass<N, T, D>
 /**
  * The SvgMpadded wrapper class for the MmlMpadded class
  */
-export const SvgMpadded = (function <N, T, D>(): SvgMpaddedClass<N, T, D> {
+export const SvgMpadded = (function (): SvgMpaddedClass<DOM> {
   const Base = CommonMpaddedMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMpaddedClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMpaddedClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMpadded extends Base implements SvgMpaddedaNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMpadded extends Base implements SvgMpaddedaNTD<DOM> {
     /**
      * @override
      */
@@ -130,7 +100,7 @@ export const SvgMpadded = (function <N, T, D>(): SvgMpaddedClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       let svg = this.standardSvgNodes(parents);
       const [, , , , , dw, x, y, dx] = this.getDimens();
@@ -144,10 +114,10 @@ export const SvgMpadded = (function <N, T, D>(): SvgMpaddedClass<N, T, D> {
       //   use relative positioning to move the contents
       //
       if (X || y) {
-        svg = [this.adaptor.append(svg[0], this.svg('g')) as N];
+        svg = [this.adaptor.append(svg[0], this.svg('g')) as N<DOM>];
         this.place(X, y, svg[0]);
       }
       this.addChildren(svg);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mphantom.ts
+++ b/ts/output/svg/Wrappers/mphantom.ts
@@ -25,30 +25,31 @@ import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMphantom } from '../../../core/MmlTree/MmlNodes/mphantom.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMphantom interface for the SVG Mphantom wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMphantomNTD<N, T, D> extends SvgWrapper<N, T, D> {}
+export interface SvgMphantomNTD<
+  DOM extends DOM_TYPES,
+> extends SvgWrapper<DOM> {}
 
 /**
  * The SvgMphantomClass interface for the SVG Mphantom wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMphantomClass<N, T, D> extends SvgWrapperClass<N, T, D> {
+export interface SvgMphantomClass<
+  DOM extends DOM_TYPES,
+> extends SvgWrapperClass<DOM> {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMphantomNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMphantomNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -56,21 +57,19 @@ export interface SvgMphantomClass<N, T, D> extends SvgWrapperClass<N, T, D> {
 /**
  * The SvgMphantom wrapper class for the MmlMphantom class
  */
-export const SvgMphantom = (function <N, T, D>(): SvgMphantomClass<N, T, D> {
-  return class SvgMphantom
-    extends SvgWrapper<N, T, D>
-    implements SvgMphantomNTD<N, T, D>
-  {
-    /**
-     * @override
-     */
-    public static kind = MmlMphantom.prototype.kind;
+export class SvgMphantom
+  extends SvgWrapper<DOM>
+  implements SvgMphantomNTD<DOM>
+{
+  /**
+   * @override
+   */
+  public static kind = MmlMphantom.prototype.kind;
 
-    /**
-     * @override
-     */
-    public toSVG(parents: N[]) {
-      this.standardSvgNodes(parents);
-    }
-  };
-})<any, any, any>();
+  /**
+   * @override
+   */
+  public toSVG(parents: N<DOM>[]) {
+    this.standardSvgNodes(parents);
+  }
+}

--- a/ts/output/svg/Wrappers/mroot.ts
+++ b/ts/output/svg/Wrappers/mroot.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMroot,
   CommonMrootClass,
@@ -40,62 +33,47 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMroot } from '../../../core/MmlTree/MmlNodes/mroot.js';
 import { SvgMsqrt, SvgMsqrtClass, SvgMsqrtNTD } from './msqrt.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMroot interface for the SVG Mroot wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMrootNTD<N, T, D>
+export interface SvgMrootNTD<DOM extends DOM_TYPES>
   extends
-    SvgMsqrtNTD<N, T, D>,
+    SvgMsqrtNTD<DOM>,
     CommonMroot<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMrootClass interface for the SVG Mroot wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMrootClass<N, T, D>
+export interface SvgMrootClass<DOM extends DOM_TYPES>
   extends
-    SvgMsqrtClass<N, T, D>,
+    SvgMsqrtClass<DOM>,
     CommonMrootClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMrootNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMrootNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -103,27 +81,19 @@ export interface SvgMrootClass<N, T, D>
 /**
  * The SvgMroot wrapper class for the MmlMroot class
  */
-export const SvgMroot = (function <N, T, D>(): SvgMrootClass<N, T, D> {
+export const SvgMroot = (function (): SvgMrootClass<DOM> {
   const Base = CommonMrootMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMrootClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMrootClass<DOM>
   >(SvgMsqrt);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMroot extends Base implements SvgMrootNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMroot extends Base implements SvgMrootNTD<DOM> {
     /**
      * @override
      */
@@ -133,8 +103,8 @@ export const SvgMroot = (function <N, T, D>(): SvgMrootClass<N, T, D> {
      * @override
      */
     protected addRoot(
-      ROOT: N[],
-      root: SvgWrapper<N, T, D>,
+      ROOT: N<DOM>[],
+      root: SvgWrapper<DOM>,
       sbox: BBox,
       H: number
     ) {
@@ -145,4 +115,4 @@ export const SvgMroot = (function <N, T, D>(): SvgMrootClass<N, T, D> {
       return x;
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mrow.ts
+++ b/ts/output/svg/Wrappers/mrow.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMrow,
   CommonMrowClass,
@@ -44,94 +37,67 @@ import {
   MmlInferredMrow,
 } from '../../../core/MmlTree/MmlNodes/mrow.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMrow interface for the SVG Mrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMrowNTD<N, T, D>
+export interface SvgMrowNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMrow<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMrowClass interface for the SVG Mrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMrowClass<N, T, D>
+export interface SvgMrowClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMrowClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMrowNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMrowNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMrow wrapper for the MmlMrow type
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
+export const SvgMrow = (function (): SvgMrowClass<DOM> {
   const Base = CommonMrowMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMrowClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMrowClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMrow extends Base implements SvgMrowNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMrow extends Base implements SvgMrowNTD<DOM> {
     /**
      * @override
      */
@@ -146,7 +112,7 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       this.getBBox();
       const n = (this.linebreakCount = this.isStack ? 0 : this.breakCount);
       parents =
@@ -163,12 +129,12 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
      * @param {N[]} parents  The HTML nodes in which to place the lines
      * @returns {N[]} The augmented nodes array
      */
-    protected getSvgNodes(parents: N[]) {
+    protected getSvgNodes(parents: N<DOM>[]): N<DOM>[] {
       if (this.dh) {
         const g = this.svg('g', {
           transform: `translate(0 ${this.fixed(this.dh)})`,
         });
-        parents = [this.adaptor.append(parents[0], g) as N];
+        parents = [this.adaptor.append(parents[0], g) as N<DOM>];
       }
       this.dom = parents;
       return parents;
@@ -177,7 +143,7 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
     /**
      * @param {N[]} parents  The HTML nodes in which to place the lines
      */
-    protected placeLines(parents: N[]) {
+    protected placeLines(parents: N<DOM>[]) {
       const lines = this.lineBBox;
       const display = this.jax.math.display;
       let y = this.dh;
@@ -194,7 +160,7 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
     /**
      * @override
      */
-    protected createSvgNodes(parents: N[]): N[] {
+    protected createSvgNodes(parents: N<DOM>[]): N<DOM>[] {
       const n = this.linebreakCount;
       if (!n) return super.createSvgNodes(parents);
       //
@@ -204,22 +170,22 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
       const def = this.node.isInferred
         ? { 'data-mjx-linestack': true }
         : { 'data-mml-node': this.node.kind };
-      this.dom = [adaptor.append(parents[0], this.svg('g', def)) as N];
+      this.dom = [adaptor.append(parents[0], this.svg('g', def)) as N<DOM>];
       //
       // Add an href anchor, if needed, and insert the linestack/mrow
       //
       this.dom = [
-        adaptor.append(this.handleHref(parents)[0], this.dom[0]) as N,
+        adaptor.append(this.handleHref(parents)[0], this.dom[0]) as N<DOM>,
       ];
       //
       //  Add the line boxes
       //
-      const svg = Array(n) as N[];
+      const svg = Array(n) as N<DOM>[];
       for (let i = 0; i <= n; i++) {
         svg[i] = adaptor.append(
           this.dom[0],
           this.svg('g', { 'data-mjx-linebox': true, 'data-mjx-lineno': i })
-        ) as N;
+        ) as N<DOM>;
       }
       //
       //  Return the line boxes as the parent nodes for their contents
@@ -230,7 +196,7 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
     /**
      * @override
      */
-    public addChildren(parents: N[]) {
+    public addChildren(parents: N<DOM>[]) {
       let x = 0;
       let i = 0;
       const isEmbellished = this.node.isEmbellished;
@@ -260,7 +226,7 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -268,57 +234,41 @@ export const SvgMrow = (function <N, T, D>(): SvgMrowClass<N, T, D> {
 /**
  * The SvgInferredMrow interface for the SVG InferredMrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgInferredMrowNTD<N, T, D>
+export interface SvgInferredMrowNTD<DOM extends DOM_TYPES>
   extends
-    SvgMrowNTD<N, T, D>,
+    SvgMrowNTD<DOM>,
     CommonInferredMrow<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgInferredMrowClass interface for the SVG InferredMrow wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgInferredMrowClass<N, T, D>
+export interface SvgInferredMrowClass<DOM extends DOM_TYPES>
   extends
-    SvgMrowClass<N, T, D>,
+    SvgMrowClass<DOM>,
     CommonInferredMrowClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapper<N, T, D>,
+    factory: SvgWrapper<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgInferredMrowNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgInferredMrowNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -326,38 +276,22 @@ export interface SvgInferredMrowClass<N, T, D>
 /**
  * The SvgInferredMrow wrapper for the MmlInferredMrow class
  */
-export const SvgInferredMrow = (function <N, T, D>(): SvgInferredMrowClass<
-  N,
-  T,
-  D
-> {
+export const SvgInferredMrow = (function (): SvgInferredMrowClass<DOM> {
   const Base = CommonInferredMrowMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgInferredMrowClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgInferredMrowClass<DOM>
   >(SvgMrow);
 
-  return class SvgInferredMrowNTD
-    // @ts-expect-error Avoid message about base constructors not having the
-    // same type (they should both be SvgWrapper<N, T, D>, but are thought of as
-    // different by typescript)
-    extends Base
-    // @ts-expect-error Avoid messages of use of typeof
-    implements SvgInferredMrow<N, T, D>
-  {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgInferredMrowNTD extends Base implements SvgInferredMrow<DOM> {
     /**
      * The inferred-mrow wrapper
      */
     public static kind = MmlInferredMrow.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/ms.ts
+++ b/ts/output/svg/Wrappers/ms.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMs,
   CommonMsClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/ms.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMs } from '../../../core/MmlTree/MmlNodes/ms.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMs interface for the SVG Ms wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM nodes
  */
-export interface SvgMsNTD<N, T, D>
+export interface SvgMsNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMs<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMsClass interface for the SVG Ms wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM nodes
  */
-export interface SvgMsClass<N, T, D>
+export interface SvgMsClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMsClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMsNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMsNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,30 +79,22 @@ export interface SvgMsClass<N, T, D>
 /**
  * The SvgMs wrapper class for the MmlMs class
  */
-export const SvgMs = (function <N, T, D>(): SvgMsClass<N, T, D> {
+export const SvgMs = (function (): SvgMsClass<DOM> {
   const Base = CommonMsMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMsClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMsClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMs extends Base implements SvgMsNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMs extends Base implements SvgMsNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMs.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mspace.ts
+++ b/ts/output/svg/Wrappers/mspace.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMspace,
   CommonMspaceClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mspace.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMspace } from '../../../core/MmlTree/MmlNodes/mspace.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMspace interface for the SVG Mspace wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMspaceNTD<N, T, D>
+export interface SvgMspaceNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMspace<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMspaceClass interface for the SVG Mspace wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMspaceClass<N, T, D>
+export interface SvgMspaceClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMspaceClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMspaceNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMspaceNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,30 +79,22 @@ export interface SvgMspaceClass<N, T, D>
 /**
  * The SvgMspace wrapper class for the MmlMspace class
  */
-export const SvgMspace = (function <N, T, D>(): SvgMspaceClass<N, T, D> {
+export const SvgMspace = (function (): SvgMspaceClass<DOM> {
   const Base = CommonMspaceMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMspaceClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMspaceClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMspace extends Base implements SvgMspaceNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMspace extends Base implements SvgMspaceNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMspace.prototype.kind;
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/msqrt.ts
+++ b/ts/output/svg/Wrappers/msqrt.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMsqrt,
   CommonMsqrtClass,
@@ -40,31 +33,24 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMsqrt } from '../../../core/MmlTree/MmlNodes/msqrt.js';
 import { SvgMoNTD } from './mo.js';
 import { BBox } from '../../../util/BBox.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMsqrt interface for the SVG Msqrt wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsqrtNTD<N, T, D>
+export interface SvgMsqrtNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMsqrt<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   /**
    * Indent due to root
@@ -75,64 +61,44 @@ export interface SvgMsqrtNTD<N, T, D>
 /**
  * The SvgMsqrtClass interface for the SVG Msqrt wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsqrtClass<N, T, D>
+export interface SvgMsqrtClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMsqrtClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMsqrtNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMsqrtNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMsqrt wrapper for the MmlMsqrt class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
+export const SvgMsqrt = (function (): SvgMsqrtClass<DOM> {
   const Base = CommonMsqrtMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMsqrtClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMsqrtClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMsqrt extends Base implements SvgMsqrtNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMsqrt extends Base implements SvgMsqrtNTD<DOM> {
     /**
      * @override
      */
@@ -153,8 +119,8 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
      * @returns {number}          The offset required by the root
      */
     protected addRoot(
-      _ROOT: N[],
-      _root: SvgWrapper<N, T, D>,
+      _ROOT: N<DOM>[],
+      _root: SvgWrapper<DOM>,
       _sbox: BBox,
       _H: number
     ): number {
@@ -166,8 +132,8 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
-      const surd = this.surd as SvgMoNTD<N, T, D>;
+    public toSVG(parents: N<DOM>[]) {
+      const surd = this.surd as SvgMoNTD<DOM>;
       const base = this.childNodes[this.base];
       const root = this.root ? this.childNodes[this.root] : null;
       //
@@ -184,7 +150,7 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
       const SVG = this.standardSvgNodes(parents);
       surd.toSVG(SVG);
       const dx = this.addRoot(SVG, root, sbox, H);
-      const BASE = this.adaptor.append(SVG[0], this.svg('g')) as N;
+      const BASE = this.adaptor.append(SVG[0], this.svg('g')) as N<DOM>;
       base.toSVG([BASE]);
       //
       //  Place the children
@@ -202,4 +168,4 @@ export const SvgMsqrt = (function <N, T, D>(): SvgMsqrtClass<N, T, D> {
       );
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/msubsup.ts
+++ b/ts/output/svg/Wrappers/msubsup.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMsub,
   CommonMsubClass,
@@ -54,62 +47,47 @@ import {
   MmlMsub,
   MmlMsup,
 } from '../../../core/MmlTree/MmlNodes/msubsup.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMsub interface for the SVG Msub wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsubNTD<N, T, D>
+export interface SvgMsubNTD<DOM extends DOM_TYPES>
   extends
-    SvgScriptbaseNTD<N, T, D>,
+    SvgScriptbaseNTD<DOM>,
     CommonMsub<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMsubClass interface for the SVG Msub wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsubClass<N, T, D>
+export interface SvgMsubClass<DOM extends DOM_TYPES>
   extends
-    SvgScriptbaseClass<N, T, D>,
+    SvgScriptbaseClass<DOM>,
     CommonMsubClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMsubNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMsubNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -117,89 +95,65 @@ export interface SvgMsubClass<N, T, D>
 /**
  * The SvgMsub wrapper class for the MmlMsub class
  */
-export const SvgMsub = (function <N, T, D>(): SvgMsubClass<N, T, D> {
+export const SvgMsub = (function (): SvgMsubClass<DOM> {
   const Base = CommonMsubMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMsubClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMsubClass<DOM>
   >(SvgScriptbase);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMsub extends Base implements SvgMsubNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMsub extends Base implements SvgMsubNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMsub.prototype.kind;
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /**
  * The SvgMsup interface for the SVG Msup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsupNTD<N, T, D>
+export interface SvgMsupNTD<DOM extends DOM_TYPES>
   extends
-    SvgScriptbaseNTD<N, T, D>,
+    SvgScriptbaseNTD<DOM>,
     CommonMsup<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMsupClass interface for the SVG Msup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsupClass<N, T, D>
+export interface SvgMsupClass<DOM extends DOM_TYPES>
   extends
-    SvgScriptbaseClass<N, T, D>,
+    SvgScriptbaseClass<DOM>,
     CommonMsupClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMsupNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMsupNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -207,89 +161,65 @@ export interface SvgMsupClass<N, T, D>
 /**
  * The SvgMsup wrapper class for the MmlMsup class
  */
-export const SvgMsup = (function <N, T, D>(): SvgMsupClass<N, T, D> {
+export const SvgMsup = (function (): SvgMsupClass<DOM> {
   const Base = CommonMsupMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMsupClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMsupClass<DOM>
   >(SvgScriptbase);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMsup extends Base implements SvgMsupNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMsup extends Base implements SvgMsupNTD<DOM> {
     /**
      * @override
      */
     public static kind = MmlMsup.prototype.kind;
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /**
  * The SvgMglyph interface for the SVG Msubsup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsubsupNTD<N, T, D>
+export interface SvgMsubsupNTD<DOM extends DOM_TYPES>
   extends
-    SvgScriptbaseNTD<N, T, D>,
+    SvgScriptbaseNTD<DOM>,
     CommonMsubsup<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMsubsupClass interface for the SVG Msubsup wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMsubsupClass<N, T, D>
+export interface SvgMsubsupClass<DOM extends DOM_TYPES>
   extends
-    SvgScriptbaseClass<N, T, D>,
+    SvgScriptbaseClass<DOM>,
     CommonMsubsupClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMsubsupNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMsubsupNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -297,27 +227,19 @@ export interface SvgMsubsupClass<N, T, D>
 /**
  * The SvgMsubsup wrapper class for the MmlMsubsup class
  */
-export const SvgMsubsup = (function <N, T, D>(): SvgMsubsupClass<N, T, D> {
+export const SvgMsubsup = (function (): SvgMsubsupClass<DOM> {
   const Base = CommonMsubsupMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMsubsupClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMsubsupClass<DOM>
   >(SvgScriptbase);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMsubsup extends Base implements SvgMsubsupNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMsubsup extends Base implements SvgMsubsupNTD<DOM> {
     /**
      * @override
      */
@@ -326,7 +248,7 @@ export const SvgMsubsup = (function <N, T, D>(): SvgMsubsupClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       const svg = this.standardSvgNodes(parents);
       const [base, sup, sub] = [this.baseChild, this.supChild, this.subChild];
@@ -344,4 +266,4 @@ export const SvgMsubsup = (function <N, T, D>(): SvgMsubsupClass<N, T, D> {
       sup.place(w + x, u);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mtable.ts
+++ b/ts/output/svg/Wrappers/mtable.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtable,
   CommonMtableClass,
@@ -42,6 +35,7 @@ import { SvgMtrNTD } from './mtr.js';
 import { SvgMtdNTD } from './mtd.js';
 import { OptionList } from '../../../util/Options.js';
 import { StyleJson } from '../../../util/StyleJson.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 const CLASSPREFIX = 'mjx-';
 
@@ -49,96 +43,68 @@ const CLASSPREFIX = 'mjx-';
 /**
  * The SvgMtable interface for the SVG Mtable wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMtableNTD<N, T, D>
+export interface SvgMtableNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMtable<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass,
-      SvgMtrNTD<N, T, D>
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>,
+      SvgMtrNTD<DOM>
     > {
   /**
    * The column for labels
    */
-  labels: N;
+  labels: N<DOM>;
 }
 
 /**
  * The SvgMtableClass interface for the SVG Mtable wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMtableClass<N, T, D>
+export interface SvgMtableClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMtableClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMtableNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMtableNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMtable wrapper class for the MmlMtable class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
+export const SvgMtable = (function (): SvgMtableClass<DOM> {
   const Base = CommonMtableMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMtrNTD<N, T, D>,
-    SvgMtableClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMtrNTD<DOM>,
+    SvgMtableClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMtable extends Base implements SvgMtableNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMtable extends Base implements SvgMtableNTD<DOM> {
     /**
      * @override
      */
@@ -175,14 +141,14 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
     /**
      * @override
      */
-    public labels: N;
+    public labels: N<DOM>;
 
     /******************************************************************/
 
     /**
      * @param {N} svg  The container in which to place the rows
      */
-    protected placeRows(svg: N) {
+    protected placeRows(svg: N<DOM>) {
       const equal = this.node.attributes.get('equalrows') as boolean;
       const { H, D } = this.getTableData();
       const HD = this.getEqualRowHeight();
@@ -190,7 +156,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
       const rLines = [this.fLine, ...this.rLines, this.fLine];
       let y = this.getBBox().h - rLines[0];
       for (let i = 0; i < this.numRows; i++) {
-        const row = this.childNodes[i] as SvgMtrNTD<N, T, D>;
+        const row = this.childNodes[i] as SvgMtrNTD<DOM>;
         [row.H, row.D] = this.getRowHD(equal, HD, H[i], D[i]);
         [row.tSpace, row.bSpace] = [rSpace[i], rSpace[i + 1]];
         [row.tLine, row.bLine] = [rLines[i], rLines[i + 1]];
@@ -234,7 +200,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      *
      * @param {N} svg   The container for the table
      */
-    protected handleColumnLines(svg: N) {
+    protected handleColumnLines(svg: N<DOM>) {
       if (this.node.attributes.get('columnlines') === 'none') return;
       const lines = this.getColumnAttributes('columnlines');
       if (!lines) return;
@@ -256,7 +222,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      *
      * @param {N} svg   The container for the table
      */
-    protected handleRowLines(svg: N) {
+    protected handleRowLines(svg: N<DOM>) {
       if (this.node.attributes.get('rowlines') === 'none') return;
       const lines = this.getRowAttributes('rowlines');
       if (!lines) return;
@@ -281,7 +247,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      *
      * @param {N} svg   The container for the table
      */
-    protected handleFrame(svg: N) {
+    protected handleFrame(svg: N<DOM>) {
       if (this.frame && this.fLine) {
         const { h, d, w } = this.getBBox();
         const style = this.node.attributes.get('frame') as string;
@@ -293,7 +259,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {N} svg The svg element
      * @returns {number}   The x-adjustement needed to handle the true size of percentage-width tables
      */
-    protected handlePWidth(svg: N): number {
+    protected handlePWidth(svg: N<DOM>): number {
       if (!this.pWidth) {
         return 0;
       }
@@ -332,7 +298,12 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {string} style   The border style for the frame
      * @returns {N}            The SVG element for the frame
      */
-    protected makeFrame(w: number, h: number, d: number, style: string): N {
+    protected makeFrame(
+      w: number,
+      h: number,
+      d: number,
+      style: string
+    ): N<DOM> {
       const t = this.fLine;
       return this.svg(
         'rect',
@@ -353,7 +324,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {number} t       The line thickness
      * @returns {N}            The SVG element for the line
      */
-    protected makeVLine(x: number, style: string, t: number): N {
+    protected makeVLine(x: number, style: string, t: number): N<DOM> {
       const { h, d } = this.getBBox();
       const dt = style === 'dotted' ? t / 2 : 0;
       const X = this.fixed(x + t / 2);
@@ -376,7 +347,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {number} t       The line thickness
      * @returns {N}            The SVG element for the line
      */
-    protected makeHLine(y: number, style: string, t: number): N {
+    protected makeHLine(y: number, style: string, t: number): N<DOM> {
       const w = this.getBBox().w;
       const dt = style === 'dotted' ? t / 2 : 0;
       const Y = this.fixed(y - t / 2);
@@ -423,7 +394,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {N} _parent   The parent containing the the table
      * @param {number} dx   The adjustement for percentage width tables
      */
-    protected handleLabels(svg: N, _parent: N, dx: number) {
+    protected handleLabels(svg: N<DOM>, _parent: N<DOM>, dx: number) {
       if (!this.hasLabels) return;
       const labels = this.labels;
       const attributes = this.node.attributes;
@@ -457,11 +428,11 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
       //    and line thickness for each non-labeled row.
       //
       let y = h - this.fLine;
-      let current = adaptor.firstChild(this.labels) as N;
+      let current = adaptor.firstChild(this.labels) as N<DOM>;
       for (let i = 0; i < this.numRows; i++) {
-        const row = this.childNodes[i] as SvgMtrNTD<N, T, D>;
+        const row = this.childNodes[i] as SvgMtrNTD<DOM>;
         if (row.node.isKind('mlabeledtr')) {
-          const cell = row.childNodes[0] as SvgMtdNTD<N, T, D>;
+          const cell = row.childNodes[0] as SvgMtdNTD<DOM>;
           y -= space[i] + row.H;
           row.placeCell(cell, {
             x: 0,
@@ -473,7 +444,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
             rLine: 0,
           });
           y -= row.D + space[i + 1] + this.rLines[i];
-          current = adaptor.next(current) as N;
+          current = adaptor.next(current) as N<DOM>;
         } else {
           y -= space[i] + row.H + row.D + space[i + 1] + this.rLines[i];
         }
@@ -487,7 +458,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {N} labels      The group of labels
      * @param {string} side   The side alignment (left or right)
      */
-    protected topTable(svg: N, labels: N, side: string) {
+    protected topTable(svg: N<DOM>, labels: N<DOM>, side: string) {
       const adaptor = this.adaptor;
       const { h, d, w, L, R } = this.getBBox();
       const W = L + (this.pWidth || w) + R;
@@ -539,7 +510,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @param {string} side   The side alignment (left or right)
      * @param {number} dx     The adjustement for percentage width tables
      */
-    protected subTable(svg: N, labels: N, side: string, dx: number) {
+    protected subTable(svg: N<DOM>, labels: N<DOM>, side: string, dx: number) {
       const adaptor = this.adaptor;
       const { w, L, R } = this.getBBox();
       const W = L + (this.pWidth || w) + R;
@@ -570,9 +541,9 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
      * @override
      */
     constructor(
-      factory: SvgWrapperFactory<N, T, D>,
+      factory: SvgWrapperFactory<DOM>,
       node: MmlNode,
-      parent: SvgWrapper<N, T, D> = null
+      parent: SvgWrapper<DOM> = null
     ) {
       super(factory, node, parent);
       const def: OptionList = { 'data-labels': true };
@@ -585,7 +556,7 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const svg = this.standardSvgNodes(parents)[0];
       this.placeRows(svg);
       this.handleColumnLines(svg);
@@ -595,4 +566,4 @@ export const SvgMtable = (function <N, T, D>(): SvgMtableClass<N, T, D> {
       this.handleLabels(svg, parents[0], dx);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mtd.ts
+++ b/ts/output/svg/Wrappers/mtd.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtd,
   CommonMtdClass,
@@ -38,31 +31,24 @@ import {
 } from '../../common/Wrappers/mtd.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtd } from '../../../core/MmlTree/MmlNodes/mtd.js';
+import { DOM, DOM_TYPES } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMtd interface for the SVG Mtd wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMtdNTD<N, T, D>
+export interface SvgMtdNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMtd<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   /**
    * @param {number} x    The x offset of the left side of the cell
@@ -92,32 +78,24 @@ export interface SvgMtdNTD<N, T, D>
 /**
  * The SvgMtdClass interface for the SVG Mtd wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMtdClass<N, T, D>
+export interface SvgMtdClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMtdClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMtdNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMtdNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -125,27 +103,19 @@ export interface SvgMtdClass<N, T, D>
 /**
  * The SvgMtd wrapper class for the MmlMtd class
  */
-export const SvgMtd = (function <N, T, D>(): SvgMtdClass<N, T, D> {
+export const SvgMtd = (function (): SvgMtdClass<DOM> {
   const Base = CommonMtdMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMtdClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMtdClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMtd extends Base implements SvgMtdNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMtd extends Base implements SvgMtdNTD<DOM> {
     /**
      * @override
      */
@@ -190,4 +160,4 @@ export const SvgMtd = (function <N, T, D>(): SvgMtdClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mtext.ts
+++ b/ts/output/svg/Wrappers/mtext.ts
@@ -21,16 +21,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtext,
   CommonMtextClass,
@@ -38,62 +31,47 @@ import {
 } from '../../common/Wrappers/mtext.js';
 import { MmlNode, TextNode } from '../../../core/MmlTree/MmlNode.js';
 import { MmlMtext } from '../../../core/MmlTree/MmlNodes/mtext.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMtext interface for the SVG Mtext wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM types
  */
-export interface SvgMtextNTD<N, T, D>
+export interface SvgMtextNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMtext<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMtextClass interface for the SVG Mtext wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM types
  */
-export interface SvgMtextClass<N, T, D>
+export interface SvgMtextClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMtextClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMtextNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMtextNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -101,27 +79,19 @@ export interface SvgMtextClass<N, T, D>
 /**
  * The SvgMtext wrapper class for the MmlMtext class
  */
-export const SvgMtext = (function <N, T, D>(): SvgMtextClass<N, T, D> {
+export const SvgMtext = (function (): SvgMtextClass<DOM> {
   const Base = CommonMtextMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMtextClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMtextClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMtext extends Base implements SvgMtextNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMtext extends Base implements SvgMtextNTD<DOM> {
     /**
      * @override
      */
@@ -130,7 +100,7 @@ export const SvgMtext = (function <N, T, D>(): SvgMtextClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       //
       // If no breakpoints, do the usual thing
       //
@@ -190,4 +160,4 @@ export const SvgMtext = (function <N, T, D>(): SvgMtextClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/mtr.ts
+++ b/ts/output/svg/Wrappers/mtr.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonMtr,
   CommonMtrClass,
@@ -44,6 +37,7 @@ import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
 import { SvgMtdNTD } from './mtd.js';
 import { SvgMtableNTD } from './mtable.js';
 import { MmlMtr, MmlMlabeledtr } from '../../../core/MmlTree/MmlNodes/mtr.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /**
  * The data needed for placeCell()
@@ -62,26 +56,18 @@ export type SizeData = {
 /**
  * The SvgMtr interface for the SVG Mtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMtrNTD<N, T, D>
+export interface SvgMtrNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonMtr<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   /**
    * The height of the row
@@ -113,70 +99,50 @@ export interface SvgMtrNTD<N, T, D>
    * @param {SizeData} sizes   The positioning information
    * @returns {number}         The new x position
    */
-  placeCell(cell: SvgMtdNTD<N, T, D>, sizes: SizeData): number;
+  placeCell(cell: SvgMtdNTD<DOM>, sizes: SizeData): number;
 }
 
 /**
  * The SvgMtrClass interface for the SVG Mtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMtrClass<N, T, D>
+export interface SvgMtrClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonMtrClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMtrNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMtrNTD<DOM>;
 }
 
 /*****************************************************************/
 
 /**
  * The SvgMtr wrapper class for the MmlMtr class
- *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
  */
-export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
+export const SvgMtr = (function (): SvgMtrClass<DOM> {
   const Base = CommonMtrMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMtrClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMtrClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMtr extends Base implements SvgMtrNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMtr extends Base implements SvgMtrNTD<DOM> {
     /**
      * @override
      */
@@ -210,7 +176,7 @@ export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
     /**
      * @override
      */
-    public placeCell(cell: SvgMtdNTD<N, T, D>, sizes: SizeData): number {
+    public placeCell(cell: SvgMtdNTD<DOM>, sizes: SizeData): number {
       const { x, y, lSpace, w, rSpace, lLine, rLine } = sizes;
       const scale = 1 / this.getBBox().rscale;
       const [h, d] = [this.H * scale, this.D * scale];
@@ -231,15 +197,15 @@ export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
      *
      * @param {N[]} svg   The containers for the table
      */
-    protected placeCells(svg: N[]) {
-      const parent = this.parent as SvgMtableNTD<N, T, D>;
+    protected placeCells(svg: N<DOM>[]) {
+      const parent = this.parent as SvgMtableNTD<DOM>;
       const cSpace = parent.getColumnHalfSpacing();
       const cLines = [parent.fLine, ...parent.cLines, parent.fLine];
       const cWidth = parent.getComputedWidths();
       const scale = 1 / this.getBBox().rscale;
       let x = cLines[0];
       for (let i = 0; i < this.numCells; i++) {
-        const child = this.getChild(i) as SvgMtdNTD<N, T, D>;
+        const child = this.getChild(i) as SvgMtdNTD<DOM>;
         child.toSVG(svg);
         x += this.placeCell(child, {
           x: x,
@@ -272,7 +238,7 @@ export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
         adaptor.setAttribute(
           child,
           'width',
-          this.fixed((this.parent as SvgMtableNTD<N, T, D>).getWidth() * scale)
+          this.fixed((this.parent as SvgMtableNTD<DOM>).getWidth() * scale)
         );
         adaptor.setAttribute(
           child,
@@ -287,69 +253,53 @@ export const SvgMtr = (function <N, T, D>(): SvgMtrClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const svg = this.standardSvgNodes(parents);
       this.placeCells(svg);
       this.placeColor();
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /**
  * The SvgMlabeledtr interface for the SVG Mlabeledtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMlabeledtrNTD<N, T, D>
+export interface SvgMlabeledtrNTD<DOM extends DOM_TYPES>
   extends
-    SvgMtrNTD<N, T, D>,
+    SvgMtrNTD<DOM>,
     CommonMlabeledtr<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMlabeledtrClass interface for the SVG Mlabeledtr wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgMlabeledtrClass<N, T, D>
+export interface SvgMlabeledtrClass<DOM extends DOM_TYPES>
   extends
-    SvgMtrClass<N, T, D>,
+    SvgMtrClass<DOM>,
     CommonMlabeledtrClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMlabeledtrNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMlabeledtrNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -357,31 +307,19 @@ export interface SvgMlabeledtrClass<N, T, D>
 /**
  * The SvgMlabeledtr wrapper class for the MmlMlabeledtr class
  */
-export const SvgMlabeledtr = (function <N, T, D>(): SvgMlabeledtrClass<
-  N,
-  T,
-  D
-> {
+export const SvgMlabeledtr = (function (): SvgMlabeledtrClass<DOM> {
   const Base = CommonMlabeledtrMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMlabeledtrClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMlabeledtrClass<DOM>
   >(SvgMtr);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMlabeledtr extends Base implements SvgMlabeledtrNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMlabeledtr extends Base implements SvgMlabeledtrNTD<DOM> {
     /**
      * @override
      */
@@ -390,12 +328,12 @@ export const SvgMlabeledtr = (function <N, T, D>(): SvgMlabeledtrClass<
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       super.toSVG(parents);
       const child = this.childNodes[0];
       if (child) {
-        child.toSVG([(this.parent as SvgMtableNTD<N, T, D>).labels]);
+        child.toSVG([(this.parent as SvgMtableNTD<DOM>).labels]);
       }
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/munderover.ts
+++ b/ts/output/svg/Wrappers/munderover.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   SvgMsub,
   SvgMsubClass,
@@ -60,62 +53,47 @@ import {
   MmlMunder,
   MmlMover,
 } from '../../../core/MmlTree/MmlNodes/munderover.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgMunder interface for the SVG Munder wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgMunderNTD<N, T, D>
+export interface SvgMunderNTD<DOM extends DOM_TYPES>
   extends
-    SvgMsubNTD<N, T, D>,
+    SvgMsubNTD<DOM>,
     CommonMunder<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMunderClass interface for the SVG Munder wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgMunderClass<N, T, D>
+export interface SvgMunderClass<DOM extends DOM_TYPES>
   extends
-    SvgMsubClass<N, T, D>,
+    SvgMsubClass<DOM>,
     CommonMunderClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMunderNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMunderNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -123,27 +101,19 @@ export interface SvgMunderClass<N, T, D>
 /**
  * The SvgMunder wrapper class for the MmlMunder class
  */
-export const SvgMunder = (function <N, T, D>(): SvgMunderClass<N, T, D> {
+export const SvgMunder = (function (): SvgMunderClass<DOM> {
   const Base = CommonMunderMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMunderClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMunderClass<DOM>
   >(SvgMsub);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMunder extends Base implements SvgMunderNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMunder extends Base implements SvgMunderNTD<DOM> {
     /**
      * @override
      */
@@ -152,7 +122,7 @@ export const SvgMunder = (function <N, T, D>(): SvgMunderClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       if (this.hasMovableLimits()) {
         super.toSVG(parents);
@@ -176,7 +146,7 @@ export const SvgMunder = (function <N, T, D>(): SvgMunderClass<N, T, D> {
       script.place(sx, v);
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -184,57 +154,41 @@ export const SvgMunder = (function <N, T, D>(): SvgMunderClass<N, T, D> {
 /**
  * The SvgMover interface for the SVG Mover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgMoverNTD<N, T, D>
+export interface SvgMoverNTD<DOM extends DOM_TYPES>
   extends
-    SvgMsupNTD<N, T, D>,
+    SvgMsupNTD<DOM>,
     CommonMover<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMoverClass interface for the SVG Mover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgMoverClass<N, T, D>
+export interface SvgMoverClass<DOM extends DOM_TYPES>
   extends
-    SvgMsupClass<N, T, D>,
+    SvgMsupClass<DOM>,
     CommonMoverClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMoverNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMoverNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -242,27 +196,19 @@ export interface SvgMoverClass<N, T, D>
 /**
  * The SvgMover wrapper class for the MmlMover class
  */
-export const SvgMover = (function <N, T, D>(): SvgMoverClass<N, T, D> {
+export const SvgMover = (function (): SvgMoverClass<DOM> {
   const Base = CommonMoverMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMoverClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMoverClass<DOM>
   >(SvgMsup);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgMover extends Base implements SvgMoverNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMover extends Base implements SvgMoverNTD<DOM> {
     /**
      * @override
      */
@@ -271,7 +217,7 @@ export const SvgMover = (function <N, T, D>(): SvgMoverClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       if (this.hasMovableLimits()) {
         super.toSVG(parents);
@@ -292,7 +238,7 @@ export const SvgMover = (function <N, T, D>(): SvgMoverClass<N, T, D> {
       script.place(sx, u);
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /*****************************************************************/
@@ -300,57 +246,41 @@ export const SvgMover = (function <N, T, D>(): SvgMoverClass<N, T, D> {
 /**
  * The SvgMunderover interface for the SVG Munderover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgMunderoverNTD<N, T, D>
+export interface SvgMunderoverNTD<DOM extends DOM_TYPES>
   extends
-    SvgMsubsupNTD<N, T, D>,
+    SvgMsubsupNTD<DOM>,
     CommonMunderover<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgMunderoverClass interface for the SVG Munderover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM Node types
  */
-export interface SvgMunderoverClass<N, T, D>
+export interface SvgMunderoverClass<DOM extends DOM_TYPES>
   extends
-    SvgMsubsupClass<N, T, D>,
+    SvgMsubsupClass<DOM>,
     CommonMunderoverClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgMunderoverNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgMunderoverNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -358,31 +288,19 @@ export interface SvgMunderoverClass<N, T, D>
 /**
  * The SvgMunderover wrapper class for the MmlMunderover class
  */
-export const SvgMunderover = (function <N, T, D>(): SvgMunderoverClass<
-  N,
-  T,
-  D
-> {
+export const SvgMunderover = (function (): SvgMunderoverClass<DOM> {
   const Base = CommonMunderoverMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgMunderoverClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgMunderoverClass<DOM>
   >(SvgMsubsup);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  //   type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  //   different by typescript)
-  return class SvgMunderover extends Base implements SvgMunderoverNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgMunderover extends Base implements SvgMunderoverNTD<DOM> {
     /**
      * @override
      */
@@ -391,7 +309,7 @@ export const SvgMunderover = (function <N, T, D>(): SvgMunderoverClass<
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       if (this.hasMovableLimits()) {
         super.toSVG(parents);
@@ -427,4 +345,4 @@ export const SvgMunderover = (function <N, T, D>(): SvgMunderoverClass<
       over.place(ox, u);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/scriptbase.ts
+++ b/ts/output/svg/Wrappers/scriptbase.ts
@@ -24,78 +24,56 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonScriptbase,
   CommonScriptbaseClass,
   CommonScriptbaseMixin,
 } from '../../common/Wrappers/scriptbase.js';
 import { MmlNode } from '../../../core/MmlTree/MmlNode.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgScriptbase interface for the SVG msub/msup/msubsup/munder/mover/munderover wrappers
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgScriptbaseNTD<N, T, D>
+export interface SvgScriptbaseNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonScriptbase<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgScriptbaseClass interface for the SVG msub/msup/msubsup/munder/mover/munderover wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgScriptbaseClass<N, T, D>
+export interface SvgScriptbaseClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonScriptbaseClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgScriptbaseNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgScriptbaseNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -103,31 +81,19 @@ export interface SvgScriptbaseClass<N, T, D>
 /**
  * The SvgScriptbase wrapper class for the msub/msup/msubsup/munder/mover/munderover class
  */
-export const SvgScriptbase = (function <N, T, D>(): SvgScriptbaseClass<
-  N,
-  T,
-  D
-> {
+export const SvgScriptbase = (function (): SvgScriptbaseClass<DOM> {
   const Base = CommonScriptbaseMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgScriptbaseClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgScriptbaseClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgScriptbase extends Base implements SvgScriptbaseNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgScriptbase extends Base implements SvgScriptbaseNTD<DOM> {
     /**
      * @override
      */
@@ -139,7 +105,7 @@ export const SvgScriptbase = (function <N, T, D>(): SvgScriptbaseClass<
      *
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       const svg = this.standardSvgNodes(parents);
       const w = this.getBaseWidth();
@@ -150,4 +116,4 @@ export const SvgScriptbase = (function <N, T, D>(): SvgScriptbaseClass<
       this.scriptChild.place(w + x, v);
     }
   };
-})<any, any, any>();
+})();

--- a/ts/output/svg/Wrappers/semantics.ts
+++ b/ts/output/svg/Wrappers/semantics.ts
@@ -22,16 +22,9 @@
  * @author dpvc@mathjax.org (Davide Cervone)
  */
 
-import { SVG } from '../../svg.js';
+import { SVG, SVG_FONT } from '../../svg.js';
 import { SvgWrapper, SvgWrapperClass } from '../Wrapper.js';
 import { SvgWrapperFactory } from '../WrapperFactory.js';
-import {
-  SvgCharOptions,
-  SvgVariantData,
-  SvgDelimiterData,
-  SvgFontData,
-  SvgFontDataClass,
-} from '../FontData.js';
 import {
   CommonSemantics,
   CommonSemanticsClass,
@@ -51,62 +44,47 @@ import {
 import { XMLNode } from '../../../core/MmlTree/MmlNode.js';
 import { StyleJson } from '../../../util/StyleJson.js';
 import { StyleList } from '../../../util/Styles.js';
+import { DOM, DOM_TYPES, N } from '../../../types/Types.js';
 
 /*****************************************************************/
 /**
  * The SvgSemantics interface for the SVG Semantics wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgSemanticsNTD<N, T, D>
+export interface SvgSemanticsNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonSemantics<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgSemanticsClass interface for the SVG Semantics wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgSemanticsClass<N, T, D>
+export interface SvgSemanticsClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonSemanticsClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgSemanticsNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgSemanticsNTD<DOM>;
 }
 
 /*****************************************************************/
@@ -114,26 +92,18 @@ export interface SvgSemanticsClass<N, T, D>
 /**
  * The SvgSemantics wrapper class for the MmlSemantics class
  */
-export const SvgSemantics = (function <N, T, D>(): SvgSemanticsClass<N, T, D> {
+export const SvgSemantics = (function (): SvgSemanticsClass<DOM> {
   const Base = CommonSemanticsMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgSemanticsClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgSemanticsClass<DOM>
   >(SvgWrapper);
 
-  // Avoid message about base constructors not having the same type
-  //   (they should both be SvgWrapper<N, T, D>, but are thought of as different by typescript)
-  return class SvgSemantics extends Base implements SvgSemanticsNTD<N, T, D> {
+  return class SvgSemantics extends Base implements SvgSemanticsNTD<DOM> {
     /**
      * @override
      */
@@ -142,7 +112,7 @@ export const SvgSemantics = (function <N, T, D>(): SvgSemanticsClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       if (this.toEmbellishedSVG(parents)) return;
       const svg = this.standardSvgNodes(parents);
       if (this.childNodes.length) {
@@ -150,147 +120,114 @@ export const SvgSemantics = (function <N, T, D>(): SvgSemanticsClass<N, T, D> {
       }
     }
   };
-})<any, any, any>();
+})();
 
 /*****************************************************************/
 /**
  * The SvgAnnotation wrapper for the MmlAnnotation object
  */
-export const SvgAnnotation = (function <N, T, D>(): SvgWrapperClass<N, T, D> {
-  return class SvgAnnotation extends SvgWrapper<N, T, D> {
-    /**
-     * The annotation wrapper
-     */
-    public static kind = MmlAnnotation.prototype.kind;
+export class SvgAnnotation extends SvgWrapper<DOM> {
+  /**
+   * The annotation wrapper
+   */
+  public static kind = MmlAnnotation.prototype.kind;
 
-    /**
-     * @override
-     */
-    public toSVG(parents: N[]) {
-      // FIXME:  output as plain text
-      super.toSVG(parents);
-    }
+  /**
+   * @override
+   */
+  public toSVG(parents: N<DOM>[]) {
+    // FIXME:  output as plain text
+    super.toSVG(parents);
+  }
 
-    /**
-     * @override
-     */
-    public computeBBox() {
-      // FIXME:  compute using the DOM, if possible
-      return this.bbox;
-    }
-  };
-})<any, any, any>();
+  /**
+   * @override
+   */
+  public computeBBox() {
+    // FIXME:  compute using the DOM, if possible
+    return this.bbox;
+  }
+}
 
 /*****************************************************************/
 /**
  * The SvgAnnotationXML wrapper for the MmlAnnotationXML object
  */
-export const SvgAnnotationXML = (function <N, T, D>(): SvgWrapperClass<
-  N,
-  T,
-  D
-> {
-  return class SvgAnnotationXML extends SvgWrapper<N, T, D> {
-    /**
-     * The annotation-xml wrapper
-     */
-    public static kind = MmlAnnotationXML.prototype.kind;
+export class SvgAnnotationXML extends SvgWrapper<DOM> {
+  /**
+   * The annotation-xml wrapper
+   */
+  public static kind = MmlAnnotationXML.prototype.kind;
 
-    /**
-     * @override
-     */
-    public static styles: StyleJson = {
-      'foreignObject[data-mjx-xml]': {
-        'font-family': 'initial',
-        'line-height': 'normal',
-        overflow: 'visible',
-      },
-    };
+  /**
+   * @override
+   */
+  public static styles: StyleJson = {
+    'foreignObject[data-mjx-xml]': {
+      'font-family': 'initial',
+      'line-height': 'normal',
+      overflow: 'visible',
+    },
   };
-})<any, any, any>();
+}
 
 /*****************************************************************/
 /**
  * The SvgXmlNode interface for the SVG XmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgXmlNodeNTD<N, T, D>
+export interface SvgXmlNodeNTD<DOM extends DOM_TYPES>
   extends
-    SvgWrapper<N, T, D>,
+    SvgWrapper<DOM>,
     CommonXmlNode<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {}
 
 /**
  * The SvgXmlNodeClass interface for the SVG XmlNode wrapper
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface SvgXmlNodeClass<N, T, D>
+export interface SvgXmlNodeClass<DOM extends DOM_TYPES>
   extends
-    SvgWrapperClass<N, T, D>,
+    SvgWrapperClass<DOM>,
     CommonXmlNodeClass<
-      N,
-      T,
-      D,
-      SVG<N, T, D>,
-      SvgWrapper<N, T, D>,
-      SvgWrapperFactory<N, T, D>,
-      SvgWrapperClass<N, T, D>,
-      SvgCharOptions,
-      SvgVariantData,
-      SvgDelimiterData,
-      SvgFontData,
-      SvgFontDataClass
+      DOM,
+      SVG_FONT,
+      SVG<DOM>,
+      SvgWrapper<DOM>,
+      SvgWrapperFactory<DOM>,
+      SvgWrapperClass<DOM>
     > {
   new (
-    factory: SvgWrapperFactory<N, T, D>,
+    factory: SvgWrapperFactory<DOM>,
     node: MmlNode,
-    parent?: SvgWrapper<N, T, D>
-  ): SvgXmlNodeNTD<N, T, D>;
+    parent?: SvgWrapper<DOM>
+  ): SvgXmlNodeNTD<DOM>;
 }
 
 /**
  * The SvgXmlNode wrapper for the XMLNode object
  */
-
-export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
+export const SvgXmlNode = (function (): SvgXmlNodeClass<DOM> {
   const Base = CommonXmlNodeMixin<
-    N,
-    T,
-    D,
-    SVG<N, T, D>,
-    SvgWrapper<N, T, D>,
-    SvgWrapperFactory<N, T, D>,
-    SvgWrapperClass<N, T, D>,
-    SvgCharOptions,
-    SvgVariantData,
-    SvgDelimiterData,
-    SvgFontData,
-    SvgFontDataClass,
-    SvgXmlNodeClass<N, T, D>
+    DOM,
+    SVG_FONT,
+    SVG<DOM>,
+    SvgWrapper<DOM>,
+    SvgWrapperFactory<DOM>,
+    SvgWrapperClass<DOM>,
+    SvgXmlNodeClass<DOM>
   >(SvgWrapper);
 
-  // @ts-expect-error Avoid message about base constructors not having the same
-  // type (they should both be SvgWrapper<N, T, D>, but are thought of as
-  // different by typescript)
-  return class SvgXmlNode extends Base implements SvgXmlNodeNTD<N, T, D> {
+  // @ts-expect-error Avoid message about base constructors not having the same type
+  return class SvgXmlNode extends Base implements SvgXmlNodeNTD<DOM> {
     /**
      * The XMLNode wrapper
      */
@@ -309,7 +246,7 @@ export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
     /**
      * @override
      */
-    public toSVG(parents: N[]) {
+    public toSVG(parents: N<DOM>[]) {
       const metrics = this.jax.math.metrics;
       const em = metrics.em * metrics.scale * this.rscale;
       const scale = this.fixed(1 / em, 3);
@@ -329,14 +266,14 @@ export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
             },
             [this.getHTML()]
           )
-        ) as N,
+        ) as N<DOM>,
       ];
     }
 
     /**
      * @override
      */
-    public addHDW(html: N, styles: StyleList): N {
+    public addHDW(html: N<DOM>, styles: StyleList): N<DOM> {
       html = this.html('mjx-html-holder', { style: styles }, [html]);
       const { h, d, w } = this.getBBox();
       const scale = this.metrics.scale;
@@ -348,4 +285,4 @@ export const SvgXmlNode = (function <N, T, D>(): SvgXmlNodeClass<N, T, D> {
       return html;
     }
   };
-})<any, any, any>();
+})();

--- a/ts/types/Components.ts
+++ b/ts/types/Components.ts
@@ -31,9 +31,6 @@ import type {
   EMPTY_COMPONENT,
   INPUTJAX,
   OUTPUTJAX,
-  N,
-  T,
-  D,
 } from './Types.js';
 
 import type { STARTUP_TYPES } from '../components/startup.js';
@@ -187,31 +184,25 @@ export type COMPONENTS<DOM extends DOM_TYPES> = {
   'output/svg': OUTPUTJAX<'svg', SVG_OPTIONS<DOM>, DOM>;
 
   'a11y/semantic-enrich':
-    | DOC_OPTIONS<ENRICH_OPTIONS<DOM>>
-    | DOC_TYPE<EnrichedMathDocument<N<DOM>, T<DOM>, D<DOM>>>;
-  'a11y/assistive-mml':
-    | DOC_OPTIONS<ASSISTIVEMML_OPTIONS>
-    | DOC_TYPE<AssistiveMmlMathDocument<N<DOM>, T<DOM>, D<DOM>>>;
+    DOC_OPTIONS<ENRICH_OPTIONS<DOM>> | DOC_TYPE<EnrichedMathDocument<DOM>>;
+  'a11y/assisitive-mml':
+    DOC_OPTIONS<ASSISTIVEMML_OPTIONS> | DOC_TYPE<AssistiveMmlMathDocument<DOM>>;
   'a11y/complexity':
     | 'a11y/semantic-enrich'
     | DOC_OPTIONS<COMPLEXITY_OPTIONS>
-    | DOC_TYPE<ComplexityMathDocument<N<DOM>, T<DOM>, D<DOM>>>;
+    | DOC_TYPE<ComplexityMathDocument<DOM>>;
   'a11y/speech':
     | 'a11y/semantic-enrich'
     | DOC_OPTIONS<SPEECH_OPTIONS<DOM>>
-    | DOC_TYPE<SpeechMathDocument<N<DOM>, T<DOM>, D<DOM>>>;
+    | DOC_TYPE<SpeechMathDocument<DOM>>;
   'a11y/explorer':
     | 'a11y/speech'
     | DOC_OPTIONS<EXPLORER_OPTIONS>
     | DOC_TYPE<ExplorerMathDocument>;
 
   'ui/menu': DOC_OPTIONS<MENU_OPTIONS> | DOC_TYPE<MenuMathDocument>;
-  'ui/lazy':
-    | DOC_OPTIONS<LAZY_OPTIONS<DOM>>
-    | DOC_TYPE<LazyMathDocument<N<DOM>, T<DOM>, D<DOM>>>;
-  'ui/safe':
-    | DOC_OPTIONS<SAFE_OPTIONS>
-    | DOC_TYPE<SafeMathDocument<N<DOM>, T<DOM>, D<DOM>>>;
+  'ui/lazy': DOC_OPTIONS<LAZY_OPTIONS<DOM>> | DOC_TYPE<LazyMathDocument<DOM>>;
+  'ui/safe': DOC_OPTIONS<SAFE_OPTIONS> | DOC_TYPE<SafeMathDocument<DOM>>;
   'ui/no-dark-mode': EMPTY_COMPONENT<'ui/no-dark-mode'>;
 
   'adaptors/liteDOM': EMPTY_COMPONENT<'adaptors/liteDOM'>;

--- a/ts/types/Types.ts
+++ b/ts/types/Types.ts
@@ -29,9 +29,9 @@ import type { mathjax } from '../mathjax.js';
  * The types for node, text, and document
  */
 export type DOM_TYPES = {
-  N: any;
-  T: any;
-  D: any;
+  N: unknown;
+  T: unknown;
+  D: unknown;
 };
 
 /**
@@ -40,6 +40,8 @@ export type DOM_TYPES = {
 export type N<DOM extends DOM_TYPES> = DOM['N'];
 export type T<DOM extends DOM_TYPES> = DOM['T'];
 export type D<DOM extends DOM_TYPES> = DOM['D'];
+
+export type NT<DOM extends DOM_TYPES> = N<DOM> | T<DOM>;
 
 /**
  * A DOM_TYPES instance

--- a/ts/ui/dialog/DraggableDialog.ts
+++ b/ts/ui/dialog/DraggableDialog.ts
@@ -25,8 +25,9 @@ import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { StyleJson, StyleJsonSheet } from '../../util/StyleJson.js';
 import { context } from '../../util/context.js';
 import { localize } from '../../core/__locales__/Component.js';
+import { HTML_DOM } from '../../types/dom/html.js';
 
-export type ADAPTOR = DOMAdaptor<HTMLElement, Text, Document>;
+export type ADAPTOR = DOMAdaptor<HTML_DOM>;
 
 export type Action = (
   dialog: DraggableDialog,

--- a/ts/ui/lazy/LazyHandler.ts
+++ b/ts/ui/lazy/LazyHandler.ts
@@ -33,11 +33,10 @@ import {
 } from '../../handlers/html/HTMLDocument.js';
 import { HTMLMathItem } from '../../handlers/html/HTMLMathItem.js';
 import { HTMLHandler } from '../../handlers/html/HTMLHandler.js';
-// import { EnrichedMathItem } from '../../a11y/semantic-enrich.js';
 import { SpeechMathItem } from '../../a11y/speech.js';
 import { expandable } from '../../util/Options.js';
 import { StyleJson } from '../../util/StyleJson.js';
-import { DOM, DOM_TYPES, N, T, D, Constructor } from '../../types/Types.js';
+import { DOM, DOM_TYPES, N, Constructor } from '../../types/Types.js';
 
 /**
  * Add the needed function to the window object.
@@ -59,8 +58,10 @@ export type LazySet = Set<string>;
 
 /**
  * The data to map expression marker IDs back to their MathItem.
+ *
+ * @template DOM   The DOM node types
  */
-export class LazyList<N, T, D> {
+export class LazyList<DOM extends DOM_TYPES> {
   /**
    * The next ID to use
    */
@@ -69,15 +70,15 @@ export class LazyList<N, T, D> {
   /**
    * The map from IDs to MathItems
    */
-  protected items: Map<string, LazyMathItem<N, T, D>> = new Map();
+  protected items: Map<string, LazyMathItem<DOM>> = new Map();
 
   /**
    * Add a MathItem to the list and return its ID
    *
    * @param {LazyMathItem} math   The item to add
-   * @returns {string}             The id for the newly added item
+   * @returns {string}            The id for the newly added item
    */
-  public add(math: LazyMathItem<N, T, D>): string {
+  public add(math: LazyMathItem<DOM>): string {
     const id = String(this.id++);
     this.items.set(id, math);
     return id;
@@ -86,10 +87,10 @@ export class LazyList<N, T, D> {
   /**
    * Get the MathItem with the given ID
    *
-   * @param {string} id       The ID of the MathItem to get
+   * @param {string} id        The ID of the MathItem to get
    * @returns {LazyMathItem}   The MathItem having that ID (if any)
    */
-  public get(id: string): LazyMathItem<N, T, D> {
+  public get(id: string): LazyMathItem<DOM> {
     return this.items.get(id);
   }
 
@@ -113,17 +114,17 @@ newState('LAZYALWAYS', STATE.FINDMATH + 3);
  */
 export const LAZYID = 'data-mjx-lazy';
 
-export type HTMLSpeechItem<N, T, D> = HTMLMathItem<N, T, D> &
-  SpeechMathItem<N, T, D>;
+export type HTMLSpeechItem<DOM extends DOM_TYPES> = HTMLMathItem<DOM> &
+  SpeechMathItem<DOM>;
 
 /**
  * The properties added to MathItem for lazy typesetting
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface LazyMathItem<N, T, D> extends HTMLSpeechItem<N, T, D> {
+export interface LazyMathItem<
+  DOM extends DOM_TYPES,
+> extends HTMLSpeechItem<DOM> {
   /**
    * True when the MathItem needs to be lazy compiled
    */
@@ -137,7 +138,7 @@ export interface LazyMathItem<N, T, D> extends HTMLSpeechItem<N, T, D> {
   /**
    * The DOM node used to mark the location of the math to be lazy typeset
    */
-  lazyMarker: N;
+  lazyMarker: N<DOM>;
 
   /**
    * True if this item is a TeX MathItem
@@ -148,20 +149,16 @@ export interface LazyMathItem<N, T, D> extends HTMLSpeechItem<N, T, D> {
 /**
  * The mixin for adding lazy typesetting to MathItems
  *
- * @param {B} BaseMathItem      The MathItem class to be extended
- * @returns {LazyMathItem}  The augmented MathItem class
+ * @param {B} BaseMathItem   The MathItem class to be extended
+ * @returns {LazyMathItem}   The augmented MathItem class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathItem class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathItem class to extend
  */
 export function LazyMathItemMixin<
-  N,
-  T,
-  D,
-  B extends Constructor<HTMLSpeechItem<N, T, D>>,
->(BaseMathItem: B): Constructor<LazyMathItem<N, T, D>> & B {
+  DOM extends DOM_TYPES,
+  B extends Constructor<HTMLSpeechItem<DOM>>,
+>(BaseMathItem: B): Constructor<LazyMathItem<DOM>> & B {
   return class extends BaseMathItem {
     /**
      * True when this item should be skipped during compilation
@@ -179,7 +176,7 @@ export function LazyMathItemMixin<
     /**
      * The marker DOM node for this item.
      */
-    public lazyMarker: N;
+    public lazyMarker: N<DOM>;
 
     /**
      * True if this is a TeX expression.
@@ -209,7 +206,7 @@ export function LazyMathItemMixin<
      *
      * @override
      */
-    public compile(document: LazyMathDocument<N, T, D>) {
+    public compile(document: LazyMathDocument<DOM>) {
       if (!this.lazyCompile) {
         super.compile(document);
         return;
@@ -238,7 +235,7 @@ export function LazyMathItemMixin<
      *
      * @override
      */
-    public typeset(document: LazyMathDocument<N, T, D>) {
+    public typeset(document: LazyMathDocument<DOM>) {
       if (!this.lazyTypeset) {
         super.typeset(document);
         return;
@@ -262,7 +259,7 @@ export function LazyMathItemMixin<
      *
      * @override
      */
-    public updateDocument(document: LazyMathDocument<N, T, D>) {
+    public updateDocument(document: LazyMathDocument<DOM>) {
       super.updateDocument(document);
       if (this.lazyTypeset) {
         document.lazyObserver.observe(this.lazyMarker as any as Element);
@@ -274,7 +271,7 @@ export function LazyMathItemMixin<
      *
      * @override
      */
-    public attachSpeech = (document: LazyMathDocument<N, T, D>) => {
+    public attachSpeech = (document: LazyMathDocument<DOM>) => {
       if (this.state() >= STATE.ATTACHSPEECH) return;
       if (!this.lazyTypeset) {
         super.attachSpeech?.(document);
@@ -299,7 +296,7 @@ export type OPTIONS<DOM extends DOM_TYPES> = {
  */
 export interface LAZY_OPTIONS<DOM extends DOM_TYPES>
   extends OPTIONS<DOM>, HTMLDOCUMENT_OPTIONS<DOM> {
-  MathItem: Constructor<LazyMathItem<N<DOM>, T<DOM>, D<DOM>>>;
+  MathItem: Constructor<LazyMathItem<DOM>>;
 }
 
 /**
@@ -315,15 +312,15 @@ const options: OPTIONS<DOM> = {
 /**
  * The properties added to MathDocument for lazy typesetting
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export interface LazyMathDocument<N, T, D> extends HTMLDocument<N, T, D> {
+export interface LazyMathDocument<
+  DOM extends DOM_TYPES,
+> extends HTMLDocument<DOM> {
   /**
    * @override
    */
-  options: LAZY_OPTIONS<DOM<N, T, D>>;
+  options: LAZY_OPTIONS<DOM>;
 
   /**
    * The Intersection Observer used to track the appearance of the expression markers
@@ -333,12 +330,12 @@ export interface LazyMathDocument<N, T, D> extends HTMLDocument<N, T, D> {
   /**
    * The mapping of markers to MathItems
    */
-  lazyList: LazyList<N, T, D>;
+  lazyList: LazyList<DOM>;
 
   /**
    * The containers whose contents should always be typeset
    */
-  lazyAlwaysContainers: N[];
+  lazyAlwaysContainers: N<DOM>[];
 
   /**
    * A function that will typeset all the remaining expressions (e.g., for printing)
@@ -354,22 +351,16 @@ export interface LazyMathDocument<N, T, D> extends HTMLDocument<N, T, D> {
 /**
  * The mixin for adding lazy typesetting to MathDocuments
  *
- * @param {B} BaseDocument        The MathDocument class to be extended
- * @returns {LazyMathDocument}     The Lazy MathDocument class
+ * @param {B} BaseDocument       The MathDocument class to be extended
+ * @returns {LazyMathDocument}   The Lazy MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The MathDocument class to extend
+ * @template DOM   The DOM node types
+ * @template B     The MathDocument class to extend
  */
 export function LazyMathDocumentMixin<
-  N,
-  T,
-  D,
-  B extends MathDocumentConstructor<HTMLDocument<N, T, D>, DOM<N, T, D>>,
->(
-  BaseDocument: B
-): MathDocumentConstructor<HTMLDocument<N, T, D>, DOM<N, T, D>> & B {
+  DOM extends DOM_TYPES,
+  B extends MathDocumentConstructor<HTMLDocument<DOM>, DOM>,
+>(BaseDocument: B): MathDocumentConstructor<HTMLDocument<DOM>, DOM> & B {
   return class BaseClass extends BaseDocument {
     /**
      * @override
@@ -377,7 +368,7 @@ export function LazyMathDocumentMixin<
     public static OPTIONS = {
       ...BaseDocument.OPTIONS,
       ...options,
-      renderActions: expandable<RenderActions<any, any, any>>({
+      renderActions: expandable<RenderActions<DOM>>({
         ...BaseDocument.OPTIONS.renderActions,
         lazyAlways: [STATE.LAZYALWAYS, 'lazyAlways', '', false],
       }),
@@ -386,7 +377,7 @@ export function LazyMathDocumentMixin<
     /**
      * @override
      */
-    public options: LAZY_OPTIONS<DOM<N, T, D>>;
+    public options: LAZY_OPTIONS<DOM>;
 
     /**
      * The Intersection Observer used to track the appearance of the expression markers
@@ -396,12 +387,12 @@ export function LazyMathDocumentMixin<
     /**
      * The mapping of markers to MathItems
      */
-    public lazyList: LazyList<N, T, D>;
+    public lazyList: LazyList<DOM>;
 
     /**
      * The containers whose contents should always be typeset
      */
-    public lazyAlwaysContainers: N[] = null;
+    public lazyAlwaysContainers: N<DOM>[] = null;
 
     /**
      * Index of last container where math was found in lazyAlwaysContainers
@@ -459,10 +450,8 @@ export function LazyMathDocumentMixin<
       //  Use the LazyMathItem for math items
       //
       this.options.MathItem = LazyMathItemMixin<
-        N,
-        T,
-        D,
-        Constructor<HTMLMathItem<N, T, D> & SpeechMathItem<N, T, D>>
+        DOM,
+        Constructor<HTMLMathItem<DOM> & SpeechMathItem<DOM>>
       >(this.options.MathItem);
       //
       //  Allocate a process bit for lazyAlways
@@ -478,7 +467,7 @@ export function LazyMathDocumentMixin<
         this.lazyObserve.bind(this),
         { rootMargin: this.options.lazyMargin }
       );
-      this.lazyList = new LazyList<N, T, D>();
+      this.lazyList = new LazyList<DOM>();
       const callback = this.lazyHandleSet.bind(this);
       this.lazyProcessSet =
         window && window.requestIdleCallback
@@ -507,7 +496,7 @@ export function LazyMathDocumentMixin<
       if (!this.lazyAlwaysContainers || this.processed.isSet('lazyAlways'))
         return;
       for (const item of this.math) {
-        const math = item as LazyMathItem<N, T, D>;
+        const math = item as LazyMathItem<DOM>;
         if (math.lazyTypeset && this.lazyIsAlways(math)) {
           math.lazyCompile = math.lazyTypeset = false;
         }
@@ -520,10 +509,10 @@ export function LazyMathDocumentMixin<
      *  (start looking using the last container where math was found,
      *   in case the next math is in the same container).
      *
-     * @param {LazyMathItem<N,T,D>} math   The MathItem to test
-     * @returns {boolean}   True if one of the document's containers holds the MathItem
+     * @param {LazyMathItem<DOM>} math   The MathItem to test
+     * @returns {boolean}                True if one of the document's containers holds the MathItem
      */
-    protected lazyIsAlways(math: LazyMathItem<N, T, D>): boolean {
+    protected lazyIsAlways(math: LazyMathItem<DOM>): boolean {
       if (math.state() < STATE.LAZYALWAYS) {
         math.state(STATE.LAZYALWAYS);
         const node = math.start.node;
@@ -566,7 +555,7 @@ export function LazyMathDocumentMixin<
       // Loop through all the math...
       //
       for (const item of this.math) {
-        const math = item as LazyMathItem<N, T, D>;
+        const math = item as LazyMathItem<DOM>;
         //
         // If it is not lazy compile or typeset, skip it.
         //
@@ -638,7 +627,10 @@ export function LazyMathDocumentMixin<
      */
     protected lazyObserve(entries: IntersectionObserverEntry[]) {
       for (const entry of entries) {
-        const id = this.adaptor.getAttribute(entry.target as any as N, LAZYID);
+        const id = this.adaptor.getAttribute(
+          entry.target as any as N<DOM>,
+          LAZYID
+        );
         const math = this.lazyList.get(id);
         if (!math) continue;
         if (!entry.isIntersecting) {
@@ -680,7 +672,7 @@ export function LazyMathDocumentMixin<
      *
      * @param {LazySet} set    The set of math items to update
      * @param {number} state   The state needed for the items
-     * @returns {number}        The updated state based on the items
+     * @returns {number}       The updated state based on the items
      */
     protected resetStates(set: LazySet, state: number): number {
       for (const id of set.values()) {
@@ -706,14 +698,14 @@ export function LazyMathDocumentMixin<
      * Mark any TeX items (earlier than the ones in the set) to be compiled.
      *
      * @param {LazySet} set   The set of items that are newly visible
-     * @returns {boolean}      True if there are TeX items to be typeset
+     * @returns {boolean}     True if there are TeX items to be typeset
      */
     protected compileEarlierItems(set: LazySet): boolean {
       const math = this.earliestTex(set);
       if (!math) return false;
       let compile = false;
       for (const item of this.math) {
-        const earlier = item as LazyMathItem<N, T, D>;
+        const earlier = item as LazyMathItem<DOM>;
         if (earlier === math || !earlier?.lazyCompile || !earlier.lazyTex) {
           break;
         }
@@ -730,10 +722,10 @@ export function LazyMathDocumentMixin<
     /**
      * Find the earliest TeX math item in the set, if any.
      *
-     * @param {LazySet} set     The set of newly visble math items
+     * @param {LazySet} set      The set of newly visble math items
      * @returns {LazyMathItem}   The earliest TeX math item in the set, if any
      */
-    protected earliestTex(set: LazySet): LazyMathItem<N, T, D> {
+    protected earliestTex(set: LazySet): LazyMathItem<DOM> {
       let min: number = null;
       let minMath = null;
       for (const id of set.values()) {
@@ -752,12 +744,10 @@ export function LazyMathDocumentMixin<
      *
      * @override
      */
-    public clearMathItemsWithin(containers: ContainerList<N>) {
-      const items = super.clearMathItemsWithin(containers) as LazyMathItem<
-        N,
-        T,
-        D
-      >[];
+    public clearMathItemsWithin(containers: ContainerList<DOM>) {
+      const items = super.clearMathItemsWithin(
+        containers
+      ) as LazyMathItem<DOM>[];
       for (const math of items) {
         const marker = math.lazyMarker;
         if (marker) {
@@ -795,25 +785,21 @@ export function LazyMathDocumentMixin<
  * Add lazy typesetting support to a Handler instance
  *
  * @param {HTMLHandler} handler   The Handler instance to enhance
- * @returns {HTMLHandler}          The handler that was modified (for purposes of chaining extensions)
+ * @returns {HTMLHandler}         The handler that was modified (for purposes of chaining extensions)
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export function LazyHandler<N, T, D>(
-  handler: HTMLHandler<N, T, D>
-): HTMLHandler<N, T, D> {
+export function LazyHandler<DOM extends DOM_TYPES>(
+  handler: HTMLHandler<DOM>
+): HTMLHandler<DOM> {
   //
   // Only update the document class if we can handle IntersectionObservers
   //
   if (typeof IntersectionObserver !== 'undefined') {
     handler.documentClass = LazyMathDocumentMixin<
-      N,
-      T,
-      D,
-      MathDocumentConstructor<HTMLDocument<N, T, D>>
-    >(handler.documentClass) as typeof HTMLDocument;
+      DOM,
+      MathDocumentConstructor<HTMLDocument<DOM>, DOM>
+    >(handler.documentClass as any);
   }
   return handler;
 }

--- a/ts/ui/menu/MJContextMenu.ts
+++ b/ts/ui/menu/MJContextMenu.ts
@@ -26,6 +26,7 @@ import { OptionList } from '../../util/Options.js';
 import { JaxList } from './Menu.js';
 import { localize } from './__locales__/Component.js';
 import { ExplorerMathItem } from '../../a11y/explorer.js';
+import { HTML_DOM } from '../../types/dom/html.js';
 
 import {
   ContextMenu,
@@ -82,7 +83,7 @@ export class MJContextMenu extends ContextMenu {
   /**
    * The MathItem that has posted the menu
    */
-  public mathItem: MathItem<HTMLElement, Text, Document> = null;
+  public mathItem: MathItem<HTML_DOM> = null;
 
   /**
    * Records the mathItem's nofocus value when a SelectInfo dialog is opened

--- a/ts/ui/menu/Menu.ts
+++ b/ts/ui/menu/Menu.ts
@@ -50,6 +50,7 @@ import { MmlVisitor } from './MmlVisitor.js';
 import { MenuMathDocument } from './MenuHandler.js';
 import * as MenuUtil from './MenuUtil.js';
 import { locales } from './locales.js';
+import { HTML_DOM } from '../../types/dom/html.js';
 
 import { Parser, Rule, CssStyles, Submenu } from './mj-context-menu.js';
 
@@ -72,10 +73,10 @@ const XMLDECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>';
 
 /*==========================================================================*/
 
-export type HTMLMATHITEM = MathItem<HTMLElement, Text, Document>;
+export type HTMLMATHITEM = MathItem<HTML_DOM>;
 
 export type JaxList = {
-  [name: string]: OutputJax<HTMLElement, Text, Document>;
+  [name: string]: OutputJax<HTML_DOM>;
 };
 
 type A11Y = Partial<A11Y_OPTIONS['a11y']>;
@@ -251,7 +252,7 @@ export class Menu {
   /**
    * A MathML serializer that has options corresponding to the menu settings
    */
-  public MmlVisitor = new MmlVisitor<HTMLElement, Text, Document>();
+  public MmlVisitor = new MmlVisitor<HTML_DOM>();
 
   /**
    * The MathDocument in which we are working
@@ -1120,8 +1121,8 @@ export class Menu {
    * @returns {OutputJax<HTMLElement, Text, Document>}        The adjusted output jax.
    */
   protected applyRendererOptions(
-    output: OutputJax<HTMLElement, Text, Document>
-  ): OutputJax<HTMLElement, Text, Document> {
+    output: OutputJax<HTML_DOM>
+  ): OutputJax<HTML_DOM> {
     const settings = this.settings;
     const options = output.options;
     options.scale = settings.scale;
@@ -1610,7 +1611,7 @@ export class Menu {
     cache: 'local' | 'global' | 'none',
     breaks: boolean
   ): Promise<string> {
-    const jax = this.jax.SVG as SVG<HTMLElement, Text, Document>;
+    const jax = this.jax.SVG as SVG<HTML_DOM>;
     const div = jax.html('div');
     if (cache === 'global') {
       jax.options.fontCache = 'local';

--- a/ts/ui/menu/MenuHandler.ts
+++ b/ts/ui/menu/MenuHandler.ts
@@ -46,7 +46,7 @@ import type {
 } from '../../a11y/speech.js';
 import type { EXPLORER_OPTIONS } from '../../a11y/explorer.ts';
 import { expandable } from '../../util/Options.js';
-import { DOM, Constructor } from '../../types/Types.js';
+import { Constructor } from '../../types/Types.js';
 import { HTML_DOM } from '../../types/dom/html.js';
 
 import { Menu, OPTIONS as SETTINGS } from './Menu.js';
@@ -59,9 +59,9 @@ import '../../a11y/speech/SpeechMenu.js';
  */
 /* prettier-ignore */
 export type A11yMathItem =
-  SpeechMathItem<HTMLElement, Text, Document> &
-  ComplexityMathItem<HTMLElement, Text, Document> &
-  AssistiveMmlMathItem<HTMLElement, Text, Document>;
+  SpeechMathItem<HTML_DOM> &
+  ComplexityMathItem<HTML_DOM> &
+  AssistiveMmlMathItem<HTML_DOM>;
 
 /**
  * Constructor for base MathItem for MenuMathItem
@@ -75,16 +75,16 @@ export type A11yMathItemConstructor = {
  */
 /* prettier-ignore */
 export type A11yMathDocument =
-  ComplexityMathDocument<HTMLElement, Text, Document> &
-  SpeechMathDocument<HTMLElement, Text, Document> &
-  AssistiveMmlMathDocument<HTMLElement, Text, Document>;
+  ComplexityMathDocument<HTML_DOM> &
+  SpeechMathDocument<HTML_DOM> &
+  AssistiveMmlMathDocument<HTML_DOM>;
 
 /**
  * Constructor for base document for MenuMathDocument
  */
 export type A11yDocumentConstructor = MathDocumentConstructor<
   A11yMathDocument,
-  DOM<HTMLElement, Text, Document>
+  HTML_DOM
 >;
 
 /*==========================================================================*/
@@ -119,7 +119,7 @@ export interface MenuMathItem extends A11yMathItem {
  * The mixin for adding context menus to MathItems
  *
  * @param {B} BaseMathItem   The MathItem class to be extended
- * @returns {MenuMathItem}    The extended MathItem class
+ * @returns {MenuMathItem}   The extended MathItem class
  *
  * @template B  The MathItem class to extend
  */
@@ -244,8 +244,8 @@ export interface MenuMathDocument extends A11yMathDocument {
 /**
  * The mixin for adding context menus to MathDocuments
  *
- * @param {B} BaseDocument     The MathDocument class to be extended
- * @returns {MenuMathDocument}      The extended MathDocument class
+ * @param {B} BaseDocument       The MathDocument class to be extended
+ * @returns {MenuMathDocument}   The extended MathDocument class
  *
  * @template B  The MathDocument class to extend
  */
@@ -265,7 +265,7 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
       a11y:
         (BaseDocument.OPTIONS as SPEECH_OPTIONS<HTML_DOM>).a11y ||
         expandable({}),
-      renderActions: expandable<RenderActions<HTMLElement, Text, Document>>({
+      renderActions: expandable<RenderActions<HTML_DOM>>({
         ...BaseDocument.OPTIONS.renderActions,
         addMenu: [STATE.CONTEXT_MENU],
         getMenus: [STATE.INSERTED + 5, false],
@@ -392,11 +392,9 @@ export function MenuMathDocumentMixin<B extends A11yDocumentConstructor>(
  * Add context-menu support to a Handler instance
  *
  * @param {Handler} handler   The Handler instance to enhance
- * @returns {Handler}          The handler that was modified (for purposes of chaining extensions)
+ * @returns {Handler}         The handler that was modified (for purposes of chaining extensions)
  */
-export function MenuHandler(
-  handler: Handler<HTMLElement, Text, Document>
-): Handler<HTMLElement, Text, Document> {
+export function MenuHandler(handler: Handler<HTML_DOM>): Handler<HTML_DOM> {
   handler.documentClass = MenuMathDocumentMixin<A11yDocumentConstructor>(
     handler.documentClass as any
   );

--- a/ts/ui/menu/MmlVisitor.ts
+++ b/ts/ui/menu/MmlVisitor.ts
@@ -26,17 +26,16 @@ import { MmlNode } from '../../core/MmlTree/MmlNode.js';
 import { PropertyList } from '../../core/Tree/Node.js';
 import { SerializedMmlVisitor } from '../../core/MmlTree/SerializedMmlVisitor.js';
 import { OptionList, userOptions } from '../../util/Options.js';
+import { DOM_TYPES } from '../../types/Types.js';
 
 /*==========================================================================*/
 
 /**
  * The visitor to serialize MathML
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
+export class MmlVisitor<DOM extends DOM_TYPES> extends SerializedMmlVisitor {
   /**
    * The options controlling the serialization
    */
@@ -50,7 +49,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
   /**
    * The MathItem currently being processed
    */
-  public mathItem: MathItem<N, T, D> = null;
+  public mathItem: MathItem<DOM> = null;
 
   /**
    * @param {MmlNode} node         The internal MathML node to serialize
@@ -60,7 +59,7 @@ export class MmlVisitor<N, T, D> extends SerializedMmlVisitor {
    */
   public visitTree(
     node: MmlNode,
-    math: MathItem<N, T, D> = null,
+    math: MathItem<DOM> = null,
     options: OptionList = {}
   ) {
     this.mathItem = math;

--- a/ts/ui/no-dark-mode/no-dark-mode.ts
+++ b/ts/ui/no-dark-mode/no-dark-mode.ts
@@ -24,6 +24,7 @@
 import { MathJax } from '../../components/global.js';
 import { MathJaxObject } from '../../components/startup.js';
 import { AbstractHandler } from '../../core/Handler.js';
+import { DOM } from '../../types/Types.js';
 
 [
   [
@@ -47,7 +48,7 @@ import { AbstractHandler } from '../../core/Handler.js';
         'mjx-ignore'
       ] = { ignore: 1 };
       (MathJax as MathJaxObject).startup.extendHandler(
-        (handler: AbstractHandler<any, any, any>) => {
+        (handler: AbstractHandler<DOM>) => {
           delete (handler.documentClass as any).speechStyles[
             '@media (prefers-color-scheme: dark) /* explorer */'
           ];

--- a/ts/ui/safe/SafeHandler.ts
+++ b/ts/ui/safe/SafeHandler.ts
@@ -28,7 +28,7 @@ import {
   DOCUMENT_OPTIONS,
 } from '../../core/MathDocument.js';
 import { Handler } from '../../core/Handler.js';
-import { DOM, DOM_TYPES, Constructor } from '../../types/Types.js';
+import { DOM_TYPES, Constructor } from '../../types/Types.js';
 
 import { Safe } from './safe.js';
 
@@ -81,38 +81,31 @@ const options: OPTIONS = {
 
 /**
  * The properties needed in the MathDocument for sanitizing the internal MathML
+ *
+ * @template DOM   The DOM node types
  */
-export interface SafeMathDocument<N, T, D> extends AbstractMathDocument<
-  N,
-  T,
-  D
-> {
+export interface SafeMathDocument<
+  DOM extends DOM_TYPES,
+> extends AbstractMathDocument<DOM> {
   /**
    * The Safe object for this document
    */
-  safe: Safe<N, T, D>;
+  safe: Safe<DOM>;
 }
 
 /**
  * The mixin for adding safe render action to MathDocuments
  *
- * @param {B} BaseDocument              The MathDocument class to be extended
- * @returns {SafeMathDocument<N,T,D>}   The extended MathDocument class
+ * @param {B} BaseDocument       The MathDocument class to be extended
+ * @returns {SafeMathDocument}   The extended MathDocument class
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
- * @template B  The Base document
+ * @template DOM   The DOM node types
+ * @template B     The Base document
  */
 export function SafeMathDocumentMixin<
-  N,
-  T,
-  D,
-  B extends MathDocumentConstructor<
-    AbstractMathDocument<N, T, D>,
-    DOM<N, T, D>
-  >,
->(BaseDocument: B): Constructor<SafeMathDocument<N, T, D>> & B {
+  DOM extends DOM_TYPES,
+  B extends MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>,
+>(BaseDocument: B): Constructor<SafeMathDocument<DOM>> & B {
   return class extends BaseDocument {
     /**
      * @override
@@ -122,12 +115,12 @@ export function SafeMathDocumentMixin<
       ...options,
     };
 
-    public options: SAFE_OPTIONS<DOM<N, T, D>>;
+    public options: SAFE_OPTIONS<DOM>;
 
     /**
      * An instance of the Safe object
      */
-    public safe: Safe<N, T, D>;
+    public safe: Safe<DOM>;
 
     /**
      * Extend the MathItem class used for this MathDocument
@@ -154,13 +147,13 @@ export function SafeMathDocumentMixin<
 
     /**
      * @param {object} data The argument containing math item and document
-     * @param {MathItem<N, T, D>} data.math The math item to sanitize
-     * @param {SafeMathDocument<N, T, D>} data.document The document to use for the
+     * @param {MathItem<DOM>} data.math The math item to sanitize
+     * @param {SafeMathDocument<DOM>} data.document The document to use for the
      *     filter (note: this has been bound to the input jax)
      */
     protected sanitize(data: {
-      math: MathItem<N, T, D>;
-      document: SafeMathDocument<N, T, D>;
+      math: MathItem<DOM>;
+      document: SafeMathDocument<DOM>;
     }) {
       data.math.root = (this as any).parseOptions.root;
       data.document.safe.sanitize(data.math, data.document);
@@ -176,9 +169,12 @@ export function SafeMathDocumentMixin<
  * @param {Handler} handler   The Handler instance to enhance
  * @returns {Handler}         The handler that was modified (for purposes of chaining extensions)
  */
-export function SafeHandler<N, T, D>(
-  handler: Handler<N, T, D>
-): Handler<N, T, D> {
-  handler.documentClass = SafeMathDocumentMixin(handler.documentClass);
+export function SafeHandler<DOM extends DOM_TYPES>(
+  handler: Handler<DOM>
+): Handler<DOM> {
+  handler.documentClass = SafeMathDocumentMixin<
+    DOM,
+    MathDocumentConstructor<AbstractMathDocument<DOM>, DOM>
+  >(handler.documentClass);
   return handler;
 }

--- a/ts/ui/safe/SafeMethods.ts
+++ b/ts/ui/safe/SafeMethods.ts
@@ -23,23 +23,25 @@
 
 import { length2em } from '../../util/lengths.js';
 import { Safe, FilterFunction } from './safe.js';
+import { DOM, DOM_TYPES, N } from '../../types/Types.js';
 
 /**
  * The default attribute-filtering functions
  */
-export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
+export const SafeMethods: { [name: string]: FilterFunction<DOM> } = {
   /**
    * Filter HREF URL's
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
-   * @param {string} url        The URL being tested
-   * @returns {string|null}     The URL if OK and null if not
+   * @param {Safe} safe       The Safe object being used
+   * @param {string} url      The URL being tested
+   * @returns {string|null}   The URL if OK and null if not
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterURL<N, T, D>(safe: Safe<N, T, D>, url: string): string | null {
+  filterURL<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
+    url: string
+  ): string | null {
     const protocol = (url.match(/^\s*([a-z\n\r]+):/i) || [null, ''])[1]
       .replace(/[\n\r]/g, '')
       .toLowerCase();
@@ -53,15 +55,16 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter a class list
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} list       The class list being tested
    * @returns {string|null}     The class list if OK and null if not
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterClassList<N, T, D>(safe: Safe<N, T, D>, list: string): string | null {
+  filterClassList<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
+    list: string
+  ): string | null {
     const classes = list.trim().replace(/\s\s+/g, ' ').split(/ /);
     return classes
       .map((name) => this.filterClass(safe, name) || '')
@@ -73,15 +76,16 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter a class name
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} CLASS      The class being tested
-   * @returns {string|null}      The class if OK and null if not
+   * @returns {string|null}     The class if OK and null if not
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterClass<N, T, D>(safe: Safe<N, T, D>, CLASS: string): string | null {
+  filterClass<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
+    CLASS: string
+  ): string | null {
     const allow = safe.allow.classes;
     return allow === 'all' ||
       (allow === 'safe' && CLASS.match(safe.options.classPattern))
@@ -92,15 +96,13 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter ids
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} id         The id being tested
    * @returns {string|null}     The id if OK and null if not
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterID<N, T, D>(safe: Safe<N, T, D>, id: string): string | null {
+  filterID<DOM extends DOM_TYPES>(safe: Safe<DOM>, id: string): string | null {
     const allow = safe.allow.cssIDs;
     return allow === 'all' ||
       (allow === 'safe' && id.match(safe.options.idPattern))
@@ -111,15 +113,13 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter style strings
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} styles     The style string being tested
    * @returns {string}          The sanitized style string
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterStyles<N, T, D>(safe: Safe<N, T, D>, styles: string): string {
+  filterStyles<DOM extends DOM_TYPES>(safe: Safe<DOM>, styles: string): string {
     if (safe.allow.styles === 'all') return styles;
     if (safe.allow.styles !== 'safe') return null;
     const adaptor = safe.adaptor;
@@ -163,19 +163,17 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter an individual name:value style pair
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} style      The style name being tested
    * @param {N} div             The temp DIV node containing the style object to be tested
    * @returns {string|null}     The sanitized style string or null if invalid
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterStyle<N, T, D>(
-    safe: Safe<N, T, D>,
+  filterStyle<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
     style: string,
-    div: N
+    div: N<DOM>
   ): string | null {
     const value = safe.adaptor.getStyle(div, style);
     if (
@@ -197,21 +195,19 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter a style's value, handling compound values (e.g., borders that have widths as well as styles and colors)
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} style      The style name being tested
    * @param {string} value      The value of the style to test
    * @param {N} div             The temp DIV node containing the style object to be tested
    * @returns {string|null}     The sanitized style string or null if invalid
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterStyleValue<N, T, D>(
-    safe: Safe<N, T, D>,
+  filterStyleValue<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
     style: string,
     value: string,
-    div: N
+    div: N<DOM>
   ): string | null {
     const name = safe.options.styleLengths[style];
     if (!name) {
@@ -235,17 +231,15 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter a length value
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} style      The style name being tested
    * @param {string} value      The value of the style to test
    * @returns {string|null}     The sanitized length value
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterStyleLength<N, T, D>(
-    safe: Safe<N, T, D>,
+  filterStyleLength<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
     style: string,
     value: string
   ): string | null {
@@ -263,30 +257,32 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter a font size
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} size       The font size to test
    * @returns {string|null}     The sanitized style string or null if invalid
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterFontSize<N, T, D>(safe: Safe<N, T, D>, size: string): string | null {
+  filterFontSize<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
+    size: string
+  ): string | null {
     return this.filterStyleLength(safe, 'fontSize', size);
   },
 
   /**
    * Filter scriptsizemultiplier
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} size       The script size multiplier to test
    * @returns {string}          The sanitized size
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterSizeMultiplier<N, T, D>(safe: Safe<N, T, D>, size: string): string {
+  filterSizeMultiplier<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
+    size: string
+  ): string {
     const [m, M] = safe.options.scriptsizemultiplierRange || [
       -Infinity,
       Infinity,
@@ -297,16 +293,14 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    *  Filter scriptLevel
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} level      The scriptlevel to test
    * @returns {string|null}     The sanitized scriptlevel or null
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterScriptLevel<N, T, D>(
-    safe: Safe<N, T, D>,
+  filterScriptLevel<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
     level: string
   ): string | null {
     const [m, M] = safe.options.scriptlevelRange || [-Infinity, Infinity];
@@ -316,17 +310,15 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter a data-* attribute
    *
-   * @param {Safe<N,T,D>} safe  The Safe object being used
+   * @param {Safe} safe         The Safe object being used
    * @param {string} value      The attribute's value
    * @param {string} id         The attribute's id (e.g., data-mjx-variant)
    * @returns {number|null}     The sanitized value or null
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterData<N, T, D>(
-    safe: Safe<N, T, D>,
+  filterData<DOM extends DOM_TYPES>(
+    safe: Safe<DOM>,
     value: string,
     id: string
   ): string | null {
@@ -336,17 +328,15 @@ export const SafeMethods: { [name: string]: FilterFunction<any, any, any> } = {
   /**
    * Filter an on* attribute (don't allow them)
    *
-   * @param {Safe<N,T,D>} _safe  The Safe object being used
+   * @param {Safe} _safe         The Safe object being used
    * @param {string} _value      The attribute's value
    * @param {string} _id         The attribute's id (e.g., data-mjx-variant)
    * @returns {string|null}      The sanitized value or null
    *
-   * @template N  The HTMLElement node class
-   * @template T  The Text node class
-   * @template D  The Document class
+   * @template DOM  The DOM node types
    */
-  filterListeners<N, T, D>(
-    _safe: Safe<N, T, D>,
+  filterListeners<DOM extends DOM_TYPES>(
+    _safe: Safe<DOM>,
     _value: string,
     _id: string
   ): string | null {

--- a/ts/ui/safe/safe.ts
+++ b/ts/ui/safe/safe.ts
@@ -29,20 +29,22 @@ import { OptionList, expandable } from '../../util/Options.js';
 import { DOMAdaptor } from '../../core/DOMAdaptor.js';
 import { SafeMethods } from './SafeMethods.js';
 import type { OPTIONS, SAFE_LIST, LENGTH_LIST } from './SafeHandler.js';
+import type { DOM_TYPES } from '../../types/Types.js';
 
 /**
  * Function type for filtering attributes
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export type FilterFunction<N, T, D> = (
-  safe: Safe<N, T, D>,
+export type FilterFunction<DOM extends DOM_TYPES> = (
+  safe: Safe<DOM>,
   value: Property,
   ...args: any[]
 ) => Property;
 
+/**
+ * The default options for the safe extension
+ */
 const options: OPTIONS['safeOptions'] = {
   allow: {
     //
@@ -144,11 +146,9 @@ const options: OPTIONS['safeOptions'] = {
 /**
  * The Safe object for sanitizing the internal MathML representation of an expression
  *
- * @template N  The HTMLElement node class
- * @template T  The Text node class
- * @template D  The Document class
+ * @template DOM   The DOM node types
  */
-export class Safe<N, T, D> {
+export class Safe<DOM extends DOM_TYPES> {
   /**
    * The options controlling the handling of the safe extension
    */
@@ -189,20 +189,20 @@ export class Safe<N, T, D> {
   /**
    * The DOM adaptor from the document
    */
-  public adaptor: DOMAdaptor<N, T, D>;
+  public adaptor: DOMAdaptor<DOM>;
 
   /**
    * The methods for filtering the MathML attributes
    */
-  public filterMethods: { [name: string]: FilterFunction<N, T, D> } = {
+  public filterMethods: { [name: string]: FilterFunction<DOM> } = {
     ...SafeMethods,
   };
 
   /**
-   * @param {MathDocument<N,T,D>} document  The MathDocument we are sanitizing
-   * @param {OptionList} options            The safeOptions from the document
+   * @param {MathDocument} document   The MathDocument we are sanitizing
+   * @param {OptionList} options      The safeOptions from the document
    */
-  constructor(document: MathDocument<N, T, D>, options: OptionList) {
+  constructor(document: MathDocument<DOM>, options: OptionList) {
     this.adaptor = document.adaptor;
     this.options = options;
     this.allow = this.options.allow;
@@ -211,15 +211,15 @@ export class Safe<N, T, D> {
   /**
    * Sanitize a MathItem's root MathML tree
    *
-   * @param {MathItem<N,T,D>} math           The MathItem to sanitize
-   * @param {MathDocument<N,T,D>} document   The MathDocument in which it lives
+   * @param {MathItem} math           The MathItem to sanitize
+   * @param {MathDocument} document   The MathDocument in which it lives
    */
-  public sanitize(math: MathItem<N, T, D>, document: MathDocument<N, T, D>) {
+  public sanitize(math: MathItem<DOM>, document: MathDocument<DOM>) {
     try {
       math.root.walkTree(this.sanitizeNode.bind(this));
     } catch (err) {
       document.options.compileError(
-        document as AbstractMathDocument<N, T, D>,
+        document as AbstractMathDocument<DOM>,
         math,
         err
       );
@@ -256,8 +256,8 @@ export class Safe<N, T, D> {
   /**
    * Sanitize a MathML input attribute
    *
-   * @param {string} id      The name of the attribute
-   * @param {string} value   The value of the attribute
+   * @param {string} id       The name of the attribute
+   * @param {string} value    The value of the attribute
    * @returns {string|null}   The sanitized value
    */
   public mmlAttribute(id: string, value: string): string | null {
@@ -283,7 +283,7 @@ export class Safe<N, T, D> {
    * Sanitize a list of class names
    *
    * @param {string[]} list   The list of class names
-   * @returns {string[]}       The sanitized list
+   * @returns {string[]}      The sanitized list
    */
   public mmlClassList(list: string[]): string[] {
     return list


### PR DESCRIPTION
This PR builds on the idea of the `DOM` type introduced in #1554 in order to reduce the number of template variables used in the various classes that require information about the DOM nodes being used.  In the past, we used `<N, T, D>` for this, but this PR changes that to use `<DOM>`, as in the various option types added in #1554, so something like `MathDocument<N, T, D>` now becomes `MathDocumetn<DOM>`.  To access the `N`, `T`, and `D` values, the class uses `N<DOM>`, T<DOM>` and `D<DOM>` instead.  This helps clarify that the type refers to a DOM node type.  This reduces the templates from three to just one in many cases.

The biggest impact is in the `ts/output/common` files, where there were 12 template variables.  By merging `N`, `T`, and `D` into `DOM`, and combing the five font-based template values into a single `COMMON_FONT` (or `CHTML_FONT` or `SVG_FONT`) type, those templates are cut in half, to only six.  The other four are interdependent and I could don't find an away to combine them into a single type, but six is still better than 12.  That reduces the need for `/* prettier-ignore */` statements, and shortens up the template declarations considerably.  The cost is using `N<DOM>` rather than `N`, but as mentioned above, I think that actually helps clarify what these values are.  But it also allow `<N<DOM>, T<DOM>, D<DOM>>` that was introduced in #1554 to be replaced by `<DOM>`, so that is a savings as well.

In addition to removing `/* prettier-ignore */` for the extensive template usage, I tried to remove `/* prettier-ignore */` in other cases that were just there for comments, so you will see some comment adjustments for that purpose.  I also did some alignment adjustments in the comments that had gotten skewed due to earlier changes, so you might want to view this with white-space changes hidden.

Some modules used explicit `<HTMLElement, Text, Document>` template values; these are replaced by `<HTML_DOM>` where `HTML_DOM` comes from `ts/types/dom/html.ts` as part of the new typing system.

There is really nothing else going on in this PR, so although there are a lot of files involved (anything that uses `MathItem` or `MathDocument`, which is just about everything), the changes are really just in the templates.

One issue to consider, however, is that this is a potentially breaking change to people using MathJax in Typescript projects, as something like `new TeX<HTMLElement, Text, Document>()` will have to be changed to `new TeX<HTML_DOM>()` and `HTML_DOM` will need to be imported.  But the new `HTML_DOM` should make such things easier, especially for node use, where `new TeX<LITE_DOM>` with one import for `LITE_DOM` is easier than importing `LiteElement`, `LiteText`, and `LiteDocument` from three separate files, and using `new TeX<LiteElement, LiteText, LiteDocument>()`.  So I think this (along with the new typing mechanism) will be a welcome change for developers.